### PR TITLE
Improve handling of $this within arguments

### DIFF
--- a/fhir-server/src/main/java/au/csiro/pathling/fhirpath/NonLiteralPath.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/fhirpath/NonLiteralPath.java
@@ -7,7 +7,6 @@
 package au.csiro.pathling.fhirpath;
 
 import static au.csiro.pathling.QueryHelpers.createColumn;
-import static au.csiro.pathling.utilities.Preconditions.check;
 import static au.csiro.pathling.utilities.Preconditions.checkArgument;
 
 import au.csiro.pathling.QueryHelpers.DatasetWithColumn;
@@ -84,9 +83,6 @@ public abstract class NonLiteralPath implements FhirPath {
         "$this column name not present in dataset"));
     eidColumn.ifPresent(col -> checkArgument(datasetColumns.contains(col.toString()),
         "eid column name not present in dataset"));
-
-    // Singular paths should have an empty element ID column.
-    check(!singular || eidColumn.isEmpty());
 
     this.expression = expression;
     this.dataset = dataset;
@@ -188,7 +184,7 @@ public abstract class NonLiteralPath implements FhirPath {
         this.getDataset(), this.makeThisColumn());
 
     return copy(NamedFunction.THIS, inputWithThis.getDataset(), this.getIdColumn(),
-        Optional.empty(), this.getValueColumn(), true,
+        this.getEidColumn(), this.getValueColumn(), true,
         Optional.of(inputWithThis.getColumn()));
   }
 

--- a/fhir-server/src/main/java/au/csiro/pathling/fhirpath/function/WhereFunction.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/fhirpath/function/WhereFunction.java
@@ -15,7 +15,6 @@ import static org.apache.spark.sql.functions.when;
 import au.csiro.pathling.fhirpath.FhirPath;
 import au.csiro.pathling.fhirpath.NonLiteralPath;
 import au.csiro.pathling.fhirpath.element.BooleanPath;
-import java.util.Optional;
 import javax.annotation.Nonnull;
 import org.apache.spark.sql.Column;
 
@@ -62,7 +61,7 @@ public class WhereFunction implements NamedFunction {
     return inputPath
         .copy(expression, argumentPath.getDataset(), idColumn,
             inputPath.getEidColumn().map(c -> thisEid), valueColumn, inputPath.isSingular(),
-            Optional.empty());
+            inputPath.getThisColumn());
   }
 
 }

--- a/fhir-server/src/main/java/au/csiro/pathling/fhirpath/operator/BooleanOperator.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/fhirpath/operator/BooleanOperator.java
@@ -94,7 +94,7 @@ public class BooleanOperator implements Operator {
     }
 
     final String expression = left.getExpression() + " " + type + " " + right.getExpression();
-    final Dataset<Row> dataset = join(left, right, JoinType.LEFT_OUTER);
+    final Dataset<Row> dataset = join(input.getContext(), left, right, JoinType.LEFT_OUTER);
     final Column idColumn = left.getIdColumn();
     final Optional<Column> eidColumn = findEidColumn(left, right);
     final Optional<Column> thisColumn = findThisColumn(left, right);

