### PR TITLE
Add example Java and Scala projects

### DIFF
--- a/encoders/pom.xml
+++ b/encoders/pom.xml
@@ -163,10 +163,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
 
     <!-- Lombok -->
     <dependency>

--- a/examples/java/PathlingJavaApp/.gitignore
+++ b/examples/java/PathlingJavaApp/.gitignore
@@ -1,0 +1,38 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/examples/java/PathlingJavaApp/README.md
+++ b/examples/java/PathlingJavaApp/README.md
@@ -1,0 +1,188 @@
+# Pathling Java Example Application
+
+This example demonstrates how to use the Pathling Java API within a Java
+project. The application shows how to query FHIR data using Pathling's SQL on
+FHIR view runner within a Java environment.
+
+## Overview
+
+The application demonstrates:
+
+- Creating a Pathling context
+- Reading NDJSON FHIR data
+- Building and executing FHIR views to extract structured data
+
+## Prerequisites
+
+- Java 17
+- Maven 3.6+
+- NDJSON FHIR data files (for testing)
+
+## Project Structure
+
+```
+PathlingJavaApp/
+├── pom.xml                           # Maven build configuration
+├── src/
+│   ├── main/
+│   │   ├── java/
+│   │   │   └── au/csiro/pathling/examples/
+│   │   │       └── PathlingJavaApp.java # Main application
+│   │   └── resources/
+│   │       └── log4j2.properties        # Logging configuration
+│   └── test/
+│       └── java/
+└── target/                           # Compiled classes and artifacts
+```
+
+## Dependencies
+
+The project uses the following key dependencies:
+
+- `au.csiro.pathling:library-runtime:8.0.0-SNAPSHOT` - Pathling library for FHIR
+  data processing
+- `org.apache.spark:spark-sql_2.12:3.5.6` - Apache Spark 3.5.6, the same version used
+  by Pathling 8
+
+## Running the Application
+
+1. Ensure you have NDJSON FHIR data available at `/tmp/ndjson`
+2. From the project root directory, run:
+
+```bash
+mvn compile exec:exec
+```
+
+The exec plugin is configured to automatically include the required JVM parameters:
+- `-ea` - enables assertions
+- `-Duser.timezone=UTC` - sets timezone to UTC
+- `--add-exports=java.base/sun.nio.ch=ALL-UNNAMED` - exports sun.nio.ch package
+- `--add-opens=java.base/java.net=ALL-UNNAMED` - opens java.net package
+
+## Key Concepts
+
+### PathlingContext
+
+The `PathlingContext` is the entry point for all Pathling operations. It
+provides methods to read FHIR data from various sources.
+
+### FhirView
+
+`FhirView` allows you to define structured queries against FHIR resources using
+a declarative approach:
+
+- `ofResource()` - Specifies the FHIR resource type to query
+- `select()` - Defines the columns to extract
+- `column()` - Extracts a single value using FHIRPath expressions
+- `forEach()` - Iterates over collections (like codings in a CodeableConcept)
+
+### FHIRPath Expressions
+
+The example uses FHIRPath expressions like:
+
+- `getResourceKey()` - Returns the primary identifier of the resource
+- `code.coding` - Navigates to the coding elements within a code field
+- `system`, `code`, `display` - Extracts specific properties from coding
+  elements
+
+## Data Requirements
+
+The application expects NDJSON FHIR data containing Observation resources. Each
+line should be a valid FHIR Observation resource in JSON format.
+
+Example Observation:
+
+```json
+{
+    "resourceType": "Observation",
+    "id": "f9747cfe-8f03-8ff9-0b86-80cf5404ec27",
+    "status": "final",
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "vital-signs",
+                    "display": "vital-signs"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://loinc.org",
+                "code": "8302-2",
+                "display": "Body Height"
+            }
+        ],
+        "text": "Body Height"
+    },
+    "subject": {
+        "reference": "Patient/b2ad1727-cc6f-c11f-2cad-e0430ddfb60b"
+    },
+    "encounter": {
+        "reference": "Encounter/6db6fb6b-f7e3-56b3-0d0d-1e2fc64a6c25"
+    },
+    "effectiveDateTime": "2015-03-02T14:07:50+10:00",
+    "issued": "2015-03-02T14:07:50.223+10:00",
+    "valueQuantity": {
+        "value": 54.7,
+        "unit": "cm",
+        "system": "http://unitsofmeasure.org",
+        "code": "cm"
+    }
+}
+```
+
+## Example output
+
+When you run the application with sample FHIR Observation data, you can expect
+to see output similar to the following:
+
+| patient_id                                       | code_system      | code_code | code_display                                                  |
+|--------------------------------------------------|------------------|-----------|---------------------------------------------------------------|
+| Observation/f9747cfe-8f03-8ff9-0b86-80cf5404ec27 | http://loinc.org | 8302-2    | Body Height                                                   |
+| Observation/c00e77a5-cc35-4e12-c070-c681d9ca3ff8 | http://loinc.org | 72514-3   | Pain severity - 0-10 verbal numeric rating [Score] - Reported |
+| Observation/333d87a4-ca3a-d3fb-dfae-3cfe407f40ec | http://loinc.org | 29463-7   | Body Weight                                                   |
+| Observation/943837c3-5564-1139-7491-117f4cf9deb9 | http://loinc.org | 77606-2   | Weight-for-length Per age and sex                             |
+| Observation/79537fc8-ac8a-2831-e657-5b9260238068 | http://loinc.org | 8302-2    | Body Height                                                   |
+| Observation/1d77634a-c24a-05f2-2c20-e3b8d9ac1e6d | http://loinc.org | 8302-2    | Body Height                                                   |
+| Observation/78b0fd9c-ba9b-4d12-e899-4c5bf312bb69 | http://loinc.org | 8302-2    | Body Height                                                   |
+| Observation/7a0ae01d-549a-fa1e-0a19-fdb71b03fb5c | http://loinc.org | 9843-4    | Head Occipital-frontal circumference                          |
+| Observation/23a86873-00ef-6000-282e-ecf9f14e61e4 | http://loinc.org | 72514-3   | Pain severity - 0-10 verbal numeric rating [Score] - Reported |
+| Observation/e2a2eb53-10d5-90c6-9bf3-4d3d0d64bcbf | http://loinc.org | 72514-3   | Pain severity - 0-10 verbal numeric rating [Score] - Reported |
+| Observation/d3d217d9-49b8-2bf5-863f-46f6b85713f9 | http://loinc.org | 29463-7   | Body Weight                                                   |
+| Observation/7b0872b7-2983-2ad2-17b8-ed586f1cc7c2 | http://loinc.org | 29463-7   | Body Weight                                                   |
+| Observation/318e1e37-1fa6-a04a-bf40-50031f55a13d | http://loinc.org | 85354-9   | Blood Pressure                                                |
+| Observation/bbe5c4ee-2326-8dba-1635-13e749058a0e | http://loinc.org | 72514-3   | Pain severity - 0-10 verbal numeric rating [Score] - Reported |
+| Observation/ea78a4a5-686b-e3a9-2663-df4a6f5dfe94 | http://loinc.org | 77606-2   | Weight-for-length Per age and sex                             |
+| Observation/82c43a52-b268-cf74-efb5-c2df2d79f791 | http://loinc.org | 8867-4    | Heart rate                                                    |
+| Observation/3ef730cf-8744-08c6-81b6-e7bf093e2a4e | http://loinc.org | 29463-7   | Body Weight                                                   |
+| Observation/3f4c4d15-6bb1-d0bf-1b54-3c67f3aa4b23 | http://loinc.org | 9843-4    | Head Occipital-frontal circumference                          |
+| Observation/eb170e05-fed2-326a-09cb-d79c4fe498ff | http://loinc.org | 9279-1    | Respiratory rate                                              |
+| Observation/9960d02d-7666-f3f4-59ca-65222f4b73ea | http://loinc.org | 77606-2   | Weight-for-length Per age and sex                             |
+
+We ran this on the `sm` dataset from
+the [Pathling paper](https://doi.org/10.1186/s13326-022-00277-1), which is
+available from
+the [CSIRO Data Access Portal](https://doi.org/10.25919/er9r-0228).
+
+## Customisation
+
+To adapt this example for your use case:
+
+1. **Change the data source**: Modify the `pc.read().ndjson()` call to point to
+   your FHIR data location
+2. **Select different resources**: Replace "Observation" with other FHIR
+   resource types
+3. **Extract different fields**: Modify the `column()` and `forEach()`
+   expressions to extract the data you need
+4. **Add filtering**: Use FHIRPath expressions to filter resources based on
+   specific criteria
+
+## Further Reading
+
+- [Pathling documentation](https://pathling.csiro.au/docs)
+- [FHIRPath specification](https://hl7.org/fhirpath)
+- [FHIR specification](https://hl7.org/fhir)

--- a/examples/java/PathlingJavaApp/pom.xml
+++ b/examples/java/PathlingJavaApp/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>au.csiro.pathling.examples</groupId>
+  <artifactId>PathlingJavaApp</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  
+  <dependencies>
+    <dependency>
+      <groupId>au.csiro.pathling</groupId>
+      <artifactId>library-runtime</artifactId>
+      <version>8.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.12</artifactId>
+      <version>3.5.6</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/examples/java/PathlingJavaApp/pom.xml
+++ b/examples/java/PathlingJavaApp/pom.xml
@@ -27,4 +27,26 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <executable>java</executable>
+          <arguments>
+            <argument>-ea</argument>
+            <argument>-Duser.timezone=UTC</argument>
+            <argument>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED</argument>
+            <argument>--add-opens=java.base/java.net=ALL-UNNAMED</argument>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>au.csiro.pathling.examples.PathlingJavaApp</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/examples/java/PathlingJavaApp/src/main/java/au/csiro/pathling/examples/PathlingJavaApp.java
+++ b/examples/java/PathlingJavaApp/src/main/java/au/csiro/pathling/examples/PathlingJavaApp.java
@@ -1,0 +1,35 @@
+package au.csiro.pathling.examples;
+
+import static au.csiro.pathling.views.FhirView.column;
+import static au.csiro.pathling.views.FhirView.columns;
+import static au.csiro.pathling.views.FhirView.forEach;
+
+import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
+import au.csiro.pathling.views.FhirView;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+
+public class PathlingJavaApp {
+
+  public static void main(String[] args) {
+    PathlingContext pc = PathlingContext.create();
+    final QueryableDataSource data = pc.read().ndjson("/tmp/ndjson");
+
+    final FhirView view = FhirView.ofResource("Observation")
+        .select(
+            columns(
+                column("patient_id", "getResourceKey()")
+            ),
+            forEach("code.coding",
+                column("code_system", "system"),
+                column("code_code", "code"),
+                column("code_display", "display")
+            )
+        ).build();
+
+    final Dataset<Row> result = data.view(view).execute();
+
+    result.show(false);
+  }
+}

--- a/examples/java/PathlingJavaApp/src/main/resources/log4j2.properties
+++ b/examples/java/PathlingJavaApp/src/main/resources/log4j2.properties
@@ -1,0 +1,10 @@
+# Set root logger level to WARN to reduce noise
+rootLogger.level=WARN
+rootLogger.appenderRef.console.ref=console
+
+# Console appender configuration
+appender.console.type=Console
+appender.console.name=console
+appender.console.target=SYSTEM_OUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/examples/scala/PathlingScalaApp/.gitignore
+++ b/examples/scala/PathlingScalaApp/.gitignore
@@ -1,0 +1,47 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store
+
+### Scala ###
+.bsp/

--- a/examples/scala/PathlingScalaApp/README.md
+++ b/examples/scala/PathlingScalaApp/README.md
@@ -154,7 +154,7 @@ to see output similar to the following:
 | Observation/eb170e05-fed2-326a-09cb-d79c4fe498ff | http://loinc.org | 9279-1    | Respiratory rate                                              |
 | Observation/9960d02d-7666-f3f4-59ca-65222f4b73ea | http://loinc.org | 77606-2   | Weight-for-length Per age and sex                             |
 
-We ran this on the `paper-sm` dataset from
+We ran this on the `sm` dataset from
 the [Pathling paper](https://doi.org/10.1186/s13326-022-00277-1), which is
 available from
 the [CSIRO Data Access Portal](https://doi.org/10.25919/er9r-0228).

--- a/examples/scala/PathlingScalaApp/README.md
+++ b/examples/scala/PathlingScalaApp/README.md
@@ -1,0 +1,179 @@
+# Pathling Scala Example Application
+
+This example demonstrates how to use the Pathling Java API within a Scala
+project. The application shows how to query FHIR data using Pathling's SQL on
+FHIR view runner within a Scala environment.
+
+## Overview
+
+The application demonstrates:
+
+- Creating a Pathling context
+- Reading NDJSON FHIR data
+- Building and executing FHIR views to extract structured data
+
+## Prerequisites
+
+- Java 17
+- Scala 2.12
+- SBT (Scala Build Tool)
+- NDJSON FHIR data files (for testing)
+
+## Project Structure
+
+```
+PathlingScalaApp/
+├── build.sbt                     # SBT build configuration
+├── project/
+│   ├── build.properties          # SBT version
+│   └── plugins.sbt               # SBT plugins
+└── src/main/scala/
+    └── au/csiro/pathling/examples/
+        └── PathlingScalaApp.scala # Main application
+```
+
+## Dependencies
+
+The project uses the following key dependencies:
+
+- `au.csiro.pathling:library-runtime:8.0.0-SNAPSHOT` - Pathling library for FHIR
+  data processing
+- `org.apache.spark:spark-sql:3.5.6` - Apache Spark 3.5.6, the same version used
+  by Pathling 8
+
+## Running the Application
+
+1. Ensure you have NDJSON FHIR data available at `/tmp/ndjson`
+2. From the project root directory, run:
+
+```bash
+sbt run
+```
+
+## Key Concepts
+
+### PathlingContext
+
+The `PathlingContext` is the entry point for all Pathling operations. It
+provides methods to read FHIR data from various sources.
+
+### FhirView
+
+`FhirView` allows you to define structured queries against FHIR resources using
+a declarative approach:
+
+- `ofResource()` - Specifies the FHIR resource type to query
+- `select()` - Defines the columns to extract
+- `column()` - Extracts a single value using FHIRPath expressions
+- `forEach()` - Iterates over collections (like codings in a CodeableConcept)
+
+### FHIRPath Expressions
+
+The example uses FHIRPath expressions like:
+
+- `getResourceKey()` - Returns the primary identifier of the resource
+- `code.coding` - Navigates to the coding elements within a code field
+- `system`, `code`, `display` - Extracts specific properties from coding
+  elements
+
+## Data Requirements
+
+The application expects NDJSON FHIR data containing Observation resources. Each
+line should be a valid FHIR Observation resource in JSON format.
+
+Example Observation:
+
+```json
+{
+    "resourceType": "Observation",
+    "id": "f9747cfe-8f03-8ff9-0b86-80cf5404ec27",
+    "status": "final",
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "vital-signs",
+                    "display": "vital-signs"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://loinc.org",
+                "code": "8302-2",
+                "display": "Body Height"
+            }
+        ],
+        "text": "Body Height"
+    },
+    "subject": {
+        "reference": "Patient/b2ad1727-cc6f-c11f-2cad-e0430ddfb60b"
+    },
+    "encounter": {
+        "reference": "Encounter/6db6fb6b-f7e3-56b3-0d0d-1e2fc64a6c25"
+    },
+    "effectiveDateTime": "2015-03-02T14:07:50+10:00",
+    "issued": "2015-03-02T14:07:50.223+10:00",
+    "valueQuantity": {
+        "value": 54.7,
+        "unit": "cm",
+        "system": "http://unitsofmeasure.org",
+        "code": "cm"
+    }
+}
+```
+
+## Example output
+
+When you run the application with sample FHIR Observation data, you can expect
+to see output similar to the following:
+
+| patient_id                                       | code_system      | code_code | code_display                                                  |
+|--------------------------------------------------|------------------|-----------|---------------------------------------------------------------|
+| Observation/f9747cfe-8f03-8ff9-0b86-80cf5404ec27 | http://loinc.org | 8302-2    | Body Height                                                   |
+| Observation/c00e77a5-cc35-4e12-c070-c681d9ca3ff8 | http://loinc.org | 72514-3   | Pain severity - 0-10 verbal numeric rating [Score] - Reported |
+| Observation/333d87a4-ca3a-d3fb-dfae-3cfe407f40ec | http://loinc.org | 29463-7   | Body Weight                                                   |
+| Observation/943837c3-5564-1139-7491-117f4cf9deb9 | http://loinc.org | 77606-2   | Weight-for-length Per age and sex                             |
+| Observation/79537fc8-ac8a-2831-e657-5b9260238068 | http://loinc.org | 8302-2    | Body Height                                                   |
+| Observation/1d77634a-c24a-05f2-2c20-e3b8d9ac1e6d | http://loinc.org | 8302-2    | Body Height                                                   |
+| Observation/78b0fd9c-ba9b-4d12-e899-4c5bf312bb69 | http://loinc.org | 8302-2    | Body Height                                                   |
+| Observation/7a0ae01d-549a-fa1e-0a19-fdb71b03fb5c | http://loinc.org | 9843-4    | Head Occipital-frontal circumference                          |
+| Observation/23a86873-00ef-6000-282e-ecf9f14e61e4 | http://loinc.org | 72514-3   | Pain severity - 0-10 verbal numeric rating [Score] - Reported |
+| Observation/e2a2eb53-10d5-90c6-9bf3-4d3d0d64bcbf | http://loinc.org | 72514-3   | Pain severity - 0-10 verbal numeric rating [Score] - Reported |
+| Observation/d3d217d9-49b8-2bf5-863f-46f6b85713f9 | http://loinc.org | 29463-7   | Body Weight                                                   |
+| Observation/7b0872b7-2983-2ad2-17b8-ed586f1cc7c2 | http://loinc.org | 29463-7   | Body Weight                                                   |
+| Observation/318e1e37-1fa6-a04a-bf40-50031f55a13d | http://loinc.org | 85354-9   | Blood Pressure                                                |
+| Observation/bbe5c4ee-2326-8dba-1635-13e749058a0e | http://loinc.org | 72514-3   | Pain severity - 0-10 verbal numeric rating [Score] - Reported |
+| Observation/ea78a4a5-686b-e3a9-2663-df4a6f5dfe94 | http://loinc.org | 77606-2   | Weight-for-length Per age and sex                             |
+| Observation/82c43a52-b268-cf74-efb5-c2df2d79f791 | http://loinc.org | 8867-4    | Heart rate                                                    |
+| Observation/3ef730cf-8744-08c6-81b6-e7bf093e2a4e | http://loinc.org | 29463-7   | Body Weight                                                   |
+| Observation/3f4c4d15-6bb1-d0bf-1b54-3c67f3aa4b23 | http://loinc.org | 9843-4    | Head Occipital-frontal circumference                          |
+| Observation/eb170e05-fed2-326a-09cb-d79c4fe498ff | http://loinc.org | 9279-1    | Respiratory rate                                              |
+| Observation/9960d02d-7666-f3f4-59ca-65222f4b73ea | http://loinc.org | 77606-2   | Weight-for-length Per age and sex                             |
+
+We ran this on the `paper-sm` dataset from
+the [Pathling paper](https://doi.org/10.1186/s13326-022-00277-1), which is
+available from
+the [CSIRO Data Access Portal](https://doi.org/10.25919/e4eh-6155).
+
+## Customisation
+
+To adapt this example for your use case:
+
+1. **Change the data source**: Modify the `pc.read().ndjson()` call to point to
+   your FHIR data location
+2. **Select different resources**: Replace "Observation" with other FHIR
+   resource types
+3. **Extract different fields**: Modify the `column()` and `forEach()`
+   expressions to extract the data you need
+4. **Add filtering**: Use FHIRPath expressions to filter resources based on
+   specific criteria
+
+## Further Reading
+
+- [Pathling documentation](https://pathling.csiro.au/docs)
+- [FHIRPath specification](https://hl7.org/fhirpath)
+- [FHIR specification](https://hl7.org/fhir)

--- a/examples/scala/PathlingScalaApp/README.md
+++ b/examples/scala/PathlingScalaApp/README.md
@@ -157,7 +157,7 @@ to see output similar to the following:
 We ran this on the `paper-sm` dataset from
 the [Pathling paper](https://doi.org/10.1186/s13326-022-00277-1), which is
 available from
-the [CSIRO Data Access Portal](https://doi.org/10.25919/e4eh-6155).
+the [CSIRO Data Access Portal](https://doi.org/10.25919/er9r-0228).
 
 ## Customisation
 

--- a/examples/scala/PathlingScalaApp/build.sbt
+++ b/examples/scala/PathlingScalaApp/build.sbt
@@ -1,0 +1,16 @@
+ThisBuild / version := "0.1.0-SNAPSHOT"
+
+ThisBuild / scalaVersion := "2.12.20"
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "PathlingScalaApp",
+    resolvers ++= Seq(
+      Resolver.mavenLocal,
+      Resolver.mavenCentral
+    ),
+    libraryDependencies ++= Seq(
+      "au.csiro.pathling" % "library-runtime" % "8.0.0-SNAPSHOT",
+      "org.apache.spark" %% "spark-sql" % "3.5.6"
+    )
+  )

--- a/examples/scala/PathlingScalaApp/build.sbt
+++ b/examples/scala/PathlingScalaApp/build.sbt
@@ -12,5 +12,12 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       "au.csiro.pathling" % "library-runtime" % "8.0.0-SNAPSHOT",
       "org.apache.spark" %% "spark-sql" % "3.5.6"
+    ),
+    run / fork := true,
+    run / javaOptions ++= Seq(
+      "-ea",
+      "-Duser.timezone=UTC",
+      "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
+      "--add-opens=java.base/java.net=ALL-UNNAMED"
     )
   )

--- a/examples/scala/PathlingScalaApp/project/build.properties
+++ b/examples/scala/PathlingScalaApp/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.11.3

--- a/examples/scala/PathlingScalaApp/project/plugins.sbt
+++ b/examples/scala/PathlingScalaApp/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.2")

--- a/examples/scala/PathlingScalaApp/src/main/resources/log4j2.properties
+++ b/examples/scala/PathlingScalaApp/src/main/resources/log4j2.properties
@@ -1,0 +1,10 @@
+# Set root logger level to WARN to reduce noise
+rootLogger.level=WARN
+rootLogger.appenderRef.console.ref=console
+
+# Console appender configuration
+appender.console.type=Console
+appender.console.name=console
+appender.console.target=SYSTEM_OUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/examples/scala/PathlingScalaApp/src/main/scala/au/csiro/pathling/examples/PathlingScalaApp.scala
+++ b/examples/scala/PathlingScalaApp/src/main/scala/au/csiro/pathling/examples/PathlingScalaApp.scala
@@ -1,0 +1,29 @@
+package au.csiro.pathling.examples
+
+import au.csiro.pathling.library.PathlingContext
+import au.csiro.pathling.views.FhirView
+import au.csiro.pathling.views.FhirView.{column, columns, forEach}
+
+object PathlingScalaApp {
+
+  def main(args: Array[String]): Unit = {
+    val pc = PathlingContext.create()
+    val data = pc.read().ndjson("/tmp/ndjson")
+
+    val view = FhirView.ofResource("Observation")
+      .select(
+        columns(
+          column("patient_id", "getResourceKey()")
+        ),
+        forEach("code.coding",
+          column("code_system", "system"),
+          column("code_code", "code"),
+          column("code_display", "display")
+        )
+      ).build()
+
+    val result = data.view(view).execute()
+
+    result.show()
+  }
+}

--- a/examples/scala/PathlingScalaApp/src/main/scala/au/csiro/pathling/examples/PathlingScalaApp.scala
+++ b/examples/scala/PathlingScalaApp/src/main/scala/au/csiro/pathling/examples/PathlingScalaApp.scala
@@ -24,6 +24,6 @@ object PathlingScalaApp {
 
     val result = data.view(view).execute()
 
-    result.show()
+    result.show(truncate = false)
   }
 }

--- a/fhirpath/pom.xml
+++ b/fhirpath/pom.xml
@@ -153,6 +153,10 @@
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-maven-plugin</artifactId>
         <version>${pathling.antlrVersion}</version>

--- a/fhirpath/src/main/java/au/csiro/pathling/views/Column.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/views/Column.java
@@ -28,11 +28,6 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode(callSuper = false)
 public class Column implements SelectionElement {
 
-  public Column(final String name, final String path) {
-    this.name = name;
-    this.path = path;
-  }
-
   @SuppressWarnings("unused")
   public static class ColumnBuilder {
     // for javadocs

--- a/fhirpath/src/main/java/au/csiro/pathling/views/FhirView.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/views/FhirView.java
@@ -70,7 +70,7 @@ public class FhirView {
 
   @Nonnull
   public static Column column(@Nonnull final String name, @Nonnull final String path) {
-    return new Column(name, path);
+    return Column.single(name, path);
   }
 
   @Nonnull

--- a/fhirpath/src/test/java/au/csiro/pathling/views/FhirViewValidationTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/views/FhirViewValidationTest.java
@@ -173,7 +173,7 @@ class FhirViewValidationTest {
     final SelectClause invalidSelectClause = SelectClause.builder()
         .forEach("Patient.name")
         .forEachOrNull("Patient.address")
-        .column(new Column("id", "Patient.id"))
+        .column(Column.single("id", "Patient.id"))
         .build();
 
     final FhirView fhirView = FhirView.ofResource("Patient")

--- a/library-api/pom.xml
+++ b/library-api/pom.xml
@@ -197,10 +197,28 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Bundle-Name>Pathling Library API Sources (including FHIRPath)</Bundle-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <includeDependencySources>true</includeDependencySources>
+          <dependencySourceIncludes>
+            <dependencySourceInclude>au.csiro.pathling:fhirpath</dependencySourceInclude>
+          </dependencySourceIncludes>
+          <archive>
+            <manifestEntries>
+              <Bundle-Name>Pathling Library API Javadoc (including FHIRPath)</Bundle-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -219,6 +237,62 @@
               <includeScope>test</includeScope>
               <excludeTransitive>true</excludeTransitive>
               <outputDirectory>${project.build.directory}/encoders-tests</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>unpack-fhirpath-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>au.csiro.pathling</groupId>
+                  <artifactId>fhirpath</artifactId>
+                  <version>${project.version}</version>
+                  <classifier>sources</classifier>
+                  <type>jar</type>
+                  <outputDirectory>${project.build.directory}/aggregated-sources</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+          <execution>
+            <id>unpack-fhirpath-javadoc</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>au.csiro.pathling</groupId>
+                  <artifactId>fhirpath</artifactId>
+                  <version>${project.version}</version>
+                  <classifier>javadoc</classifier>
+                  <type>jar</type>
+                  <outputDirectory>${project.build.directory}/aggregated-javadoc</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-fhirpath-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/aggregated-sources</source>
+              </sources>
             </configuration>
           </execution>
         </executions>

--- a/library-runtime/pom.xml
+++ b/library-runtime/pom.xml
@@ -136,26 +136,72 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack-library-api-sources</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>au.csiro.pathling</groupId>
+                  <artifactId>library-api</artifactId>
+                  <version>${project.version}</version>
+                  <classifier>sources</classifier>
+                  <type>jar</type>
+                  <outputDirectory>${project.build.directory}/unpacked-sources</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+          <execution>
+            <id>unpack-library-api-javadoc</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>au.csiro.pathling</groupId>
+                  <artifactId>library-api</artifactId>
+                  <version>${project.version}</version>
+                  <classifier>javadoc</classifier>
+                  <type>jar</type>
+                  <outputDirectory>${project.build.directory}/unpacked-javadoc</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
-            <id>empty-sources</id>
+            <id>library-api-sources</id>
             <phase>package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
             <configuration>
               <classifier>sources</classifier>
+              <classesDirectory>${project.build.directory}/unpacked-sources</classesDirectory>
             </configuration>
           </execution>
           <execution>
-            <id>empty-javadoc</id>
+            <id>library-api-javadoc</id>
             <phase>package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
             <configuration>
               <classifier>javadoc</classifier>
+              <classesDirectory>${project.build.directory}/unpacked-javadoc</classesDirectory>
             </configuration>
           </execution> 
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <pathling.antlrVersion>4.9.3</pathling.antlrVersion>
     <pathling.lombokVersion>1.18.38</pathling.lombokVersion>
     <pathling.infinispanVersion>15.0.3.Final</pathling.infinispanVersion>
-    <pathling.jacksonVersion>2.16.1</pathling.jacksonVersion>
+    <pathling.jacksonVersion>2.15.4</pathling.jacksonVersion>
     <pathling.jerseyVersion>2.40</pathling.jerseyVersion>
     <pathling.surefireVersion>3.2.5</pathling.surefireVersion>
     <pathling.logbackVersion>1.5.18</pathling.logbackVersion>

--- a/terminology/pom.xml
+++ b/terminology/pom.xml
@@ -137,10 +137,6 @@
       <artifactId>wiremock-jre8-standalone</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -63,10 +63,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
- Adding new Scala and Java example projects
- Fixed Column constructor in FhirView.column() method to use Column.single() builder instead of deprecated constructor
- Updated test to use proper Column builder pattern
- Downgraded Jackson version from 2.16.1 to 2.15.4 for compatibility
- Modified the build to pass sources and docs from `library-api` and `fhirpath` modules into the library runtime

Resolves #2456.