### PR TITLE
Implementing changes necessary run on Databricks with Spark 3.5.0 (RT 14.3 LTS)

### DIFF
--- a/encoders/src/main/scala/au/csiro/pathling/encoders/Catalyst.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/Catalyst.scala
@@ -1,0 +1,32 @@
+package au.csiro.pathling.encoders
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
+import org.apache.spark.sql.types.DataType
+
+object Catalyst {
+  lazy val staticInvokeAdapter:(Class[_],DataType, String, Seq[Expression]) => StaticInvoke = {
+    val constructor = classOf[StaticInvoke].getConstructors.head
+    if (constructor.getParameterCount == 8) {
+      StaticInvoke.apply(_,_,_,_)
+    } else {
+      (staticObject: Class[_], dataType: DataType, functionName: String, arguments: Seq[Expression]) =>
+        constructor.newInstance(staticObject, dataType, functionName, 
+          arguments,
+          Nil,
+          Boolean.box(true),
+          Boolean.box(true),
+          Boolean.box(true), 
+          None).asInstanceOf[StaticInvoke]
+    }
+  }
+
+  def staticInvoke(
+                    staticObject: Class[_],
+                    dataType: DataType,
+                    functionName: String,
+                    arguments: Seq[Expression] = Nil): StaticInvoke = {
+    staticInvokeAdapter(staticObject, dataType, functionName, arguments)
+  }
+
+}

--- a/encoders/src/main/scala/au/csiro/pathling/encoders/Catalyst.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/Catalyst.scala
@@ -4,23 +4,47 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.types.DataType
 
