### PR TITLE
Allow greater control over S3 configuration

### DIFF
--- a/fhir-server/src/main/java/au/csiro/pathling/config/StorageConfiguration.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/config/StorageConfiguration.java
@@ -6,15 +6,10 @@
 
 package au.csiro.pathling.config;
 
-import java.util.Optional;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import lombok.Data;
-import lombok.ToString;
 
 /**
  * Configuration relating to the storage of data.
@@ -37,56 +32,5 @@ public class StorageConfiguration {
   @Pattern(regexp = "[A-Za-z0-9-_]+")
   @Size(min = 1, max = 50)
   private String databaseName;
-
-  @NotNull
-  private Aws aws;
-
-  /**
-   * Configuration relating to storage of data using Amazon Web Services (AWS).
-   */
-  @Data
-  public static class Aws {
-
-    /**
-     * Public buckets can be accessed by default, set this to false to access protected buckets.
-     */
-    @NotNull
-    private boolean anonymousAccess;
-
-    /**
-     * Authentication details for connecting to a protected Amazon S3 bucket.
-     */
-    @Nullable
-    private String accessKeyId;
-
-    /**
-     * Authentication details for connecting to a protected Amazon S3 bucket.
-     */
-    @Nullable
-    @ToString.Exclude
-    private String secretAccessKey;
-
-    /**
-     * The ARN of an IAM role that should be assumed using STS.
-     */
-    @Nullable
-    private String assumedRole;
-
-    @Nonnull
-    public Optional<String> getAccessKeyId() {
-      return Optional.ofNullable(accessKeyId);
-    }
-
-    @Nonnull
-    public Optional<String> getSecretAccessKey() {
-      return Optional.ofNullable(secretAccessKey);
-    }
-
-    @Nonnull
-    public Optional<String> getAssumedRole() {
-      return Optional.ofNullable(assumedRole);
-    }
-
-  }
 
 }

--- a/fhir-server/src/main/java/au/csiro/pathling/spark/Spark.java
+++ b/fhir-server/src/main/java/au/csiro/pathling/spark/Spark.java
@@ -6,14 +6,15 @@
 
 package au.csiro.pathling.spark;
 
-import au.csiro.pathling.config.Configuration;
-import au.csiro.pathling.config.StorageConfiguration.Aws;
 import au.csiro.pathling.async.SparkListener;
+import au.csiro.pathling.config.Configuration;
 import au.csiro.pathling.sql.CodingToLiteral;
 import au.csiro.pathling.sql.PathlingStrategy;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.SparkSession;
