### PR TITLE
Remove hadoop-aws from default Spark config in Python and R libraries

### DIFF
--- a/lib/R/R/dependencies.R
+++ b/lib/R/R/dependencies.R
@@ -18,7 +18,7 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
   sparklyr::spark_dependency(
       packages = c(
           paste0("au.csiro.pathling:library-runtime:", pathling_version()),
-          paste0("io.delta:delta-spark_", spark_info$scala_version, ":", spark_info$delta_version),
+          paste0("io.delta:delta-spark_", spark_info$scala_version, ":", spark_info$delta_version)
       )
   )
 }

--- a/lib/R/R/dependencies.R
+++ b/lib/R/R/dependencies.R
@@ -19,7 +19,6 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
       packages = c(
           paste0("au.csiro.pathling:library-runtime:", pathling_version()),
           paste0("io.delta:delta-spark_", spark_info$scala_version, ":", spark_info$delta_version),
-          paste0("org.apache.hadoop:hadoop-aws:", spark_info$hadoop_version)
       )
   )
 }

--- a/lib/python/pathling/context.py
+++ b/lib/python/pathling/context.py
@@ -187,7 +187,6 @@ class PathlingContext:
                     "spark.jars.packages",
                     f"au.csiro.pathling:library-runtime:{__java_version__},"
                     f"io.delta:delta-spark_{__scala_version__}:{__delta_version__},"
-                    f"org.apache.hadoop:hadoop-aws:{__hadoop_version__}",
                 )
                 .config(
                     "spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension"


### PR DESCRIPTION
Resolves #2487.