### PR TITLE
Switching to Cast() constructor common between spark-catalyst 3.3 and 3.4

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -49,3 +49,6 @@ CVE-2022-1586
 # This vulnerability relates to deserialization of untrusted data within spring-web, which is not
 # relevant to Pathling.
 CVE-2016-1000027
+
+# This vulnerability relates to Freetype, which is not a dependency of Pathling.
+CVE-2022-27404

--- a/encoders/pom.xml
+++ b/encoders/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>au.csiro.pathling</groupId>
     <artifactId>pathling</artifactId>
-    <version>6.1.3</version>
+    <version>6.1.4-SNAPSHOT</version>
   </parent>
   <artifactId>encoders</artifactId>
   <packaging>jar</packaging>

--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>au.csiro.pathling</groupId>
     <artifactId>pathling</artifactId>
-    <version>6.1.3</version>
+    <version>6.1.4-SNAPSHOT</version>
   </parent>
   <artifactId>fhir-server</artifactId>
   <packaging>jar</packaging>

--- a/lib/import/pom.xml
+++ b/lib/import/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>au.csiro.pathling</groupId>
     <artifactId>pathling</artifactId>
-    <version>6.1.3</version>
+    <version>6.1.4-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>import</artifactId>

--- a/lib/js/pom.xml
+++ b/lib/js/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>au.csiro.pathling</groupId>
     <artifactId>pathling</artifactId>
-    <version>6.1.3</version>
+    <version>6.1.4-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>js</artifactId>

--- a/lib/python/Dockerfile
+++ b/lib/python/Dockerfile
@@ -2,7 +2,7 @@ FROM jupyter/all-spark-notebook
 
 USER root
 RUN echo "spark.executor.userClassPathFirst true" >> /usr/local/spark/conf/spark-defaults.conf
-RUN echo "spark.jars.packages au.csiro.pathling:library-api:6.1.3" >> /usr/local/spark/conf/spark-defaults.conf
+RUN echo "spark.jars.packages au.csiro.pathling:library-api:6.1.4-SNAPSHOT" >> /usr/local/spark/conf/spark-defaults.conf
 
 USER ${NB_UID}
 

--- a/lib/python/pom.xml
+++ b/lib/python/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>au.csiro.pathling</groupId>
     <artifactId>pathling</artifactId>
-    <version>6.1.3</version>
+    <version>6.1.4-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>python</artifactId>

--- a/library-api/pom.xml
+++ b/library-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>pathling</artifactId>
     <groupId>au.csiro.pathling</groupId>
-    <version>6.1.3</version>
+    <version>6.1.4-SNAPSHOT</version>
   </parent>
   <artifactId>library-api</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <groupId>au.csiro.pathling</groupId>
   <artifactId>pathling</artifactId>
-  <version>6.1.3</version>
+  <version>6.1.4-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Pathling</name>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>au.csiro.pathling</groupId>
     <artifactId>pathling</artifactId>
-    <version>6.1.3</version>
+    <version>6.1.4-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>site</artifactId>

--- a/terminology/pom.xml
+++ b/terminology/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>pathling</artifactId>
     <groupId>au.csiro.pathling</groupId>
-    <version>6.1.3</version>
+    <version>6.1.4-SNAPSHOT</version>
   </parent>
   <artifactId>terminology</artifactId>
   <packaging>jar</packaging>

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <artifactId>pathling</artifactId>
     <groupId>au.csiro.pathling</groupId>
-    <version>6.1.3</version>
+    <version>6.1.4-SNAPSHOT</version>
   </parent>
   <artifactId>utilities</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
Resolves #1220.

Tested on Databricks runtimes 11.3, 12.0 and 12.1.


