### PR TITLE
Remove logging_level parameter and improve documentation

### DIFF
--- a/lib/python/pathling/context.py
+++ b/lib/python/pathling/context.py
@@ -112,7 +112,8 @@ class PathlingContext:
         classpath. You can get the path for the JAR (which is bundled with the Python package)
         using the `pathling.etc.find_jar` method.
 
-        :param spark: The :class:`SparkSession` instance.
+        :param spark: a pre-configured :class:`SparkSession` instance, use this if you need to
+               control the way that the session is set up
         :param max_nesting_level: controls the maximum depth of nested element data that is encoded
                upon import. This affects certain elements within FHIR resources that contain
                recursive references, e.g. `QuestionnaireResponse.item

--- a/lib/python/pathling/context.py
+++ b/lib/python/pathling/context.py
@@ -129,7 +129,10 @@ class PathlingContext:
                server can use to resolve terminology queries. The default server is suitable for
                testing purposes only.
         :param terminology_verbose_request_logging: setting this option to `True` will enable
-               additional logging of the details of requests to the terminology service
+               additional logging of the details of requests to the terminology service. Note that
+               logging is subject to the Spark logging level, which you can set using
+               `SparkContext.setLogLevel`. Verbose request logging is sent to the `DEBUG` logging
+               level.
         :param terminology_socket_timeout: the maximum period (in milliseconds) that the server
                should wait for incoming data from the HTTP service
         :param max_connections_total: the maximum total number of connections for the client

--- a/lib/python/pathling/context.py
+++ b/lib/python/pathling/context.py
@@ -13,7 +13,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
 from typing import Optional, Sequence
 
 from deprecated import deprecated
@@ -96,7 +95,6 @@ class PathlingContext:
         client_secret: Optional[str] = None,
         scope: Optional[str] = None,
         token_expiry_tolerance: Optional[int] = 120,
-        logging_level: Optional[int] = logging.INFO,
     ) -> "PathlingContext":
         """
         Creates a :class:`PathlingContext` with the given configuration options. This should only
@@ -156,7 +154,6 @@ class PathlingContext:
         :param scope: a scope value for use with the client credentials grant
         :param token_expiry_tolerance: the minimum number of seconds that a token should have
                before expiry when deciding whether to send it with a terminology request
-        :param logging_level: the logging level to use
         :return: a :class:`PathlingContext` instance initialized with the specified configuration
         """
         spark = (
@@ -165,12 +162,6 @@ class PathlingContext:
             or SparkSession.builder.config("spark.jars", find_jar()).getOrCreate()
         )
         jvm = spark._jvm
-
-        # Configure logging.
-        jvm.py4j.GatewayServer.turnLoggingOn()
-        logger = logging.getLogger("py4j")
-        logger.setLevel(logging_level)
-        logger.addHandler(logging.StreamHandler())
 
         # Build an encoders configuration object from the provided parameters.
         encoders_config = (


### PR DESCRIPTION
Within the library, logging happens through Spark and is governed by the configuration that gets fed to Spark. This is not always under our control.

There doesn't seem to be an easy way to configure Pathling logging independently of Spark logging - at least not one that would work well in all deployment contexts.

Resolves #1180.