### PR TITLE
Moving benchmark execution to a forked VM and adding spring context cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -444,6 +444,7 @@ jobs:
           -P${{ env.PATHLING_PROFILES }}
           -DskipSurefireTests
           -Dpathling.benchmark.testIterations=100
+          -Dpathling.benchmark.warmupIterations=10
         timeout-minutes: 720
       - name: Upload benchmark artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -401,11 +401,6 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: arn:aws:iam::865780493209:role/PathlingBenchmarkUpload
-          aws-region: ap-southeast-2
       - name: Checkout code
         uses: actions/checkout@v3
         with:
@@ -451,6 +446,11 @@ jobs:
         with:
           name: benchmark-results
           path: "**/jmh-*.json"
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::865780493209:role/PathlingBenchmarkUpload
+          aws-region: ap-southeast-2
       - name: Upload benchmark file to S3
         run: aws s3 sync fhir-server/target/benchmark s3://pathling-benchmark/${{ github.ref }}/${{ github.run_id }}/${{ steps.timestamp.outputs.timestamp }}/
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -443,7 +443,8 @@ jobs:
           -pl fhir-server -am
           -P${{ env.PATHLING_PROFILES }}
           -DskipSurefireTests
-        timeout-minutes: 80
+          -Dpathling.benchmark.testIterations=100
+        timeout-minutes: 720
       - name: Upload benchmark artifact
         uses: actions/upload-artifact@v3
         with:

--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -40,6 +40,8 @@
     <pathling.dockerBaseImage>amazoncorretto:17</pathling.dockerBaseImage>
     <pathling.benchmark.warehouseUrl>file://${project.basedir}/src/test/resources/test-data</pathling.benchmark.warehouseUrl>
     <pathling.benchmark.databaseName>parquet</pathling.benchmark.databaseName>
+    <pathling.benchmark.warmupIterations>1</pathling.benchmark.warmupIterations>
+    <pathling.benchmark.testIterations>5</pathling.benchmark.testIterations>
   </properties>
 
   <dependencies>
@@ -457,6 +459,8 @@
                     <argument>-Dspring.profiles.active=unit-test</argument>
                     <argument>-Dpathling.storage.warehouseUrl=${pathling.benchmark.warehouseUrl}</argument>
                     <argument>-Dpathling.storage.databaseName=${pathling.benchmark.databaseName}</argument>
+                    <argument>-Dbenchmark.test.iterations=${pathling.benchmark.testIterations}</argument>
+                    <argument>-Dbenchmark.warmup.iterations=${pathling.benchmark.warmupIterations}</argument>
                     <argument>au.csiro.pathling.test.benchmark.PathlingBenchmarkRunner</argument>
                     <argument>${project.build.directory}/benchmark</argument>
                   </arguments>

--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -38,6 +38,8 @@
     <pathling.dockerArchitecture>arm64</pathling.dockerArchitecture>
     <jmh.version>1.37</jmh.version>
     <pathling.dockerBaseImage>amazoncorretto:17</pathling.dockerBaseImage>
+    <pathling.benchmark.warehouseUrl>file://${project.basedir}/src/test/resources/test-data</pathling.benchmark.warehouseUrl>
+    <pathling.benchmark.databaseName>parquet</pathling.benchmark.databaseName>
   </properties>
 
   <dependencies>
@@ -453,8 +455,8 @@
                     <argument>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED</argument>
                     <argument>--add-opens=java.base/java.net=ALL-UNNAMED</argument>
                     <argument>-Dspring.profiles.active=unit-test</argument>
-                    <argument>-Dpathling.storage.warehouseUrl=file://${project.basedir}/src/test/resources/test-data</argument>
-                    <argument>-Dpathling.storage.databaseName=parquet</argument>
+                    <argument>-Dpathling.storage.warehouseUrl=${pathling.benchmark.warehouseUrl}</argument>
+                    <argument>-Dpathling.storage.databaseName=${pathling.benchmark.databaseName}</argument>
                     <argument>au.csiro.pathling.test.benchmark.PathlingBenchmarkRunner</argument>
                     <argument>${project.build.directory}/benchmark</argument>
                   </arguments>

--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -438,29 +438,27 @@
                 <id>run-benchmark</id>
                 <phase>test</phase>
                 <goals>
-                  <goal>java</goal>
+                  <goal>exec</goal>
                 </goals>
                 <configuration>
-                  <mainClass>au.csiro.pathling.test.benchmark.PathlingBenchmarkRunner</mainClass>
-                  <classpathScope>test</classpathScope>
-                  <cleanupDaemonThreads>false</cleanupDaemonThreads>
-                  <systemProperties>
-                    <property>
-                      <key>spring.profiles.active</key>
-                      <value>unit-test</value>
-                    </property>
-                    <property>
-                      <key>pathling.storage.warehouseUrl</key>
-                      <value>file://${project.basedir}/src/test/resources/test-data</value>
-                    </property>
-                    <property>
-                      <key>pathling.storage.databaseName</key>
-                      <value>parquet</value>
-                    </property>
-                  </systemProperties>
+                  <executable>java</executable>
                   <arguments>
