### PR TITLE
feat: Implement FHIRPath select() function

### DIFF
--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/FilteringAndProjectionFunctions.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/FilteringAndProjectionFunctions.java
@@ -64,6 +64,26 @@ public class FilteringAndProjectionFunctions {
   }
 
   /**
+   * Returns a collection containing the result of evaluating the projection expression for each
+   * item in the input collection. The results are flattened: if evaluation produces multiple items,
+   * all are added to the output; if evaluation produces empty, nothing is added.
+   *
+   * <p>If the input collection is empty, the result is empty.
+   *
+   * @param input The input collection
+   * @param expression The projection expression
+   * @return A collection containing the projected results
+   * @see <a
+   *     href="https://build.fhir.org/ig/HL7/FHIRPath/#selectprojection--expression--collection">select</a>
+   */
+  @FhirPathFunction
+  @Nonnull
+  public static Collection select(
+      @Nonnull final Collection input, @Nonnull final CollectionTransform expression) {
+    return input.project(expression);
+  }
+
+  /**
    * Returns a collection that contains all items in the input collection that are of the given type
    * or a subclass thereof. If the input collection is empty, the result is empty. The type argument
    * is an identifier that must resolve to the name of a type in a model. For implementations with

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/dsl/SelectFunctionDslTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/dsl/SelectFunctionDslTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.fhirpath.dsl;
+
+import au.csiro.pathling.test.dsl.FhirPathDslTestBase;
+import au.csiro.pathling.test.dsl.FhirPathTest;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+
+/** Tests for the FHIRPath select() function. */
+public class SelectFunctionDslTest extends FhirPathDslTestBase {
+
+  @FhirPathTest
+  public Stream<DynamicTest> testSelectSimpleProperty() {
+    return builder()
+        .withSubject(
+            sb ->
+                sb.elementArray(
+                    "people",
+                    person1 -> person1.string("name", "Alice").integer("age", 25),
+                    person2 -> person2.string("name", "Bob").integer("age", 40),
+                    person3 -> person3.string("name", "Charlie").integer("age", 35)))
+        .group("select() simple property projection")
+        .testEquals(
+            List.of("Alice", "Bob", "Charlie"),
+            "people.select(name)",
+            "select() projects a simple string property from each element")
+        .testEquals(
+            List.of(25, 40, 35),
+            "people.select(age)",
+            "select() projects a simple integer property from each element")
+        .build();
+  }
+
+  @FhirPathTest
+  public Stream<DynamicTest> testSelectFlatteningMultiValued() {
+    return builder()
+        .withSubject(
+            sb ->
+                sb.elementArray(
+                    "contacts",
+                    c1 -> c1.string("name", "Alice").stringArray("phones", "111", "222"),
+                    c2 -> c2.string("name", "Bob").stringArray("phones", "333"),
+                    c3 -> c3.string("name", "Charlie").stringArray("phones", "444", "555", "666")))
+        .group("select() flattening of multi-valued results")
+        .testEquals(
+            List.of("111", "222", "333", "444", "555", "666"),
+            "contacts.select(phones)",
+            "select() flattens multi-valued projection results into a single collection")
+        .build();
+  }
+
+  @FhirPathTest
+  public Stream<DynamicTest> testSelectEmptyResults() {
+    return builder()
+        .withSubject(
+            sb ->
+                sb.elementArray(
+                    "items",
+                    item1 -> item1.string("label", "first").stringEmpty("note"),
+                    item2 -> item2.string("label", "second").string("note", "important"),
+                    item3 -> item3.string("label", "third").stringEmpty("note")))
+        .group("select() empty projection results")
+        .testEquals(
+            "important",
+            "items.select(note)",
+            "select() omits elements whose projection evaluates to empty")
+        .build();
+  }
+
+  @FhirPathTest
+  public Stream<DynamicTest> testSelectEmptyInput() {
+    return builder()
+        .withSubject(sb -> sb.string("dummy", "value"))
+        .group("select() empty input collection")
+        .testEmpty("{}.select($this)", "select() on an empty collection returns empty")
+        .build();
+  }
+
+  @FhirPathTest
+  public Stream<DynamicTest> testSelectExpression() {
+    return builder()
+        .withSubject(
+            sb ->
+                sb.stringArray("names", "Alice", "Bob", "Charlie")
+                    .integerArray("numbers", 1, 2, 3, 4, 5))
+        .group("select() with expressions")
+        .testEquals(
+            List.of(true, true, true),
+            "names.select($this.exists())",
+            "select() evaluates an expression for each element")
+        .testEquals(
+            List.of(true, true, true, true, true),
+            "numbers.select($this > 0)",
+            "select() evaluates a comparison expression for each element")
+        .build();
+  }
+}

