### PR TITLE
Upgrade to Spark 3.0.0

### DIFF
--- a/encoders/pom.xml
+++ b/encoders/pom.xml
@@ -74,12 +74,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.4</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>3.3.2</version>
+          <version>4.3.1</version>
           <executions>
             <execution>
               <id>scala-compile-first</id>

--- a/fhir-server/Dockerfile
+++ b/fhir-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:11
 
 LABEL copyright="Copyright © 2018-2020, Commonwealth Scientific and Industrial Research Organisation (CSIRO) ABN 41 687 119 230. Licensed under the CSIRO Open Source Software Licence Agreement." \
   author="John Grimes <John.Grimes@csiro.au>"

--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -62,6 +62,10 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-aws</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
 
     <!-- Encoders -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
 
   <properties>
     <hapiFhirVersion>4.2.0</hapiFhirVersion>
-    <sparkVersion>2.4.5</sparkVersion>
-    <sparkScalaVersion>2.11</sparkScalaVersion>
+    <sparkVersion>3.0.0</sparkVersion>
+    <sparkScalaVersion>2.12</sparkScalaVersion>
     <hadoopVersion>2.7.7</hadoopVersion>
     <hadoopMirror>https://mirror.aarnet.edu.au/pub/apache/hadoop/common</hadoopMirror>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -138,6 +138,11 @@
             <artifactId>jackson-annotations</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>2.10.3</version>
       </dependency>
 
       <!-- Encoders -->
@@ -278,6 +283,15 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <repositories>
+    <repository>
+        <name>Spark 3 Staging</name>
+        <id>spark3-staging</id>
+        <url>https://repository.apache.org/content/repositories/orgapachespark-1341/</url>
+        <layout>default</layout>
+    </repository>
+  </repositories>
 
   <profiles>
     <profile>


### PR DESCRIPTION
This branch is currently getting Spark 3.0.0-rc1 from the Spark 3 staging repository, as it has not been released yet: https://repository.apache.org/content/repositories/orgapachespark-1341/

- Moved to OpenJDK 11
- Made updates to encoders to account for changes to Catalyst APIs
- Made some necessary updates to dependencies

Note that there are still failing tests, and this does not seem to have solved the JVM core dump issue (#5). There is still more work to be done on this pull request before it can be merged.