+                    <argument>-classpath</argument>
+                    <classpath/>
+                    <argument>-Xmx6g</argument>
+                    <argument>-XX:MaxMetaspaceSize=400m</argument>
+                    <argument>-XX:ReservedCodeCacheSize=240m</argument>
+                    <argument>-Xss1m</argument>
+                    <argument>-Duser.timezone=UTC</argument>
+                    <argument>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED</argument>
+                    <argument>--add-opens=java.base/java.net=ALL-UNNAMED</argument>
+                    <argument>-Dspring.profiles.active=unit-test</argument>
+                    <argument>-Dpathling.storage.warehouseUrl=file://${project.basedir}/src/test/resources/test-data</argument>
+                    <argument>-Dpathling.storage.databaseName=parquet</argument>
+                    <argument>au.csiro.pathling.test.benchmark.PathlingBenchmarkRunner</argument>
                     <argument>${project.build.directory}/benchmark</argument>
                   </arguments>
+                  <classpathScope>test</classpathScope>
                 </configuration>
               </execution>
             </executions>

--- a/fhir-server/src/test/java/au/csiro/pathling/jmh/SpringBootJmhContext.java
+++ b/fhir-server/src/test/java/au/csiro/pathling/jmh/SpringBootJmhContext.java
@@ -20,6 +20,7 @@ package au.csiro.pathling.jmh;
 import jakarta.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
+import org.springframework.test.annotation.DirtiesContext.HierarchyMode;
 import org.springframework.test.context.TestContextManager;
 
 /**
@@ -51,5 +52,18 @@ public class SpringBootJmhContext {
   public static void autowireWithTestContext(@Nonnull final Object testLikeObject)
       throws Exception {
     getOrCreate(testLikeObject.getClass()).prepareTestInstance(testLikeObject);
+  }
+
+
+  /**
+   * Cleans up the contexts of all the classes that have been autowired using this class.
+   * This also destroys and clean up all the test application contexts created thus far.
+   */
+  public static void cleanUpAll() {
+    synchronized (contextManagers) {
+      contextManagers.forEach((k, v) -> v.getTestContext().markApplicationContextDirty(
+          HierarchyMode.EXHAUSTIVE));
+      contextManagers.clear();
+    }
   }
 }

--- a/fhir-server/src/test/java/au/csiro/pathling/test/benchmark/AggregateBenchmark.java
+++ b/fhir-server/src/test/java/au/csiro/pathling/test/benchmark/AggregateBenchmark.java
@@ -98,7 +98,7 @@ public class AggregateBenchmark {
       SharedMocks.resetAll();
       mockResource(ResourceType.PATIENT, ResourceType.CONDITION, ResourceType.ENCOUNTER,
           ResourceType.PROCEDURE, ResourceType.MEDICATIONREQUEST, ResourceType.OBSERVATION,
-          ResourceType.DIAGNOSTICREPORT, ResourceType.ORGANIZATION, ResourceType.QUESTIONNAIRE,
+          ResourceType.DIAGNOSTICREPORT, ResourceType.ORGANIZATION,
           ResourceType.CAREPLAN);
 
       executor = new AggregateExecutor(configuration, fhirContext, spark, database,

--- a/fhir-server/src/test/java/au/csiro/pathling/test/benchmark/PathlingBenchmarkRunner.java
+++ b/fhir-server/src/test/java/au/csiro/pathling/test/benchmark/PathlingBenchmarkRunner.java
@@ -43,7 +43,7 @@ public class PathlingBenchmarkRunner {
                              ? argc[0]
                              : "target/benchmark";
 
-    final Properties properties = PropertiesLoaderUtils.loadAllProperties("benchmark.properties");
+    final Properties properties = System.getProperties();
 
     final int warmup = Integer
         .parseInt(properties.getProperty("benchmark.warmup.iterations", "1"));

--- a/fhir-server/src/test/java/au/csiro/pathling/test/benchmark/PathlingBenchmarkRunner.java
+++ b/fhir-server/src/test/java/au/csiro/pathling/test/benchmark/PathlingBenchmarkRunner.java
@@ -21,6 +21,7 @@ import static au.csiro.pathling.jmh.JmhUtils.buildResultsFileName;
 
 import java.io.File;
 import java.util.Properties;
+import au.csiro.pathling.jmh.SpringBootJmhContext;
 import lombok.extern.slf4j.Slf4j;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
@@ -79,7 +80,12 @@ public class PathlingBenchmarkRunner {
         .shouldFailOnError(true)
         .jvmArgs("-server -Xmx4g -ea -Duser.timezone=UTC")
         .build();
-    new Runner(opt).run();
+    try {
+      new Runner(opt).run();
+    } finally {
+      // clean up the test application contexts created by the benchmarks
+      SpringBootJmhContext.cleanUpAll();
+    }
   }
 
 }


### PR DESCRIPTION
Moving benchmark execution to a forked VM (from the maven one) and adding the explicit cleanup of the application context(s) created for the spring autowired benchmarks.

This should provide better isolation of the benchmark run from the maven build process.