--- a/fhirpath/src/test/resources/fhirpath-js/config.yaml
+++ b/fhirpath/src/test/resources/fhirpath-js/config.yaml
@@ -414,6 +414,15 @@ excludeSet:
         type: wontfix
         any:
           - "Patient.name.exists(given)"
+      - title: "length without parentheses treated as child traversal"
+        type: wontfix
+        outcome: failure
+        comment: |
+          FHIRPath length() requires parentheses. The test uses $this.length
+          (without parentheses), which Pathling treats as a child field access
+          rather than the length() function, returning null.
+        any:
+          - "Patient.name.given.select($this.length) = Patient.name.given.select(length)"
       - title: "Unsupported type runner feature: expression maps"
         type: new-feature
         any:
@@ -578,6 +587,8 @@ excludeSet:
         any:
           - "mixedTypeVals.as(Integer)"
           - "mixedTypeVals as Integer"
+          - "mixedTypeVals.select($this as Integer)"
+          - "mixedTypeVals.select($this.as(Integer))"
       - title: "Operator precedence of is/as causes union type errors"
         type: wontfix
         outcome: error
@@ -594,4 +605,3 @@ excludeSet:
           This is correct behavior per spec operator precedence rules.
         any:
           - "1 | 1 is Integer"
-

--- a/openspec/changes/archive/2026-02-25-support-select-function/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-25-support-select-function/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-25

--- a/openspec/changes/archive/2026-02-25-support-select-function/design.md
+++ b/openspec/changes/archive/2026-02-25-support-select-function/design.md
@@ -1,0 +1,41 @@
+## Context
+
+Pathling's FHIRPath engine implements functions as annotated static methods in provider classes (e.g., `FilteringAndProjectionFunctions`). The `where` function already demonstrates the pattern for functions that take an expression parameter: it receives a `CollectionTransform` that wraps the parsed FHIRPath expression, converts it to a `ColumnTransform`, and applies it via `Collection.filter()`.
+
+The `select` function is closely related to `where` - both iterate over elements and evaluate an expression per element. The difference is that `where` uses the expression result as a boolean filter, while `select` uses it as a projection (the expression result replaces the element).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Implement the FHIRPath `select(projection: expression) : collection` function per the specification
+- Follow existing patterns established by `where` for expression-parameter functions
+- Support flattening of results (collections produced by the projection are merged into the output)
+
+**Non-Goals:**
+
+- Supporting `$this` and `$index` special variables within `select` expressions (these may already work through existing infrastructure, but are not a specific goal)
+- Optimising for deeply nested projections
+
+## Decisions
+
+### 1. Implement as a new method in `FilteringAndProjectionFunctions`
+
+**Rationale:** The FHIRPath spec groups `select` under "Filtering and projection" alongside `where`. The existing class already handles this category. Adding `select` here maintains the logical grouping.
+
+**Alternative considered:** Creating a separate provider class. Rejected because it would fragment closely related functions.
+
+### 2. Use `CollectionTransform.toColumnTransformation()` for expression application
+
+**Rationale:** The `toColumnTransformation` method already handles the pattern of applying an expression to each element by creating a copy of the input with the element's column, evaluating the expression, and returning the resulting column. This is exactly what `select` needs - the only difference from `where` is what we do with the result column (use it directly vs. use it as a filter predicate).
+
+### 3. Add a `project` method to `Collection`
+
+**Rationale:** `Collection.filter()` handles the `where` semantics (filtering by boolean). We need a parallel method for `select` semantics (replacing the element with the expression result). The `project` method will apply a `ColumnTransform` and return a new collection with the projected values. Unlike `filter`, the result collection's type information will come from the expression result rather than the input.
+
+**Alternative considered:** Reusing `Collection.map()` directly. However, `map` preserves the input collection's type metadata, while `select` should adopt the type of the projection expression result.
+
+## Risks / Trade-offs
+
+- **[Type information loss]** → The projection expression may produce a different type than the input collection. The `CollectionTransform` approach captures the full result including type, so we should extract type info from the expression result.
+- **[Flattening semantics]** → In the columnar Spark model, "flattening" of nested arrays from projection results may require special handling. However, the existing column representation already handles array semantics, so this should work naturally.

