### PR TITLE
Implemented custom coder for IdType.

### DIFF
--- a/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/IdCustomCoder.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/IdCustomCoder.scala
@@ -1,0 +1,59 @@
+/*
+ * This is a modified version of the Bunsen library, originally published at
+ * https://github.com/cerner/bunsen.
+ *
+ * Bunsen is copyright 2017 Cerner Innovation, Inc., and is licensed under
+ * the Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * These modifications are copyright © 2018-2021, Commonwealth Scientific
+ * and Industrial Research Organisation (CSIRO) ABN 41 687 119 230. Licensed
+ * under the CSIRO Open Source Software Licence Agreement.
+ */
+
+package au.csiro.pathling.encoders.datatypes
+
+import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, NewInstance, StaticInvoke}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
+import org.hl7.fhir.r4.model.IdType
+
+
+/**
+ * Custom coder for IdType.
+ * Represents IdType on two dataset columns:
+ * 'id' column hold the abbreviated unversioned id.
+ * 'id_versioned' column holds the full id with version, type etc.
+ *
+ * @param elementName the name of the element.
+ */
+case class IdCustomCoder(elementName: String) extends CustomCoder {
+
+  def primitiveClass: Class[IdType] = classOf[IdType]
+
+  val versionedName: String = elementName + "_versioned"
+
+  override val schema: Seq[StructField] = Seq(StructField(elementName, DataTypes.StringType), StructField(versionedName, DataTypes.StringType))
+
+  override def customDeserializer(addToPath: String => Expression): Map[String, Expression] = {
+
+    val expression = NewInstance(primitiveClass,
+      Invoke(addToPath(versionedName), "toString", ObjectType(classOf[String])) :: Nil,
+      ObjectType(primitiveClass))
+
+    Map(elementName -> expression)
+  }
+
+  override def customSerializer(inputObject: Expression): List[Expression] = {
+
+    val idExpression = StaticInvoke(classOf[UTF8String], DataTypes.StringType, "fromString",
+      List(Invoke(inputObject, "getIdPart", ObjectType(classOf[String]))))
+
+    val versionedIdExpression = StaticInvoke(classOf[UTF8String], DataTypes.StringType, "fromString",
+      List(Invoke(inputObject, "getValue", ObjectType(classOf[String]))))
+
+    List(Literal(elementName), idExpression, Literal(versionedName), versionedIdExpression)
+  }
+}
+
+

--- a/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/R4DataTypeMappings.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/R4DataTypeMappings.scala
@@ -21,7 +21,6 @@ import org.apache.spark.sql.catalyst.analysis.GetColumnByOrdinal
 import org.apache.spark.sql.catalyst.expressions.objects.{InitializeJavaBean, Invoke, NewInstance, StaticInvoke}
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, Literal}
 import org.apache.spark.sql.types.{DataType, DataTypes, ObjectType}
-import org.apache.spark.unsafe.types.UTF8String
 import org.hl7.fhir.instance.model.api.{IBaseBundle, IBaseDatatype, IBaseResource, IPrimitiveType}
 import org.hl7.fhir.r4.model._
 
@@ -132,9 +131,9 @@ class R4DataTypeMappings extends DataTypeMappings {
 
     primitive.getImplementingClass match {
 
-      case idClass if idClass == classOf[org.hl7.fhir.r4.model.IdType] =>
-        StaticInvoke(classOf[UTF8String], DataTypes.StringType, "fromString",
-          List(Invoke(inputObject, "getIdPart", ObjectType(classOf[String]))))
+      //      case idClass if idClass == classOf[org.hl7.fhir.r4.model.IdType] =>
+      //        StaticInvoke(classOf[UTF8String], DataTypes.StringType, "fromString",
+      //          List(Invoke(inputObject, "getIdPart", ObjectType(classOf[String]))))
 
       // If the FHIR primitive is serialized as a string, convert it to UTF8.
       case cls if fhirPrimitiveToSparkTypes.get(cls).contains(DataTypes.StringType) =>
@@ -232,6 +231,10 @@ class R4DataTypeMappings extends DataTypeMappings {
           case primitive: RuntimePrimitiveDatatypeDefinition
             if classOf[org.hl7.fhir.r4.model.DecimalType] == primitive.getImplementingClass => {
             Some(DecimalCustomCoder(childDefinition.getElementName))
+          }
+          case primitive: RuntimePrimitiveDatatypeDefinition
+            if classOf[org.hl7.fhir.r4.model.IdType] == primitive.getImplementingClass => {
+            Some(IdCustomCoder(childDefinition.getElementName))
           }
           case _ => super.customEncoder(childDefinition)
         }

--- a/encoders/src/test/java/au/csiro/pathling/encoders/FhirEncodersTest.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/FhirEncodersTest.java
@@ -116,15 +116,15 @@ public class FhirEncodersTest {
 
   @Test
   public void testResourceWithVersionId() {
+    conditionsWithVersionDataset.show();
+
     Assert.assertEquals("with-version",
         conditionsWithVersionDataset.select("id").head().get(0));
 
-    // A current limitation of the implementation is that technical version information is not
-    // preserved on the way out.
-    //
-    // TODO: Work out a way to preserve the technical version information when serializing the data
-    //  back out.
-    Assert.assertEquals("with-version",
+    Assert.assertEquals(conditionWithVersion.getId(),
+        conditionsWithVersionDataset.select("id_versioned").head().get(0));
+
+    Assert.assertEquals(conditionWithVersion.getId(),
         decodedConditionWithVersion.getId());
   }
 
@@ -375,7 +375,7 @@ public class FhirEncodersTest {
   }
 
   @Test
-  public void testEncoderCached() throws IOException {
+  public void testEncoderCached() {
 
     Assert.assertSame(encoders.of(Condition.class),
         encoders.of(Condition.class));


### PR DESCRIPTION
IdType is not encoded on two columns:

 * 'id' column hold the abbreviated unversioned id.
 * 'id_versioned' column holds the full id with version, type etc.

Resolves #222.
