### PR TITLE
Update git-commit-id-plugin to version 9.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -608,9 +608,9 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>pl.project13.maven</groupId>
-          <artifactId>git-commit-id-plugin</artifactId>
-          <version>4.9.10</version>
+          <groupId>io.github.git-commit-id</groupId>
+          <artifactId>git-commit-id-maven-plugin</artifactId>
+          <version>9.0.2</version>
           <executions>
             <execution>
               <goals>

--- a/terminology/pom.xml
+++ b/terminology/pom.xml
@@ -154,10 +154,7 @@
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>pl.project13.maven</groupId>
-        <artifactId>git-commit-id-plugin</artifactId>
-      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -124,6 +124,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
This modification updates the git-commit-id-plugin from version 4.9.10 to 9.0.2 and relocates the plugin configuration from the terminology module to the utilities module where PathlingVersion.java reads the generated properties file.

  - Plugin configuration removed from terminology/pom.xml
  - Plugin configuration added to utilities/pom.xml
  - Maven coordinates updated: pl.project13.maven:git-commit-id-plugin → io.github.git-commit-id:git-commit-id-maven-plugin
  - Version updated: 4.9.10 → 9.0.2
