### PR TITLE
Upgrade HAPI minor version to avoid build issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
+# Maven
+target/
+tmp/
+
+# Eclipse
 .classpath
 .project
 .settings/
-target/
-tmp/
+
+# IDEA
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <version>1.0.0</version>
 
   <properties>
-    <hapiFhirVersion>4.0.0</hapiFhirVersion>
+    <hapiFhirVersion>4.0.3</hapiFhirVersion>
     <sparkVersion>2.4.4</sparkVersion>
     <sparkScalaVersion>2.11</sparkScalaVersion>
     <hadoopVersion>2.7.7</hadoopVersion>


### PR DESCRIPTION
Hi @johngrimes,

I needed to upgrade the HAPI version from 4.0.0 to 4.0.3 to avoid a dependency on a 4.0.0-SNAPSHOT pom which is not available in Maven Central.

The HAPI 4.0.3 release notes confirm the issue: https://hapifhir.io/hapi-fhir/docs/introduction/changelog.html#hapi-fhir-403-igloo-point-release

Cheers.