### PR TITLE
Fix incorrect counting of resources when references are in use

### DIFF
--- a/fhir-server/src/main/java/au/csiro/pathling/fhirpath/function/CountFunction.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/fhirpath/function/CountFunction.java
@@ -12,7 +12,6 @@ import static org.apache.spark.sql.functions.when;
 
 import au.csiro.pathling.fhirpath.FhirPath;
 import au.csiro.pathling.fhirpath.NonLiteralPath;
-import au.csiro.pathling.fhirpath.ResourcePath;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 import org.apache.spark.sql.Column;
@@ -44,7 +43,7 @@ public class CountFunction extends AggregateFunction implements NamedFunction {
     // there may be duplicate IDs in the dataset.
     // When we are counting elements, we use a non-distinct count, to account for the fact that it
     // is valid to have multiple elements with the same value.
-    final Function<Column, Column> countFunction = inputPath instanceof ResourcePath
+    final Function<Column, Column> countFunction = inputPath == input.getContext().getInputContext()
                                                    ? functions::countDistinct
                                                    : functions::count;
 

--- a/fhir-server/src/main/java/au/csiro/pathling/fhirpath/function/CountFunction.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/fhirpath/function/CountFunction.java
@@ -39,10 +39,10 @@ public class CountFunction extends AggregateFunction implements NamedFunction {
     final String expression = expressionFromInput(input, NAME);
     final Column subjectColumn = inputPath.getValueColumn();
 
-    // When we are counting resources, we use the distinct count to account for the fact that
-    // there may be duplicate IDs in the dataset.
-    // When we are counting elements, we use a non-distinct count, to account for the fact that it
-    // is valid to have multiple elements with the same value.
+    // When we are counting resources from the input context, we use the distinct count to account
+    // for the fact that there may be duplicate IDs in the dataset.
+    // When we are counting anything else, we use a non-distinct count, to account for the fact that
+    // it is valid to have multiple of the same value.
     final Function<Column, Column> countFunction = inputPath == input.getContext().getInputContext()
                                                    ? functions::countDistinct
                                                    : functions::count;

--- a/fhir-server/src/test/java/au/csiro/pathling/test/TestDataImporter.java
+++ b/fhir-server/src/test/java/au/csiro/pathling/test/TestDataImporter.java
@@ -84,7 +84,7 @@ public class TestDataImporter implements CommandLineRunner {
           targetPath + "/" + subjectResource.toCode() + ".parquet";
 
       log.info("Writing: " + outputParquet);
-      resourcesDataset.repartition(1).write().mode(SaveMode.Overwrite).parquet(outputParquet);
+      resourcesDataset.write().mode(SaveMode.Overwrite).parquet(outputParquet);
     }
   }
 

--- a/fhir-server/src/test/java/au/csiro/pathling/test/TestDataImporter.java
+++ b/fhir-server/src/test/java/au/csiro/pathling/test/TestDataImporter.java
@@ -84,7 +84,7 @@ public class TestDataImporter implements CommandLineRunner {
           targetPath + "/" + subjectResource.toCode() + ".parquet";
 
       log.info("Writing: " + outputParquet);
-      resourcesDataset.write().mode(SaveMode.Overwrite).parquet(outputParquet);
+      resourcesDataset.repartition(1).write().mode(SaveMode.Overwrite).parquet(outputParquet);
     }
   }
 

--- a/fhir-server/src/test/java/au/csiro/pathling/test/builders/DatasetBuilder.java
+++ b/fhir-server/src/test/java/au/csiro/pathling/test/builders/DatasetBuilder.java
@@ -193,9 +193,9 @@ public class DatasetBuilder {
     final StructType schema;
     schema = new StructType(columns.toArray(new StructField[]{}));
 
-    final Dataset<Row> dataFrame = spark.createDataFrame(datasetRows, schema);
+    Dataset<Row> dataFrame = spark.createDataFrame(datasetRows, schema);
     checkNotNull(dataFrame);
-    log.info("Number of partitions in dataframe: " + dataFrame.rdd().getNumPartitions());
+    dataFrame = dataFrame.repartition(1);
     // needs to allow for empty datasets with 0 partitions
     checkState(dataFrame.rdd().getNumPartitions() <= 1,
         "at most one partition expected in test datasets constructed from rows, but got: "

--- a/fhir-server/src/test/java/au/csiro/pathling/test/builders/DatasetBuilder.java
+++ b/fhir-server/src/test/java/au/csiro/pathling/test/builders/DatasetBuilder.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -28,6 +29,7 @@ import org.apache.spark.sql.types.*;
  *
  * @author John Grimes
  */
+@Slf4j
 public class DatasetBuilder {
 
   @Nonnull
@@ -193,6 +195,7 @@ public class DatasetBuilder {
 
     final Dataset<Row> dataFrame = spark.createDataFrame(datasetRows, schema);
     checkNotNull(dataFrame);
+    log.info("Number of partitions in dataframe: " + dataFrame.rdd().getNumPartitions());
     // needs to allow for empty datasets with 0 partitions
     checkState(dataFrame.rdd().getNumPartitions() <= 1,
         "at most one partition expected in test datasets constructed from rows, but got: "


### PR DESCRIPTION
This change fixes an issue where the result of the `count` function would be incorrect when used on the result of the `resolve` or `reverseResolve` function.

An example of an expression which is affected by this is:

```
Patient.reverseResolve(Condition.subject)
    .subject
    .resolve()
    .ofType(Patient)
    .count()
```

The result should be equal to the number of Condition resources associated to the Patient resource through the `subject` element.