### PR TITLE
Fixing R build to always generate the 'NAMESPACE' file.

### DIFF
--- a/lib/R/pom.xml
+++ b/lib/R/pom.xml
@@ -226,6 +226,21 @@
             </configuration>
           </execution>
           <execution>
+            <id>generate-docs</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>Rscript</executable>
+              <workingDirectory>${project.basedir}</workingDirectory>
+              <arguments>
+                <argument>-e</argument>
+                <argument>roxygen2::roxygenise()</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
             <id>test</id>
             <phase>test</phase>
             <goals>
@@ -308,21 +323,6 @@
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
             <executions>
-              <execution>
-                <id>generate-docs</id>
-                <phase>process-sources</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <executable>Rscript</executable>
-                  <workingDirectory>${project.basedir}</workingDirectory>
-                  <arguments>
-                    <argument>-e</argument>
-                    <argument>roxygen2::roxygenise()</argument>
-                  </arguments>
-                </configuration>
-              </execution>
               <execution>
                 <id>generate-site</id>
                 <phase>process-sources</phase>


### PR DESCRIPTION
Fixing R build to always run 'doxygen2' and generate the 'NAMESPACE' file required for package installation.
Previously it was only generated with 'docs' profile enabled.