--- a/openspec/changes/archive/2026-02-25-support-select-function/proposal.md
+++ b/openspec/changes/archive/2026-02-25-support-select-function/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The FHIRPath `select` function is a core filtering and projection function defined in the [FHIRPath specification](https://hl7.org/fhirpath/#filtering-and-projection). It evaluates a projection expression for each item in the input collection and flattens the results. Pathling currently supports the closely related `where` function but lacks `select`, which limits the expressiveness of FHIRPath queries that need to project or transform collection elements.
+
+## What Changes
+
+- Add `select(projection: expression) : collection` function to the FHIRPath engine
+- The function evaluates the projection expression for each item in the input collection
+- Results are flattened: if evaluation produces multiple items, all are added to the output; if evaluation produces empty, nothing is added
+- Empty input collections produce empty output
+
+## Capabilities
+
+### New Capabilities
+
+- `fhirpath-select`: FHIRPath `select` function for projecting and transforming collection elements
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- **Code**: `fhirpath` module - `FilteringAndProjectionFunctions.java`, `Collection.java` (may need a new projection/flatMap method)
+- **Tests**: New DSL tests for the `select` function, YAML reference test compatibility
+- **APIs**: No public API changes - `select` is available through FHIRPath expression evaluation
+- **Dependencies**: None

--- a/openspec/changes/archive/2026-02-25-support-select-function/specs/fhirpath-select/spec.md
+++ b/openspec/changes/archive/2026-02-25-support-select-function/specs/fhirpath-select/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Select function evaluates projection for each element
+
+The FHIRPath engine SHALL support the `select(projection: expression) : collection` function. The function SHALL evaluate the projection expression for each item in the input collection. The result of each evaluation SHALL be added to the output collection.
+
+#### Scenario: Simple property projection
+
+- **WHEN** `select` is called with a property path expression on a collection of resources (e.g., `Patient.name.select(family)`)
+- **THEN** the result SHALL contain the values of that property for each element in the input collection
+
+#### Scenario: Expression projection
+
+- **WHEN** `select` is called with a complex expression (e.g., `Patient.name.select(given + ' ' + family)`)
+- **THEN** the result SHALL contain the evaluated expression result for each element
+
+### Requirement: Select function flattens results
+
+If the evaluation of the projection expression for an element results in a collection with multiple items, all items SHALL be added to the output collection (collections resulting from evaluation of the projection are flattened).
+
+#### Scenario: Projection returns multiple items
+
+- **WHEN** `select` is called with an expression that returns multiple values per element (e.g., `Patient.name.select(given)` where a name has multiple given names)
+- **THEN** all values from each element's projection SHALL be included in the output collection
+
+### Requirement: Select function handles empty results
+
+If the evaluation of the projection expression for an element results in the empty collection, no element SHALL be added to the result for that input element.
+
+#### Scenario: Projection returns empty for some elements
+
+- **WHEN** `select` is called and the projection expression evaluates to empty for some input elements
+- **THEN** those elements SHALL not contribute to the output collection
+
+### Requirement: Select function handles empty input
+
+If the input collection is empty, the result SHALL be empty.
+
+#### Scenario: Empty input collection
+
+- **WHEN** `select` is called on an empty collection
+- **THEN** the result SHALL be an empty collection
+
+### Requirement: Select function is available as a FHIRPath function
+
+The `select` function SHALL be registered and invocable using standard FHIRPath function call syntax (e.g., `collection.select(expression)`).
+
+#### Scenario: Function invocation syntax
+
+- **WHEN** a FHIRPath expression uses `select` with dot notation (e.g., `Patient.contact.select(name)`)
+- **THEN** the function SHALL be resolved and executed correctly

--- a/openspec/changes/archive/2026-02-25-support-select-function/tasks.md
+++ b/openspec/changes/archive/2026-02-25-support-select-function/tasks.md
@@ -1,0 +1,9 @@
+## 1. Core Implementation
+
+- [x] 1.1 Add `select` function to `FilteringAndProjectionFunctions.java` using `CollectionTransform` parameter, following the `where` function pattern
+- [x] 1.2 Add a `project` method (or equivalent) to `Collection.java` that applies a `CollectionTransform` expression and returns the projected result collection
+
+## 2. Testing
+
+- [x] 2.1 Write DSL tests for the `select` function covering: simple property projection, expression projection, flattening of multi-valued results, empty projection results, and empty input collections
+- [x] 2.2 Run YAML reference tests (`YamlReferenceImplTest`) and add exclusions for any `select`-related tests that are not yet supported, with user approval

--- a/openspec/specs/fhirpath-select/spec.md
+++ b/openspec/specs/fhirpath-select/spec.md
@@ -1,0 +1,49 @@
+### Requirement: Select function evaluates projection for each element
+
+The FHIRPath engine SHALL support the `select(projection: expression) : collection` function. The function SHALL evaluate the projection expression for each item in the input collection. The result of each evaluation SHALL be added to the output collection.
+
+#### Scenario: Simple property projection
+
+- **WHEN** `select` is called with a property path expression on a collection of resources (e.g., `Patient.name.select(family)`)
+- **THEN** the result SHALL contain the values of that property for each element in the input collection
+
+#### Scenario: Expression projection
+
+- **WHEN** `select` is called with a complex expression (e.g., `Patient.name.select(given + ' ' + family)`)
+- **THEN** the result SHALL contain the evaluated expression result for each element
+
+### Requirement: Select function flattens results
+
+If the evaluation of the projection expression for an element results in a collection with multiple items, all items SHALL be added to the output collection (collections resulting from evaluation of the projection are flattened).
+
+#### Scenario: Projection returns multiple items
+
+- **WHEN** `select` is called with an expression that returns multiple values per element (e.g., `Patient.name.select(given)` where a name has multiple given names)
+- **THEN** all values from each element's projection SHALL be included in the output collection
+
+### Requirement: Select function handles empty results
+
+If the evaluation of the projection expression for an element results in the empty collection, no element SHALL be added to the result for that input element.
+
+#### Scenario: Projection returns empty for some elements
+
+- **WHEN** `select` is called and the projection expression evaluates to empty for some input elements
+- **THEN** those elements SHALL not contribute to the output collection
+
+### Requirement: Select function handles empty input
+
+If the input collection is empty, the result SHALL be empty.
+
+#### Scenario: Empty input collection
+
+- **WHEN** `select` is called on an empty collection
+- **THEN** the result SHALL be an empty collection
+
+### Requirement: Select function is available as a FHIRPath function
+
+The `select` function SHALL be registered and invocable using standard FHIRPath function call syntax (e.g., `collection.select(expression)`).
+
+#### Scenario: Function invocation syntax
+
+- **WHEN** a FHIRPath expression uses `select` with dot notation (e.g., `Patient.contact.select(name)`)
+- **THEN** the function SHALL be resolved and executed correctly


### PR DESCRIPTION
Resolves #2568

## Summary
- Add the FHIRPath `select(projection: expression)` function, which evaluates a projection expression per element and flattens results
- Add `Collection.project()` method paralleling `Collection.filter()` for projection semantics
- Add DSL tests covering simple property projection, expression projection, multi-valued flattening, empty results, and empty input
- Add YAML reference test exclusions for 3 pre-existing limitations exercised through `select()`

## Test plan
- [x] 7 DSL tests pass (`SelectFunctionDslTest`)
- [x] 10 previously-skipped YAML reference tests now pass
- [x] 3 YAML reference tests excluded (pre-existing `as` on mixed types, `length` without parentheses)
- [x] Full `fhirpath` module test suite passes (no new failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)