@@ -52,7 +53,11 @@ public class Spark {
       @Nonnull final Environment environment,
       @Nonnull final Optional<SparkListener> sparkListener) {
     log.debug("Creating Spark session");
-    resolveSparkConfiguration(environment);
+
+    // Pass through Spark configuration.
+    resolveThirdPartyConfiguration(environment, List.of("spark."),
+        property -> System.setProperty(property,
+            Objects.requireNonNull(environment.getProperty(property))));
 
     final SparkSession spark = SparkSession.builder()
         .appName(configuration.getSpark().getAppName())
@@ -64,54 +69,26 @@ public class Spark {
     spark.udf()
         .register(CodingToLiteral.FUNCTION_NAME, new CodingToLiteral(), DataTypes.StringType);
 
-    // Configure AWS driver and credentials.
-    configureAwsDriver(configuration, spark);
+    // Pass through Hadoop AWS configuration.
+    resolveThirdPartyConfiguration(environment, List.of("fs.s3a."),
+        property -> spark.sparkContext().hadoopConfiguration().set(property,
+            Objects.requireNonNull(environment.getProperty(property))));
 
     return spark;
   }
 
-  private static void configureAwsDriver(@Nonnull final Configuration configuration,
-      @Nonnull final SparkSession spark) {
-    final Aws awsConfig = configuration.getStorage().getAws();
-    final org.apache.hadoop.conf.Configuration hadoopConfig = spark.sparkContext()
-        .hadoopConfiguration();
-
-    // We need to use the anonymous credentials provider if we are not using AWS credentials.
-    if (awsConfig.isAnonymousAccess()) {
-      hadoopConfig.set("fs.s3a.aws.credentials.provider",
-          "org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider");
-    }
-
-    // Set credentials if provided.
-    awsConfig.getAccessKeyId()
-        .ifPresent(accessKeyId -> hadoopConfig.set("fs.s3a.access.key", accessKeyId));
-    awsConfig.getSecretAccessKey()
-        .ifPresent(secretAccessKey -> hadoopConfig.set("fs.s3a.secret.key", secretAccessKey));
-    hadoopConfig.set("fs.s3a.connection.maximum", "100");
-    hadoopConfig.set("fs.s3a.committer.magic.enabled", "true");
-    hadoopConfig.set("fs.s3a.committer.name", "magic");
-
-    // Assume role if configured.
-    awsConfig.getAssumedRole()
-        .ifPresent(assumedRole -> {
-          hadoopConfig.set("fs.s3a.aws.credentials.provider",
-              "org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider");
-          hadoopConfig.set("fs.s3a.assumed.role.arn", assumedRole);
-        });
-  }
-
-  private static void resolveSparkConfiguration(@Nonnull final PropertyResolver resolver) {
-    // This goes through the properties within the Spring configuration and copies the Spark
-    // configuration into Java system properties, which Spark will then pick up.
+  private static void resolveThirdPartyConfiguration(@Nonnull final PropertyResolver resolver,
+      @Nonnull final List<String> prefixes, @Nonnull final Consumer<String> setter) {
+    // This goes through the properties within the Spring configuration and invokes the provided 
+    // setter function for each property that matches one of the supplied prefixes.
     final MutablePropertySources propertySources = ((AbstractEnvironment) resolver)
         .getPropertySources();
     propertySources.stream()
         .filter(propertySource -> propertySource instanceof EnumerablePropertySource)
         .flatMap(propertySource -> Arrays
             .stream(((EnumerablePropertySource<?>) propertySource).getPropertyNames()))
-        .filter(property -> property.startsWith("spark."))
-        .forEach(property -> System.setProperty(property,
-            Objects.requireNonNull(resolver.getProperty(property))));
+        .filter(property -> prefixes.stream().anyMatch(property::startsWith))
+        .forEach(setter);
   }
 
 }

--- a/fhir-server/src/main/resources/application.yml
+++ b/fhir-server/src/main/resources/application.yml
@@ -42,18 +42,6 @@ pathling:
     # The subdirectory within the warehouse path used to read and write data.
     databaseName: default
 
-    # Configuration relating to accessing data hosted within Amazon Web Services.
-    aws:
-      # Public S3 buckets can be accessed by default, set this to false to access protected buckets.
-      anonymousAccess: true
-
-      # Authentication details for connecting to protected Amazon S3 locations.
-      # accessKeyId: [AWS access key ID]
-      # secretAccessKey: [AWS secret access key]
-
-      # The ARN of an IAM role to be assumed using STS.
-      # assumedRole: [ARN of IAM role]
-
   terminology:
     # Enables the use of terminology functions.
     enabled: true
@@ -200,3 +188,30 @@ spark:
           enabled: true
   scheduler:
     mode: FAIR
+
+# Use this section to set or override configuration relating to S3 configuration.
+# See: https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html
+fs:
+  s3a:
+    aws:
+    # credentials:
+    #   provider: org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider
+    #   provider: org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider
+    #
+    # For use with: SimpleAWSCredentialsProvider
+    # access:
+    #   key: [access key]
+    # secret:
+    #   key: [secret key]
+    #
+    # For use with: AssumedRoleCredentialProvider
+    # assumed:
+    #   role:
+    #     arn: [role ARN]
+    #
+    connection:
+      maximum: 100
+    committer:
+      name: magic
+      magic:
+        enabled: true


### PR DESCRIPTION
This change does away with the S3 variables in the Pathling configuration, in favor of allowing the user to set the Hadoop AWS configuration directly.

This allows for advanced configurations such as setting credentials via environment variables and via the EC2 metadata service. By default the configuration now supports a chain of authentication providers that should work for most use cases.