--- a/fhir-server/src/main/java/au/csiro/pathling/fhirpath/operator/ComparisonOperator.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/fhirpath/operator/ComparisonOperator.java
@@ -58,7 +58,7 @@ public class ComparisonOperator implements Operator {
     checkArgumentsAreComparable(input, type.toString());
 
     final String expression = buildExpression(input, type.toString());
-    final Dataset<Row> dataset = join(left, right, JoinType.LEFT_OUTER);
+    final Dataset<Row> dataset = join(input.getContext(), left, right, JoinType.LEFT_OUTER);
 
     final Comparable leftComparable = (Comparable) left;
     final Comparable rightComparable = (Comparable) right;

--- a/fhir-server/src/main/java/au/csiro/pathling/fhirpath/operator/MathOperator.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/fhirpath/operator/MathOperator.java
@@ -52,7 +52,7 @@ public class MathOperator implements Operator {
         "Right operand to " + type + " operator must be singular: " + right.getExpression());
 
     final String expression = buildExpression(input, type.toString());
-    final Dataset<Row> dataset = join(left, right, JoinType.LEFT_OUTER);
+    final Dataset<Row> dataset = join(input.getContext(), left, right, JoinType.LEFT_OUTER);
 
     final Numeric leftNumeric = (Numeric) left;
     final Numeric rightNumeric = (Numeric) right;

--- a/fhir-server/src/main/java/au/csiro/pathling/fhirpath/operator/MembershipOperator.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/fhirpath/operator/MembershipOperator.java
@@ -75,7 +75,7 @@ public class MembershipOperator extends AggregateFunction implements Operator {
         .otherwise(equality);
 
     // We need to join the datasets in order to access values from both operands.
-    final Dataset<Row> dataset = join(left, right, JoinType.LEFT_OUTER);
+    final Dataset<Row> dataset = join(input.getContext(), left, right, JoinType.LEFT_OUTER);
 
     // In order to reduce the result to a single Boolean, we take the max of the boolean equality
     // values.

--- a/fhir-server/src/main/java/au/csiro/pathling/fhirpath/parser/InvocationVisitor.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/fhirpath/parser/InvocationVisitor.java
@@ -122,7 +122,7 @@ class InvocationVisitor extends FhirPathBaseVisitor<FhirPath> {
           // If the expression is not a resource reference, treat it as a path traversal from the
           // input context.
           final PathTraversalInput pathTraversalInput = new PathTraversalInput(context,
-              context.getInputContext(), fhirPath);
+              context.getThisContext().get(), fhirPath);
           return new PathTraversalOperator().invoke(pathTraversalInput);
         }
 
@@ -178,7 +178,7 @@ class InvocationVisitor extends FhirPathBaseVisitor<FhirPath> {
       // Create and alias the $this column.
       final FhirPath thisPath = nonLiteral.toThisPath();
 
-      // Create a new ParserContext, which includes information about how to evaluate the `$this` 
+      // Create a new ParserContext, which includes information about how to evaluate the `$this`
       // expression.
       final ParserContext argumentContext = new ParserContext(context.getInputContext(),
           context.getFhirContext(), context.getSparkSession(),

--- a/fhir-server/src/test/java/au/csiro/pathling/fhirpath/parser/ParserTest.java
+++ b/fhir-server/src/test/java/au/csiro/pathling/fhirpath/parser/ParserTest.java
@@ -268,7 +268,7 @@ public class ParserTest {
 
     // on the same collection should return all True (even though one is CodeableConcept)
     assertThatResultOf(
-        "reverseResolve(Condition.subject).code.coding.subsumes(reverseResolve(Condition.subject).code)")
+        "reverseResolve(Condition.subject).code.coding.subsumes(%resource.reverseResolve(Condition.subject).code)")
         .selectOrderedResult()
         .hasRows("responses/ParserTest/testSubsumesAndSubsumedBy-subsumes-self.csv");
 
@@ -303,18 +303,6 @@ public class ParserTest {
     assertThatResultOf("where($this.name.given contains 'Karina848').gender")
         .selectOrderedResult()
         .hasRows(allPatientsWithValue((String) null).changeValue(PATIENT_ID_9360820c, "female"));
-  }
-
-  /**
-   * This tests that the value from the `$this` context gets preserved successfully, when used in
-   * the "collection" operand to the membership operator.
-   */
-  @Test
-  public void testWhereWithInOperator() {
-    // @TODO: Change to a non-trivial case?
-    assertThatResultOf("where($this.name.first().family in contact.name.family).gender")
-        .selectOrderedResult()
-        .hasRows(allPatientsWithValue((Boolean) null));
   }
 
   @Test
@@ -354,14 +342,18 @@ public class ParserTest {
         .hasRows("responses/ParserTest/testWhereWithMemberOf.csv");
   }
 
+  /**
+   * This tests that the value from the `$this` context gets preserved successfully, when used in
+   * the "collection" operand to the membership operator. It also tests that aggregation can be
+   * applied successfully following a nested where invocation.
+   */
   @Test
   public void testAggregationFollowingNestedWhere() {
-
-    // TODO: Change to a non-trivial case?
-    assertThatResultOf("where($this.name.first().family in contact.name.where("
-        + "$this.given contains 'Joe').first().family).gender")
-        .selectOrderedResult().
-        hasRows(allPatientsWithValue((String) null));
+    assertThatResultOf(
+        "where(name.where(use = 'official').first().given.first() in "
+            + "name.where(use = 'maiden').first().given).gender")
+        .selectOrderedResult()
+        .hasRows("responses/ParserTest/testAggregationFollowingNestedWhere.csv");
   }
 
   @Test

--- a/fhir-server/src/test/resources/responses/ParserTest/testAggregationFollowingNestedWhere.csv
+++ b/fhir-server/src/test/resources/responses/ParserTest/testAggregationFollowingNestedWhere.csv
@@ -1,0 +1,9 @@
+Patient/121503c8-9564-4b48-9086-a22df717948e,""
+Patient/2b36c1e2-bbe1-45ae-8124-4adad2677702,""
+Patient/7001ad9c-34d2-4eb5-8165-5fdc2147f469,""
+Patient/8ee183e2-b3c0-4151-be94-b945d6aa8c6d,""
+Patient/9360820c-8602-4335-8b50-c88d627a0c20,female
+Patient/a7eb2ce7-1075-426c-addd-957b861b0e55,""
+Patient/bbd33563-70d9-4f6d-a79a-dd1fc55f5ad9,""
+Patient/beff242e-580b-47c0-9844-c1a68c36c5bf,""
+Patient/e62e52ae-2d75-4070-a0ae-3cc78d35ed08,""


### PR DESCRIPTION
Omission of `$this` now resolves correctly to the current element, and `$this` is passed through to nested function invocations. The outer resource can be accessed through `%resource` or `%context`.

Joining within function arguments uses the element ID from the $this context to handle multiple rows per resource.

Fixes #202.