### PR TITLE
feat: sql run operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ server/client-tests
 
 *-local.yml
 *-local.properties
+lib/import/lib
+lib/js/lib

--- a/server/src/main/java/au/csiro/pathling/Dependencies.java
+++ b/server/src/main/java/au/csiro/pathling/Dependencies.java
@@ -89,7 +89,8 @@ public class Dependencies {
         baseSource,
         pathlingContext.getSpark(),
         databaseLocation,
-        pathlingContext.getFhirEncoders());
+        pathlingContext.getFhirEncoders(),
+        serverConfiguration.getStorage());
   }
 
   @Bean

--- a/server/src/main/java/au/csiro/pathling/FhirServer.java
+++ b/server/src/main/java/au/csiro/pathling/FhirServer.java
@@ -174,6 +174,14 @@ public class FhirServer extends RestfulServer {
 
   @Nonnull private final transient ViewDefinitionExportProvider viewDefinitionExportProvider;
 
+  @Nonnull
+  private final transient au.csiro.pathling.operations.sqlquery.SqlQueryRunProvider
+      sqlQueryRunProvider;
+
+  @Nonnull
+  private final transient au.csiro.pathling.operations.sqlquery.SqlQueryInstanceRunProvider
+      sqlQueryInstanceRunProvider;
+
   /**
    * Constructs a new FhirServer.
    *
@@ -203,7 +211,10 @@ public class FhirServer extends RestfulServer {
    * @param viewDefinitionRunProvider the view definition run provider
    * @param viewDefinitionInstanceRunProvider the view definition instance run provider
    * @param viewDefinitionExportProvider the view definition export provider
+   * @param sqlQueryRunProvider the SQL query run provider
+   * @param sqlQueryInstanceRunProvider the SQL query instance run provider
    */
+  @SuppressWarnings("java:S107")
   public FhirServer(
       @Nonnull final FhirContext fhirContext,
       @Nonnull final ServerConfiguration configuration,
@@ -230,7 +241,11 @@ public class FhirServer extends RestfulServer {
       @Nonnull final BatchProvider batchProvider,
       @Nonnull final ViewDefinitionRunProvider viewDefinitionRunProvider,
       @Nonnull final ViewDefinitionInstanceRunProvider viewDefinitionInstanceRunProvider,
-      @Nonnull final ViewDefinitionExportProvider viewDefinitionExportProvider) {
+      @Nonnull final ViewDefinitionExportProvider viewDefinitionExportProvider,
+      @Nonnull final au.csiro.pathling.operations.sqlquery.SqlQueryRunProvider sqlQueryRunProvider,
+      @Nonnull
+          final au.csiro.pathling.operations.sqlquery.SqlQueryInstanceRunProvider
+              sqlQueryInstanceRunProvider) {
     // Pass the FhirContext to the RestfulServer superclass to ensure custom types like
     // ViewDefinitionResource are recognized when parsing request bodies.
     super(fhirContext);
@@ -259,6 +274,8 @@ public class FhirServer extends RestfulServer {
     this.viewDefinitionRunProvider = viewDefinitionRunProvider;
     this.viewDefinitionInstanceRunProvider = viewDefinitionInstanceRunProvider;
     this.viewDefinitionExportProvider = viewDefinitionExportProvider;
+    this.sqlQueryRunProvider = sqlQueryRunProvider;
+    this.sqlQueryInstanceRunProvider = sqlQueryInstanceRunProvider;
   }
 
   @Override
@@ -375,6 +392,12 @@ public class FhirServer extends RestfulServer {
       // Register view definition export provider.
       if (ops.isViewDefinitionExportEnabled()) {
         registerProvider(viewDefinitionExportProvider);
+      }
+
+      // Register SQL query run providers.
+      if (ops.isSqlQueryRunEnabled()) {
+        registerProvider(sqlQueryRunProvider);
+        registerProvider(sqlQueryInstanceRunProvider);
       }
 
       // CORS configuration.

--- a/server/src/main/java/au/csiro/pathling/config/OperationConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/OperationConfiguration.java
@@ -70,6 +70,9 @@ public class OperationConfiguration {
   /** Enables $viewdefinition-export operation. */
   private boolean viewDefinitionExportEnabled = true;
 
+  /** Enables $sqlquery-run operation. */
+  private boolean sqlQueryRunEnabled = true;
+
   /** Enables $bulk-submit operation. */
   private boolean bulkSubmitEnabled = true;
 

--- a/server/src/main/java/au/csiro/pathling/config/StorageConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/StorageConfiguration.java
@@ -62,4 +62,11 @@ public class StorageConfiguration {
   @Min(1)
   @Builder.Default
   private int compactionThreshold = 10;
+
+  /**
+   * When enabled, Delta Lake merge operations will automatically evolve the table schema to
+   * accommodate new columns present in the incoming data. This is useful when the FHIR encoder adds
+   * new fields (e.g. synthetic columns) that are not yet present in an existing table.
+   */
+  @NotNull @Builder.Default private Boolean schemaAutoMerge = false;
 }

--- a/server/src/main/java/au/csiro/pathling/fhir/ConformanceProvider.java
+++ b/server/src/main/java/au/csiro/pathling/fhir/ConformanceProvider.java
@@ -504,6 +504,9 @@ public class ConformanceProvider
     addOperationIfEnabled(operations, "viewdefinition-run", ops.isViewDefinitionRunEnabled());
     addOperationIfEnabled(operations, "viewdefinition-export", ops.isViewDefinitionExportEnabled());
 
+    // Add SQL query run operation.
+    addOperationIfEnabled(operations, "sqlquery-run", ops.isSqlQueryRunEnabled());
+
     // Add bulk submit operations if configured and enabled.
     if (configuration.getBulkSubmit() != null && ops.isBulkSubmitEnabled()) {
       addOperationIfEnabled(operations, "bulk-submit", true);

--- a/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
@@ -18,6 +18,7 @@
 package au.csiro.pathling.io;
 
 import au.csiro.pathling.QueryHelpers;
+import au.csiro.pathling.config.StorageConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.io.source.DataSource;
 import au.csiro.pathling.library.io.FileSystemPersistence;
@@ -56,6 +57,8 @@ public class DynamicDeltaSource implements QueryableDataSource {
 
   @Nonnull private final FhirEncoders fhirEncoders;
 
+  private final boolean cacheDatasets;
+
   @Nonnull private final Set<String> dynamicallyDiscoveredTypes = ConcurrentHashMap.newKeySet();
 
   /**
@@ -65,16 +68,19 @@ public class DynamicDeltaSource implements QueryableDataSource {
    * @param spark the Spark session for Delta table operations
    * @param databasePath the path to the Delta database
    * @param fhirEncoders the FHIR encoders for creating empty datasets
+   * @param storageConfiguration the storage configuration
    */
   public DynamicDeltaSource(
       @Nonnull final QueryableDataSource delegate,
       @Nonnull final SparkSession spark,
       @Nonnull final String databasePath,
-      @Nonnull final FhirEncoders fhirEncoders) {
+      @Nonnull final FhirEncoders fhirEncoders,
+      @Nonnull final StorageConfiguration storageConfiguration) {
     this.delegate = delegate;
     this.spark = spark;
     this.databasePath = databasePath;
     this.fhirEncoders = fhirEncoders;
+    this.cacheDatasets = storageConfiguration.getCacheDatasets();
   }
 
   @Override
@@ -86,12 +92,12 @@ public class DynamicDeltaSource implements QueryableDataSource {
 
     // If delegate knows about this type, use it.
     if (delegate.getResourceTypes().contains(resourceCode)) {
-      return delegate.read(resourceCode);
+      return cacheIfEnabled(delegate.read(resourceCode));
     }
 
     // If we've already discovered this type dynamically, read from Delta.
     if (dynamicallyDiscoveredTypes.contains(resourceCode)) {
-      return readFromDelta(resourceCode);
+      return cacheIfEnabled(readFromDelta(resourceCode));
     }
 
     // Try to discover the Delta table.
@@ -99,7 +105,7 @@ public class DynamicDeltaSource implements QueryableDataSource {
     if (DeltaTable.isDeltaTable(spark, tablePath)) {
       log.debug("Dynamically discovered Delta table for resource type: {}", resourceCode);
       dynamicallyDiscoveredTypes.add(resourceCode);
-      return readFromDelta(resourceCode);
+      return cacheIfEnabled(readFromDelta(resourceCode));
     }
 
     // No data found - return an empty dataset with the correct schema.
@@ -151,6 +157,14 @@ public class DynamicDeltaSource implements QueryableDataSource {
   @Nonnull
   public DataSource cache() {
     return delegate.cache();
+  }
+
+  @Nonnull
+  private Dataset<Row> cacheIfEnabled(@Nonnull final Dataset<Row> dataset) {
+    if (cacheDatasets) {
+      return dataset.cache();
+    }
+    return dataset;
   }
 
   @Nonnull

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ParsedSqlQuery.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ParsedSqlQuery.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import jakarta.annotation.Nonnull;
+import java.util.List;
+import lombok.Value;
+
+/**
+ * Represents a parsed SQLQuery Library resource containing the SQL text, ViewDefinition
+ * dependencies, and declared parameters.
+ */
+@Value
+public class ParsedSqlQuery {
+
+  /** The decoded SQL query text. */
+  @Nonnull String sql;
+
+  /** The ViewDefinition dependencies referenced in the SQL query. */
+  @Nonnull List<ViewArtifactReference> viewReferences;
+
+  /** The declared parameters that can be bound at execution time. */
+  @Nonnull List<SqlParameterDeclaration> declaredParameters;
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlParameterDeclaration.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlParameterDeclaration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import jakarta.annotation.Nonnull;
+import lombok.Value;
+
+/**
+ * Represents a declared parameter within a SQLQuery Library resource. Each parameter has a name
+ * (used as a placeholder in the SQL via colon-prefix notation) and a FHIR type.
+ */
+@Value
+public class SqlParameterDeclaration {
+
+  /** The name of the parameter, referenced in SQL as {@code :name}. */
+  @Nonnull String name;
+
+  /** The FHIR type code of the parameter (e.g., "string", "integer", "date"). */
+  @Nonnull String type;
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
+import au.csiro.pathling.operations.view.ResultStreamingHelper;
+import au.csiro.pathling.read.ReadExecutor;
+import au.csiro.pathling.security.PathlingAuthority;
+import au.csiro.pathling.security.ResourceAccess.AccessType;
+import au.csiro.pathling.security.SecurityAspect;
+import au.csiro.pathling.views.FhirView;
+import au.csiro.pathling.views.ViewDefinitionGson;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r4.model.Type;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Orchestrates the execution of the {@code $sqlquery-run} operation. Parses the SQLQuery Library
+ * resource, resolves ViewDefinition dependencies, validates and executes the SQL query, and streams
+ * results in the requested format.
+ */
+@Slf4j
+@Component
+public class SqlQueryExecutionHelper {
+
+  @Nonnull private final SparkSession sparkSession;
+
+  @Nonnull private final QueryableDataSource deltaLake;
+
+  @Nonnull private final FhirContext fhirContext;
+
+  @Nonnull private final ServerConfiguration serverConfiguration;
+
+  @Nonnull private final SqlQueryLibraryParser libraryParser;
+
+  @Nonnull private final SqlValidator sqlValidator;
+
+  @Nonnull private final ViewRegistrationService viewRegistrationService;
+
+  @Nonnull private final ReadExecutor readExecutor;
+
+  @Nonnull private final Gson gson;
+
+  @Nonnull private final ResultStreamingHelper streamingHelper;
+
+  /**
+   * Constructs a new SqlQueryExecutionHelper.
+   *
+   * @param sparkSession the Spark session
+   * @param deltaLake the queryable data source
+   * @param fhirContext the FHIR context
+   * @param serverConfiguration the server configuration
+   * @param libraryParser the SQLQuery Library parser
+   * @param sqlValidator the SQL validator
+   * @param viewRegistrationService the view registration service
+   * @param readExecutor the read executor for reading stored resources
+   */
+  @SuppressWarnings("java:S107")
+  @Autowired
+  public SqlQueryExecutionHelper(
+      @Nonnull final SparkSession sparkSession,
+      @Nonnull final QueryableDataSource deltaLake,
+      @Nonnull final FhirContext fhirContext,
+      @Nonnull final ServerConfiguration serverConfiguration,
+      @Nonnull final SqlQueryLibraryParser libraryParser,
+      @Nonnull final SqlValidator sqlValidator,
+      @Nonnull final ViewRegistrationService viewRegistrationService,
+      @Nonnull final ReadExecutor readExecutor) {
+    this.sparkSession = sparkSession;
+    this.deltaLake = deltaLake;
+    this.fhirContext = fhirContext;
+    this.serverConfiguration = serverConfiguration;
+    this.libraryParser = libraryParser;
+    this.sqlValidator = sqlValidator;
+    this.viewRegistrationService = viewRegistrationService;
+    this.readExecutor = readExecutor;
+    this.gson = ViewDefinitionGson.create();
+    this.streamingHelper = new ResultStreamingHelper(gson);
+  }
+
+  /**
+   * Executes a SQL query from a Library resource and streams results to the HTTP response.
+   *
+   * @param libraryResource the Library resource containing the SQLQuery
+   * @param format the output format, overrides Accept header if provided
+   * @param acceptHeader the HTTP Accept header value, used as fallback if format is not provided
+   * @param includeHeader whether to include a header row in CSV output
+   * @param limit the maximum number of rows to return
+   * @param parameterValues runtime parameter values to bind to the SQL query
+   * @param response the HTTP response for streaming output
+   */
+  @SuppressWarnings("java:S107")
+  public void executeSqlQuery(
+      @Nonnull final IBaseResource libraryResource,
+      @Nullable final String format,
+      @Nullable final String acceptHeader,
+      @Nullable final BooleanType includeHeader,
+      @Nullable final IntegerType limit,
+      @Nullable final List<ParametersParameterComponent> parameterValues,
+      @Nullable final HttpServletResponse response) {
+
+    if (response == null) {
+      throw new InvalidRequestException("HTTP response is required for this operation");
+    }
+
+    // Parse the Library resource as a SQLQuery.
+    final Library library = castToLibrary(libraryResource);
+    final ParsedSqlQuery parsedQuery = libraryParser.parse(library);
+
+    // Resolve ViewDefinitions and check authorization.
+    final Map<String, FhirView> resolvedViews = resolveViewDefinitions(parsedQuery);
+
+    // Validate the SQL structure before execution.
+    sqlValidator.validate(parsedQuery.getSql());
+
+    // Determine output format.
+    final SqlQueryOutputFormat outputFormat =
+        (format != null && !format.isBlank())
+            ? SqlQueryOutputFormat.fromString(format)
+            : SqlQueryOutputFormat.fromAcceptHeader(acceptHeader);
+    final boolean shouldIncludeHeader = includeHeader == null || includeHeader.booleanValue();
+
+    // Register views and execute the query.
+    Map<String, String> registeredViews = Map.of();
+    try {
+      registeredViews = viewRegistrationService.registerViews(resolvedViews, deltaLake);
+
+      // Rewrite SQL to use prefixed temp view names.
+      final String rewrittenSql =
+          viewRegistrationService.rewriteSql(parsedQuery.getSql(), registeredViews);
+
+      // Build parameter map for Spark parameterized queries.
+      final Map<String, String> parameterMap = buildParameterMap(parameterValues);
+
+      // Execute the SQL query. Use parameterized queries only when parameters are provided.
+      Dataset<Row> result;
+      if (parameterMap.isEmpty()) {
+        result = sparkSession.sql(rewrittenSql);
+      } else {
+        @SuppressWarnings("unchecked")
+        final java.util.Map<String, Object> objectMap =
+            (java.util.Map<String, Object>) (java.util.Map<String, ?>) parameterMap;
+        result = sparkSession.sql(rewrittenSql, objectMap);
+      }
+
+      // Apply limit if specified.
+      if (limit != null && limit.getValue() != null) {
+        result = result.limit(limit.getValue());
+      }
+
+      // Stream results.
+      streamResults(result, outputFormat, shouldIncludeHeader, response);
+
+    } finally {
+      viewRegistrationService.dropViews(registeredViews.values());
+    }
+  }
+
+  /** Casts a FHIR resource to a Library, throwing if it is not a Library. */
+  @Nonnull
+  private Library castToLibrary(@Nonnull final IBaseResource resource) {
+    if (resource instanceof final Library library) {
+      return library;
+    }
+    throw new InvalidRequestException(
+        "Expected a Library resource but received: " + resource.fhirType());
+  }
+
+  /**
+   * Resolves ViewDefinition references from the parsed SQL query. Each relatedArtifact reference is
+   * resolved to a FhirView. Authorization is checked for each referenced resource type.
+   */
+  @Nonnull
+  private Map<String, FhirView> resolveViewDefinitions(@Nonnull final ParsedSqlQuery parsedQuery) {
+    final Map<String, FhirView> resolvedViews = new LinkedHashMap<>();
+
+    for (final ViewArtifactReference ref : parsedQuery.getViewReferences()) {
+      final String viewDefinitionId = extractViewDefinitionId(ref.getCanonicalUrl());
+      final IBaseResource viewResource;
+      try {
+        viewResource = readExecutor.read("ViewDefinition", viewDefinitionId);
+      } catch (final Exception e) {
+        throw new InvalidRequestException(
+            "Failed to resolve ViewDefinition for label '"
+                + ref.getLabel()
+                + "' with reference '"
+                + ref.getCanonicalUrl()
+                + "': "
+                + e.getMessage());
+      }
+
+      // Parse the ViewDefinition into a FhirView.
+      final FhirView view = parseViewDefinition(viewResource);
+
+      // Check resource-level authorization for the ViewDefinition's target resource type.
+      if (serverConfiguration.getAuth().isEnabled()) {
+        SecurityAspect.checkHasAuthority(
+            PathlingAuthority.resourceAccess(AccessType.READ, view.getResource()));
+      }
+
+      resolvedViews.put(ref.getLabel(), view);
+    }
+
+    return resolvedViews;
+  }
+
+  /**
+   * Extracts a ViewDefinition ID from a canonical URL or relative reference. Supports relative
+   * references like "ViewDefinition/my-id" and plain IDs.
+   */
+  @Nonnull
+  private String extractViewDefinitionId(@Nonnull final String canonicalUrl) {
+    // Handle relative references like "ViewDefinition/my-id".
+    if (canonicalUrl.contains("/")) {
+      final String[] parts = canonicalUrl.split("/");
+      return parts[parts.length - 1];
+    }
+    // Plain ID.
+    return canonicalUrl;
+  }
+
+  /** Parses a ViewDefinition resource into a FhirView using JSON round-tripping. */
+  @Nonnull
+  private FhirView parseViewDefinition(@Nonnull final IBaseResource viewResource) {
+    try {
+      final String viewJson = fhirContext.newJsonParser().encodeResourceToString(viewResource);
+      return gson.fromJson(viewJson, FhirView.class);
+    } catch (final JsonSyntaxException e) {
+      throw new InvalidRequestException("Invalid ViewDefinition: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Builds a parameter map from FHIR Parameters components. Parameter values are converted to
+   * string representations for Spark's parameterized query API.
+   */
+  @Nonnull
+  private Map<String, String> buildParameterMap(
+      @Nullable final List<ParametersParameterComponent> parameterValues) {
+    final Map<String, String> params = new HashMap<>();
+    if (parameterValues == null) {
+      return params;
+    }
+
+    for (final ParametersParameterComponent param : parameterValues) {
+      // Each parameter component has 'name' and 'value' parts.
+      String name = null;
+      String value = null;
+
+      for (final ParametersParameterComponent part : param.getPart()) {
+        if ("name".equals(part.getName()) && part.getValue() != null) {
+          name = part.getValue().primitiveValue();
+        } else if ("value".equals(part.getName()) && part.getValue() != null) {
+          final Type valueType = part.getValue();
+          value = valueType.primitiveValue();
+        }
+      }
+
+      if (name != null && value != null) {
+        params.put(name, value);
+      }
+    }
+
+    return params;
+  }
+
+  /** Streams query results to the HTTP response in the specified format. */
+  private void streamResults(
+      @Nonnull final Dataset<Row> result,
+      @Nonnull final SqlQueryOutputFormat outputFormat,
+      final boolean shouldIncludeHeader,
+      @Nonnull final HttpServletResponse response) {
+
+    response.setContentType(outputFormat.getContentType());
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    response.setStatus(HttpServletResponse.SC_OK);
+
+    try {
+      if (outputFormat == SqlQueryOutputFormat.PARQUET) {
+        streamParquet(result, response);
+      } else {
+        streamTabular(result, outputFormat, shouldIncludeHeader, response);
+      }
+    } catch (final IOException e) {
+      log.error("Error streaming SQL query results", e);
+      throw new InvalidRequestException("Error streaming results: " + e.getMessage());
+    }
+  }
+
+  /** Streams results in a tabular format (NDJSON, CSV, or JSON). */
+  private void streamTabular(
+      @Nonnull final Dataset<Row> result,
+      @Nonnull final SqlQueryOutputFormat outputFormat,
+      final boolean shouldIncludeHeader,
+      @Nonnull final HttpServletResponse response)
+      throws IOException {
+
+    final OutputStream outputStream = response.getOutputStream();
+    final StructType schema = result.schema();
+
+    // For CSV with header, write header immediately to minimise TTFB.
+    if (outputFormat == SqlQueryOutputFormat.CSV && shouldIncludeHeader) {
+      final List<String> columnNames = java.util.Arrays.stream(schema.fieldNames()).toList();
+      streamingHelper.writeCsvHeader(outputStream, columnNames);
+      outputStream.flush();
+    }
+
+    final Iterator<Row> iterator = result.toLocalIterator();
+    switch (outputFormat) {
+      case NDJSON -> streamingHelper.streamNdjson(outputStream, iterator, schema);
+      case JSON -> streamingHelper.writeJson(outputStream, iterator, schema);
+      default -> streamingHelper.streamCsv(outputStream, iterator, schema);
+    }
+    outputStream.flush();
+  }
+
+  /** Writes results as Parquet to a temporary file and streams it to the HTTP response. */
+  private void streamParquet(
+      @Nonnull final Dataset<Row> result, @Nonnull final HttpServletResponse response)
+      throws IOException {
+
+    final Path tempDir = Files.createTempDirectory("sqlquery-parquet-");
+    final String outputPath = tempDir.resolve("result").toString();
+
+    try {
+      result.coalesce(1).write().mode(SaveMode.Overwrite).parquet(outputPath);
+
+      // Find the generated Parquet file.
+      final Path parquetFile = findParquetFile(Path.of(outputPath));
+      if (parquetFile == null) {
+        throw new InvalidRequestException("Failed to generate Parquet output");
+      }
+
+      // Stream the Parquet file to the response.
+      response.setContentType(SqlQueryOutputFormat.PARQUET.getContentType());
+      try (final var inputStream = Files.newInputStream(parquetFile);
+          final var outputStream = response.getOutputStream()) {
+        inputStream.transferTo(outputStream);
+        outputStream.flush();
+      }
+    } finally {
+      // Clean up temp directory.
+      deleteRecursively(tempDir);
+    }
+  }
+
+  /** Finds the first Parquet file in the given directory. */
+  @Nullable
+  private Path findParquetFile(@Nonnull final Path directory) throws IOException {
+    if (!Files.isDirectory(directory)) {
+      return null;
+    }
+    try (final var stream = Files.list(directory)) {
+      return stream.filter(p -> p.toString().endsWith(".parquet")).findFirst().orElse(null);
+    }
+  }
+
+  /** Recursively deletes a directory and its contents. */
+  private void deleteRecursively(@Nonnull final Path path) {
+    try {
+      if (Files.isDirectory(path)) {
+        try (final var stream = Files.list(path)) {
+          stream.forEach(this::deleteRecursively);
+        }
+      }
+      Files.deleteIfExists(path);
+    } catch (final IOException e) {
+      log.warn("Failed to clean up temporary file: {}", path, e);
+    }
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
@@ -149,7 +149,23 @@ public class SqlQueryExecutionHelper {
 
     // Parse the Library resource as a SQLQuery.
     final Library library = castToLibrary(libraryResource);
+
+    // Log the raw Library contents for debugging.
+    log.info(
+        "SQLQuery Library has {} relatedArtifact entries", library.getRelatedArtifact().size());
+    for (final org.hl7.fhir.r4.model.RelatedArtifact ra : library.getRelatedArtifact()) {
+      log.info(
+          "  relatedArtifact: type={}, label={}, resource={}",
+          ra.getType(),
+          ra.getLabel(),
+          ra.getResource());
+    }
+
     final ParsedSqlQuery parsedQuery = libraryParser.parse(library);
+    log.info(
+        "Parsed SQL query: {} view references, {} parameters",
+        parsedQuery.getViewReferences().size(),
+        parsedQuery.getDeclaredParameters().size());
 
     // Resolve ViewDefinitions and check authorization.
     final Map<String, FhirView> resolvedViews = resolveViewDefinitions(parsedQuery);
@@ -165,26 +181,23 @@ public class SqlQueryExecutionHelper {
     final boolean shouldIncludeHeader = includeHeader == null || includeHeader.booleanValue();
 
     // Register views and execute the query.
-    Map<String, String> registeredViews = Map.of();
+    List<String> registeredViewNames = List.of();
     try {
-      registeredViews = viewRegistrationService.registerViews(resolvedViews, deltaLake);
-
-      // Rewrite SQL to use prefixed temp view names.
-      final String rewrittenSql =
-          viewRegistrationService.rewriteSql(parsedQuery.getSql(), registeredViews);
+      registeredViewNames = viewRegistrationService.registerViews(resolvedViews, deltaLake);
 
       // Build parameter map for Spark parameterized queries.
+      final String sql = parsedQuery.getSql();
       final Map<String, String> parameterMap = buildParameterMap(parameterValues);
 
       // Execute the SQL query. Use parameterized queries only when parameters are provided.
       Dataset<Row> result;
       if (parameterMap.isEmpty()) {
-        result = sparkSession.sql(rewrittenSql);
+        result = sparkSession.sql(sql);
       } else {
         @SuppressWarnings("unchecked")
         final java.util.Map<String, Object> objectMap =
             (java.util.Map<String, Object>) (java.util.Map<String, ?>) parameterMap;
-        result = sparkSession.sql(rewrittenSql, objectMap);
+        result = sparkSession.sql(sql, objectMap);
       }
 
       // Apply limit if specified.
@@ -196,7 +209,7 @@ public class SqlQueryExecutionHelper {
       streamResults(result, outputFormat, shouldIncludeHeader, response);
 
     } finally {
-      viewRegistrationService.dropViews(registeredViews.values());
+      viewRegistrationService.dropViews(registeredViewNames);
     }
   }
 

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryInstanceRunProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryInstanceRunProvider.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.errors.ResourceNotFoundError;
+import au.csiro.pathling.read.ReadExecutor;
+import au.csiro.pathling.security.OperationAccess;
+import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.server.IResourceProvider;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Provider for the type-level and instance-level {@code $sqlquery-run} operations for Library
+ * resources.
+ *
+ * <p>This provides operations at:
+ *
+ * <ul>
+ *   <li>{@code POST /fhir/Library/$sqlquery-run} — Type-level operation with queryResource
+ *       parameter
+ *   <li>{@code POST /fhir/Library/[id]/$sqlquery-run} — Instance-level operation using stored
+ *       Library
+ * </ul>
+ *
+ * @see <a
+ *     href="https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/OperationDefinition-SQLQueryRun.html">SQLQueryRun</a>
+ * @see SqlQueryRunProvider for system-level $sqlquery-run operation
+ */
+@Component
+public class SqlQueryInstanceRunProvider implements IResourceProvider {
+
+  @Nonnull private final SqlQueryExecutionHelper executionHelper;
+
+  @Nonnull private final ReadExecutor readExecutor;
+
+  /**
+   * Constructs a new SqlQueryInstanceRunProvider.
+   *
+   * @param executionHelper the helper for executing SQL queries
+   * @param readExecutor the read executor for reading stored Library resources
+   */
+  @Autowired
+  public SqlQueryInstanceRunProvider(
+      @Nonnull final SqlQueryExecutionHelper executionHelper,
+      @Nonnull final ReadExecutor readExecutor) {
+    this.executionHelper = executionHelper;
+    this.readExecutor = readExecutor;
+  }
+
+  @Override
+  public Class<Library> getResourceType() {
+    return Library.class;
+  }
+
+  /**
+   * Type-level {@code $sqlquery-run} operation that accepts a SQLQuery Library inline.
+   *
+   * @param queryResource the SQLQuery Library resource
+   * @param format the output format (ndjson, csv, json, or parquet), overrides Accept header
+   * @param includeHeader whether to include a header row in CSV output
+   * @param limit the maximum number of rows to return
+   * @param parameterValues query parameter values to bind
+   * @param requestDetails the servlet request details containing HTTP headers
+   * @param response the HTTP response for streaming output
+   */
+  @Operation(name = "$sqlquery-run", idempotent = true, manualResponse = true)
+  @OperationAccess("sqlquery-run")
+  public void runTypeLevel(
+      @Nonnull @OperationParam(name = "queryResource") final IBaseResource queryResource,
+      @Nullable @OperationParam(name = "_format") final String format,
+      @Nullable @OperationParam(name = "header") final BooleanType includeHeader,
+      @Nullable @OperationParam(name = "_limit") final IntegerType limit,
+      @Nullable @OperationParam(name = "parameter")
+          final List<ParametersParameterComponent> parameterValues,
+      @Nonnull final ServletRequestDetails requestDetails,
+      @Nullable final HttpServletResponse response) {
+
+    final String acceptHeader = requestDetails.getServletRequest().getHeader("Accept");
+
+    executionHelper.executeSqlQuery(
+        queryResource, format, acceptHeader, includeHeader, limit, parameterValues, response);
+  }
+
+  /**
+   * Instance-level {@code $sqlquery-run} operation that uses a stored Library by ID.
+   *
+   * @param libraryId the ID of the stored Library resource
+   * @param format the output format (ndjson, csv, json, or parquet), overrides Accept header
+   * @param includeHeader whether to include a header row in CSV output
+   * @param limit the maximum number of rows to return
+   * @param parameterValues query parameter values to bind
+   * @param requestDetails the servlet request details containing HTTP headers
+   * @param response the HTTP response for streaming output
+   */
+  @Operation(name = "$sqlquery-run", idempotent = true, manualResponse = true)
+  @OperationAccess("sqlquery-run")
+  public void runById(
+      @IdParam final IdType libraryId,
+      @Nullable @OperationParam(name = "_format") final String format,
+      @Nullable @OperationParam(name = "header") final BooleanType includeHeader,
+      @Nullable @OperationParam(name = "_limit") final IntegerType limit,
+      @Nullable @OperationParam(name = "parameter")
+          final List<ParametersParameterComponent> parameterValues,
+      @Nonnull final ServletRequestDetails requestDetails,
+      @Nullable final HttpServletResponse response) {
+
+    final IBaseResource libraryResource = readLibrary(libraryId);
+    final String acceptHeader = requestDetails.getServletRequest().getHeader("Accept");
+
+    executionHelper.executeSqlQuery(
+        libraryResource, format, acceptHeader, includeHeader, limit, parameterValues, response);
+  }
+
+  /** Reads a Library resource by ID. */
+  @Nonnull
+  private IBaseResource readLibrary(@Nonnull final IdType libraryId) {
+    try {
+      return readExecutor.read("Library", libraryId.getIdPart());
+    } catch (final ResourceNotFoundError e) {
+      throw new ResourceNotFoundException(
+          "Library with ID '" + libraryId.getIdPart() + "' not found");
+    } catch (final IllegalArgumentException e) {
+      if (e.getMessage() != null && e.getMessage().contains("No data found for resource type")) {
+        throw new ResourceNotFoundException(
+            "Library with ID '" + libraryId.getIdPart() + "' not found");
+      }
+      throw e;
+    }
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParser.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParser.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import jakarta.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.hl7.fhir.r4.model.Attachment;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.ParameterDefinition;
+import org.hl7.fhir.r4.model.RelatedArtifact;
+import org.springframework.stereotype.Component;
+
+/**
+ * Parses a FHIR R4 Library resource conforming to the SQLQuery profile. Extracts the SQL text,
+ * ViewDefinition dependencies, and parameter declarations.
+ *
+ * <p>The SQLQuery profile requires:
+ *
+ * <ul>
+ *   <li>A {@code content} entry with content type starting with {@code application/sql} containing
+ *       Base64-encoded SQL text.
+ *   <li>Zero or more {@code relatedArtifact} entries, each with a {@code label} (table alias) and
+ *       {@code resource} (canonical URL of the ViewDefinition).
+ *   <li>Zero or more {@code parameter} entries declaring typed input parameters.
+ * </ul>
+ *
+ * @see <a
+ *     href="https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/StructureDefinition-SQLQuery.html">SQLQuery</a>
+ */
+@Component
+public class SqlQueryLibraryParser {
+
+  private static final String SQL_CONTENT_TYPE_PREFIX = "application/sql";
+
+  /**
+   * Parses a Library resource into a {@link ParsedSqlQuery}.
+   *
+   * @param library the Library resource to parse
+   * @return the parsed SQL query containing SQL text, view references, and parameter declarations
+   * @throws InvalidRequestException if the Library does not conform to the SQLQuery profile
+   */
+  @Nonnull
+  public ParsedSqlQuery parse(@Nonnull final Library library) {
+    final String sql = extractSql(library);
+    final List<ViewArtifactReference> viewReferences = extractViewReferences(library);
+    final List<SqlParameterDeclaration> parameters = extractParameters(library);
+    return new ParsedSqlQuery(sql, viewReferences, parameters);
+  }
+
+  /**
+   * Extracts the SQL text from the Library's content entries.
+   *
+   * @param library the Library resource
+   * @return the decoded SQL text
+   * @throws InvalidRequestException if no SQL content is found or the content is invalid
+   */
+  @Nonnull
+  private String extractSql(@Nonnull final Library library) {
+    for (final Attachment attachment : library.getContent()) {
+      final String contentType = attachment.getContentType();
+      if (contentType != null && contentType.startsWith(SQL_CONTENT_TYPE_PREFIX)) {
+        final byte[] data = attachment.getData();
+        if (data == null || data.length == 0) {
+          throw new InvalidRequestException(
+              "SQLQuery Library has an application/sql content entry with no data");
+        }
+        // The data is Base64-encoded in the FHIR resource. HAPI decodes it automatically when
+        // using getData(), so we can use it directly.
+        return new String(data, StandardCharsets.UTF_8);
+      }
+    }
+    throw new InvalidRequestException(
+        "SQLQuery Library must contain a content entry with content type application/sql");
+  }
+
+  /**
+   * Extracts ViewDefinition references from the Library's related artifacts.
+   *
+   * @param library the Library resource
+   * @return the list of view artifact references
+   */
+  @Nonnull
+  private List<ViewArtifactReference> extractViewReferences(@Nonnull final Library library) {
+    final List<ViewArtifactReference> references = new ArrayList<>();
+    for (final RelatedArtifact artifact : library.getRelatedArtifact()) {
+      final String label = artifact.getLabel();
+      final String resource = artifact.getResource();
+      if (label == null || label.isBlank()) {
+        throw new InvalidRequestException(
+            "Each relatedArtifact in the SQLQuery Library must have a label");
+      }
+      if (resource == null || resource.isBlank()) {
+        throw new InvalidRequestException(
+            "Each relatedArtifact in the SQLQuery Library must have a resource reference");
+      }
+      references.add(new ViewArtifactReference(label, resource));
+    }
+    return references;
+  }
+
+  /**
+   * Extracts parameter declarations from the Library's parameter entries.
+   *
+   * @param library the Library resource
+   * @return the list of parameter declarations
+   */
+  @Nonnull
+  private List<SqlParameterDeclaration> extractParameters(@Nonnull final Library library) {
+    final List<SqlParameterDeclaration> parameters = new ArrayList<>();
+    for (final ParameterDefinition param : library.getParameter()) {
+      final String name = param.getName();
+      final String type = param.getType();
+      if (name == null || name.isBlank()) {
+        throw new InvalidRequestException(
+            "Each parameter in the SQLQuery Library must have a name");
+      }
+      if (type == null || type.isBlank()) {
+        throw new InvalidRequestException(
+            "Each parameter in the SQLQuery Library must have a type");
+      }
+      parameters.add(new SqlParameterDeclaration(name, type));
+    }
+    return parameters;
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryOutputFormat.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryOutputFormat.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
+import lombok.Getter;
+
+/**
+ * Output format options for the {@code $sqlquery-run} operation. Supports NDJSON, CSV, JSON, and
+ * Parquet formats as specified in the SQL on FHIR v2 specification.
+ */
+@Getter
+public enum SqlQueryOutputFormat {
+
+  /** Newline-delimited JSON format. */
+  NDJSON("ndjson", "application/x-ndjson"),
+
+  /** Comma-separated values format. */
+  CSV("csv", "text/csv"),
+
+  /** JSON format — single document containing an array of objects. */
+  JSON("json", "application/json"),
+
+  /** Apache Parquet columnar format. */
+  PARQUET("parquet", "application/vnd.apache.parquet");
+
+  @Nonnull private final String code;
+
+  @Nonnull private final String contentType;
+
+  SqlQueryOutputFormat(@Nonnull final String code, @Nonnull final String contentType) {
+    this.code = code;
+    this.contentType = contentType;
+  }
+
+  /** The default format when no valid format is specified. */
+  private static final SqlQueryOutputFormat DEFAULT_FORMAT = NDJSON;
+
+  /**
+   * Parses a format string into a SqlQueryOutputFormat.
+   *
+   * @param format the format string to parse, or null for default
+   * @return the corresponding format, defaulting to NDJSON
+   */
+  @Nonnull
+  public static SqlQueryOutputFormat fromString(@Nullable final String format) {
+    if (isNullOrBlank(format)) {
+      return DEFAULT_FORMAT;
+    }
+    final String normalised = format.toLowerCase().trim();
+    return Arrays.stream(values())
+        .filter(f -> f.code.equals(normalised) || f.contentType.equals(normalised))
+        .findFirst()
+        .orElse(DEFAULT_FORMAT);
+  }
+
+  /**
+   * Parses an HTTP Accept header into a SqlQueryOutputFormat. Supports quality values (e.g.,
+   * "text/csv;q=0.9, application/x-ndjson;q=1.0") and returns the format with the highest quality
+   * value that matches a supported content type.
+   *
+   * @param acceptHeader the Accept header value, or null for default
+   * @return the corresponding format, defaulting to NDJSON
+   */
+  @Nonnull
+  public static SqlQueryOutputFormat fromAcceptHeader(@Nullable final String acceptHeader) {
+    if (isNullOrBlank(acceptHeader)) {
+      return DEFAULT_FORMAT;
+    }
+
+    return Arrays.stream(acceptHeader.split(","))
+        .map(SqlQueryOutputFormat::parseMediaType)
+        .sorted(Comparator.comparingDouble(MediaType::quality).reversed())
+        .map(mt -> matchContentType(mt.type()))
+        .flatMap(Optional::stream)
+        .findFirst()
+        .orElse(DEFAULT_FORMAT);
+  }
+
+  /** Checks if a string is null or blank. */
+  private static boolean isNullOrBlank(@Nullable final String value) {
+    return value == null || value.isBlank();
+  }
+
+  /** Matches a content type string against supported formats. */
+  @Nonnull
+  private static Optional<SqlQueryOutputFormat> matchContentType(
+      @Nonnull final String contentType) {
+    if ("*/*".equals(contentType)) {
+      return Optional.of(DEFAULT_FORMAT);
+    }
+    return Arrays.stream(values()).filter(f -> f.contentType.equals(contentType)).findFirst();
+  }
+
+  /** Parses a single media type entry from an Accept header (e.g., "text/csv;q=0.9"). */
+  @Nonnull
+  private static MediaType parseMediaType(@Nonnull final String mediaTypeString) {
+    final String[] parts = mediaTypeString.split(";");
+    final String type = parts[0].trim().toLowerCase();
+    final double quality = extractQualityValue(parts);
+    return new MediaType(type, quality);
+  }
+
+  /** Extracts the quality value from media type parameters, defaulting to 1.0. */
+  private static double extractQualityValue(@Nonnull final String[] parts) {
+    for (int i = 1; i < parts.length; i++) {
+      final String param = parts[i].trim();
+      if (param.startsWith("q=")) {
+        try {
+          return Double.parseDouble(param.substring(2).trim());
+        } catch (final NumberFormatException e) {
+          return 1.0;
+        }
+      }
+    }
+    return 1.0;
+  }
+
+  /** Represents a parsed media type with its quality value. */
+  private record MediaType(@Nonnull String type, double quality) {}
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.security.OperationAccess;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Provider for the system-level {@code $sqlquery-run} operation from the SQL on FHIR v2
+ * specification. Executes a SQL query against materialised ViewDefinition tables.
+ *
+ * <p>This provides a system-level operation at {@code /fhir/$sqlquery-run} that accepts a SQLQuery
+ * Library resource inline or by reference.
+ *
+ * @see <a
+ *     href="https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/OperationDefinition-SQLQueryRun.html">SQLQueryRun</a>
+ * @see SqlQueryInstanceRunProvider for type-level and instance-level operations
+ */
+@Component
+public class SqlQueryRunProvider {
+
+  @Nonnull private final SqlQueryExecutionHelper executionHelper;
+
+  /**
+   * Constructs a new SqlQueryRunProvider.
+   *
+   * @param executionHelper the helper for executing SQL queries
+   */
+  @Autowired
+  public SqlQueryRunProvider(@Nonnull final SqlQueryExecutionHelper executionHelper) {
+    this.executionHelper = executionHelper;
+  }
+
+  /**
+   * Executes a SQL query provided inline as a Library resource and returns the results in the
+   * requested format. This is the system-level operation at {@code /fhir/$sqlquery-run}.
+   *
+   * @param queryResource the SQLQuery Library resource
+   * @param format the output format (ndjson, csv, json, or parquet), overrides Accept header
+   * @param includeHeader whether to include a header row in CSV output
+   * @param limit the maximum number of rows to return
+   * @param parameterValues query parameter values to bind
+   * @param requestDetails the servlet request details containing HTTP headers
+   * @param response the HTTP response for streaming output
+   */
+  @Operation(name = "$sqlquery-run", idempotent = true, manualResponse = true)
+  @OperationAccess("sqlquery-run")
+  public void run(
+      @Nonnull @OperationParam(name = "queryResource") final IBaseResource queryResource,
+      @Nullable @OperationParam(name = "_format") final String format,
+      @Nullable @OperationParam(name = "header") final BooleanType includeHeader,
+      @Nullable @OperationParam(name = "_limit") final IntegerType limit,
+      @Nullable @OperationParam(name = "parameter")
+          final List<ParametersParameterComponent> parameterValues,
+      @Nonnull final ServletRequestDetails requestDetails,
+      @Nullable final HttpServletResponse response) {
+
+    final String acceptHeader = requestDetails.getServletRequest().getHeader("Accept");
+
+    executionHelper.executeSqlQuery(
+        queryResource, format, acceptHeader, includeHeader, limit, parameterValues, response);
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
@@ -1,0 +1,461 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import jakarta.annotation.Nonnull;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.UnresolvedFunction;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.ScalaUDF;
+import org.apache.spark.sql.catalyst.expressions.SubqueryExpression;
+import org.apache.spark.sql.catalyst.plans.logical.Command;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import scala.Option;
+import scala.jdk.javaapi.CollectionConverters;
+
+/**
+ * Validates that SQL queries are strictly read-only and contain only allowed operations. This
+ * prevents SQL injection attacks and ensures that users cannot execute DDL, DML, or other dangerous
+ * operations through the {@code $sqlquery-run} endpoint.
+ *
+ * <p>Validation is performed on the unresolved logical plan produced by Spark's SQL parser. The
+ * validator walks the entire plan tree and checks every plan node and expression against a
+ * whitelist. Any node not in the whitelist causes the query to be rejected.
+ *
+ * <p>Three validation layers are applied:
+ *
+ * <ol>
+ *   <li><strong>Plan node whitelist</strong> — only read-only plan nodes are permitted.
+ *   <li><strong>Expression whitelist</strong> — only safe expression types are permitted.
+ *   <li><strong>UDF allowlist</strong> — {@code ScalaUDF} is permitted only for Pathling's
+ *       registered UDFs.
+ * </ol>
+ *
+ * @see <a
+ *     href="https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/OperationDefinition-SQLQueryRun.html">SQLQueryRun</a>
+ */
+@Slf4j
+@Component
+public class SqlValidator {
+
+  @Nonnull private final SparkSession sparkSession;
+
+  // Allowed plan node class names (simple names). Any plan node not in this set is rejected.
+  // All Command subclasses (DDL/DML) are additionally rejected via instanceof check.
+  private static final Set<String> ALLOWED_PLAN_NODES =
+      Set.of(
+          // Basic operations.
+          "Project",
+          "Filter",
+          "Sort",
+          "GlobalLimit",
+          "LocalLimit",
+          "Tail",
+          "Offset",
+          "ReturnAnswer",
+          // Set operations.
+          "Union",
+          "Intersect",
+          "Except",
+          // Joins.
+          "Join",
+          "LateralJoin",
+          "AsOfJoin",
+          // Aggregation and grouping.
+          "Aggregate",
+          "Expand",
+          "Window",
+          "WithWindowDefinition",
+          // Table and relation access.
+          "UnresolvedRelation",
+          "SubqueryAlias",
+          "LocalRelation",
+          "OneRowRelation",
+          "EmptyRelation",
+          "Range",
+          "View",
+          "UnresolvedInlineTable",
+          "UnresolvedTableValuedFunction",
+          // Common table expressions.
+          "WithCTE",
+          "CTERelationDef",
+          "CTERelationRef",
+          "UnresolvedWith",
+          // Deduplication.
+          "Distinct",
+          "Deduplicate",
+          // Pivot and unpivot.
+          "Pivot",
+          "Unpivot",
+          // Generate (LATERAL VIEW / EXPLODE).
+          "Generate",
+          // Hints.
+          "ResolvedHint",
+          "UnresolvedHint",
+          // Sampling.
+          "Sample",
+          // Repartitioning (read-only).
+          "Repartition",
+          "RebalancePartitions",
+          // Transposition.
+          "Transpose",
+          // Subquery wrapper.
+          "Subquery",
+          // Unresolved plan-specific nodes.
+          "UnresolvedSubqueryColumnAliases");
+
+  // Function names that are explicitly rejected because they enable arbitrary code execution.
+  private static final Set<String> REJECTED_FUNCTION_NAMES =
+      Set.of("reflect", "java_method", "try_reflect");
+
+  // Pathling-registered UDF names that are allowed in ScalaUDF expressions.
+  private static final Set<String> ALLOWED_UDF_NAMES =
+      Set.of(
+          // Terminology UDFs (registered by TerminologyUdfRegistrar).
+          "display",
+          "member_of",
+          "subsumes",
+          "designation",
+          "translate_coding",
+          "property_string",
+          "property_code",
+          "property_integer",
+          "property_boolean",
+          "property_decimal",
+          "property_dateTime",
+          "property_Coding",
+          // FHIRPath UDFs (registered by PathlingUdfRegistrar).
+          "to_null",
+          "string_to_quantity",
+          "quantity_to_literal",
+          "decimal_to_literal",
+          "coding_to_literal",
+          "convert_quantity_to_unit",
+          "low_boundary_for_date",
+          "high_boundary_for_date",
+          "low_boundary_for_time",
+          "high_boundary_for_time");
+
+  // Allowed expression class names for the unresolved plan. Expressions not in this set (and not
+  // covered by special handling for UnresolvedFunction and ScalaUDF) are rejected.
+  @SuppressWarnings("java:S1192")
+  private static final Set<String> ALLOWED_EXPRESSION_NAMES =
+      Set.of(
+          // Literals and references.
+          "Literal",
+          "UnresolvedAttribute",
+          "UnresolvedStar",
+          "UnresolvedNamedLambdaVariable",
+          "NamedLambdaVariable",
+          "LambdaVariable",
+          "Alias",
+          "UnresolvedAlias",
+          "OuterReference",
+          "UnresolvedOrdinal",
+          "VariableReference",
+          "AttributeReference",
+          "BoundReference",
+          // Arithmetic.
+          "Add",
+          "Subtract",
+          "Multiply",
+          "Divide",
+          "IntegralDivide",
+          "Remainder",
+          "Pmod",
+          "UnaryMinus",
+          "UnaryPositive",
+          "Abs",
+          // Comparison.
+          "EqualTo",
+          "EqualNullSafe",
+          "LessThan",
+          "LessThanOrEqual",
+          "GreaterThan",
+          "GreaterThanOrEqual",
+          // Predicates.
+          "In",
+          "InSet",
+          "InSubquery",
+          "Between",
+          "Like",
+          "ILike",
+          "RLike",
+          "LikeAll",
+          "LikeAny",
+          "NotLikeAll",
+          "NotLikeAny",
+          "Contains",
+          "StartsWith",
+          "EndsWith",
+          "StringInstr",
+          "StringLocate",
+          "FindInSet",
+          // Logical operators.
+          "And",
+          "Or",
+          "Not",
+          // Null handling.
+          "IsNull",
+          "IsNotNull",
+          "Coalesce",
+          "NullIf",
+          "Nvl",
+          "Nvl2",
+          "IfNull",
+          "NaNvl",
+          "IsNaN",
+          // Conditional.
+          "If",
+          "CaseWhen",
+          "Greatest",
+          "Least",
+          // Type casting.
+          "Cast",
+          "AnsiCast",
+          "ToBinary",
+          "TryToBinary",
+          "ToNumber",
+          "TryToNumber",
+          "ToCharacter",
+          // Sorting.
+          "SortOrder",
+          // Subquery expressions.
+          "ScalarSubquery",
+          "Exists",
+          "ListQuery",
+          "LateralSubquery",
+          // Generator expressions.
+          "Explode",
+          "PosExplode",
+          "Inline",
+          "Stack",
+          // Window expressions.
+          "WindowExpression",
+          "WindowSpecDefinition",
+          "SpecifiedWindowFrame",
+          "UnspecifiedFrame",
+          // Struct, array, and map expressions.
+          "CreateNamedStruct",
+          "CreateArray",
+          "CreateMap",
+          "GetStructField",
+          "GetArrayStructFields",
+          "GetArrayItem",
+          "GetMapValue",
+          // Higher-order functions.
+          "LambdaFunction",
+          // Grouping.
+          "Grouping",
+          "GroupingID",
+          // Unresolved expression types.
+          "UnresolvedExtractValue",
+          "UnresolvedRegex",
+          "NamedArgumentExpression",
+          // Non-deterministic (safe).
+          "Rand",
+          "Randn",
+          "Uuid",
+          "Shuffle",
+          "RandStr",
+          "Uniform",
+          // Error handling.
+          "RaiseError",
+          "TryEval",
+          "AssertTrue",
+          // Utility.
+          "Empty2Null",
+          "TypeOf",
+          // Bitwise operations.
+          "BitwiseAnd",
+          "BitwiseOr",
+          "BitwiseXor",
+          "BitwiseNot");
+
+  // Expression types that are explicitly rejected because they enable unsafe operations.
+  private static final Set<String> REJECTED_EXPRESSION_NAMES =
+      Set.of(
+          "CallMethodViaReflection",
+          "TryReflect",
+          "PythonUDF",
+          "HiveSimpleUDF",
+          "HiveGenericUDF",
+          "HiveUDAF",
+          "PrintToStderr",
+          "StaticInvoke",
+          "Invoke",
+          "NewInstance");
+
+  /**
+   * Constructs a new SqlValidator.
+   *
+   * @param sparkSession the Spark session used for SQL parsing
+   */
+  @Autowired
+  public SqlValidator(@Nonnull final SparkSession sparkSession) {
+    this.sparkSession = sparkSession;
+  }
+
+  /**
+   * Validates that the given SQL query is read-only and contains only allowed operations.
+   *
+   * @param sql the SQL query to validate
+   * @throws InvalidRequestException if the query contains disallowed operations
+   */
+  public void validate(@Nonnull final String sql) {
+    final LogicalPlan plan;
+    try {
+      plan = sparkSession.sessionState().sqlParser().parsePlan(sql);
+    } catch (final Exception e) {
+      throw new InvalidRequestException("Invalid SQL syntax: " + e.getMessage());
+    }
+    walkPlan(plan);
+  }
+
+  /**
+   * Recursively validates a logical plan node and all its children and expressions.
+   *
+   * @param plan the logical plan node to validate
+   */
+  private void walkPlan(@Nonnull final LogicalPlan plan) {
+    validatePlanNode(plan);
+    final List<Expression> expressions = CollectionConverters.asJava(plan.expressions());
+    for (final Expression expr : expressions) {
+      walkExpression(expr);
+    }
+    final List<LogicalPlan> children = CollectionConverters.asJava(plan.children());
+    for (final LogicalPlan child : children) {
+      walkPlan(child);
+    }
+  }
+
+  /**
+   * Recursively validates an expression and all its child expressions. If the expression is a
+   * subquery expression, its inner plan is also validated.
+   *
+   * @param expr the expression to validate
+   */
+  private void walkExpression(@Nonnull final Expression expr) {
+    validateExpression(expr);
+    // Subquery expressions contain an inner logical plan that must also be validated.
+    if (expr instanceof final SubqueryExpression subquery) {
+      walkPlan(subquery.plan());
+    }
+    final List<Expression> children = CollectionConverters.asJava(expr.children());
+    for (final Expression child : children) {
+      walkExpression(child);
+    }
+  }
+
+  /**
+   * Validates that a plan node is in the allowed set.
+   *
+   * @param plan the plan node to validate
+   * @throws InvalidRequestException if the plan node is not allowed
+   */
+  private void validatePlanNode(@Nonnull final LogicalPlan plan) {
+    // All Command subclasses are rejected (DDL, DML, SHOW, DESCRIBE, etc.).
+    if (plan instanceof Command) {
+      throw new InvalidRequestException(
+          "SQL contains a disallowed operation: " + plan.getClass().getSimpleName());
+    }
+    final String className = plan.getClass().getSimpleName();
+    // Scala objects have a trailing '$' in their class name which must be stripped for matching.
+    final String normalised =
+        className.endsWith("$") ? className.substring(0, className.length() - 1) : className;
+    if (!ALLOWED_PLAN_NODES.contains(normalised)) {
+      throw new InvalidRequestException("SQL contains a disallowed plan node: " + className);
+    }
+  }
+
+  /**
+   * Validates that an expression is in the allowed set.
+   *
+   * @param expr the expression to validate
+   * @throws InvalidRequestException if the expression is not allowed
+   */
+  private void validateExpression(@Nonnull final Expression expr) {
+    final String className = expr.getClass().getSimpleName();
+
+    // Check explicitly rejected types first.
+    if (REJECTED_EXPRESSION_NAMES.contains(className)) {
+      throw new InvalidRequestException("SQL contains a disallowed expression: " + className);
+    }
+
+    // Special handling for UnresolvedFunction: validate the function name.
+    if (expr instanceof final UnresolvedFunction unresolvedFunc) {
+      validateFunctionName(unresolvedFunc);
+      return;
+    }
+
+    // Special handling for ScalaUDF: validate against UDF allowlist.
+    if (expr instanceof final ScalaUDF scalaUdf) {
+      validateUdf(scalaUdf);
+      return;
+    }
+
+    // Check against the allowed expression names. Scala objects have a trailing '$' in their
+    // class name which must be stripped for matching.
+    final String normalised =
+        className.endsWith("$") ? className.substring(0, className.length() - 1) : className;
+    if (!ALLOWED_EXPRESSION_NAMES.contains(normalised)) {
+      throw new InvalidRequestException("SQL contains a disallowed expression: " + className);
+    }
+  }
+
+  /**
+   * Validates that an unresolved function is not a known-dangerous function.
+   *
+   * @param func the unresolved function to validate
+   * @throws InvalidRequestException if the function is dangerous
+   */
+  private void validateFunctionName(@Nonnull final UnresolvedFunction func) {
+    final List<String> nameParts = CollectionConverters.asJava(func.nameParts());
+    if (!nameParts.isEmpty()) {
+      final String simpleName = nameParts.getLast().toLowerCase();
+      if (REJECTED_FUNCTION_NAMES.contains(simpleName)) {
+        throw new InvalidRequestException(
+            "SQL contains a disallowed function: " + String.join(".", nameParts));
+      }
+    }
+  }
+
+  /**
+   * Validates that a ScalaUDF is in the Pathling UDF allowlist.
+   *
+   * @param udf the ScalaUDF to validate
+   * @throws InvalidRequestException if the UDF is not in the allowlist
+   */
+  private void validateUdf(@Nonnull final ScalaUDF udf) {
+    final Option<String> nameOpt = udf.udfName();
+    if (nameOpt.isDefined()) {
+      final String name = nameOpt.get();
+      if (!ALLOWED_UDF_NAMES.contains(name)) {
+        throw new InvalidRequestException("SQL contains a disallowed UDF: " + name);
+      }
+    } else {
+      throw new InvalidRequestException("SQL contains an unnamed UDF, which is not allowed");
+    }
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewArtifactReference.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewArtifactReference.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import jakarta.annotation.Nonnull;
+import lombok.Value;
+
+/**
+ * Represents a reference to a ViewDefinition dependency within a SQLQuery Library resource. Each
+ * reference has a label (the table alias used in the SQL) and a canonical URL pointing to the
+ * ViewDefinition.
+ */
+@Value
+public class ViewArtifactReference {
+
+  /** The table alias used in the SQL query to reference this ViewDefinition. */
+  @Nonnull String label;
+
+  /** The canonical URL or relative reference to the ViewDefinition resource. */
+  @Nonnull String canonicalUrl;
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.config.QueryConfiguration;
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.io.source.DataSource;
+import au.csiro.pathling.views.FhirView;
+import au.csiro.pathling.views.FhirViewExecutor;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import jakarta.annotation.Nonnull;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Manages the lifecycle of Spark temporary views for SQL query execution. Each execution registers
+ * ViewDefinition results as temporary views with UUID-prefixed names for thread safety, and drops
+ * them after execution completes.
+ */
+@Slf4j
+@Component
+public class ViewRegistrationService {
+
+  private static final String VIEW_NAME_PREFIX = "sqlquery_";
+
+  @Nonnull private final SparkSession sparkSession;
+
+  @Nonnull private final FhirContext fhirContext;
+
+  @Nonnull private final QueryConfiguration queryConfiguration;
+
+  /**
+   * Constructs a new ViewRegistrationService.
+   *
+   * @param sparkSession the Spark session
+   * @param fhirContext the FHIR context
+   * @param serverConfiguration the server configuration
+   */
+  @Autowired
+  public ViewRegistrationService(
+      @Nonnull final SparkSession sparkSession,
+      @Nonnull final FhirContext fhirContext,
+      @Nonnull final ServerConfiguration serverConfiguration) {
+    this.sparkSession = sparkSession;
+    this.fhirContext = fhirContext;
+    this.queryConfiguration = serverConfiguration.getQuery();
+  }
+
+  /**
+   * Registers resolved ViewDefinitions as Spark temporary views. Each view is given a UUID-prefixed
+   * name to avoid conflicts between concurrent executions.
+   *
+   * @param resolvedViews a map from label (table alias) to the parsed FhirView
+   * @param dataSource the data source to use for view execution
+   * @return a map from original label to the actual temporary view name
+   */
+  @Nonnull
+  public Map<String, String> registerViews(
+      @Nonnull final Map<String, FhirView> resolvedViews, @Nonnull final DataSource dataSource) {
+
+    final String executionId = UUID.randomUUID().toString().replace("-", "");
+    final Map<String, String> labelToViewName = new LinkedHashMap<>();
+
+    for (final Map.Entry<String, FhirView> entry : resolvedViews.entrySet()) {
+      final String label = entry.getKey();
+      final FhirView view = entry.getValue();
+      final String tempViewName = VIEW_NAME_PREFIX + executionId + "_" + label;
+
+      final FhirViewExecutor executor =
+          new FhirViewExecutor(fhirContext, dataSource, queryConfiguration);
+      final Dataset<Row> result;
+      try {
+        result = executor.buildQuery(view);
+      } catch (final Exception e) {
+        // Drop any views that were already registered before failing.
+        dropViews(labelToViewName.values());
+        throw new InvalidRequestException(
+            "Failed to execute ViewDefinition for label '" + label + "': " + e.getMessage());
+      }
+
+      result.createOrReplaceTempView(tempViewName);
+      labelToViewName.put(label, tempViewName);
+      log.debug("Registered temporary view '{}' for label '{}'", tempViewName, label);
+    }
+
+    return labelToViewName;
+  }
+
+  /**
+   * Drops the specified temporary views from the Spark session.
+   *
+   * @param tempViewNames the names of the temporary views to drop
+   */
+  public void dropViews(@Nonnull final Collection<String> tempViewNames) {
+    for (final String viewName : tempViewNames) {
+      try {
+        sparkSession.catalog().dropTempView(viewName);
+        log.debug("Dropped temporary view '{}'", viewName);
+      } catch (final Exception e) {
+        log.warn("Failed to drop temporary view '{}': {}", viewName, e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Rewrites SQL table references to use the prefixed temporary view names. Each label in the SQL
+   * is replaced with the corresponding temporary view name.
+   *
+   * @param sql the original SQL query
+   * @param labelToViewName the mapping from labels to temporary view names
+   * @return the rewritten SQL query
+   */
+  @Nonnull
+  public String rewriteSql(
+      @Nonnull final String sql, @Nonnull final Map<String, String> labelToViewName) {
+
+    String rewritten = sql;
+    // Replace labels in order of longest first to avoid partial replacements.
+    final var sortedEntries =
+        labelToViewName.entrySet().stream()
+            .sorted((a, b) -> Integer.compare(b.getKey().length(), a.getKey().length()))
+            .toList();
+
+    for (final Map.Entry<String, String> entry : sortedEntries) {
+      final String label = entry.getKey();
+      final String viewName = entry.getValue();
+      // Replace word-boundary-delimited occurrences of the label. This handles the label as a
+      // table reference in FROM, JOIN, and subquery contexts.
+      final Pattern pattern = Pattern.compile("\\b" + Pattern.quote(label) + "\\b");
+      final Matcher matcher = pattern.matcher(rewritten);
+      rewritten = matcher.replaceAll(viewName);
+    }
+
+    return rewritten;
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
@@ -25,12 +25,10 @@ import au.csiro.pathling.views.FhirViewExecutor;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import jakarta.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -39,15 +37,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * Manages the lifecycle of Spark temporary views for SQL query execution. Each execution registers
- * ViewDefinition results as temporary views with UUID-prefixed names for thread safety, and drops
- * them after execution completes.
+ * Manages the lifecycle of Spark temporary views for SQL query execution. Views are registered
+ * using the label names from the SQLQuery Library's relatedArtifact entries, so the SQL can
+ * reference them directly. All registered views are dropped after execution completes.
  */
 @Slf4j
 @Component
 public class ViewRegistrationService {
-
-  private static final String VIEW_NAME_PREFIX = "sqlquery_";
 
   @Nonnull private final SparkSession sparkSession;
 
@@ -73,24 +69,22 @@ public class ViewRegistrationService {
   }
 
   /**
-   * Registers resolved ViewDefinitions as Spark temporary views. Each view is given a UUID-prefixed
-   * name to avoid conflicts between concurrent executions.
+   * Registers resolved ViewDefinitions as Spark temporary views. Each view is registered using its
+   * label name directly, so the SQL query can reference it without rewriting.
    *
    * @param resolvedViews a map from label (table alias) to the parsed FhirView
    * @param dataSource the data source to use for view execution
-   * @return a map from original label to the actual temporary view name
+   * @return the list of registered view names (for cleanup)
    */
   @Nonnull
-  public Map<String, String> registerViews(
+  public List<String> registerViews(
       @Nonnull final Map<String, FhirView> resolvedViews, @Nonnull final DataSource dataSource) {
 
-    final String executionId = UUID.randomUUID().toString().replace("-", "");
-    final Map<String, String> labelToViewName = new LinkedHashMap<>();
+    final List<String> registeredViewNames = new ArrayList<>();
 
     for (final Map.Entry<String, FhirView> entry : resolvedViews.entrySet()) {
       final String label = entry.getKey();
       final FhirView view = entry.getValue();
-      final String tempViewName = VIEW_NAME_PREFIX + executionId + "_" + label;
 
       final FhirViewExecutor executor =
           new FhirViewExecutor(fhirContext, dataSource, queryConfiguration);
@@ -99,26 +93,26 @@ public class ViewRegistrationService {
         result = executor.buildQuery(view);
       } catch (final Exception e) {
         // Drop any views that were already registered before failing.
-        dropViews(labelToViewName.values());
+        dropViews(registeredViewNames);
         throw new InvalidRequestException(
             "Failed to execute ViewDefinition for label '" + label + "': " + e.getMessage());
       }
 
-      result.createOrReplaceTempView(tempViewName);
-      labelToViewName.put(label, tempViewName);
-      log.debug("Registered temporary view '{}' for label '{}'", tempViewName, label);
+      result.createOrReplaceTempView(label);
+      registeredViewNames.add(label);
+      log.info("Registered temporary view '{}' for resource type '{}'", label, view.getResource());
     }
 
-    return labelToViewName;
+    return registeredViewNames;
   }
 
   /**
    * Drops the specified temporary views from the Spark session.
    *
-   * @param tempViewNames the names of the temporary views to drop
+   * @param viewNames the names of the temporary views to drop
    */
-  public void dropViews(@Nonnull final Collection<String> tempViewNames) {
-    for (final String viewName : tempViewNames) {
+  public void dropViews(@Nonnull final Collection<String> viewNames) {
+    for (final String viewName : viewNames) {
       try {
         sparkSession.catalog().dropTempView(viewName);
         log.debug("Dropped temporary view '{}'", viewName);
@@ -126,37 +120,5 @@ public class ViewRegistrationService {
         log.warn("Failed to drop temporary view '{}': {}", viewName, e.getMessage());
       }
     }
-  }
-
-  /**
-   * Rewrites SQL table references to use the prefixed temporary view names. Each label in the SQL
-   * is replaced with the corresponding temporary view name.
-   *
-   * @param sql the original SQL query
-   * @param labelToViewName the mapping from labels to temporary view names
-   * @return the rewritten SQL query
-   */
-  @Nonnull
-  public String rewriteSql(
-      @Nonnull final String sql, @Nonnull final Map<String, String> labelToViewName) {
-
-    String rewritten = sql;
-    // Replace labels in order of longest first to avoid partial replacements.
-    final var sortedEntries =
-        labelToViewName.entrySet().stream()
-            .sorted((a, b) -> Integer.compare(b.getKey().length(), a.getKey().length()))
-            .toList();
-
-    for (final Map.Entry<String, String> entry : sortedEntries) {
-      final String label = entry.getKey();
-      final String viewName = entry.getValue();
-      // Replace word-boundary-delimited occurrences of the label. This handles the label as a
-      // table reference in FROM, JOIN, and subquery contexts.
-      final Pattern pattern = Pattern.compile("\\b" + Pattern.quote(label) + "\\b");
-      final Matcher matcher = pattern.matcher(rewritten);
-      rewritten = matcher.replaceAll(viewName);
-    }
-
-    return rewritten;
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
@@ -53,6 +53,8 @@ public class UpdateExecutor {
 
   @Nonnull private final CacheableDatabase cacheableDatabase;
 
+  private final boolean schemaAutoMerge;
+
   /**
    * Constructs a new UpdateExecutor.
    *
@@ -60,17 +62,20 @@ public class UpdateExecutor {
    * @param fhirEncoders encoders for converting FHIR resources to Spark Datasets
    * @param databasePath the path to the Delta database
    * @param cacheableDatabase the cacheable database for cache invalidation
+   * @param schemaAutoMerge whether to enable Delta Lake schema auto-merge during merge operations
    */
   public UpdateExecutor(
       @Nonnull final PathlingContext pathlingContext,
       @Nonnull final FhirEncoders fhirEncoders,
       @Value("${pathling.storage.warehouseUrl}/${pathling.storage.databaseName}") @Nonnull
           final String databasePath,
-      @Nonnull final CacheableDatabase cacheableDatabase) {
+      @Nonnull final CacheableDatabase cacheableDatabase,
+      @Value("${pathling.storage.schemaAutoMerge:false}") final boolean schemaAutoMerge) {
     this.pathlingContext = pathlingContext;
     this.fhirEncoders = fhirEncoders;
     this.databasePath = databasePath;
     this.cacheableDatabase = cacheableDatabase;
+    this.schemaAutoMerge = schemaAutoMerge;
   }
 
   /**
@@ -129,16 +134,27 @@ public class UpdateExecutor {
     final String tablePath = getTablePath(resourceCode);
 
     if (deltaTableExists(spark, tablePath)) {
-      // Perform a merge operation on the existing table.
-      final DeltaTable table = DeltaTable.forPath(spark, tablePath);
-      table
-          .as("original")
-          .merge(updates.as("updates"), "original.id = updates.id")
-          .whenMatched()
-          .updateAll()
-          .whenNotMatched()
-          .insertAll()
-          .execute();
+      if (schemaAutoMerge) {
+        // Enable automatic schema merging so that tables created with an older encoder schema can
+        // accept resources encoded with a newer schema (e.g. additional synthetic fields).
+        spark.conf().set("spark.databricks.delta.schema.autoMerge.enabled", "true");
+      }
+      try {
+        // Perform a merge operation on the existing table.
+        final DeltaTable table = DeltaTable.forPath(spark, tablePath);
+        table
+            .as("original")
+            .merge(updates.as("updates"), "original.id = updates.id")
+            .whenMatched()
+            .updateAll()
+            .whenNotMatched()
+            .insertAll()
+            .execute();
+      } finally {
+        if (schemaAutoMerge) {
+          spark.conf().set("spark.databricks.delta.schema.autoMerge.enabled", "false");
+        }
+      }
     } else {
       // Create a new table with the resources.
       log.debug("Creating new Delta table for resource type: {}", resourceCode);

--- a/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
@@ -135,26 +135,37 @@ public class UpdateExecutor {
 
     if (deltaTableExists(spark, tablePath)) {
       if (schemaAutoMerge) {
-        // Enable automatic schema merging so that tables created with an older encoder schema can
-        // accept resources encoded with a newer schema (e.g. additional synthetic fields).
-        spark.conf().set("spark.databricks.delta.schema.autoMerge.enabled", "true");
+        // Delta's MERGE — even with spark.databricks.delta.schema.autoMerge.enabled=true —
+        // does not support adding new fields to nested structs inside arrays. This is the exact
+        // failure mode when the FHIR encoder gains new value-type columns (e.g. valueDecimal,
+        // valueDecimal_scale inside the extension element struct): the MERGE planner throws
+        // DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION because it cannot cast the richer source struct
+        // to the narrower target struct.
+        //
+        // A regular write with mergeSchema=true DOES support nested-struct field evolution.
+        // Writing limit(0) — zero rows, same schema as the encoder output — causes Delta to add
+        // any missing nested fields to the target table schema (with null for existing rows)
+        // without inserting any data. The MERGE that follows then sees compatible schemas and
+        // succeeds.
+        updates
+            .limit(0)
+            .write()
+            .format("delta")
+            .mode(SaveMode.Append)
+            .option("mergeSchema", "true")
+            .save(tablePath);
       }
-      try {
-        // Perform a merge operation on the existing table.
-        final DeltaTable table = DeltaTable.forPath(spark, tablePath);
-        table
-            .as("original")
-            .merge(updates.as("updates"), "original.id = updates.id")
-            .whenMatched()
-            .updateAll()
-            .whenNotMatched()
-            .insertAll()
-            .execute();
-      } finally {
-        if (schemaAutoMerge) {
-          spark.conf().set("spark.databricks.delta.schema.autoMerge.enabled", "false");
-        }
-      }
+
+      // Perform a merge operation on the existing table.
+      final DeltaTable table = DeltaTable.forPath(spark, tablePath);
+      table
+          .as("original")
+          .merge(updates.as("updates"), "original.id = updates.id")
+          .whenMatched()
+          .updateAll()
+          .whenNotMatched()
+          .insertAll()
+          .execute();
     } else {
       // Create a new table with the resources.
       log.debug("Creating new Delta table for resource type: {}", resourceCode);

--- a/server/src/main/java/au/csiro/pathling/operations/view/ResultStreamingHelper.java
+++ b/server/src/main/java/au/csiro/pathling/operations/view/ResultStreamingHelper.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.view;
+
+import com.google.gson.Gson;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import scala.jdk.javaapi.CollectionConverters;
+
+/**
+ * Shared utility methods for streaming query results in different formats (NDJSON, CSV, JSON). Used
+ * by both {@link ViewExecutionHelper} and the {@code $sqlquery-run} operation.
+ */
+public class ResultStreamingHelper {
+
+  @Nonnull private final Gson gson;
+
+  /**
+   * Constructs a new ResultStreamingHelper.
+   *
+   * @param gson the Gson instance for JSON serialisation
+   */
+  public ResultStreamingHelper(@Nonnull final Gson gson) {
+    this.gson = gson;
+  }
+
+  /**
+   * Writes the CSV header row.
+   *
+   * @param outputStream the output stream to write to
+   * @param columnNames the column names for the header
+   * @throws IOException if writing fails
+   */
+  public void writeCsvHeader(
+      @Nonnull final OutputStream outputStream, @Nonnull final List<String> columnNames)
+      throws IOException {
+    final OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
+    final CSVPrinter printer =
+        new CSVPrinter(
+            writer,
+            CSVFormat.DEFAULT
+                .builder()
+                .setHeader(columnNames.toArray(String[]::new))
+                .setSkipHeaderRecord(false)
+                .build());
+    printer.flush();
+  }
+
+  /**
+   * Streams results as NDJSON.
+   *
+   * @param outputStream the output stream to write to
+   * @param iterator the row iterator
+   * @param schema the result schema
+   * @throws IOException if writing fails
+   */
+  public void streamNdjson(
+      @Nonnull final OutputStream outputStream,
+      @Nonnull final Iterator<Row> iterator,
+      @Nonnull final StructType schema)
+      throws IOException {
+    while (iterator.hasNext()) {
+      final Row row = iterator.next();
+      final String json = rowToJson(row, schema);
+      outputStream.write(json.getBytes(StandardCharsets.UTF_8));
+      outputStream.write('\n');
+      outputStream.flush();
+    }
+  }
+
+  /**
+   * Streams results as CSV. The header is written separately for TTFB optimisation.
+   *
+   * @param outputStream the output stream to write to
+   * @param iterator the row iterator
+   * @param schema the result schema
+   * @throws IOException if writing fails
+   */
+  public void streamCsv(
+      @Nonnull final OutputStream outputStream,
+      @Nonnull final Iterator<Row> iterator,
+      @Nonnull final StructType schema)
+      throws IOException {
+    final OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
+    final CSVPrinter printer = new CSVPrinter(writer, CSVFormat.DEFAULT);
+
+    while (iterator.hasNext()) {
+      final Row row = iterator.next();
+      printer.printRecord(rowToList(row, schema));
+      printer.flush();
+    }
+  }
+
+  /**
+   * Writes results as a single JSON document containing an array. Unlike NDJSON, this cannot be
+   * streamed row-by-row as it requires proper JSON array formatting.
+   *
+   * @param outputStream the output stream to write to
+   * @param iterator the row iterator
+   * @param schema the result schema
+   * @throws IOException if writing fails
+   */
+  public void writeJson(
+      @Nonnull final OutputStream outputStream,
+      @Nonnull final Iterator<Row> iterator,
+      @Nonnull final StructType schema)
+      throws IOException {
+    final List<Map<String, Object>> rows = new ArrayList<>();
+    while (iterator.hasNext()) {
+      final Row row = iterator.next();
+      rows.add(rowToMap(row, schema));
+    }
+    final String json = gson.toJson(rows);
+    outputStream.write(json.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /** Converts a Spark Row to a Map for JSON serialisation. */
+  @Nonnull
+  public Map<String, Object> rowToMap(@Nonnull final Row row, @Nonnull final StructType schema) {
+    final Map<String, Object> map = new LinkedHashMap<>();
+    final StructField[] fields = schema.fields();
+    for (int i = 0; i < fields.length; i++) {
+      final String name = fields[i].name();
+      final Object value = row.get(i);
+      if (value != null) {
+        map.put(name, convertValue(value, fields[i].dataType()));
+      }
+    }
+    return map;
+  }
+
+  /** Converts a Spark Row to a JSON string. */
+  @Nonnull
+  public String rowToJson(@Nonnull final Row row, @Nonnull final StructType schema) {
+    return gson.toJson(rowToMap(row, schema));
+  }
+
+  /** Converts a value for JSON serialisation. */
+  @Nullable
+  public Object convertValue(
+      @Nullable final Object value, @Nonnull final org.apache.spark.sql.types.DataType dataType) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof final Row nestedRow && dataType instanceof final StructType structType) {
+      final Map<String, Object> nested = new LinkedHashMap<>();
+      final StructField[] fields = structType.fields();
+      for (int i = 0; i < fields.length; i++) {
+        final Object nestedValue = nestedRow.get(i);
+        if (nestedValue != null) {
+          nested.put(fields[i].name(), convertValue(nestedValue, fields[i].dataType()));
+        }
+      }
+      return nested;
+    }
+    if (value instanceof final scala.collection.Seq<?> seq) {
+      final List<?> list = CollectionConverters.asJava(seq);
+      if (dataType instanceof final ArrayType arrayType) {
+        return list.stream().map(item -> convertValue(item, arrayType.elementType())).toList();
+      }
+      return list;
+    }
+    return value;
+  }
+
+  /** Converts a Spark Row to a list of values for CSV output. */
+  @Nonnull
+  public List<Object> rowToList(@Nonnull final Row row, @Nonnull final StructType schema) {
+    final List<Object> values = new ArrayList<>();
+    final StructField[] fields = schema.fields();
+    for (int i = 0; i < fields.length; i++) {
+      final Object value = row.get(i);
+      values.add(convertValueForCsv(value, fields[i].dataType()));
+    }
+    return values;
+  }
+
+  /** Converts a value for CSV output. */
+  @Nullable
+  public Object convertValueForCsv(
+      @Nullable final Object value, @Nonnull final org.apache.spark.sql.types.DataType dataType) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Row || value instanceof scala.collection.Seq<?>) {
+      return gson.toJson(convertValue(value, dataType));
+    }
+    return value;
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/view/ViewExecutionHelper.java
+++ b/server/src/main/java/au/csiro/pathling/operations/view/ViewExecutionHelper.java
@@ -42,23 +42,16 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.ConstraintViolationException;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.types.ArrayType;
-import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.BooleanType;
@@ -67,7 +60,6 @@ import org.hl7.fhir.r4.model.InstantType;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import scala.jdk.javaapi.CollectionConverters;
 
 /**
  * Helper class for executing ViewDefinition queries. Contains shared logic used by both {@link
@@ -94,6 +86,8 @@ public class ViewExecutionHelper {
   @Nonnull private final ServerConfiguration serverConfiguration;
 
   @Nonnull private final Gson gson;
+
+  @Nonnull private final ResultStreamingHelper streamingHelper;
 
   /**
    * Constructs a new ViewExecutionHelper.
@@ -123,6 +117,7 @@ public class ViewExecutionHelper {
     this.groupMemberService = groupMemberService;
     this.serverConfiguration = serverConfiguration;
     this.gson = ViewDefinitionGson.create();
+    this.streamingHelper = new ResultStreamingHelper(gson);
   }
 
   /**
@@ -188,7 +183,7 @@ public class ViewExecutionHelper {
 
       // For CSV with header, write header immediately to minimise TTFB.
       if (outputFormat == ViewOutputFormat.CSV && shouldIncludeHeader) {
-        writeCsvHeader(outputStream, columnNames);
+        streamingHelper.writeCsvHeader(outputStream, columnNames);
         outputStream.flush();
       }
 
@@ -234,9 +229,9 @@ public class ViewExecutionHelper {
     final Iterator<Row> iterator = result.toLocalIterator();
 
     switch (outputFormat) {
-      case NDJSON -> streamNdjson(outputStream, iterator, schema);
-      case JSON -> writeJson(outputStream, iterator, schema);
-      default -> streamCsv(outputStream, iterator, schema);
+      case NDJSON -> streamingHelper.streamNdjson(outputStream, iterator, schema);
+      case JSON -> streamingHelper.writeJson(outputStream, iterator, schema);
+      default -> streamingHelper.streamCsv(outputStream, iterator, schema);
     }
   }
 
@@ -343,147 +338,13 @@ public class ViewExecutionHelper {
         });
   }
 
-  /** Writes the CSV header row. */
-  private void writeCsvHeader(
-      @Nonnull final OutputStream outputStream, @Nonnull final List<String> columnNames)
-      throws IOException {
-    final OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
-    final CSVPrinter printer =
-        new CSVPrinter(
-            writer,
-            CSVFormat.DEFAULT
-                .builder()
-                .setHeader(columnNames.toArray(String[]::new))
-                .setSkipHeaderRecord(false)
-                .build());
-    printer.flush();
-    // Don't close the printer as we need to keep the stream open.
-  }
-
-  /** Streams results as NDJSON. */
-  private void streamNdjson(
-      @Nonnull final OutputStream outputStream,
-      @Nonnull final Iterator<Row> iterator,
-      @Nonnull final StructType schema)
-      throws IOException {
-    while (iterator.hasNext()) {
-      final Row row = iterator.next();
-      final String json = rowToJson(row, schema);
-      outputStream.write(json.getBytes(StandardCharsets.UTF_8));
-      outputStream.write('\n');
-      outputStream.flush();
-    }
-  }
-
-  /** Streams results as CSV. The header is written separately for TTFB optimisation. */
-  private void streamCsv(
-      @Nonnull final OutputStream outputStream,
-      @Nonnull final Iterator<Row> iterator,
-      @Nonnull final StructType schema)
-      throws IOException {
-    final OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
-    // Header was already written for TTFB optimisation, so always use DEFAULT (no header).
-    final CSVPrinter printer = new CSVPrinter(writer, CSVFormat.DEFAULT);
-
-    while (iterator.hasNext()) {
-      final Row row = iterator.next();
-      printer.printRecord(rowToList(row, schema));
-      printer.flush();
-    }
-  }
-
   /**
-   * Writes results as a single JSON document containing an array. Unlike NDJSON, this cannot be
-   * streamed row-by-row as it requires proper JSON array formatting.
+   * Returns the result streaming helper for use by other components.
+   *
+   * @return the result streaming helper
    */
-  private void writeJson(
-      @Nonnull final OutputStream outputStream,
-      @Nonnull final Iterator<Row> iterator,
-      @Nonnull final StructType schema)
-      throws IOException {
-    final List<Map<String, Object>> rows = new ArrayList<>();
-    while (iterator.hasNext()) {
-      final Row row = iterator.next();
-      rows.add(rowToMap(row, schema));
-    }
-    final String json = gson.toJson(rows);
-    outputStream.write(json.getBytes(StandardCharsets.UTF_8));
-  }
-
-  /** Converts a Spark Row to a Map for JSON serialisation. */
   @Nonnull
-  private Map<String, Object> rowToMap(@Nonnull final Row row, @Nonnull final StructType schema) {
-    final Map<String, Object> map = new LinkedHashMap<>();
-    final StructField[] fields = schema.fields();
-    for (int i = 0; i < fields.length; i++) {
-      final String name = fields[i].name();
-      final Object value = row.get(i);
-      if (value != null) {
-        map.put(name, convertValue(value, fields[i].dataType()));
-      }
-    }
-    return map;
-  }
-
-  /** Converts a Spark Row to a JSON string. */
-  @Nonnull
-  private String rowToJson(@Nonnull final Row row, @Nonnull final StructType schema) {
-    return gson.toJson(rowToMap(row, schema));
-  }
-
-  /** Converts a value for JSON serialisation. */
-  @Nullable
-  private Object convertValue(
-      @Nullable final Object value, @Nonnull final org.apache.spark.sql.types.DataType dataType) {
-    if (value == null) {
-      return null;
-    }
-    // Handle nested struct.
-    if (value instanceof final Row nestedRow && dataType instanceof final StructType structType) {
-      final Map<String, Object> nested = new LinkedHashMap<>();
-      final StructField[] fields = structType.fields();
-      for (int i = 0; i < fields.length; i++) {
-        final Object nestedValue = nestedRow.get(i);
-        if (nestedValue != null) {
-          nested.put(fields[i].name(), convertValue(nestedValue, fields[i].dataType()));
-        }
-      }
-      return nested;
-    }
-    // Handle array.
-    if (value instanceof final scala.collection.Seq<?> seq) {
-      final List<?> list = CollectionConverters.asJava(seq);
-      if (dataType instanceof final ArrayType arrayType) {
-        return list.stream().map(item -> convertValue(item, arrayType.elementType())).toList();
-      }
-      return list;
-    }
-    return value;
-  }
-
-  /** Converts a Spark Row to a list of values for CSV output. */
-  @Nonnull
-  private List<Object> rowToList(@Nonnull final Row row, @Nonnull final StructType schema) {
-    final List<Object> values = new ArrayList<>();
-    final StructField[] fields = schema.fields();
-    for (int i = 0; i < fields.length; i++) {
-      final Object value = row.get(i);
-      values.add(convertValueForCsv(value, fields[i].dataType()));
-    }
-    return values;
-  }
-
-  /** Converts a value for CSV output. */
-  @Nullable
-  private Object convertValueForCsv(
-      @Nullable final Object value, @Nonnull final org.apache.spark.sql.types.DataType dataType) {
-    if (value == null) {
-      return null;
-    }
-    if (value instanceof Row || value instanceof scala.collection.Seq<?>) {
-      // For complex types in CSV, serialise as JSON.
-      return gson.toJson(convertValue(value, dataType));
-    }
-    return value;
+  public ResultStreamingHelper getStreamingHelper() {
+    return streamingHelper;
   }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -53,6 +53,11 @@ pathling:
     # prevents large numbers of small updates causing poor subsequent query performance.
     compactionThreshold: 10
 
+    # When enabled, Delta Lake merge operations will automatically evolve the table schema to
+    # accommodate new columns present in the incoming data. This is useful when the FHIR encoder
+    # adds new fields (e.g. synthetic columns) that are not yet present in an existing table.
+    schemaAutoMerge: false
+
   query:
     # Setting this option to true will enable additional logging relating to the query plan used to
     # execute queries.

--- a/server/src/main/resources/examples/sqlquery-run-examples.md
+++ b/server/src/main/resources/examples/sqlquery-run-examples.md
@@ -1,0 +1,486 @@
+# $sqlquery-run Operation Examples
+
+These examples demonstrate the `$sqlquery-run` operation alongside the
+existing `$viewdefinition-run` operation. They use a small synthetic dataset
+of Patients and Conditions.
+
+## Prerequisites
+
+Start the server with a writable warehouse directory:
+
+```bash
+WAREHOUSE_DIR=$(mktemp -d)/warehouse
+mkdir -p "$WAREHOUSE_DIR"
+
+PATHLING_STORAGE_WAREHOUSEURL="file://${WAREHOUSE_DIR}" \
+PATHLING_STORAGE_DATABASENAME="default" \
+mvn spring-boot:run
+```
+
+## 1. Load Test Data
+
+### Patients
+
+```bash
+for p in \
+  '{"resourceType":"Patient","id":"pat-1","gender":"male","birthDate":"1990-05-15","name":[{"use":"official","family":"Smith","given":["John"]}]}' \
+  '{"resourceType":"Patient","id":"pat-2","gender":"female","birthDate":"1985-11-22","name":[{"use":"official","family":"Johnson","given":["Jane"]}]}' \
+  '{"resourceType":"Patient","id":"pat-3","gender":"male","birthDate":"2000-03-08","name":[{"use":"official","family":"Williams","given":["Bob"]}]}' \
+  '{"resourceType":"Patient","id":"pat-4","gender":"female","birthDate":"1978-07-30","name":[{"use":"official","family":"Brown","given":["Alice"]}]}' \
+  '{"resourceType":"Patient","id":"pat-5","gender":"male","birthDate":"1995-12-01","name":[{"use":"official","family":"Davis","given":["Charlie"]}]}'
+do
+  id=$(echo "$p" | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+  curl -s -o /dev/null -w "Patient/$id: %{http_code}\n" \
+    -X PUT "http://localhost:8080/fhir/Patient/$id" \
+    -H "Content-Type: application/fhir+json" -d "$p"
+done
+```
+
+### Conditions
+
+```bash
+for c in \
+  '{"resourceType":"Condition","id":"cnd-1","subject":{"reference":"Patient/pat-1"},"code":{"coding":[{"system":"http://snomed.info/sct","code":"73211009","display":"Diabetes mellitus"}]},"onsetDateTime":"2015-03-12"}' \
+  '{"resourceType":"Condition","id":"cnd-2","subject":{"reference":"Patient/pat-1"},"code":{"coding":[{"system":"http://snomed.info/sct","code":"38341003","display":"Hypertension"}]},"onsetDateTime":"2018-06-01"}' \
+  '{"resourceType":"Condition","id":"cnd-3","subject":{"reference":"Patient/pat-2"},"code":{"coding":[{"system":"http://snomed.info/sct","code":"195967001","display":"Asthma"}]},"onsetDateTime":"2010-09-20"}' \
+  '{"resourceType":"Condition","id":"cnd-4","subject":{"reference":"Patient/pat-3"},"code":{"coding":[{"system":"http://snomed.info/sct","code":"73211009","display":"Diabetes mellitus"}]},"onsetDateTime":"2020-01-15"}' \
+  '{"resourceType":"Condition","id":"cnd-5","subject":{"reference":"Patient/pat-4"},"code":{"coding":[{"system":"http://snomed.info/sct","code":"38341003","display":"Hypertension"}]},"onsetDateTime":"2012-11-30"}' \
+  '{"resourceType":"Condition","id":"cnd-6","subject":{"reference":"Patient/pat-5"},"code":{"coding":[{"system":"http://snomed.info/sct","code":"195967001","display":"Asthma"}]},"onsetDateTime":"2019-04-10"}'
+do
+  id=$(echo "$c" | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+  curl -s -o /dev/null -w "Condition/$id: %{http_code}\n" \
+    -X PUT "http://localhost:8080/fhir/Condition/$id" \
+    -H "Content-Type: application/fhir+json" -d "$c"
+done
+```
+
+### ViewDefinitions
+
+Create a Patient ViewDefinition:
+
+```bash
+curl -s -X POST "http://localhost:8080/fhir/ViewDefinition" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "ViewDefinition",
+    "name": "patients",
+    "resource": "Patient",
+    "select": [
+      {
+        "column": [
+          {"path": "id", "name": "patient_id"},
+          {"path": "gender", "name": "gender"},
+          {"path": "birthDate", "name": "birth_date"}
+        ]
+      },
+      {
+        "forEach": "name.where(use = '\''official'\'')",
+        "column": [
+          {"path": "family", "name": "family_name"},
+          {"path": "given.first()", "name": "given_name"}
+        ]
+      }
+    ]
+  }'
+```
+
+Create a Condition ViewDefinition:
+
+```bash
+curl -s -X POST "http://localhost:8080/fhir/ViewDefinition" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "ViewDefinition",
+    "name": "conditions",
+    "resource": "Condition",
+    "select": [
+      {
+        "column": [
+          {"path": "id", "name": "condition_id"},
+          {"path": "subject.reference", "name": "patient_ref"},
+          {"path": "code.coding.first().code", "name": "snomed_code"},
+          {"path": "code.coding.first().display", "name": "condition_name"},
+          {"path": "onsetDateTime", "name": "onset_date"}
+        ]
+      }
+    ]
+  }'
+```
+
+Note the IDs returned in the responses. Replace `<PATIENT_VD_ID>` and
+`<CONDITION_VD_ID>` in the examples below with these values. You can also
+look them up:
+
+```bash
+curl -s "http://localhost:8080/fhir/ViewDefinition?_count=10" \
+  -H "Accept: application/fhir+json" | python3 -m json.tool
+```
+
+## 2. $viewdefinition-run Examples
+
+### Instance-level $run on a stored ViewDefinition
+
+```bash
+curl -s "http://localhost:8080/fhir/ViewDefinition/<PATIENT_VD_ID>/\$run" \
+  -H "Accept: application/x-ndjson"
+```
+
+Expected output (NDJSON):
+
+```
+{"patient_id":"pat-1","gender":"male","birth_date":"1990-05-15","family_name":"Smith","given_name":"John"}
+{"patient_id":"pat-2","gender":"female","birth_date":"1985-11-22","family_name":"Johnson","given_name":"Jane"}
+{"patient_id":"pat-3","gender":"male","birth_date":"2000-03-08","family_name":"Williams","given_name":"Bob"}
+{"patient_id":"pat-4","gender":"female","birth_date":"1978-07-30","family_name":"Brown","given_name":"Alice"}
+{"patient_id":"pat-5","gender":"male","birth_date":"1995-12-01","family_name":"Davis","given_name":"Charlie"}
+```
+
+### Stored Condition ViewDefinition as CSV
+
+```bash
+curl -s "http://localhost:8080/fhir/ViewDefinition/<CONDITION_VD_ID>/\$run?_format=csv"
+```
+
+Expected output:
+
+```
+condition_id,patient_ref,snomed_code,condition_name,onset_date
+cnd-1,Patient/pat-1,73211009,Diabetes mellitus,2015-03-12
+cnd-2,Patient/pat-1,38341003,Hypertension,2018-06-01
+cnd-3,Patient/pat-2,195967001,Asthma,2010-09-20
+cnd-4,Patient/pat-3,73211009,Diabetes mellitus,2020-01-15
+cnd-5,Patient/pat-4,38341003,Hypertension,2012-11-30
+cnd-6,Patient/pat-5,195967001,Asthma,2019-04-10
+```
+
+### Inline ViewDefinition with inline resources (no stored data needed)
+
+```bash
+curl -s -X POST "http://localhost:8080/fhir/\$viewdefinition-run" \
+  -H "Content-Type: application/fhir+json" \
+  -H "Accept: application/x-ndjson" \
+  -d '{
+    "resourceType": "Parameters",
+    "parameter": [
+      {
+        "name": "viewResource",
+        "resource": {
+          "resourceType": "ViewDefinition",
+          "name": "patient_demographics",
+          "resource": "Patient",
+          "select": [
+            {
+              "column": [
+                {"path": "id", "name": "patient_id"},
+                {"path": "gender", "name": "gender"},
+                {"path": "birthDate", "name": "birth_date"}
+              ]
+            },
+            {
+              "forEach": "name.where(use = '\''official'\'')",
+              "column": [
+                {"path": "family", "name": "family_name"},
+                {"path": "given.first()", "name": "given_name"}
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "name": "resource",
+        "valueString": "{\"resourceType\":\"Patient\",\"id\":\"p1\",\"gender\":\"male\",\"birthDate\":\"1990-05-15\",\"name\":[{\"use\":\"official\",\"family\":\"Smith\",\"given\":[\"John\"]}]}"
+      },
+      {
+        "name": "resource",
+        "valueString": "{\"resourceType\":\"Patient\",\"id\":\"p2\",\"gender\":\"female\",\"birthDate\":\"1985-11-22\",\"name\":[{\"use\":\"official\",\"family\":\"Johnson\",\"given\":[\"Jane\"]}]}"
+      }
+    ]
+  }'
+```
+
+## 3. $sqlquery-run Examples
+
+The `$sqlquery-run` operation takes a Library resource conforming to the
+SQLQuery profile. The Library contains Base64-encoded SQL in its `content`,
+and references stored ViewDefinitions via `relatedArtifact`. The `label` on
+each artifact becomes the table name used in the SQL.
+
+### JOIN patients with conditions
+
+SQL:
+
+```sql
+SELECT p.given_name, p.family_name, p.gender, p.birth_date,
+       c.condition_name, c.onset_date
+FROM patients p
+JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref
+ORDER BY p.family_name, c.onset_date
+```
+
+```bash
+SQL="SELECT p.given_name, p.family_name, p.gender, p.birth_date, c.condition_name, c.onset_date FROM patients p JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref ORDER BY p.family_name, c.onset_date"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": [
+          {\"type\": \"depends-on\", \"label\": \"patients\", \"resource\": \"ViewDefinition/<PATIENT_VD_ID>\"},
+          {\"type\": \"depends-on\", \"label\": \"conditions\", \"resource\": \"ViewDefinition/<CONDITION_VD_ID>\"}
+        ]
+      }
+    }]
+  }"
+```
+
+Expected output:
+
+```
+given_name,family_name,gender,birth_date,condition_name,onset_date
+Alice,Brown,female,1978-07-30,Hypertension,2012-11-30
+Charlie,Davis,male,1995-12-01,Asthma,2019-04-10
+Jane,Johnson,female,1985-11-22,Asthma,2010-09-20
+John,Smith,male,1990-05-15,Diabetes mellitus,2015-03-12
+John,Smith,male,1990-05-15,Hypertension,2018-06-01
+Bob,Williams,male,2000-03-08,Diabetes mellitus,2020-01-15
+```
+
+### Aggregate: patients per condition
+
+SQL:
+
+```sql
+SELECT c.condition_name, count(*) AS patient_count
+FROM conditions c
+GROUP BY c.condition_name
+ORDER BY patient_count DESC
+```
+
+```bash
+SQL="SELECT c.condition_name, count(*) AS patient_count FROM conditions c GROUP BY c.condition_name ORDER BY patient_count DESC"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": [
+          {\"type\": \"depends-on\", \"label\": \"conditions\", \"resource\": \"ViewDefinition/<CONDITION_VD_ID>\"}
+        ]
+      }
+    }]
+  }"
+```
+
+Expected output:
+
+```
+condition_name,patient_count
+Diabetes mellitus,2
+Hypertension,2
+Asthma,2
+```
+
+### Aggregate: condition count per patient
+
+SQL:
+
+```sql
+SELECT p.given_name, p.family_name,
+       count(*) AS condition_count
+FROM patients p
+JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref
+GROUP BY p.given_name, p.family_name
+ORDER BY condition_count DESC
+```
+
+```bash
+SQL="SELECT p.given_name, p.family_name, count(*) AS condition_count FROM patients p JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref GROUP BY p.given_name, p.family_name ORDER BY condition_count DESC"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": [
+          {\"type\": \"depends-on\", \"label\": \"patients\", \"resource\": \"ViewDefinition/<PATIENT_VD_ID>\"},
+          {\"type\": \"depends-on\", \"label\": \"conditions\", \"resource\": \"ViewDefinition/<CONDITION_VD_ID>\"}
+        ]
+      }
+    }]
+  }"
+```
+
+Expected output:
+
+```
+given_name,family_name,condition_count
+John,Smith,2
+Jane,Johnson,1
+Alice,Brown,1
+Charlie,Davis,1
+Bob,Williams,1
+```
+
+### Aggregate: patients by age group and condition type
+
+SQL:
+
+```sql
+SELECT
+  CASE
+    WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 30 THEN '0-29'
+    WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 50 THEN '30-49'
+    WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 70 THEN '50-69'
+    ELSE '70+'
+  END AS age_group,
+  c.condition_name,
+  count(DISTINCT p.patient_id) AS patient_count
+FROM patients p
+JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref
+GROUP BY age_group, c.condition_name
+ORDER BY age_group, c.condition_name
+```
+
+```bash
+SQL="SELECT CASE WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 30 THEN '0-29' WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 50 THEN '30-49' WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 70 THEN '50-69' ELSE '70+' END AS age_group, c.condition_name, count(DISTINCT p.patient_id) AS patient_count FROM patients p JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref GROUP BY age_group, c.condition_name ORDER BY age_group, c.condition_name"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": [
+          {\"type\": \"depends-on\", \"label\": \"patients\", \"resource\": \"ViewDefinition/<PATIENT_VD_ID>\"},
+          {\"type\": \"depends-on\", \"label\": \"conditions\", \"resource\": \"ViewDefinition/<CONDITION_VD_ID>\"}
+        ]
+      }
+    }]
+  }"
+```
+
+### Simple query against a single view (NDJSON output)
+
+```bash
+SQL="SELECT patient_id, given_name, family_name FROM patients LIMIT 3"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run" \
+  -H "Content-Type: application/fhir+json" \
+  -H "Accept: application/x-ndjson" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": [
+          {\"type\": \"depends-on\", \"label\": \"patients\", \"resource\": \"ViewDefinition/<PATIENT_VD_ID>\"}
+        ]
+      }
+    }]
+  }"
+```
+
+### JSON output format
+
+```bash
+SQL="SELECT condition_name, onset_date FROM conditions ORDER BY onset_date"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=json" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": [
+          {\"type\": \"depends-on\", \"label\": \"conditions\", \"resource\": \"ViewDefinition/<CONDITION_VD_ID>\"}
+        ]
+      }
+    }]
+  }"
+```
+
+### SQL validation: DDL/DML rejected
+
+```bash
+SQL="DROP TABLE conditions"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": []
+      }
+    }]
+  }"
+```
+
+Expected: 400 error with `"SQL contains a disallowed operation"`.

--- a/server/src/main/resources/examples/start-demo.sh
+++ b/server/src/main/resources/examples/start-demo.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+#
+# Starts the Pathling server with a temporary warehouse and loads test data
+# for demonstrating the $viewdefinition-run and $sqlquery-run operations.
+#
+# Usage (from any directory within the repository):
+#   ./server/src/main/resources/examples/start-demo.sh
+#
+# The script will print the ViewDefinition IDs needed for the $sqlquery-run
+# examples in sqlquery-run-examples.md.
+
+set -euo pipefail
+
+BASE_URL="http://localhost:8080/fhir"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Resolve the server module directory (four levels up from examples/).
+SERVER_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+cd "$SERVER_DIR"
+echo "Working directory: $(pwd)"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+wait_for_server() {
+  echo "Waiting for server..."
+  for i in $(seq 1 40); do
+    if curl -sf -o /dev/null "$BASE_URL/metadata" 2>/dev/null; then
+      echo "Server is ready."
+      return 0
+    fi
+    sleep 2
+  done
+  echo "ERROR: Server did not start within 80 seconds." >&2
+  exit 1
+}
+
+post_resource() {
+  local type="$1" body="$2"
+  curl -s -X POST "$BASE_URL/$type" \
+    -H "Content-Type: application/fhir+json" \
+    -d "$body"
+}
+
+# ── generate NDJSON test data ────────────────────────────────────────────────
+
+DATA_DIR="$(mktemp -d)"
+echo "Generating test data in $DATA_DIR ..."
+
+python3 << PYEOF
+import json, random
+
+DATA_DIR = "$DATA_DIR"
+PATIENT_COUNT = 1000
+random.seed(42)
+
+FAMILIES = [
+    "Smith", "Johnson", "Williams", "Brown", "Davis", "Miller", "Wilson",
+    "Moore", "Taylor", "Anderson", "Thomas", "Jackson", "White", "Harris",
+    "Martin", "Thompson", "Garcia", "Martinez", "Robinson", "Clark",
+    "Rodriguez", "Lewis", "Lee", "Walker", "Hall", "Allen", "Young",
+    "King", "Wright", "Scott", "Green", "Baker", "Adams", "Nelson",
+    "Hill", "Ramirez", "Campbell", "Mitchell", "Roberts", "Carter",
+]
+GIVENS_MALE = [
+    "James", "John", "Robert", "Michael", "David", "William", "Richard",
+    "Joseph", "Thomas", "Charles", "Daniel", "Matthew", "Anthony", "Mark",
+    "Steven", "Paul", "Andrew", "Joshua", "Kenneth", "Kevin",
+]
+GIVENS_FEMALE = [
+    "Mary", "Patricia", "Jennifer", "Linda", "Barbara", "Elizabeth",
+    "Susan", "Jessica", "Sarah", "Karen", "Lisa", "Nancy", "Betty",
+    "Margaret", "Sandra", "Ashley", "Emily", "Donna", "Michelle", "Carol",
+]
+CONDITIONS = [
+    {"code": "73211009", "display": "Diabetes mellitus"},
+    {"code": "38341003", "display": "Hypertension"},
+    {"code": "195967001", "display": "Asthma"},
+]
+# Every 5 patients: pat0 gets 2 conditions, the rest get 1 each.
+CONDITION_PATTERN = [
+    [CONDITIONS[0], CONDITIONS[1]],
+    [CONDITIONS[2]],
+    [CONDITIONS[0]],
+    [CONDITIONS[1]],
+    [CONDITIONS[2]],
+]
+
+def random_date(lo, hi):
+    return f"{random.randint(lo,hi):04d}-{random.randint(1,12):02d}-{random.randint(1,28):02d}"
+
+cond_idx = 0
+with open(f"{DATA_DIR}/Patient.ndjson", "w") as pf, \
+     open(f"{DATA_DIR}/Condition.ndjson", "w") as cf:
+    for i in range(PATIENT_COUNT):
+        pid = f"pat-{i+1:04d}"
+        gender = "male" if i % 2 == 0 else "female"
+        givens = GIVENS_MALE if gender == "male" else GIVENS_FEMALE
+        pf.write(json.dumps({
+            "resourceType": "Patient", "id": pid, "gender": gender,
+            "birthDate": random_date(1950, 2005),
+            "name": [{"use": "official",
+                       "family": FAMILIES[i % len(FAMILIES)],
+                       "given": [givens[i % len(givens)]]}],
+        }) + "\n")
+        for cond in CONDITION_PATTERN[i % len(CONDITION_PATTERN)]:
+            cond_idx += 1
+            cid = f"cnd-{cond_idx:04d}"
+            cf.write(json.dumps({
+                "resourceType": "Condition", "id": cid,
+                "subject": {"reference": f"Patient/{pid}"},
+                "code": {"coding": [{"system": "http://snomed.info/sct",
+                                      "code": cond["code"],
+                                      "display": cond["display"]}]},
+                "onsetDateTime": random_date(2005, 2025),
+            }) + "\n")
+
+print(f"  Generated {PATIENT_COUNT} patients, {cond_idx} conditions")
+PYEOF
+
+echo "  Patient.ndjson:   $(wc -l < "$DATA_DIR/Patient.ndjson") lines"
+echo "  Condition.ndjson: $(wc -l < "$DATA_DIR/Condition.ndjson") lines"
+
+# ── start server ─────────────────────────────────────────────────────────────
+
+WAREHOUSE_DIR="$(mktemp -d)/warehouse"
+mkdir -p "$WAREHOUSE_DIR"
+echo ""
+echo "Warehouse: $WAREHOUSE_DIR"
+
+export PATHLING_STORAGE_WAREHOUSEURL="file://$WAREHOUSE_DIR"
+export PATHLING_STORAGE_DATABASENAME="default"
+export PATHLING_IMPORT_ALLOWABLESOURCES="file://$DATA_DIR"
+
+echo "Starting Pathling server..."
+mvn -q spring-boot:run \
+  -Dspring-boot.run.jvmArguments="--add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -XX:ReservedCodeCacheSize=256m" \
+  &
+SERVER_PID=$!
+trap 'echo "Stopping server (PID $SERVER_PID)..."; kill $SERVER_PID 2>/dev/null; wait $SERVER_PID 2>/dev/null; rm -rf "$DATA_DIR"' EXIT
+
+wait_for_server
+
+# ── bulk import via $import ──────────────────────────────────────────────────
+
+echo ""
+echo "=== Importing test data via \$import ==="
+
+IMPORT_RESPONSE=$(curl -s -D- -X POST "$BASE_URL/\$import" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/fhir+json" \
+  -H "Prefer: respond-async" \
+  -d "{
+    \"inputFormat\": \"application/fhir+ndjson\",
+    \"inputSource\": \"file://$DATA_DIR\",
+    \"input\": [
+      {\"type\": \"Patient\", \"url\": \"file://$DATA_DIR/Patient.ndjson\"},
+      {\"type\": \"Condition\", \"url\": \"file://$DATA_DIR/Condition.ndjson\"}
+    ]
+  }")
+
+JOB_URL=$(echo "$IMPORT_RESPONSE" | grep -i "^Content-Location:" | tr -d '\r' | awk '{print $2}')
+if [ -z "$JOB_URL" ]; then
+  echo "ERROR: Import request failed." >&2
+  echo "$IMPORT_RESPONSE"
+  exit 1
+fi
+echo "  Import job: $JOB_URL"
+
+# Poll the job until it completes.
+echo "  Waiting for import to complete..."
+for i in $(seq 1 60); do
+  sleep 2
+  JOB_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$JOB_URL" -H "Accept: application/fhir+json")
+  if [ "$JOB_STATUS" = "200" ]; then
+    echo "  Import complete."
+    break
+  elif [ "$JOB_STATUS" = "202" ]; then
+    # Still processing.
+    :
+  else
+    echo "  Import failed (HTTP $JOB_STATUS):"
+    curl -s "$JOB_URL" -H "Accept: application/fhir+json"
+    exit 1
+  fi
+done
+
+# ── create view definitions ──────────────────────────────────────────────────
+
+echo ""
+echo "=== Creating ViewDefinitions ==="
+
+PATIENT_VD=$(post_resource ViewDefinition '{
+  "resourceType": "ViewDefinition",
+  "name": "patients",
+  "resource": "Patient",
+  "select": [
+    {
+      "column": [
+        {"path": "id", "name": "patient_id"},
+        {"path": "gender", "name": "gender"},
+        {"path": "birthDate", "name": "birth_date"}
+      ]
+    },
+    {
+      "forEach": "name.where(use = '\''official'\'')",
+      "column": [
+        {"path": "family", "name": "family_name"},
+        {"path": "given.first()", "name": "given_name"}
+      ]
+    }
+  ]
+}')
+PATIENT_VD_ID=$(echo "$PATIENT_VD" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id','UNKNOWN'))")
+echo "  patients ViewDefinition: $PATIENT_VD_ID"
+
+CONDITION_VD=$(post_resource ViewDefinition '{
+  "resourceType": "ViewDefinition",
+  "name": "conditions",
+  "resource": "Condition",
+  "select": [
+    {
+      "column": [
+        {"path": "id", "name": "condition_id"},
+        {"path": "subject.reference", "name": "patient_ref"},
+        {"path": "code.coding.first().code", "name": "snomed_code"},
+        {"path": "code.coding.first().display", "name": "condition_name"},
+        {"path": "onsetDateTime", "name": "onset_date"}
+      ]
+    }
+  ]
+}')
+CONDITION_VD_ID=$(echo "$CONDITION_VD" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id','UNKNOWN'))")
+echo "  conditions ViewDefinition: $CONDITION_VD_ID"
+
+# ── summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "============================================================"
+echo "  Demo server ready at $BASE_URL"
+echo ""
+echo "  Patients ViewDefinition ID:   $PATIENT_VD_ID"
+echo "  Conditions ViewDefinition ID: $CONDITION_VD_ID"
+echo ""
+echo "  Replace <PATIENT_VD_ID> and <CONDITION_VD_ID> in the"
+echo "  examples in sqlquery-run-examples.md with the IDs above."
+echo ""
+echo "  Press Ctrl+C to stop the server."
+echo "============================================================"
+echo ""
+
+# Keep the script alive until the user kills it.
+wait $SERVER_PID

--- a/server/src/main/resources/fhir/sqlquery-run.OperationDefinition.json
+++ b/server/src/main/resources/fhir/sqlquery-run.OperationDefinition.json
@@ -1,0 +1,83 @@
+{
+  "resourceType": "OperationDefinition",
+  "name": "sqlquery-run",
+  "title": "Pathling SQLQuery Run Operation",
+  "status": "active",
+  "kind": "operation",
+  "experimental": false,
+  "publisher": "Australian e-Health Research Centre, CSIRO",
+  "description": "This operation executes a SQL query against materialised ViewDefinition tables within the Pathling server. The query is provided as a Library resource conforming to the SQLQuery profile from the SQL on FHIR v2 specification.",
+  "affectsState": false,
+  "code": "sqlquery-run",
+  "system": true,
+  "type": true,
+  "instance": true,
+  "resource": ["Library"],
+  "parameter": [
+    {
+      "name": "queryResource",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "documentation": "An inline Library resource conforming to the SQLQuery profile. Contains the SQL query, ViewDefinition dependencies, and parameter declarations.",
+      "type": "Resource"
+    },
+    {
+      "name": "queryReference",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "documentation": "A reference to a stored Library resource conforming to the SQLQuery profile.",
+      "type": "Reference"
+    },
+    {
+      "name": "_format",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "documentation": "The output format for the query results. Supported values are 'ndjson' (default), 'csv', 'json', and 'parquet'.",
+      "type": "code"
+    },
+    {
+      "name": "header",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "documentation": "For CSV output, whether to include a header row. Defaults to true.",
+      "type": "boolean"
+    },
+    {
+      "name": "_limit",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "documentation": "Maximum number of rows to return in the result.",
+      "type": "integer"
+    },
+    {
+      "name": "parameter",
+      "use": "in",
+      "min": 0,
+      "max": "*",
+      "documentation": "Query parameter values to bind to the SQL query. Each parameter has a name and a value.",
+      "part": [
+        {
+          "name": "name",
+          "use": "in",
+          "min": 1,
+          "max": "1",
+          "documentation": "The name of the parameter, matching the colon-prefixed placeholder in the SQL.",
+          "type": "string"
+        },
+        {
+          "name": "value",
+          "use": "in",
+          "min": 1,
+          "max": "1",
+          "documentation": "The value to bind to the parameter.",
+          "type": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
@@ -19,6 +19,7 @@ package au.csiro.pathling.io;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import au.csiro.pathling.config.StorageConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
@@ -57,7 +58,8 @@ class DynamicDeltaSourceTest {
         Path.of("src/test/resources/test-data/bulk/fhir/delta").toAbsolutePath().toString();
     final QueryableDataSource baseSource = pathlingContext.read().delta(databasePath);
     dynamicDeltaSource =
-        new DynamicDeltaSource(baseSource, sparkSession, databasePath, fhirEncoders);
+        new DynamicDeltaSource(
+            baseSource, sparkSession, databasePath, fhirEncoders, new StorageConfiguration());
   }
 
   // Verifies that reading a resource type that doesn't exist in the database returns an empty

--- a/server/src/test/java/au/csiro/pathling/operations/create/CreateProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/create/CreateProviderTest.java
@@ -87,7 +87,8 @@ class CreateProviderTest {
             pathlingContext,
             fhirEncoders,
             tempDatabasePath.toAbsolutePath().toString(),
-            cacheableDatabase);
+            cacheableDatabase,
+            false);
 
     // Create the CreateProvider.
     createProvider = new CreateProvider(updateExecutor, fhirContext, Patient.class);

--- a/server/src/test/java/au/csiro/pathling/operations/delete/DeleteProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/delete/DeleteProviderTest.java
@@ -84,7 +84,8 @@ class DeleteProviderTest {
             pathlingContext,
             fhirEncoders,
             tempDatabasePath.toAbsolutePath().toString(),
-            cacheableDatabase);
+            cacheableDatabase,
+            false);
 
     // Create DeleteExecutor with the temp database path.
     final DeleteExecutor deleteExecutor =

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParserTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParserTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import java.nio.charset.StandardCharsets;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.RelatedArtifact;
+import org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link SqlQueryLibraryParser}. */
+class SqlQueryLibraryParserTest {
+
+  private SqlQueryLibraryParser parser;
+
+  @BeforeEach
+  void setUp() {
+    parser = new SqlQueryLibraryParser();
+  }
+
+  @Test
+  void extractsSqlFromLibrary() {
+    final Library library = createMinimalLibrary("SELECT * FROM patients");
+    final ParsedSqlQuery result = parser.parse(library);
+    assertThat(result.getSql()).isEqualTo("SELECT * FROM patients");
+  }
+
+  @Test
+  void extractsViewReferences() {
+    final Library library = createMinimalLibrary("SELECT * FROM patients");
+    library.addRelatedArtifact(
+        new RelatedArtifact()
+            .setType(RelatedArtifactType.DEPENDSON)
+            .setLabel("patients")
+            .setResource("ViewDefinition/patient-view"));
+    library.addRelatedArtifact(
+        new RelatedArtifact()
+            .setType(RelatedArtifactType.DEPENDSON)
+            .setLabel("observations")
+            .setResource("ViewDefinition/obs-view"));
+
+    final ParsedSqlQuery result = parser.parse(library);
+
+    assertThat(result.getViewReferences()).hasSize(2);
+    assertThat(result.getViewReferences().get(0).getLabel()).isEqualTo("patients");
+    assertThat(result.getViewReferences().get(0).getCanonicalUrl())
+        .isEqualTo("ViewDefinition/patient-view");
+    assertThat(result.getViewReferences().get(1).getLabel()).isEqualTo("observations");
+    assertThat(result.getViewReferences().get(1).getCanonicalUrl())
+        .isEqualTo("ViewDefinition/obs-view");
+  }
+
+  @Test
+  void extractsParameters() {
+    final Library library = createMinimalLibrary("SELECT * FROM t WHERE age > :min_age");
+    library
+        .addParameter()
+        .setName("min_age")
+        .setType("integer")
+        .setUse(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.IN);
+
+    final ParsedSqlQuery result = parser.parse(library);
+
+    assertThat(result.getDeclaredParameters()).hasSize(1);
+    assertThat(result.getDeclaredParameters().get(0).getName()).isEqualTo("min_age");
+    assertThat(result.getDeclaredParameters().get(0).getType()).isEqualTo("integer");
+  }
+
+  @Test
+  void handlesEmptyViewReferencesAndParameters() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    final ParsedSqlQuery result = parser.parse(library);
+
+    assertThat(result.getSql()).isEqualTo("SELECT 1");
+    assertThat(result.getViewReferences()).isEmpty();
+    assertThat(result.getDeclaredParameters()).isEmpty();
+  }
+
+  @Test
+  void rejectsLibraryWithNoSqlContent() {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("application/sql");
+  }
+
+  @Test
+  void rejectsLibraryWithWrongContentType() {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library
+        .addContent()
+        .setContentType("text/plain")
+        .setData("SELECT 1".getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("application/sql");
+  }
+
+  @Test
+  void rejectsLibraryWithEmptySqlData() {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library.addContent().setContentType("application/sql").setData(new byte[0]);
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("no data");
+  }
+
+  @Test
+  void rejectsRelatedArtifactWithMissingLabel() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library.addRelatedArtifact(
+        new RelatedArtifact()
+            .setType(RelatedArtifactType.DEPENDSON)
+            .setResource("ViewDefinition/my-view"));
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("label");
+  }
+
+  @Test
+  void rejectsRelatedArtifactWithMissingResource() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library.addRelatedArtifact(
+        new RelatedArtifact().setType(RelatedArtifactType.DEPENDSON).setLabel("my_table"));
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("resource reference");
+  }
+
+  @Test
+  void rejectsParameterWithMissingName() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library
+        .addParameter()
+        .setType("string")
+        .setUse(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.IN);
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("name");
+  }
+
+  @Test
+  void rejectsParameterWithMissingType() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library
+        .addParameter()
+        .setName("param1")
+        .setUse(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.IN);
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("type");
+  }
+
+  @Test
+  void acceptsSqlContentTypeWithDialect() {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library
+        .addContent()
+        .setContentType("application/sql;dialect=spark")
+        .setData("SELECT 1".getBytes(StandardCharsets.UTF_8));
+
+    final ParsedSqlQuery result = parser.parse(library);
+    assertThat(result.getSql()).isEqualTo("SELECT 1");
+  }
+
+  /** Creates a minimal Library resource with the given SQL as Base64-encoded content. */
+  private Library createMinimalLibrary(final String sql) {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library
+        .addContent()
+        .setContentType("application/sql")
+        .setData(sql.getBytes(StandardCharsets.UTF_8));
+    return library;
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import au.csiro.pathling.test.SpringBootUnitTest;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+/** Unit tests for {@link SqlValidator}. */
+@Import(SqlValidator.class)
+@SpringBootUnitTest
+class SqlValidatorTest {
+
+  @Autowired private SqlValidator sqlValidator;
+
+  // -------------------------------------------------------------------------
+  // Valid SQL queries — should not throw.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void acceptsSimpleSelect() {
+    assertThatCode(() -> sqlValidator.validate("SELECT 1")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithAlias() {
+    assertThatCode(() -> sqlValidator.validate("SELECT 1 AS value")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectFromTable() {
+    assertThatCode(() -> sqlValidator.validate("SELECT * FROM my_view")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithWhere() {
+    assertThatCode(() -> sqlValidator.validate("SELECT a, b FROM t WHERE a > 10"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithJoin() {
+    assertThatCode(
+            () -> sqlValidator.validate("SELECT a.id, b.name FROM a JOIN b ON a.id = b.a_id"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithAggregation() {
+    assertThatCode(() -> sqlValidator.validate("SELECT count(*), sum(x) FROM t GROUP BY y"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithSubquery() {
+    assertThatCode(() -> sqlValidator.validate("SELECT * FROM (SELECT 1 AS x) sub"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithCte() {
+    assertThatCode(() -> sqlValidator.validate("WITH cte AS (SELECT 1 AS x) SELECT * FROM cte"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithOrderByAndLimit() {
+    assertThatCode(() -> sqlValidator.validate("SELECT * FROM t ORDER BY id LIMIT 10"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithCaseWhen() {
+    assertThatCode(
+            () ->
+                sqlValidator.validate(
+                    "SELECT CASE WHEN x > 0 THEN 'positive' ELSE 'negative' END FROM t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithStringFunctions() {
+    assertThatCode(
+            () -> sqlValidator.validate("SELECT upper(name), lower(name), length(name) FROM t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithMathFunctions() {
+    assertThatCode(() -> sqlValidator.validate("SELECT abs(-1), sqrt(4), round(3.14, 1)"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithDateFunctions() {
+    assertThatCode(() -> sqlValidator.validate("SELECT current_date(), current_timestamp()"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithUnion() {
+    assertThatCode(() -> sqlValidator.validate("SELECT 1 AS x UNION ALL SELECT 2 AS x"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithWindowFunction() {
+    assertThatCode(
+            () -> sqlValidator.validate("SELECT id, row_number() OVER (ORDER BY id) AS rn FROM t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithDistinct() {
+    assertThatCode(() -> sqlValidator.validate("SELECT DISTINCT name FROM t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithInClause() {
+    assertThatCode(() -> sqlValidator.validate("SELECT * FROM t WHERE id IN (1, 2, 3)"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithCast() {
+    assertThatCode(() -> sqlValidator.validate("SELECT CAST(x AS STRING) FROM t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithCoalesce() {
+    assertThatCode(() -> sqlValidator.validate("SELECT coalesce(a, b, 'default') FROM t"))
+        .doesNotThrowAnyException();
+  }
+
+  // -------------------------------------------------------------------------
+  // Invalid SQL — should reject DDL and DML.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void rejectsDropTable() {
+    assertThatThrownBy(() -> sqlValidator.validate("DROP TABLE my_table"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed");
+  }
+
+  @Test
+  void rejectsCreateTable() {
+    assertThatThrownBy(() -> sqlValidator.validate("CREATE TABLE my_table (id INT)"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed");
+  }
+
+  @Test
+  void rejectsInsertInto() {
+    assertThatThrownBy(() -> sqlValidator.validate("INSERT INTO my_table VALUES (1, 'a')"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed");
+  }
+
+  @Test
+  void rejectsDeleteFrom() {
+    assertThatThrownBy(() -> sqlValidator.validate("DELETE FROM my_table WHERE id = 1"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed");
+  }
+
+  @Test
+  void rejectsUpdateStatement() {
+    assertThatThrownBy(() -> sqlValidator.validate("UPDATE my_table SET name = 'x' WHERE id = 1"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed");
+  }
+
+  @Test
+  void rejectsCreateView() {
+    assertThatThrownBy(() -> sqlValidator.validate("CREATE VIEW my_view AS SELECT 1"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed");
+  }
+
+  // -------------------------------------------------------------------------
+  // Invalid SQL — should reject dangerous functions.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void rejectsReflectFunction() {
+    assertThatThrownBy(
+            () -> sqlValidator.validate("SELECT reflect('java.lang.Runtime', 'getRuntime') FROM t"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed function");
+  }
+
+  @Test
+  void rejectsJavaMethodFunction() {
+    assertThatThrownBy(
+            () -> sqlValidator.validate("SELECT java_method('java.lang.Math', 'random') FROM t"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed function");
+  }
+
+  // -------------------------------------------------------------------------
+  // Invalid SQL syntax.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void rejectsInvalidSqlSyntax() {
+    assertThatThrownBy(() -> sqlValidator.validate("NOT VALID SQL AT ALL"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("Invalid SQL syntax");
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/update/BatchProviderCreateTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/BatchProviderCreateTest.java
@@ -86,7 +86,8 @@ class BatchProviderCreateTest {
             pathlingContext,
             fhirEncoders,
             tempDatabasePath.toAbsolutePath().toString(),
-            cacheableDatabase);
+            cacheableDatabase,
+            false);
 
     // Create DeleteExecutor with the temp database path.
     deleteExecutor =

--- a/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionCreateTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionCreateTest.java
@@ -77,13 +77,14 @@ class ViewDefinitionCreateTest {
     // Create a temporary directory for the Delta Lake database.
     tempDatabasePath = Files.createTempDirectory("viewdefinition-create-test-");
 
-    // Create UpdateExecutor with the temp database path.
+    // Create UpdateExecutor with the temp database path (schema auto-merge disabled by default).
     final UpdateExecutor updateExecutor =
         new UpdateExecutor(
             pathlingContext,
             fhirEncoders,
             tempDatabasePath.toAbsolutePath().toString(),
-            cacheableDatabase);
+            cacheableDatabase,
+            false);
 
     // Create the CreateProvider for ViewDefinition.
     createProvider = new CreateProvider(updateExecutor, fhirContext, ViewDefinitionResource.class);
@@ -184,6 +185,56 @@ class ViewDefinitionCreateTest {
     final String tablePath = tempDatabasePath.resolve("ViewDefinition.parquet").toString();
     final Dataset<Row> dataset = sparkSession.read().format("delta").load(tablePath);
     assertThat(dataset.count()).isEqualTo(2);
+  }
+
+  @Test
+  void createViewDefinitionSucceedsWhenDeltaTableHasOlderSchema() {
+    // Given: a provider with schema auto-merge enabled.
+    final UpdateExecutor autoMergeExecutor =
+        new UpdateExecutor(
+            pathlingContext,
+            fhirEncoders,
+            tempDatabasePath.toAbsolutePath().toString(),
+            cacheableDatabase,
+            true);
+    final CreateProvider autoMergeProvider =
+        new CreateProvider(autoMergeExecutor, fhirContext, ViewDefinitionResource.class);
+
+    // Create a ViewDefinition, establishing a Delta table.
+    final ViewDefinitionResource viewDef1 = createViewDefinition(null, "view_1", "Patient");
+    autoMergeProvider.create(viewDef1);
+
+    final String tablePath = tempDatabasePath.resolve("ViewDefinition.parquet").toString();
+    assertThat(DeltaTable.isDeltaTable(sparkSession, tablePath)).isTrue();
+
+    // Simulate an older schema by dropping a column from the existing Delta table.
+    // This reproduces the real-world scenario where the encoder adds new fields
+    // (e.g. valueDecimal, valueDecimal_scale) but the persisted table lacks them.
+    final Dataset<Row> original = sparkSession.read().format("delta").load(tablePath);
+    final String columnToDrop = original.columns()[original.columns().length - 1];
+    final Dataset<Row> narrowed = original.drop(columnToDrop);
+    narrowed
+        .write()
+        .format("delta")
+        .mode("overwrite")
+        .option("overwriteSchema", "true")
+        .save(tablePath);
+
+    // Verify the column was actually dropped.
+    final Dataset<Row> reloaded = sparkSession.read().format("delta").load(tablePath);
+    assertThat(reloaded.schema().fieldNames()).doesNotContain(columnToDrop);
+
+    // When: creating another ViewDefinition (which uses the full current schema).
+    final ViewDefinitionResource viewDef2 = createViewDefinition(null, "view_2", "Observation");
+    final MethodOutcome outcome2 = autoMergeProvider.create(viewDef2);
+
+    // Then: it should succeed despite the schema mismatch.
+    assertThat(outcome2.getId()).isNotNull();
+    assertThat(outcome2.getCreated()).isTrue();
+
+    // And both rows should be present.
+    final Dataset<Row> result = sparkSession.read().format("delta").load(tablePath);
+    assertThat(result.count()).isEqualTo(2);
   }
 
   @Test


### PR DESCRIPTION
A yolo implementation of https://github.com/aehrc/pathling/issues/2561 :

This pull request introduces support for the `$sqlquery-run` FHIR operation, enabling execution of SQL queries defined in FHIR Library resources. It adds new providers, configuration options, and parsing logic to handle SQLQuery Libraries, their parameters, and dependencies. The changes also ensure that the new operation is configurable and properly registered within the server.

**New SQL Query Operation Support:**

* Added new providers: `SqlQueryRunProvider` and `SqlQueryInstanceRunProvider` to handle both type-level and instance-level `$sqlquery-run` operations for FHIR Library resources, including parameter binding and output formatting. (`[[1]](diffhunk://#diff-7441f4e261837a0c47fe3ba576c977a207bbdc04c5aaadb30c844232af85cdebR177-R184)`, `[[2]](diffhunk://#diff-7441f4e261837a0c47fe3ba576c977a207bbdc04c5aaadb30c844232af85cdebL233-R248)`, `[[3]](diffhunk://#diff-7441f4e261837a0c47fe3ba576c977a207bbdc04c5aaadb30c844232af85cdebR277-R278)`, `[[4]](diffhunk://#diff-5acafa29251cd0573c336431c5e7f133d74246a4f80c9281d3216e3dbc3b83bbR1-R160)`)

* Registered the new SQL query run providers within the `FhirServer` initialization logic, gated by a new configuration flag. (`[server/src/main/java/au/csiro/pathling/FhirServer.javaR397-R402](diffhunk://#diff-7441f4e261837a0c47fe3ba576c977a207bbdc04c5aaadb30c844232af85cdebR397-R402)`)

**Configuration and Capability Statement:**

* Introduced a new configuration property `sqlQueryRunEnabled` to enable or disable the `$sqlquery-run` operation. (`[server/src/main/java/au/csiro/pathling/config/OperationConfiguration.javaR73-R75](diffhunk://#diff-d253d305020a8cff17b5936c099e7e2e7d731120bcc273135f5973795605eaccR73-R75)`)

* Updated the conformance/capability statement logic to advertise the `$sqlquery-run` operation when enabled. (`[server/src/main/java/au/csiro/pathling/fhir/ConformanceProvider.javaR507-R509](diffhunk://#diff-dd39c622cbec81a9a667a477be7664401ec1272b7a9d1445a2bd2a5791c8c1e5R507-R509)`)

**SQLQuery Library Parsing:**

* Added `SqlQueryLibraryParser`, which parses FHIR Library resources conforming to the SQLQuery profile, extracting SQL text, ViewDefinition dependencies, and parameter declarations. (`[server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParser.javaR1-R143](diffhunk://#diff-1f739feb2f4b660e33bb7305adbdbbd1cbb1bbc1e9531ef64010f931193a8495R1-R143)`)

* Introduced supporting classes: `ParsedSqlQuery` (holds parsed SQL, dependencies, parameters) and `SqlParameterDeclaration` (represents a named, typed parameter). (`[[1]](diffhunk://#diff-2e4ab2cf0cdde8df9f81de693a4b02979a8b9aad69dc64988fa3690fd1523a63R1-R39)`, `[[2]](diffhunk://#diff-dcc4e4e7afa0be80e5b6930026fd9a0d0f141902bbe9983bb1b8ca72d636987aR1-R35)`)