### PR TITLE
Added Spring Boot Actuator and metrics endpoints

### DIFF
--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -122,6 +122,10 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
       <scope>test</scope>
@@ -166,6 +170,11 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <version>1.11.3</version>
     </dependency>
 
     <!-- Testing -->

--- a/fhir-server/src/main/resources/application.yml
+++ b/fhir-server/src/main/resources/application.yml
@@ -6,6 +6,14 @@ spring:
   banner:
     location: classpath:banner.txt
 
+# Actuator endpoints let you monitor and interact with your application.
+# <https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints>
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,prometheus"
+
 pathling:
   # Controls the description of this server as displayed within the FHIR CapabilityStatement.
   implementationDescription: Yet Another Pathling Server
@@ -20,7 +28,7 @@ pathling:
   spark:
     # The name that Pathling will be identified as within the Spark cluster.
     appName: pathling
-    
+
   storage:
     # The base URL at which Pathling will look for data files, and where it will save data received
     # within import requests. Can be an Amazon S3 (s3://), HDFS (hdfs://) or filesystem (file://)
@@ -29,8 +37,8 @@ pathling:
 
     # The subdirectory within the warehouse path used to read and write data.
     databaseName: default
-    
-    # This controls whether the built-in caching within Spark is used for resource datasets 
+
+    # This controls whether the built-in caching within Spark is used for resource datasets
     # It may be useful to turn this off for large datasets in memory-constrained environments.
     cacheDatasets: true
 
@@ -44,7 +52,7 @@ pathling:
     # execute queries.
     explainQueries: false
 
-    # This controls whether the built-in caching within Spark is used for search results. 
+    # This controls whether the built-in caching within Spark is used for search results.
     # It may be useful to turn this off for large datasets in memory-constrained environments.
     cacheResults: true
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <pathling.antlrVersion>4.9.3</pathling.antlrVersion>
     <pathling.dockerJavaVersion>3.2.13</pathling.dockerJavaVersion>
     <pathling.awsSdkVersion>1.12.503</pathling.awsSdkVersion>
-    <!-- we do not use recent version 1.18.24 as it (wrongly) copies the JSR-380 NonNull 
+    <!-- we do not use recent version 1.18.24 as it (wrongly) copies the JSR-380 NonNull
          annotations from fields to getters resulting in duplicate constraint violations.
          This has been fixed in the main branch but not released yet -->
     <pathling.lombokVersion>1.18.28</pathling.lombokVersion>
@@ -366,6 +366,11 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-security</artifactId>
+        <version>${pathling.springBootVersion}</version>
+      </dependency>
+      <dependency>
+      <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-actuator</artifactId>
         <version>${pathling.springBootVersion}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Closes #1671 .

This adds the spring-boot-starter-actuator and micrometer-registry-prometheus dependencies, which expose health and metrics endpoints.
In the default configuration, health-endpoints are exposed under `:8080/actuator/health` and metrics at ``:8080/actuator/prometheus`. 