### PR TITLE
Implement extract operation

### DIFF
--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -145,6 +145,12 @@
       <version>${pathling.antlrVersion}</version>
     </dependency>
 
+    <!-- AWS SDK -->
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+    </dependency>
+
     <!-- Error monitoring -->
     <dependency>
       <groupId>io.sentry</groupId>

--- a/fhir-server/src/main/java/au/csiro/pathling/Configuration.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/Configuration.java
@@ -176,6 +176,12 @@ public class Configuration {
       @ToString.Exclude
       private String secretAccessKey;
 
+      /**
+       * Number of seconds that S3 pre-signed URLs should remain valid for.
+       */
+      @NotNull
+      private long signedUrlExpiry;
+
       @Nonnull
       public Optional<String> getAccessKeyId() {
         return Optional.ofNullable(accessKeyId);

--- a/fhir-server/src/main/java/au/csiro/pathling/Configuration.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/Configuration.java
@@ -141,6 +141,13 @@ public class Configuration {
     @Size(min = 1, max = 50)
     private String databaseName;
 
+    /**
+     * The URL that Pathling will use to output the results of bulk operations such as Extract. Can
+     * be an Amazon S3 ({@code s3://}), HDFS ({@code hdfs://}) or filesystem ({@code file://}) URL.
+     */
+    @NotBlank
+    private String resultUrl;
+
     @NotNull
     private Aws aws;
 

--- a/fhir-server/src/main/java/au/csiro/pathling/QueryExecutor.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/QueryExecutor.java
@@ -8,16 +8,21 @@ package au.csiro.pathling;
 
 import static au.csiro.pathling.QueryHelpers.join;
 import static au.csiro.pathling.utilities.Preconditions.checkArgument;
+import static au.csiro.pathling.utilities.Preconditions.checkUserInput;
 
 import au.csiro.pathling.QueryHelpers.JoinType;
 import au.csiro.pathling.fhir.TerminologyServiceFactory;
 import au.csiro.pathling.fhirpath.FhirPath;
+import au.csiro.pathling.fhirpath.Materializable;
+import au.csiro.pathling.fhirpath.element.BooleanPath;
+import au.csiro.pathling.fhirpath.parser.Parser;
 import au.csiro.pathling.fhirpath.parser.ParserContext;
 import au.csiro.pathling.io.ResourceReader;
 import ca.uhn.fhir.context.FhirContext;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.Getter;
 import org.apache.spark.sql.Column;
@@ -59,6 +64,67 @@ public abstract class QueryExecutor {
     this.terminologyClientFactory = terminologyClientFactory;
   }
 
+  protected ParserContext buildParserContext(@Nonnull final FhirPath inputContext) {
+    return buildParserContext(inputContext, Optional.empty());
+  }
+
+  protected ParserContext buildParserContext(@Nonnull final FhirPath inputContext,
+      @Nonnull final Optional<List<Column>> groupingColumns) {
+    return new ParserContext(inputContext, fhirContext, sparkSession, resourceReader,
+        terminologyClientFactory, groupingColumns);
+  }
+
+  @Nonnull
+  protected List<FhirPath> parseMaterializableExpressions(@Nonnull final Parser parser,
+      @Nonnull final Collection<String> expressions, @Nonnull final String display) {
+    return expressions.stream()
+        .map(expression -> {
+          final FhirPath result = parser.parse(expression);
+          // Each expression must evaluate to a Materializable path, or a user error will be thrown.
+          // There is no requirement for it to be singular.
+          checkUserInput(result instanceof Materializable,
+              display + " expression is not of a supported type: " + expression);
+          return result;
+        }).collect(Collectors.toList());
+  }
+
+  @Nonnull
+  protected List<FhirPath> parseFilters(@Nonnull final Parser parser,
+      @Nonnull final Collection<String> filters) {
+    return filters.stream().map(expression -> {
+      final FhirPath result = parser.parse(expression);
+      // Each filter expression must evaluate to a singular Boolean value, or a user error will be
+      // thrown.
+      checkUserInput(result instanceof BooleanPath,
+          "Filter expression is not a non-literal boolean: " + expression);
+      checkUserInput(result.isSingular(),
+          "Filter expression must represent a singular value: " + expression);
+      return result;
+    }).collect(Collectors.toList());
+  }
+
+  @Nonnull
+  protected Dataset<Row> joinExpressionsAndFilters(final FhirPath inputContext,
+      @Nonnull final Collection<FhirPath> expressions,
+      @Nonnull final Collection<FhirPath> filters, @Nonnull final Column idColumn) {
+    final List<Dataset<Row>> datasets = expressions.stream()
+        .map(expression -> {
+          // We need to remove any trailing null values from non-empty collections, so that
+          // aggregations do not count non-empty collections in the empty collection grouping. We do
+          // this by joining the distinct set of resource IDs to the dataset using an outer join,
+          // where the value is not null.
+          return join(expression.getDataset(), idColumn, inputContext.getDataset(),
+              idColumn, expression.getValueColumn().isNotNull(), JoinType.RIGHT_OUTER);
+        }).collect(Collectors.toList());
+    datasets.addAll(filters.stream()
+        .map(FhirPath::getDataset)
+        .collect(Collectors.toList()));
+
+    return datasets.stream()
+        .reduce((a, b) -> join(a, idColumn, b, idColumn, JoinType.LEFT_OUTER))
+        .orElseThrow();
+  }
+
   /**
    * Joins the datasets in a list together the provided set of shared columns.
    *
@@ -86,16 +152,6 @@ public abstract class QueryExecutor {
         .reduce(Column::and)
         .flatMap(filter -> Optional.of(dataset.filter(filter)))
         .orElse(dataset);
-  }
-
-  protected ParserContext buildParserContext(@Nonnull final FhirPath inputContext) {
-    return buildParserContext(inputContext, Optional.empty());
-  }
-
-  protected ParserContext buildParserContext(@Nonnull final FhirPath inputContext,
-      @Nonnull final Optional<List<Column>> groupingColumns) {
-    return new ParserContext(inputContext, fhirContext, sparkSession, resourceReader,
-        terminologyClientFactory, groupingColumns);
   }
 
 }

--- a/fhir-server/src/main/java/au/csiro/pathling/extract/ExtractExecutor.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/extract/ExtractExecutor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2018-2021, Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230. Licensed under the CSIRO Open Source
+ * Software Licence Agreement.
+ */
+
+package au.csiro.pathling.extract;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author John Grimes
+ */
+public interface ExtractExecutor {
+
+  /**
+   * Executes a {@link ExtractRequest}, producing an {@link ExtractResponse}.
+   *
+   * @param query The {@link ExtractRequest} to execute.
+   * @return an {@link ExtractResponse}
+   */
+  ExtractResponse execute(@Nonnull final ExtractRequest query);
+
+}

--- a/fhir-server/src/main/java/au/csiro/pathling/extract/ExtractProvider.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/extract/ExtractProvider.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2018-2021, Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230. Licensed under the CSIRO Open Source
+ * Software Licence Agreement.
+ */
+
+package au.csiro.pathling.extract;
+
+import static au.csiro.pathling.fhir.FhirServer.resourceTypeFromClass;
+
+import au.csiro.pathling.security.OperationAccess;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.server.IResourceProvider;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Enumerations.ResourceType;
+import org.hl7.fhir.r4.model.Parameters;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/**
+ * HAPI resource provider that provides an entry point for the "extract" type-level operation.
+ *
+ * @author John Grimes
+ * @see <a href="https://pathling.csiro.au/docs/extract.html">Extract</a>
+ */
+@Component
+@Scope("prototype")
+@Profile("server")
+public class ExtractProvider implements IResourceProvider {
+
+  @Nonnull
+  private final ExtractExecutor extractExecutor;
+
+  @Nonnull
+  private final Class<? extends IBaseResource> resourceClass;
+
+  @Nonnull
+  private final ResourceType resourceType;
+
+  /**
+   * @param extractExecutor an instance of {@link ExtractExecutor} to process requests
+   * @param resourceClass the resource class that this provider will receive requests for
+   */
+  public ExtractProvider(@Nonnull final ExtractExecutor extractExecutor,
+      @Nonnull final Class<? extends IBaseResource> resourceClass) {
+    this.extractExecutor = extractExecutor;
+    this.resourceClass = resourceClass;
+    resourceType = resourceTypeFromClass(resourceClass);
+  }
+
+  @Override
+  public Class<? extends IBaseResource> getResourceType() {
+    return resourceClass;
+  }
+
+  /**
+   * Extended FHIR operation: "extract".
+   *
+   * @param column a list of column expressions
+   * @param filter a list of filter expressions
+   * @return {@link Parameters} object representing the result
+   */
+  @Operation(name = "$extract", idempotent = true)
+  @OperationAccess("extract")
+  public Parameters extract(
+      @Nullable @OperationParam(name = "column") final List<String> column,
+      @Nullable @OperationParam(name = "filter") final List<String> filter) {
+    final ExtractRequest query = new ExtractRequest(
+        resourceType, Optional.ofNullable(column), Optional.ofNullable(filter));
+    final ExtractResponse result = extractExecutor.execute(query);
+    return result.toParameters();
+  }
+
+}

--- a/fhir-server/src/main/java/au/csiro/pathling/extract/ExtractRequest.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/extract/ExtractRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2018-2021, Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230. Licensed under the CSIRO Open Source
+ * Software Licence Agreement.
+ */
+
+package au.csiro.pathling.extract;
+
+import static au.csiro.pathling.utilities.Preconditions.checkUserInput;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import lombok.Value;
+import org.hl7.fhir.r4.model.Enumerations.ResourceType;
+
+/**
+ * Represents the information provided as part of an invocation of the "extract" operation.
+ *
+ * @author John Grimes
+ */
+@Value
+public class ExtractRequest {
+
+  @Nonnull
+  ResourceType subjectResource;
+
+  @Nonnull
+  List<String> columns;
+
+  @Nonnull
+  List<String> filters;
+
+  /**
+   * @param subjectResource The resource which will serve as the input context for each expression
+   * @param columns A set of columns expressions to execute over the data
+   * @param filters The criteria by which the data should be filtered
+   */
+  public ExtractRequest(@Nonnull final ResourceType subjectResource,
+      @Nonnull final Optional<List<String>> columns,
+      @Nonnull final Optional<List<String>> filters) {
+    checkUserInput(columns.isPresent() && columns.get().size() > 0,
+        "Query must have at least one column expression");
+    checkUserInput(columns.get().stream().noneMatch(String::isBlank),
+        "Column expression cannot be blank");
+    filters.ifPresent(f -> checkUserInput(f.stream().noneMatch(String::isBlank),
+        "Filter expression cannot be blank"));
+    this.subjectResource = subjectResource;
+    this.columns = columns.get();
+    this.filters = filters.orElse(Collections.emptyList());
+  }
+
+}

--- a/fhir-server/src/main/java/au/csiro/pathling/extract/ExtractResponse.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/extract/ExtractResponse.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2018-2021, Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230. Licensed under the CSIRO Open Source
+ * Software Licence Agreement.
+ */
+
+package au.csiro.pathling.extract;
+
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r4.model.UriType;
+
+/**
+ * Represents the information to be provided as the result of the invocation of the "extract"
+ * operation.
+ *
+ * @author John Grimes
+ */
+@Getter
+public class ExtractResponse {
+
+  @Nonnull
+  private final String url;
+
+  /**
+   * @param url A URL at which the result can be retrieved
+   */
+  public ExtractResponse(@Nonnull final String url) {
+    this.url = url;
+  }
+
+  /**
+   * Converts this to a {@link Parameters} resource, based on the definition of the result of the
+   * "extract" operation within the OperationDefinition.
+   *
+   * @return a new {@link Parameters} object
+   */
+  public Parameters toParameters() {
+    final Parameters parameters = new Parameters();
+    final ParametersParameterComponent urlParameter = new ParametersParameterComponent();
+    urlParameter.setName("url");
+    urlParameter.setValue(new UriType(url));
+    parameters.getParameter().add(urlParameter);
+    return parameters;
+  }
+
+}

--- a/fhir-server/src/main/java/au/csiro/pathling/extract/FreshExtractExecutor.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/extract/FreshExtractExecutor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2018-2021, Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230. Licensed under the CSIRO Open Source
+ * Software Licence Agreement.
+ */
+
+package au.csiro.pathling.extract;
+
+import au.csiro.pathling.Configuration;
+import au.csiro.pathling.QueryExecutor;
+import au.csiro.pathling.fhir.TerminologyServiceFactory;
+import au.csiro.pathling.fhirpath.FhirPath;
+import au.csiro.pathling.fhirpath.ResourcePath;
+import au.csiro.pathling.fhirpath.parser.Parser;
+import au.csiro.pathling.fhirpath.parser.ParserContext;
+import au.csiro.pathling.io.ResourceReader;
+import au.csiro.pathling.io.ResultWriter;
+import ca.uhn.fhir.context.FhirContext;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author John Grimes
+ */
+@Component
+@Profile("core")
+@Getter
+@Slf4j
+public class FreshExtractExecutor extends QueryExecutor implements ExtractExecutor {
+
+  @Nonnull
+  private final ResultWriter resultWriter;
+
+  /**
+   * @param configuration A {@link Configuration} object to control the behaviour of the executor
+   * @param fhirContext A {@link FhirContext} for doing FHIR stuff
+   * @param sparkSession A {@link SparkSession} for resolving Spark queries
+   * @param resourceReader A {@link ResourceReader} for retrieving resources
+   * @param terminologyClientFactory A {@link TerminologyServiceFactory} for resolving terminology
+   * @param resultWriter A {@link ResultWriter} for writing results for later retrieval
+   */
+  public FreshExtractExecutor(@Nonnull final Configuration configuration,
+      @Nonnull final FhirContext fhirContext, @Nonnull final SparkSession sparkSession,
+      @Nonnull final ResourceReader resourceReader,
+      @Nonnull final Optional<TerminologyServiceFactory> terminologyClientFactory,
+      @Nonnull final ResultWriter resultWriter) {
+    super(configuration, fhirContext, sparkSession, resourceReader,
+        terminologyClientFactory);
+    this.resultWriter = resultWriter;
+  }
+
+  @Override
+  public ExtractResponse execute(@Nonnull final ExtractRequest query) {
+    log.info("Executing request: {}", query);
+
+    // Build a new expression parser, and parse all of the column expressions within the query.
+    final ResourcePath inputContext = ResourcePath
+        .build(getFhirContext(), getResourceReader(), query.getSubjectResource(),
+            query.getSubjectResource().toCode(), true);
+    final ParserContext groupingAndFilterContext = buildParserContext(inputContext);
+    final Parser parser = new Parser(groupingAndFilterContext);
+    final List<FhirPath> columns = parseMaterializableExpressions(parser, query.getColumns(),
+        "Column");
+    final List<FhirPath> filters = parseFilters(parser, query.getFilters());
+
+    // Join all filter and column expressions together.
+    final Column idColumn = inputContext.getIdColumn();
+    Dataset<Row> columnsAndFilters = joinExpressionsAndFilters(inputContext, columns, filters,
+        idColumn);
+
+    // Apply filters.
+    columnsAndFilters = applyFilters(columnsAndFilters, filters);
+
+    // Select the column values.
+    final Column[] columnValues = columns.stream()
+        .map(FhirPath::getValueColumn).toArray(Column[]::new);
+    final Dataset<Row> result = columnsAndFilters.select(columnValues);
+
+    // Write the result and get the URL.
+    final String resultUrl = resultWriter.write(result);
+
+    return new ExtractResponse(resultUrl);
+  }
+
+}

--- a/fhir-server/src/main/java/au/csiro/pathling/fhir/FhirServer.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/fhir/FhirServer.java
@@ -133,6 +133,7 @@ public class FhirServer extends RestfulServer {
       // Register query providers.
       final Collection<Object> providers = new ArrayList<>();
       providers.addAll(buildAggregateProviders());
+      providers.addAll(buildExtractProviders());
       providers.addAll(buildSearchProviders());
       registerProviders(providers);
 
@@ -177,6 +178,19 @@ public class FhirServer extends RestfulServer {
       final IResourceProvider aggregateProvider = resourceProviderFactory
           .createAggregateResourceProvider(resourceType);
       providers.add(aggregateProvider);
+    }
+    return providers;
+  }
+
+  @Nonnull
+  private List<IResourceProvider> buildExtractProviders() {
+    final List<IResourceProvider> providers = new ArrayList<>();
+
+    // Instantiate an extract provider for every resource type in FHIR.
+    for (final ResourceType resourceType : ResourceType.values()) {
+      final IResourceProvider extractProvider = resourceProviderFactory
+          .createExtractResourceProvider(resourceType);
+      providers.add(extractProvider);
     }
     return providers;
   }

--- a/fhir-server/src/main/java/au/csiro/pathling/fhirpath/Materializable.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/fhirpath/Materializable.java
@@ -13,7 +13,7 @@ import org.hl7.fhir.r4.model.Type;
 
 /**
  * Designates an expression that is capable of being extracted from a Spark dataset and materialized
- * back into a FHIR value, e.g. for use in a grouping label.
+ * back into a FHIR value, e.g. for use in a grouping label or an extract column.
  *
  * @author John Grimes
  */

--- a/fhir-server/src/main/java/au/csiro/pathling/fhirpath/Materializable.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/fhirpath/Materializable.java
@@ -13,7 +13,8 @@ import org.hl7.fhir.r4.model.Type;
 
 /**
  * Designates an expression that is capable of being extracted from a Spark dataset and materialized
- * back into a FHIR value, e.g. for use in a grouping label or an extract column.
+ * back into a value featured within a result, e.g. for use in a grouping label or as part of an
+ * extract.
  *
  * @author John Grimes
  */

--- a/fhir-server/src/main/java/au/csiro/pathling/io/PersistenceScheme.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/io/PersistenceScheme.java
@@ -34,4 +34,13 @@ public abstract class PersistenceScheme {
     return s3Url.replaceFirst("s3:", "s3a:");
   }
 
+  /**
+   * @param s3aUrl The S3A URL that should be converted
+   * @return A S3 URL
+   */
+  @Nonnull
+  public static String convertS3aToS3Url(@Nonnull final String s3aUrl) {
+    return s3aUrl.replaceFirst("s3a:", "s3:");
+  }
+
 }

--- a/fhir-server/src/main/java/au/csiro/pathling/io/ResourceReader.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/io/ResourceReader.java
@@ -125,8 +125,7 @@ public class ResourceReader implements Cacheable {
     // types.
     @Nullable final FileStatus[] fileStatuses;
     try {
-      fileStatuses = warehouse
-          .listStatus(new Path(databasePath));
+      fileStatuses = warehouse.listStatus(new Path(databasePath));
     } catch (final IOException e) {
       throw new RuntimeException(
           "Problem listing file status at database path: " + databasePath, e);

--- a/fhir-server/src/main/java/au/csiro/pathling/io/ResultWriter.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/io/ResultWriter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2018-2021, Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230. Licensed under the CSIRO Open Source
+ * Software Licence Agreement.
+ */
+
+package au.csiro.pathling.io;
+
+import static au.csiro.pathling.io.PersistenceScheme.convertS3ToS3aUrl;
+import static au.csiro.pathling.io.PersistenceScheme.convertS3aToS3Url;
+
+import au.csiro.pathling.Configuration;
+import java.util.UUID;
+import javax.annotation.Nonnull;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.SaveMode;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class knows how to persist a Dataset of resources within a specified database.
+ *
+ * @author John Grimes
+ */
+@Component
+@Profile("core")
+public class ResultWriter {
+
+  @Nonnull
+  private final String resultUrl;
+
+  /**
+   * @param configuration A {@link Configuration} object which controls the behaviour of the writer
+   */
+  public ResultWriter(@Nonnull final Configuration configuration) {
+    this.resultUrl = convertS3ToS3aUrl(configuration.getStorage().getResultUrl());
+  }
+
+  /**
+   * Writes a result to the configured result storage area.
+   *
+   * @param result The {@link Dataset} containing the result.
+   * @return the URL of the result
+   */
+  public String write(@Nonnull final Dataset result) {
+    final String resultFileUrl = this.resultUrl + "/" + UUID.randomUUID() + ".csv";
+    result.write()
+        .mode(SaveMode.ErrorIfExists)
+        .csv(resultFileUrl);
+    //TODO: Merge partitioned files into one - possibly using FileUtil.copyMerge in Hadoop
+    return convertS3aToS3Url(resultFileUrl);
+  }
+
+}

--- a/fhir-server/src/main/resources/application.yml
+++ b/fhir-server/src/main/resources/application.yml
@@ -33,6 +33,10 @@ pathling:
     # URL.
     warehouseUrl: file:///usr/share/warehouse
 
+    # The URL that Pathling will use to output the results of bulk operations such as Extract. Can
+    # be an Amazon S3 (s3://), HDFS (hdfs://) or filesystem (file://) URL.
+    resultUrl: file:///usr/share/results
+
     # The subdirectory within the warehouse path used to read and write data.
     databaseName: default
 

--- a/fhir-server/src/main/resources/application.yml
+++ b/fhir-server/src/main/resources/application.yml
@@ -44,6 +44,8 @@ pathling:
     aws:
       # Public S3 buckets can be accessed by default, set this to false to access protected buckets.
       anonymousAccess: true
+      # Number of seconds that S3 pre-signed URLs should remain valid for.
+      signedUrlExpiry: 3600
       # Authentication details for connecting to protected Amazon S3 locations.
       # accessKeyId: [AWS access key ID]
       # secretAccessKey: [AWS secret access key]

--- a/fhir-server/src/main/resources/fhir/extract.OperationDefinition.json
+++ b/fhir-server/src/main/resources/fhir/extract.OperationDefinition.json
@@ -1,0 +1,41 @@
+{
+  "resourceType": "OperationDefinition",
+  "name": "extract",
+  "title": "Pathling Extract Operation",
+  "status": "active",
+  "kind": "operation",
+  "experimental": false,
+  "publisher": "Australian e-Health Research Centre, CSIRO",
+  "description": "This operation allows a user to perform aggregate queries on data held within the FHIR server by specifying aggregation, grouping and filter expressions.",
+  "affectsState": false,
+  "code": "extract",
+  "system": false,
+  "type": true,
+  "instance": false,
+  "parameter": [
+    {
+      "name": "column",
+      "use": "in",
+      "min": 1,
+      "max": "*",
+      "documentation": "A FHIRPath expression that defines a column within the result. The context is a single resource of the subject resource type. The expression must return a materializable type.",
+      "type": "string"
+    },
+    {
+      "name": "filter",
+      "use": "in",
+      "min": 0,
+      "max": "*",
+      "documentation": "A FHIRPath expression that can be evaluated against each resource in the data set to determine whether it is included within the result. The context is an individual resource of the type this operation was invoked against. The expression must evaluate to a singular Boolean value. Multiple filters are combined using AND logic.",
+      "type": "string"
+    },
+    {
+      "name": "url",
+      "use": "out",
+      "min": 1,
+      "max": 1,
+      "documentation": "A URL at which the result of the operation can be retrieved.",
+      "type": "string"
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
     <pathling.dockerJavaVersion>3.2.8</pathling.dockerJavaVersion>
     <pathling.hadoopVersion>2.10.1</pathling.hadoopVersion>
     <pathling.hadoopMirror>https://downloads.apache.org/hadoop/common</pathling.hadoopMirror>
+    <pathling.awsSdkVersion>1.12.47</pathling.awsSdkVersion>
   </properties>
 
   <modules>
@@ -193,6 +194,15 @@
         <groupId>au.csiro.pathling</groupId>
         <artifactId>encoders</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <!-- AWS SDK -->
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-bom</artifactId>
+        <version>${pathling.awsSdkVersion}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- Error monitoring -->

--- a/site/docs/aggregate.md
+++ b/site/docs/aggregate.md
@@ -37,12 +37,14 @@ resource. The following parameters are supported:
 
 - `aggregation [1..*]` - (string) A FHIRPath expression which is used to 
   calculate a summary value from each grouping. The context is a collection of 
-  resources of the subject resource type. The expression must evaluate to a 
-  primitive value.
+  resources of the subject resource type. The expression must return a
+  [materializable type](./fhirpath/data-types.html#materializable-types) and also be 
+  singular.
 - `grouping [0..*]` - (string) A FHIRPath expression that can be evaluated 
   against each resource in the data set to determine which groupings it should 
   be counted within. The context is an individual resource of the subject 
-  resource type. The expression must evaluate to a primitive value.
+  resource type. The expression must return a
+  [materializable type](./fhirpath/data-types.html#materializable-types).
 - `filter [0..*]` - (string) A FHIRPath expression that can be evaluated against 
   each resource in the data set to determine whether it is included within the 
   result. The context is an individual resource of the subject resource type. 
@@ -84,4 +86,4 @@ Check out example `aggregate` requests in the Postman collection:
    href="https://documenter.getpostman.com/view/634774/S17rx9Af?version=latest#d4afec33-89d8-411c-8e4d-9169b9af42e0">
 <img src="https://run.pstmn.io/button.svg" alt="Run in Postman"/></a>
 
-Next: [FHIRPath](./fhirpath)
+Next: [Extract](./extract.html)

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Configuration
-nav_order: 5
+nav_order: 6
 parent: Documentation
 ---
 

--- a/site/docs/extract.md
+++ b/site/docs/extract.md
@@ -1,0 +1,84 @@
+---
+layout: page
+title: Extract
+nav_order: 4
+parent: Documentation
+---
+
+# Extract
+
+[FHIR OperationDefinition](https://pathling.csiro.au/fhir/OperationDefinition/extract-4)
+
+Pathling provides a [FHIR&reg; REST](https://hl7.org/fhir/R4/http.html)
+interface, and the `$extract` operation is an
+[extended operation](https://hl7.org/fhir/R4/operations.html) defined on that
+interface.
+
+This operation allows a user to create arbitrary tabular extracts from FHIR 
+data, by specifying columns in terms of set of FHIRPath expressions that are 
+used to populate them. A URL is returned that points to a delimited text file 
+that contains the result of executing the expressions against each subject 
+resource.
+
+```
+GET [FHIR endpoint]/[resource type]/$extract?[parameters...]
+```
+
+```
+POST [FHIR endpoint]/[resource type]/$extract
+```
+
+<img src="/images/extract.png" 
+     srcset="/images/extract@2x.png 2x, /images/extract.png 1x"
+     alt="Extract operation" />
+
+## Request
+
+The request for the `$extract` operation is either a GET request, or a POST 
+request containing a [Parameters](https://hl7.org/fhir/R4/parameters.html) 
+resource. The following parameters are supported:
+
+- `column [1..*]` - (string) A FHIRPath expression that defines the column. The 
+  context is a single resource of the type specified in the subjectResource 
+  parameter. The expression must return a 
+  [materializable type](./fhirpath/data-types.html#materializable-types). 
+- `filter [0..*]` - (string) A FHIRPath expression that can be evaluated against 
+  each resource in the data set to determine whether it is included within the 
+  result. The context is an individual resource of the subject resource type. 
+  The expression must evaluate to a Boolean value. Multiple filters are combined 
+  using AND logic.
+  
+## Response
+
+The response for the `$extract` operation is a
+[Parameters](https://hl7.org/fhir/R4/parameters.html) resource containing the
+following parameters:
+
+- `url [1]` - A URL at which the result of the operation can be retrieved.
+
+## Asynchronous execution
+
+The `$extract` operation supports the 
+[asynchronous request pattern](https://hl7.org/fhir/r4/async.html), which allows 
+for long running operations to be run outside of the context of a normal HTTP 
+request-response interaction.
+
+You can opt-in to asynchronous execution by including the 
+`Prefer: respond-async` header in your request. The operation will immediately 
+respond with a HTTP status code of `202 Accepted`, along with a 
+`Content-Location` header containing the URL relating to the asynchronous job.
+
+You can issue a GET request to the job endpoint to check whether it is finished. 
+`202 Accepted` indicates that the job is still in progress, while a `200 OK` 
+means the job is finished, and will be accompanied by the response Parameters 
+resource.
+
+## Examples
+
+Check out example `extract` requests in the Postman collection:
+
+<a class="postman-link"
+   href="https://documenter.getpostman.com/view/634774/S17rx9Af?version=latest#d4afec33-89d8-411c-8e4d-9169b9af42e0">
+<img src="https://run.pstmn.io/button.svg" alt="Run in Postman"/></a>
+
+Next: [FHIRPath](./fhirpath)

--- a/site/docs/extract.md
+++ b/site/docs/extract.md
@@ -38,9 +38,9 @@ The request for the `$extract` operation is either a GET request, or a POST
 request containing a [Parameters](https://hl7.org/fhir/R4/parameters.html) 
 resource. The following parameters are supported:
 
-- `column [1..*]` - (string) A FHIRPath expression that defines the column. The 
-  context is a single resource of the type specified in the subjectResource 
-  parameter. The expression must return a 
+- `column [1..*]` - (string) A FHIRPath expression that defines a column within 
+  the result. The context is a single resource of the type specified in the 
+  subjectResource parameter. The expression must return a 
   [materializable type](./fhirpath/data-types.html#materializable-types). 
 - `filter [0..*]` - (string) A FHIRPath expression that can be evaluated against 
   each resource in the data set to determine whether it is included within the 

--- a/site/docs/extract.md
+++ b/site/docs/extract.md
@@ -39,8 +39,8 @@ request containing a [Parameters](https://hl7.org/fhir/R4/parameters.html)
 resource. The following parameters are supported:
 
 - `column [1..*]` - (string) A FHIRPath expression that defines a column within 
-  the result. The context is a single resource of the type specified in the 
-  subjectResource parameter. The expression must return a 
+  the result. The context is a single resource of the subject resource type. 
+  The expression must return a 
   [materializable type](./fhirpath/data-types.html#materializable-types). 
 - `filter [0..*]` - (string) A FHIRPath expression that can be evaluated against 
   each resource in the data set to determine whether it is included within the 
@@ -55,23 +55,6 @@ The response for the `$extract` operation is a
 following parameters:
 
 - `url [1]` - A URL at which the result of the operation can be retrieved.
-
-## Asynchronous execution
-
-The `$extract` operation supports the 
-[asynchronous request pattern](https://hl7.org/fhir/r4/async.html), which allows 
-for long running operations to be run outside of the context of a normal HTTP 
-request-response interaction.
-
-You can opt-in to asynchronous execution by including the 
-`Prefer: respond-async` header in your request. The operation will immediately 
-respond with a HTTP status code of `202 Accepted`, along with a 
-`Content-Location` header containing the URL relating to the asynchronous job.
-
-You can issue a GET request to the job endpoint to check whether it is finished. 
-`202 Accepted` indicates that the job is still in progress, while a `200 OK` 
-means the job is finished, and will be accompanied by the response Parameters 
-resource.
 
 ## Examples
 

--- a/site/docs/fhirpath/data-types.md
+++ b/site/docs/fhirpath/data-types.md
@@ -170,4 +170,17 @@ http://snomed.info/sct|'397956004 |Prosthetic arthroplasty of the hip|: 36370400
 
 <div class="callout warning">The <code>Coding</code> literal is not within the FHIRPath specification, and is currently unique to the Pathling implementation.</div>
 
+## Materializable types
+
+There is a subset of all possible FHIR types that can be "materialized", i.e. used as the result of a grouping expression in the Aggregate operation, or the definition of a column within the Extract operation. These types are:
+
+- [Boolean](#boolean)
+- [String](#string)
+- [Integer](#integer)
+- [Decimal](#decimal)
+- [Date](#date)
+- [DateTime](#datetime)
+- [Time](#time)
+- [Coding](#coding)
+
 Next: [Operators](./operators.html)

--- a/site/docs/fhirpath/index.md
+++ b/site/docs/fhirpath/index.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: FHIRPath
-nav_order: 4
+nav_order: 5
 parent: Documentation
 has_children: true
 ---
@@ -30,11 +30,3 @@ For convenience, this document does contain some redundant information copied
 from the source specification. Where there are variations from the
 specification, this document describes the behaviour as implemented within
 Pathling.
-
-The following sections from the FHIRPath specification are recommended reading:
-
-- [Overview](https://hl7.org/fhirpath/#overview);
-- [Navigation model](https://hl7.org/fhirpath/#navigation-model).
-- [Path selection](https://hl7.org/fhirpath/#path-selection);
-- [Collections](https://hl7.org/fhirpath/#collections), and;
-- [Paths and polymorphic items](https://hl7.org/fhirpath/#paths-and-polymorphic-items).

--- a/site/docs/roadmap.md
+++ b/site/docs/roadmap.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Roadmap
-nav_order: 6
+nav_order: 7
 parent: Documentation
 ---
 


### PR DESCRIPTION
This change will introduce a new operation called `extract`. This operation is designed for transforming FHIR data into a flattened form, for use within other tools, such as statistical and machine learning models.

Still to do:

- [ ] Look into Spring Boot caching
- [ ] Allow for extract of Coding values
- [ ] Add support for async response
- [ ] Add tests