### PR TITLE
Fix unclear error message for choice element selection

### DIFF
--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/collection/Collection.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/collection/Collection.java
@@ -183,7 +183,15 @@ public class Collection {
     // Look up the class that represents an element with the specified FHIR type.
     final FHIRDefinedType resolvedType = fhirType
         .or(() -> definition.flatMap(ElementDefinition::getFhirType))
-        .orElseThrow(() -> new IllegalArgumentException("Must have a fhirType or a definition"));
+        .orElseThrow(() -> {
+          // Check if this is a choice element selection scenario.
+          if (definition.isPresent() && definition.get().isChoiceElement()) {
+            final String elementName = definition.get().getElementName();
+            return new IllegalArgumentException(
+                "Selection of mixed collection not supported: " + elementName);
+          }
+          return new IllegalArgumentException("Must have a fhirType or a definition");
+        });
     final Class<? extends Collection> elementPathClass = classForType(
         resolvedType)
         .orElse(Collection.class);

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/dsl/SystemDslTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/dsl/SystemDslTest.java
@@ -247,6 +247,10 @@ public class SystemDslTest extends FhirPathDslTestBase {
             "correct typeOf() traversal to an missing choice value in FHIR resource")
         .testEmpty("valueInteger",
             "correct direct traversal to an missing choice value in FHIR resource")
+        .group("choice type error handling")
+        .testError("Selection of mixed collection not supported: value",
+            "value",
+            "selecting a choice type without ofType() provides helpful error message")
         .build();
   }
 


### PR DESCRIPTION
## Summary

This PR improves the error message when users attempt to select a FHIR choice element without using `ofType()`. 

Previously, users would receive a cryptic error message:
> "Must have a fhirType or a definition"

Now they receive a more helpful message:
> "Selection of mixed collection not supported: [elementName]"

This provides clearer guidance about the need to use `ofType()` when working with choice elements in FHIR resources.

## Changes

- Enhanced error handling in `Collection.java` to detect choice element selection scenarios
- Added specific error message for choice element selection attempts
- Added test case to verify the improved error message

## Testing

A new test case has been added to `SystemDslTest.java` to verify that the improved error message is shown when attempting to select a choice type without `ofType()`.

Fixes #2486