+
+/**
+ * This class provides a compatibility layer for Spark Catalyst.
+ * It is used to createnew Expressions using constructors compatible with the runtime 
+ * version of Spark Catalyst.
+ * This is necessary to address running Pathling in Databricks environments, 
+ * which habitually use different (newer) version of Catalyst that one used by 
+ * the corresponding Spark public release. 
+ */
 object Catalyst {
-  lazy val staticInvokeAdapter:(Class[_],DataType, String, Seq[Expression]) => StaticInvoke = {
+
+  private lazy val staticInvokeAdapter: (Class[_], DataType, String, Seq[Expression]) => StaticInvoke = {
     val constructor = classOf[StaticInvoke].getConstructors.head
     if (constructor.getParameterCount == 8) {
-      StaticInvoke.apply(_,_,_,_)
-    } else {
+      // catalyst 3.5.x (used by Spark 3.5.x)
+      StaticInvoke.apply(_, _, _, _)
+    } else if (constructor.getParameterCount == 9) {
+      // catalyst 4.0.0-preview-rc1 (used by Databricks runtime 14.3 LTS with Spark 3.5.0)
       (staticObject: Class[_], dataType: DataType, functionName: String, arguments: Seq[Expression]) =>
-        constructor.newInstance(staticObject, dataType, functionName, 
+        constructor.newInstance(staticObject, dataType, functionName,
           arguments,
           Nil,
           Boolean.box(true),
           Boolean.box(true),
-          Boolean.box(true), 
+          Boolean.box(true),
           None).asInstanceOf[StaticInvoke]
+    } else {
+      throw new IllegalStateException(
+        "Unsupported version of Spark Catalyst with InvokeStatic constructor: " + constructor)
     }
   }
 
+  /**
+   * Creates a new [[StaticInvoke]] expression using a constructor compatible with the runtime version of Spark Catalyst.
+   *
+   * @param staticObject the class object to invoke.
+   * @param dataType     the return type of the function.
+   * @param functionName the name of the function to invoke.
+   * @param arguments    the arguments to pass to the function.
+   * @return the new [[StaticInvoke]] expression.
+   */
   def staticInvoke(
                     staticObject: Class[_],
                     dataType: DataType,
@@ -28,5 +52,4 @@ object Catalyst {
                     arguments: Seq[Expression] = Nil): StaticInvoke = {
     staticInvokeAdapter(staticObject, dataType, functionName, arguments)
   }
-
 }

--- a/encoders/src/main/scala/au/csiro/pathling/encoders/EncoderUtils.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/EncoderUtils.scala
@@ -37,7 +37,7 @@ object EncoderUtils {
   }
 
   def arrayExpression(array: Expression): StaticInvoke = {
-    StaticInvoke(
+    Catalyst.staticInvoke(
       classOf[util.Arrays],
       ObjectType(classOf[util.List[_]]),
       "asList",

--- a/encoders/src/main/scala/au/csiro/pathling/encoders/QuantitySupport.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/QuantitySupport.scala
@@ -52,15 +52,15 @@ object QuantitySupport {
 
     val canonicalizedValue =
       createFlexiDecimalSerializer(
-        StaticInvoke(classOf[Ucum], ObjectType(classOf[java.math.BigDecimal]),
+        Catalyst.staticInvoke(classOf[Ucum], ObjectType(classOf[java.math.BigDecimal]),
           "getCanonicalValue", Seq(valueExp, codeExp)))
 
     val canonicalizedCode =
-      StaticInvoke(
+      Catalyst.staticInvoke(
         classOf[UTF8String],
         DataTypes.StringType,
         "fromString",
-        StaticInvoke(classOf[Ucum], ObjectType(classOf[java.lang.String]), "getCanonicalCode",
+        Catalyst.staticInvoke(classOf[Ucum], ObjectType(classOf[java.lang.String]), "getCanonicalCode",
           Seq(valueExp, codeExp)) :: Nil)
     Seq(
       (VALUE_CANONICALIZED_FIELD_NAME, canonicalizedValue),

--- a/encoders/src/main/scala/au/csiro/pathling/encoders/SerializerBuilder.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/SerializerBuilder.scala
@@ -95,7 +95,7 @@ private[encoders] class SerializerBuilderProcessor(expression: Expression,
   private def createExtensionsFields(definition: BaseRuntimeElementCompositeDefinition[_]): Seq[(String, Expression)] = {
     val maybeExtensionValueField = definition match {
       case _: RuntimeResourceDefinition =>
-        val collectExtensionsExpression = StaticInvoke(
+        val collectExtensionsExpression = Catalyst.staticInvoke(
           classOf[SerializerBuilderProcessor],
           ObjectType(classOf[Map[Int, java.util.List[Extension]]]),
           "flattenExtensions",
@@ -111,7 +111,7 @@ private[encoders] class SerializerBuilderProcessor(expression: Expression,
       case _ => Nil
     }
     // append _fid serializer
-    (FID_FIELD_NAME, StaticInvoke(
+    (FID_FIELD_NAME, Catalyst.staticInvoke(
       classOf[System], IntegerType, "identityHashCode",
       expression :: Nil)) :: maybeExtensionValueField
   }
@@ -207,7 +207,7 @@ private[encoders] object SerializerBuilderProcessor {
   }
 
   private def dataTypeToUtf8Expr(inputObject: Expression): Expression = {
-    StaticInvoke(
+    Catalyst.staticInvoke(
       classOf[UTF8String],
       DataTypes.StringType,
       "fromString",

--- a/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/DataTypeMappings.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/DataTypeMappings.scala
@@ -23,7 +23,7 @@
 
 package au.csiro.pathling.encoders.datatypes
 
-import au.csiro.pathling.encoders.ExpressionWithName
+import au.csiro.pathling.encoders.{Catalyst, ExpressionWithName}
 import ca.uhn.fhir.context._
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
@@ -60,7 +60,7 @@ trait DataTypeMappings {
    */
   def dataTypeToUtf8Expr(inputObject: Expression): Expression = {
 
-    StaticInvoke(
+    Catalyst.staticInvoke(
       classOf[UTF8String],
       DataTypes.StringType,
       "fromString",

--- a/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/DecimalCustomCoder.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/DecimalCustomCoder.scala
@@ -24,7 +24,7 @@
 package au.csiro.pathling.encoders.datatypes
 
 import au.csiro.pathling.encoders.EncoderUtils.arrayExpression
-import au.csiro.pathling.encoders.ExpressionWithName
+import au.csiro.pathling.encoders.{Catalyst, ExpressionWithName}
 import au.csiro.pathling.encoders.datatypes.DecimalCustomCoder.decimalType
 import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, NewInstance, StaticInvoke}
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
@@ -54,7 +54,7 @@ case class DecimalCustomCoder(elementName: String) extends CustomCoder {
       decimalExpression(addToPath)
     } else {
       // Let's to this manually as we need to zip two independent arrays into into one
-      val array = StaticInvoke(
+      val array = Catalyst.staticInvoke(
         classOf[DecimalCustomCoder],
         ObjectType(classOf[Array[Any]]),
         "zipToDecimal",
@@ -66,7 +66,7 @@ case class DecimalCustomCoder(elementName: String) extends CustomCoder {
   }
 
   override def customSerializer(evaluator: (Expression => Expression) => Expression): Seq[ExpressionWithName] = {
-    val valueExpression = evaluator(exp => StaticInvoke(classOf[Decimal],
+    val valueExpression = evaluator(exp => Catalyst.staticInvoke(classOf[Decimal],
       decimalType,
       "apply",
       Invoke(exp, "getValue", ObjectType(classOf[java.math.BigDecimal])) :: Nil))
@@ -95,7 +95,7 @@ case class DecimalCustomCoder(elementName: String) extends CustomCoder {
   }
 
   private def scaleExpression(inputObject: Expression) = {
-    StaticInvoke(classOf[Math],
+    Catalyst.staticInvoke(classOf[Math],
       IntegerType,
       "min", Literal(decimalType.scale) ::
         Invoke(Invoke(inputObject, "getValue", ObjectType(classOf[java.math.BigDecimal])),

--- a/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/IdCustomCoder.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/IdCustomCoder.scala
@@ -24,7 +24,7 @@
 package au.csiro.pathling.encoders.datatypes
 
 import au.csiro.pathling.encoders.EncoderUtils.arrayExpression
-import au.csiro.pathling.encoders.ExpressionWithName
+import au.csiro.pathling.encoders.{Catalyst, ExpressionWithName}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, MapObjects, NewInstance, StaticInvoke}
 import org.apache.spark.sql.types._
@@ -72,11 +72,11 @@ case class IdCustomCoder(elementName: String) extends CustomCoder {
 
   override def customSerializer(evaluator: (Expression => Expression) => Expression): Seq[ExpressionWithName] = {
     val idExpression = evaluator(
-      exp => StaticInvoke(classOf[UTF8String], DataTypes.StringType, "fromString",
+      exp => Catalyst.staticInvoke(classOf[UTF8String], DataTypes.StringType, "fromString",
         List(Invoke(exp, "getIdPart", ObjectType(classOf[String])))))
 
     val versionedIdExpression = evaluator(
-      exp => StaticInvoke(classOf[UTF8String], DataTypes.StringType, "fromString",
+      exp => Catalyst.staticInvoke(classOf[UTF8String], DataTypes.StringType, "fromString",
         List(Invoke(exp, "getValue", ObjectType(classOf[String])))))
     Seq((elementName, idExpression), (versionedName, versionedIdExpression))
   }

--- a/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/R4DataTypeMappings.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/R4DataTypeMappings.scala
@@ -24,7 +24,7 @@
 package au.csiro.pathling.encoders.datatypes
 
 import au.csiro.pathling.encoders.datatypes.R4DataTypeMappings.{fhirPrimitiveToSparkTypes, isValidOpenElementType}
-import au.csiro.pathling.encoders.{ExpressionWithName, StaticField}
+import au.csiro.pathling.encoders.{Catalyst, ExpressionWithName, StaticField}
 import ca.uhn.fhir.context._
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum
 import org.apache.spark.sql.catalyst.analysis.GetColumnByOrdinal
@@ -150,13 +150,13 @@ class R4DataTypeMappings extends DataTypeMappings {
           ObjectType(classOf[TemporalPrecisionEnum]),
           "MILLI")
 
-        val UTCZone = StaticInvoke(classOf[TimeZone],
+        val UTCZone = Catalyst.staticInvoke(classOf[TimeZone],
           ObjectType(classOf[TimeZone]),
           "getTimeZone",
           Literal("UTC", ObjectType(classOf[String])) :: Nil)
 
         NewInstance(primitiveClass,
-          List(StaticInvoke(org.apache.spark.sql.catalyst.util.DateTimeUtils.getClass,
+          List(Catalyst.staticInvoke(org.apache.spark.sql.catalyst.util.DateTimeUtils.getClass,
             ObjectType(classOf[java.sql.Timestamp]),
             "toJavaTimestamp",
             getPath :: Nil),

--- a/encoders/src/main/scala/au/csiro/pathling/sql/types/FlexiDecimalSupport.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/sql/types/FlexiDecimalSupport.scala
@@ -23,6 +23,7 @@
 
 package au.csiro.pathling.sql.types
 
+import au.csiro.pathling.encoders.Catalyst
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
 import org.apache.spark.sql.catalyst.expressions.{CreateNamedStruct, Expression, If, IsNull, Literal}
@@ -57,12 +58,12 @@ object FlexiDecimalSupport {
 
     // TODO: Performance: consider if the normalized value could be cached in
     //   a variable
-    val normalizedExpression: Expression = StaticInvoke(classOf[FlexiDecimal],
+    val normalizedExpression: Expression = Catalyst.staticInvoke(classOf[FlexiDecimal],
       ObjectType(classOf[java.math.BigDecimal]),
       "normalize",
       expression :: Nil)
 
-    val valueExpression: Expression = StaticInvoke(classOf[Decimal],
+    val valueExpression: Expression = Catalyst.staticInvoke(classOf[Decimal],
       FlexiDecimal.DECIMAL_TYPE,
       "apply",
       Invoke(normalizedExpression, "unscaledValue",

--- a/library-runtime/pom.xml
+++ b/library-runtime/pom.xml
@@ -124,6 +124,13 @@
                 <include>com/fasterxml/jackson/**</include>
               </includes>
             </relocation>
+            <relocation>
+              <pattern>org/</pattern>
+              <shadedPattern>${shaded.dependency.prefix}.org.</shadedPattern>
+              <includes>
+                <include>org/hibernate/validator/**</include>
+              </includes>
+            </relocation>
           </relocations>
         </configuration>
       </plugin>


### PR DESCRIPTION
Implementing changes necessary run on Databrick RT 14.3 LTS (with Spark 3.5.0).

- Relocating hibernate-validatation to avoid conflict with the older version in the runtime.
- Introducing Catalyst compatibility layer to address incompatible changes in InvokeStatic constructor introduced post 3.5.x  and deployed in Databrick runtime.