### PR TITLE
Add WireMock tests to bulk client functionality

### DIFF
--- a/lib/python/pathling/datasource.py
+++ b/lib/python/pathling/datasource.py
@@ -244,12 +244,12 @@ class DataSources(SparkConversionsMixin):
     ) -> DataSource:
         """
         Creates a data source from a FHIR Bulk Data Access API endpoint. 
-        Currently only supports bulk export in the jndjson format.
+        Currently only supports bulk export in the ndjson format.
         
         :param fhir_endpoint_url: The URL of the FHIR server to export from
         :param output_dir: The directory to write the output files to. 
                 This should be a valid path in the Spark's filesystem.
-                If not provided, a temporary directory will be used.
+                If set to `None`, a temporary directory will be used instead.
         :param overwrite: Whether to overwrite the output directory if it already exists. Defaults to True.
         :param group_id: Optional group ID for group-level export
         :param patients: Optional list of patient references for patient-level export

--- a/lib/python/pathling/datasource.py
+++ b/lib/python/pathling/datasource.py
@@ -277,7 +277,7 @@ class DataSources(SparkConversionsMixin):
         dfs = Dfs(self._pc.spark)
 
         # If `output_dir` is not provided, create a temporary directory
-        output_dir = output_dir or dfs.get_temp_dir_path(infix="bulk-export", qualified=True)
+        output_dir = output_dir or dfs.get_temp_dir_path(prefix="tmp-bulk-export", qualified=True)
         # If `overwrite`, then ensure the output directory does not exist
         if overwrite and dfs.exists(output_dir):
             dfs.delete(output_dir, recursive=True)

--- a/lib/python/pathling/spark.py
+++ b/lib/python/pathling/spark.py
@@ -1,0 +1,89 @@
+#  Copyright 2025 Commonwealth Scientific and Industrial Research
+#  Organisation (CSIRO) ABN 41 687 119 230.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import uuid
+
+from py4j.java_gateway import JavaObject, JVMView
+from pyspark import SparkContext
+from pyspark.sql import SparkSession
+
+
+class Dfs:
+    """A class for interacting with the Hadoop Distributed File System (HDFS) in Spark."""
+
+    def __init__(self, spark: SparkSession):
+        """
+        Initialize the Dfs class with a SparkSession.
+
+        :param spark: SparkSession instance
+        """
+        if not spark:
+            raise ValueError("SparkSession must be provided")
+        sc: SparkContext = spark.sparkContext
+        self._jvm: JVMView = sc._jvm
+        self._hadoop_conf: JavaObject = sc._jsc.hadoopConfiguration()
+        self._fs = self._jvm.org.apache.hadoop.fs.FileSystem.get(self._hadoop_conf)
+
+    def get_temp_dir_path(self, infix: str = "app-tmp",
+                          def_temp_base: str = "/tmp", qualified=True) -> str:
+        """
+        Returns a unique path for a temporary directory in Spark's filesystem.
+    
+        The path is constructed by appending a UUID to the base temporary directory, 
+        ensuring uniqueness for each call.
+        The directory itself is not created, only the path is returned.
+        
+        :param infix: String to insert between the base directory and the UUID (default: "app-tmp").
+        :param def_temp_base: Fallback base directory if `hadoop.tmp.dir` is not set in Hadoop configuration (default: "/tmp").
+        :param qualified: If True, returns a fully qualified Hadoop path; if False, returns a raw path string.
+        :return: String representing the unique temporary directory path.
+        """
+        base_tmp = self._hadoop_conf.get("hadoop.tmp.dir") or def_temp_base
+        uuid_suffix = str(uuid.uuid4())
+        tmp_path = f"{base_tmp}/{infix}-{uuid_suffix}"
+        path = self._jvm.org.apache.hadoop.fs.Path(tmp_path)
+        return self._fs.makeQualified(path).toString() if qualified else path.toString()
+
+    def exists(self, path: str) -> bool:
+        """
+        Check if a given path exists in the filesystem.
+
+        :param path: Path to check for existence.
+        :return: True if the path exists, False otherwise.
+        """
+        hadoop_path = self._jvm.org.apache.hadoop.fs.Path(path)
+        return self._fs.exists(hadoop_path)
+
+    def delete(self, path: str, recursive: bool = False) -> bool:
+        """
+        Delete a file or directory at the specified path.
+
+        :param path: Path to the file or directory to delete.
+        :param recursive: If True, delete directories and their contents recursively.
+        :return: True if deletion was successful, False otherwise.
+        """
+        hadoop_path = self._jvm.org.apache.hadoop.fs.Path(path)
+        return self._fs.delete(hadoop_path, recursive)
+
+    def mkdirs(self, path: str) -> bool:
+        """
+        Create a directory at the specified path.
+
+        :param path: Path to the directory to create.
+        :return: True if the directory was created successfully, False otherwise.
+        """
+        hadoop_path = self._jvm.org.apache.hadoop.fs.Path(path)
+        return self._fs.mkdirs(hadoop_path)

--- a/lib/python/requirements/dev.txt
+++ b/lib/python/requirements/dev.txt
@@ -7,3 +7,4 @@ wheel==0.43.0
 twine==5.0.0
 build==1.2.1
 pytest-cov==5.0.0
+http-server-mock==1.7

--- a/lib/python/tests/conftest.py
+++ b/lib/python/tests/conftest.py
@@ -28,6 +28,8 @@ from pathling._version import (
     __hadoop_version__,
 )
 
+from tests.mockserver import MockServer
+
 HERE = os.path.abspath(os.path.dirname(__file__))
 LIB_API_DIR = os.path.normpath(os.path.join(HERE, "..", "..", "..", "library-api"))
 TEST_DATA_DIR = os.path.join(LIB_API_DIR, "src", "test", "resources", "test-data")
@@ -107,3 +109,8 @@ def pathling_ctx(request, temp_warehouse_dir):
         spark._jsparkSession, encoders, terminology_service_factory
     )
     return PathlingContext(spark, pathling_context)
+
+
+@fixture(scope="function")
+def mock_server():
+    return MockServer(__name__, "localhost", 9876)

--- a/lib/python/tests/mockserver.py
+++ b/lib/python/tests/mockserver.py
@@ -1,0 +1,33 @@
+#  Copyright 2023 Commonwealth Scientific and Industrial Research
+#  Organisation (CSIRO) ABN 41 687 119 230.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from http_server_mock import HttpServerMock
+
+
+class MockServer(HttpServerMock):
+    def __init__(self, name, host, port):
+        super().__init__(name)
+        self.port = port
+        self.host = host
+
+    def run(self):
+        return super().run(self.host, self.port)
+
+    @property
+    def base_url(self):
+        return f"http://{self.host}:{self.port}"
+
+    def url(self, path):
+        return self.base_url + path

--- a/lib/python/tests/test_bulk.py
+++ b/lib/python/tests/test_bulk.py
@@ -1,0 +1,67 @@
+#  Copyright 2023 Commonwealth Scientific and Industrial Research
+#  Organisation (CSIRO) ABN 41 687 119 230.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+from flask import Response
+from pathling.bulk import BulkExportClient
+from datetime import datetime, timezone
+
+
+def test_runs_export(pathling_ctx, mock_server, temp_dir):
+    @mock_server.route("/fhir/$export", methods=["GET"])
+    def export():
+        resp = Response(status=202)
+        resp.headers["content-location"] = mock_server.url("/pool")
+        return resp
+
+    @mock_server.route("/pool", methods=["GET"])
+    def pool():
+        return dict(
+            transactionTime="1970-01-01T00:00:00.000Z",
+            output=[
+                dict(type="Patient", url=mock_server.url("/download"), count=1),
+            ],
+        )
+
+    @mock_server.route("/download", methods=["GET"])
+    def download():
+        return '{"id":"123"}'
+
+    output_dir = os.path.join(temp_dir, "export-output")
+
+    with mock_server.run():
+        result = BulkExportClient.for_system(
+            pathling_ctx.spark._jvm,
+            fhir_endpoint_url=mock_server.url("/fhir"),
+            output_dir=output_dir
+        ).export()
+
+        assert os.path.isdir(output_dir)
+        assert os.path.exists(os.path.join(output_dir, "_SUCCESS"))
+        assert os.path.exists(os.path.join(output_dir, "Patient.0000.ndjson"))
+        with open(os.path.join(output_dir, "Patient.0000.ndjson")) as f:
+            assert f.read() == '{"id":"123"}'
+        assert result.getTransactionTime().toString() == '1970-01-01T00:00:00Z'

--- a/lib/python/tests/test_bulk.py
+++ b/lib/python/tests/test_bulk.py
@@ -13,17 +13,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
 import os
 
 from flask import Response

--- a/lib/python/tests/test_bulk.py
+++ b/lib/python/tests/test_bulk.py
@@ -55,7 +55,7 @@ def test_bulk_client(pathling_ctx, mock_server, temp_dir):
 
     with mock_server.run():
         result = BulkExportClient.for_system(
-            pathling_ctx.spark._jvm,
+            pathling_ctx.spark,
             fhir_endpoint_url=mock_server.url("/fhir"),
             output_dir=output_dir
         ).export()
@@ -69,5 +69,5 @@ def test_bulk_client(pathling_ctx, mock_server, temp_dir):
         assert 1 == len(result.results)
         file_result = result.results[0]
         assert 12 == file_result.size
-        assert "file:" + os.path.join(output_dir, "Patient.0000.ndjson") == file_result.destination
+        assert os.path.join(output_dir, "Patient.0000.ndjson") == file_result.destination
         assert mock_server.url("/download") == file_result.source

--- a/lib/python/tests/test_bulk.py
+++ b/lib/python/tests/test_bulk.py
@@ -25,12 +25,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import os
+
 from flask import Response
+
 from pathling.bulk import BulkExportClient
-from datetime import datetime, timezone
 
 
-def test_runs_export(pathling_ctx, mock_server, temp_dir):
+def test_bulk_client(pathling_ctx, mock_server, temp_dir):
     @mock_server.route("/fhir/$export", methods=["GET"])
     def export():
         resp = Response(status=202)

--- a/lib/python/tests/test_bulk.py
+++ b/lib/python/tests/test_bulk.py
@@ -41,7 +41,7 @@ def test_bulk_client(pathling_ctx, mock_server, temp_dir):
     @mock_server.route("/pool", methods=["GET"])
     def pool():
         return dict(
-            transactionTime="1970-01-01T00:00:00.000Z",
+            transactionTime="1970-01-01T01:02:03.004Z",
             output=[
                 dict(type="Patient", url=mock_server.url("/download"), count=1),
             ],
@@ -65,4 +65,9 @@ def test_bulk_client(pathling_ctx, mock_server, temp_dir):
         assert os.path.exists(os.path.join(output_dir, "Patient.0000.ndjson"))
         with open(os.path.join(output_dir, "Patient.0000.ndjson")) as f:
             assert f.read() == '{"id":"123"}'
-        assert result.getTransactionTime().toString() == '1970-01-01T00:00:00Z'
+        assert result.transaction_time.isoformat() == "1970-01-01T01:02:03.004000+00:00"
+        assert 1 == len(result.results)
+        file_result = result.results[0]
+        assert 12 == file_result.size
+        assert "file:" + os.path.join(output_dir, "Patient.0000.ndjson") == file_result.destination
+        assert mock_server.url("/download") == file_result.source

--- a/lib/python/tests/test_datasource.py
+++ b/lib/python/tests/test_datasource.py
@@ -244,7 +244,6 @@ def test_datasource_bulk_with_temp_dir(pathling_ctx, bulk_server):
 
 
 def test_datasource_bulk_with_existing_dir(pathling_ctx, bulk_server, func_temp_dir):
-    
     assert os.path.exists(func_temp_dir)
     with bulk_server.run():
         data_source = pathling_ctx.read.bulk(

--- a/lib/python/tests/test_spark.py
+++ b/lib/python/tests/test_spark.py
@@ -1,0 +1,51 @@
+#  Copyright 2023 Commonwealth Scientific and Industrial Research
+#  Organisation (CSIRO) ABN 41 687 119 230.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import re
+from pathling.spark import Dfs
+
+
+def test_dfs_temp_dir(pathling_ctx):
+    dfs = Dfs(pathling_ctx.spark)
+    temp_path = dfs.get_temp_dir_path(infix="test", def_temp_base="/tmp", qualified=True)
+    # In local setup the path should be something like: 
+    # file:/tmp/hadoop-username/test-8e4756c1-46e4-44a5-b36d-d6afff1b168a
+    
+    # Validate the format of the temp path using regex
+    regex_pattern = r'^file:/tmp/hadoop-[^/]+/test-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    assert re.match(regex_pattern, temp_path), f"Temp path {temp_path} does not match expected format"
+
+
+def test_dfs_operations(pathling_ctx):
+    dfs = Dfs(pathling_ctx.spark)
+    temp_path = dfs.get_temp_dir_path(infix="test", def_temp_base="/tmp", qualified=True)
+    # Check if the temporary directory exists (it should not exist yet)
+    assert not dfs.exists(temp_path), f"Temporary path {temp_path} should not exist before creation"  
+    assert dfs.mkdirs(temp_path), f"Temporary path {temp_path} can be created"
+    assert dfs.exists(temp_path), f"Temporary path {temp_path} should exist after creation"
+    dfs.delete(temp_path, recursive=True)
+    assert not dfs.exists(temp_path), f"Temporary path {temp_path} should not exist after deletion"
+    

--- a/lib/python/tests/test_spark.py
+++ b/lib/python/tests/test_spark.py
@@ -13,17 +13,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
 import re
 from pathling.spark import Dfs
 


### PR DESCRIPTION
Resolves #2376.

Also make improvements to the bulk() datasource API, including support for temporary directory as the output_dir.