### PR TITLE
feat: Support FHIRPath trace() function

### DIFF
--- a/encoders/src/main/java/au/csiro/pathling/sql/TraceCollector.java
+++ b/encoders/src/main/java/au/csiro/pathling/sql/TraceCollector.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.sql;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+
+/**
+ * Collects trace data produced by the FHIRPath {@code trace()} function during expression
+ * evaluation. Implementations determine how entries are stored and retrieved.
+ *
+ * @author John Grimes
+ */
+public interface TraceCollector {
+
+  /**
+   * Adds a trace entry.
+   *
+   * @param label the trace label (the {@code name} argument to {@code trace()})
+   * @param fhirType the FHIR type code of the traced collection (e.g., {@code "HumanName"}, {@code
+   *     "string"})
+   * @param value the traced value, converted from Spark internal representation to an external
+   *     Scala type (e.g., {@link org.apache.spark.sql.Row} for structs, {@link String} for strings)
+   */
+  void add(@Nonnull String label, @Nonnull String fhirType, @Nullable Object value);
+}

--- a/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
@@ -27,12 +27,16 @@ import org.apache.spark.sql.types.DataType
 import org.slf4j.{Logger, LoggerFactory}
 
 /**
- * Shared logging and collection logic for trace expressions.
+ * Shared logging and collection logic for trace expressions. Both
+ * [[TraceExpression]] and [[TraceProjectionExpression]] use the same logger
+ * so that a single log appender can capture all trace output.
  */
 private[sql] object TraceHelper {
 
+  private[sql] val log: Logger = LoggerFactory.getLogger(classOf[TraceExpression])
+
   private[sql] def logAndCollect(
-      log: Logger, name: String, fhirType: String, collector: TraceCollector,
+      name: String, fhirType: String, collector: TraceCollector,
       value: Any, toScala: Any => Any): Unit = {
     val converted = toScala(value)
     if (log.isTraceEnabled) {
@@ -70,9 +74,6 @@ case class TraceExpression(child: Expression, name: String, fhirType: String,
                            collector: TraceCollector)
   extends UnaryExpression with CodegenFallback with Nondeterministic {
 
-  @transient
-  private lazy val log = LoggerFactory.getLogger(classOf[TraceExpression])
-
   override def dataType: DataType = child.dataType
 
   override def nullable: Boolean = child.nullable
@@ -87,8 +88,8 @@ case class TraceExpression(child: Expression, name: String, fhirType: String,
 
   override protected def evalInternal(input: InternalRow): Any = {
     val value = child.eval(input)
-    if (value != null && (log.isTraceEnabled || collector != null)) {
-      TraceHelper.logAndCollect(log, name, fhirType, collector, value, toScala)
+    if (value != null && (TraceHelper.log.isTraceEnabled || collector != null)) {
+      TraceHelper.logAndCollect(name, fhirType, collector, value, toScala)
     }
     value
   }
@@ -121,9 +122,6 @@ case class TraceProjectionExpression(left: Expression, right: Expression,
                                      collector: TraceCollector)
   extends BinaryExpression with CodegenFallback with Nondeterministic {
 
-  @transient
-  private lazy val log = LoggerFactory.getLogger(classOf[TraceExpression])
-
   override def dataType: DataType = left.dataType
 
   override def nullable: Boolean = left.nullable
@@ -143,8 +141,8 @@ case class TraceProjectionExpression(left: Expression, right: Expression,
       return null
     }
     val toLog = right.eval(input)
-    if (toLog != null && (log.isTraceEnabled || collector != null)) {
-      TraceHelper.logAndCollect(log, name, fhirType, collector, toLog, toScala)
+    if (toLog != null && (TraceHelper.log.isTraceEnabled || collector != null)) {
+      TraceHelper.logAndCollect(name, fhirType, collector, toLog, toScala)
     }
     passThrough
   }

--- a/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
@@ -20,22 +20,87 @@ package au.csiro.pathling.sql
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.CatalystTypeConverters
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{BinaryExpression, Expression, Nondeterministic}
+import org.apache.spark.sql.catalyst.expressions.{BinaryExpression, Expression,
+  Nondeterministic, UnaryExpression}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.types.DataType
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
+
+/**
+ * Shared logging and collection logic for trace expressions.
+ */
+private[sql] object TraceHelper {
+
+  private[sql] def logAndCollect(
+      log: Logger, name: String, fhirType: String, collector: TraceCollector,
+      value: Any, toScala: Any => Any): Unit = {
+    val converted = toScala(value)
+    if (log.isTraceEnabled) {
+      log.trace("[trace:{}] {}", name, toReadableString(converted))
+    }
+    if (collector != null) {
+      collector.add(name, fhirType, converted)
+    }
+  }
+
+  private def toReadableString(value: Any): String = value match {
+    case row: Row => row.json
+    case seq: scala.collection.Seq[_] => seq.map(toReadableString).mkString("[", ", ", "]")
+    case s: String => "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+    case null => "null"
+    case other => String.valueOf(other)
+  }
+}
+
+/**
+ * A Catalyst expression that logs the string representation of each evaluated
+ * value via SLF4J, then returns the value unchanged. This implements the
+ * FHIRPath trace(name) function semantics without a projection argument.
+ *
+ * This expression is marked [[Nondeterministic]] because it has side effects
+ * (logging, collector accumulation) that must not be eliminated by the Catalyst
+ * optimizer.
+ *
+ * @param child     the child expression whose value is traced and returned
+ * @param name      the diagnostic label included in log messages
+ * @param fhirType  the FHIR type code of the traced collection (e.g., "HumanName")
+ * @param collector an optional collector for programmatic trace capture, or null
+ */
+case class TraceExpression(child: Expression, name: String, fhirType: String,
+                           collector: TraceCollector)
+  extends UnaryExpression with CodegenFallback with Nondeterministic {
+
+  @transient
+  private lazy val log = LoggerFactory.getLogger(classOf[TraceExpression])
+
+  override def dataType: DataType = child.dataType
+
+  override def nullable: Boolean = child.nullable
+
+  override protected def withNewChildInternal(newChild: Expression): Expression =
+    copy(child = newChild)
+
+  override protected def initializeInternal(partitionIndex: Int): Unit = ()
+
+  @transient
+  private lazy val toScala = CatalystTypeConverters.createToScalaConverter(dataType)
+
+  override protected def evalInternal(input: InternalRow): Any = {
+    val value = child.eval(input)
+    if (value != null && (log.isTraceEnabled || collector != null)) {
+      TraceHelper.logAndCollect(log, name, fhirType, collector, value, toScala)
+    }
+    value
+  }
+
+  override def prettyName: String = "trace"
+}
 
 /**
  * A Catalyst expression that returns one value (left) while logging another
- * (right) via SLF4J. This implements the FHIRPath trace() function semantics,
- * including the optional projection argument.
- *
- * When no projection is provided, both children reference the same column, so
- * the logged value equals the returned value.
- *
- * When a [[TraceCollector]] is provided, each value is also added to the
- * collector with the trace label and FHIR type, enabling programmatic capture
- * of trace output.
+ * (right) via SLF4J. This implements the FHIRPath trace(name, projection)
+ * function semantics where the projection result is logged but the original
+ * input is returned.
  *
  * This expression is marked [[Nondeterministic]] because it has side effects
  * (logging, collector accumulation) that must not be eliminated by the Catalyst
@@ -51,8 +116,9 @@ import org.slf4j.LoggerFactory
  * @param fhirType  the FHIR type code of the logged expression (e.g., "string")
  * @param collector an optional collector for programmatic trace capture, or null
  */
-case class TraceExpression(left: Expression, right: Expression, name: String,
-                           fhirType: String, collector: TraceCollector)
+case class TraceProjectionExpression(left: Expression, right: Expression,
+                                     name: String, fhirType: String,
+                                     collector: TraceCollector)
   extends BinaryExpression with CodegenFallback with Nondeterministic {
 
   @transient
@@ -78,23 +144,9 @@ case class TraceExpression(left: Expression, right: Expression, name: String,
     }
     val toLog = right.eval(input)
     if (toLog != null && (log.isTraceEnabled || collector != null)) {
-      val converted = toScala(toLog)
-      if (log.isTraceEnabled) {
-        log.trace("[trace:{}] {}", name, toReadableString(converted))
-      }
-      if (collector != null) {
-        collector.add(name, fhirType, converted)
-      }
+      TraceHelper.logAndCollect(log, name, fhirType, collector, toLog, toScala)
     }
     passThrough
-  }
-
-  private def toReadableString(value: Any): String = value match {
-    case row: Row => row.json
-    case seq: scala.collection.Seq[_] => seq.map(toReadableString).mkString("[", ", ", "]")
-    case s: String => "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
-    case null => "null"
-    case other => String.valueOf(other)
   }
 
   override def prettyName: String = "trace"

--- a/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
@@ -29,10 +29,17 @@ import org.slf4j.LoggerFactory
  * value via SLF4J, then returns the value unchanged. This implements the
  * FHIRPath trace() function semantics.
  *
- * @param child the child expression whose value is traced
- * @param name  the diagnostic label included in log messages
+ * When a [[TraceCollector]] is provided, each value is also added to the
+ * collector with the trace label and FHIR type, enabling programmatic capture
+ * of trace output.
+ *
+ * @param child     the child expression whose value is traced
+ * @param name      the diagnostic label included in log messages
+ * @param fhirType  the FHIR type code of the traced collection (e.g., "HumanName")
+ * @param collector an optional collector for programmatic trace capture, or null
  */
-case class TraceExpression(child: Expression, name: String)
+case class TraceExpression(child: Expression, name: String, fhirType: String,
+                           collector: TraceCollector)
   extends UnaryExpression with CodegenFallback {
 
   @transient
@@ -49,7 +56,11 @@ case class TraceExpression(child: Expression, name: String)
   private lazy val toScala = CatalystTypeConverters.createToScalaConverter(dataType)
 
   override def nullSafeEval(value: Any): Any = {
-    log.info("[trace:{}] {}", name, toReadableString(toScala(value)))
+    val converted = toScala(value)
+    log.trace("[trace:{}] {}", name, toReadableString(converted))
+    if (collector != null) {
+      collector.add(name, fhirType, converted)
+    }
     value
   }
 

--- a/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
@@ -56,10 +56,14 @@ case class TraceExpression(child: Expression, name: String, fhirType: String,
   private lazy val toScala = CatalystTypeConverters.createToScalaConverter(dataType)
 
   override def nullSafeEval(value: Any): Any = {
-    val converted = toScala(value)
-    log.trace("[trace:{}] {}", name, toReadableString(converted))
-    if (collector != null) {
-      collector.add(name, fhirType, converted)
+    if (log.isTraceEnabled || collector != null) {
+      val converted = toScala(value)
+      if (log.isTraceEnabled) {
+        log.trace("[trace:{}] {}", name, toReadableString(converted))
+      }
+      if (collector != null) {
+        collector.add(name, fhirType, converted)
+      }
     }
     value
   }

--- a/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
@@ -19,50 +19,66 @@ package au.csiro.pathling.sql
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.CatalystTypeConverters
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{BinaryExpression, Expression, Nondeterministic}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.catalyst.expressions.{Expression, UnaryExpression}
 import org.apache.spark.sql.types.DataType
 import org.slf4j.LoggerFactory
 
 /**
- * A Catalyst expression that logs the string representation of each evaluated
- * value via SLF4J, then returns the value unchanged. This implements the
- * FHIRPath trace() function semantics.
+ * A Catalyst expression that returns one value (left) while logging another
+ * (right) via SLF4J. This implements the FHIRPath trace() function semantics,
+ * including the optional projection argument.
+ *
+ * When no projection is provided, both children reference the same column, so
+ * the logged value equals the returned value.
  *
  * When a [[TraceCollector]] is provided, each value is also added to the
  * collector with the trace label and FHIR type, enabling programmatic capture
  * of trace output.
  *
- * Note: this expression extends [[UnaryExpression]] and overrides
- * `nullSafeEval`, so null values are passed through without being logged or
- * collected. This is intentional — null represents an absent value in the
- * FHIRPath collection and should not produce a trace entry.
+ * This expression is marked [[Nondeterministic]] because it has side effects
+ * (logging, collector accumulation) that must not be eliminated by the Catalyst
+ * optimizer.
  *
- * @param child     the child expression whose value is traced
+ * Null handling is asymmetric: a null left (pass-through) value returns null
+ * without logging. A null right (projected) value skips logging but still
+ * returns the left value.
+ *
+ * @param left      the pass-through expression whose value is returned
+ * @param right     the expression whose value is logged
  * @param name      the diagnostic label included in log messages
- * @param fhirType  the FHIR type code of the traced collection (e.g., "HumanName")
+ * @param fhirType  the FHIR type code of the logged expression (e.g., "string")
  * @param collector an optional collector for programmatic trace capture, or null
  */
-case class TraceExpression(child: Expression, name: String, fhirType: String,
-                           collector: TraceCollector)
-  extends UnaryExpression with CodegenFallback {
+case class TraceExpression(left: Expression, right: Expression, name: String,
+                           fhirType: String, collector: TraceCollector)
+  extends BinaryExpression with CodegenFallback with Nondeterministic {
 
   @transient
   private lazy val log = LoggerFactory.getLogger(classOf[TraceExpression])
 
-  override def dataType: DataType = child.dataType
+  override def dataType: DataType = left.dataType
 
-  override def nullable: Boolean = child.nullable
+  override def nullable: Boolean = left.nullable
 
-  override protected def withNewChildInternal(newChild: Expression): Expression =
-    copy(child = newChild)
+  override protected def withNewChildrenInternal(
+      newLeft: Expression, newRight: Expression): Expression =
+    copy(left = newLeft, right = newRight)
+
+  override protected def initializeInternal(partitionIndex: Int): Unit = ()
 
   @transient
-  private lazy val toScala = CatalystTypeConverters.createToScalaConverter(dataType)
+  private lazy val toScala = CatalystTypeConverters.createToScalaConverter(right.dataType)
 
-  override def nullSafeEval(value: Any): Any = {
-    if (log.isTraceEnabled || collector != null) {
-      val converted = toScala(value)
+  override protected def evalInternal(input: InternalRow): Any = {
+    val passThrough = left.eval(input)
+    if (passThrough == null) {
+      return null
+    }
+    val toLog = right.eval(input)
+    if (toLog != null && (log.isTraceEnabled || collector != null)) {
+      val converted = toScala(toLog)
       if (log.isTraceEnabled) {
         log.trace("[trace:{}] {}", name, toReadableString(converted))
       }
@@ -70,7 +86,7 @@ case class TraceExpression(child: Expression, name: String, fhirType: String,
         collector.add(name, fhirType, converted)
       }
     }
-    value
+    passThrough
   }
 
   private def toReadableString(value: Any): String = value match {

--- a/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
@@ -33,6 +33,11 @@ import org.slf4j.LoggerFactory
  * collector with the trace label and FHIR type, enabling programmatic capture
  * of trace output.
  *
+ * Note: this expression extends [[UnaryExpression]] and overrides
+ * `nullSafeEval`, so null values are passed through without being logged or
+ * collected. This is intentional — null represents an absent value in the
+ * FHIRPath collection and should not produce a trace entry.
+ *
  * @param child     the child expression whose value is traced
  * @param name      the diagnostic label included in log messages
  * @param fhirType  the FHIR type code of the traced collection (e.g., "HumanName")

--- a/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.sql
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.CatalystTypeConverters
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.expressions.{Expression, UnaryExpression}
+import org.apache.spark.sql.types.DataType
+import org.slf4j.LoggerFactory
+
+/**
+ * A Catalyst expression that logs the string representation of each evaluated
+ * value via SLF4J, then returns the value unchanged. This implements the
+ * FHIRPath trace() function semantics.
+ *
+ * @param child the child expression whose value is traced
+ * @param name  the diagnostic label included in log messages
+ */
+case class TraceExpression(child: Expression, name: String)
+  extends UnaryExpression with CodegenFallback {
+
+  @transient
+  private lazy val log = LoggerFactory.getLogger(classOf[TraceExpression])
+
+  override def dataType: DataType = child.dataType
+
+  override def nullable: Boolean = child.nullable
+
+  override protected def withNewChildInternal(newChild: Expression): Expression =
+    copy(child = newChild)
+
+  @transient
+  private lazy val toScala = CatalystTypeConverters.createToScalaConverter(dataType)
+
+  override def nullSafeEval(value: Any): Any = {
+    log.info("[trace:{}] {}", name, toReadableString(toScala(value)))
+    value
+  }
+
+  private def toReadableString(value: Any): String = value match {
+    case row: Row => row.json
+    case seq: scala.collection.Seq[_] => seq.map(toReadableString).mkString("[", ", ", "]")
+    case s: String => "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+    case null => "null"
+    case other => String.valueOf(other)
+  }
+
+  override def prettyName: String = "trace"
+}

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/EvaluationContext.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/EvaluationContext.java
@@ -22,6 +22,7 @@ import au.csiro.pathling.fhirpath.collection.Collection;
 import au.csiro.pathling.fhirpath.collection.ResourceCollection;
 import au.csiro.pathling.fhirpath.function.NamedFunction;
 import au.csiro.pathling.fhirpath.function.registry.NoSuchFunctionError;
+import au.csiro.pathling.sql.TraceCollector;
 import jakarta.annotation.Nonnull;
 import java.util.Optional;
 
@@ -88,5 +89,15 @@ public interface EvaluationContext {
   @Nonnull
   default FhirpathConfiguration getConfiguration() {
     return FhirpathConfiguration.DEFAULT;
+  }
+
+  /**
+   * Returns the trace collector for capturing {@code trace()} output, if one is available.
+   *
+   * @return an optional containing the trace collector, or empty if trace collection is not enabled
+   */
+  @Nonnull
+  default Optional<TraceCollector> getTraceCollector() {
+    return Optional.empty();
   }
 }

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/ListTraceCollector.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/ListTraceCollector.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.fhirpath;
+
+import au.csiro.pathling.sql.TraceCollector;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link TraceCollector} backed by a plain {@link ArrayList}. This implementation is
+ * intentionally not serializable — it will fail with a clear error if used in a distributed Spark
+ * context. Use this for single-resource evaluation in local mode.
+ *
+ * @author John Grimes
+ */
+public class ListTraceCollector implements TraceCollector {
+
+  private final List<TraceEntry> entries = new ArrayList<>();
+
+  @Override
+  public void add(
+      @Nonnull final String label, @Nonnull final String fhirType, @Nullable final Object value) {
+    entries.add(new TraceEntry(label, fhirType, value));
+  }
+
+  /**
+   * Returns all collected trace entries.
+   *
+   * @return an unmodifiable view of the collected entries
+   */
+  @Nonnull
+  public List<TraceEntry> getEntries() {
+    return List.copyOf(entries);
+  }
+
+  /**
+   * A single trace entry captured during evaluation.
+   *
+   * @param label the trace label
+   * @param fhirType the FHIR type code
+   * @param value the traced value
+   */
+  public record TraceEntry(
+      @Nonnull String label, @Nonnull String fhirType, @Nullable Object value) {}
+}

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/TraceCollectorProxy.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/TraceCollectorProxy.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.fhirpath;
+
+import au.csiro.pathling.sql.TraceCollector;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.Serializable;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A serializable {@link TraceCollector} proxy that delegates to a registered collector via a static
+ * registry. Only the key is serialized — the actual collector stays on the driver JVM.
+ *
+ * <p>Usage:
+ *
+ * <ol>
+ *   <li>Create the real collector (e.g., {@link ListTraceCollector}).
+ *   <li>Create a proxy via {@link #create(TraceCollector)}.
+ *   <li>Pass the proxy into the evaluation (it survives Spark serialization).
+ *   <li>After materialization, read from the real collector.
+ *   <li>Call {@link #close()} to remove the registry entry.
+ * </ol>
+ *
+ * @author John Grimes
+ */
+public class TraceCollectorProxy implements TraceCollector, Serializable, AutoCloseable {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final ConcurrentHashMap<String, TraceCollector> REGISTRY =
+      new ConcurrentHashMap<>();
+
+  @Nonnull private final String key;
+
+  private TraceCollectorProxy(@Nonnull final String key) {
+    this.key = key;
+  }
+
+  /**
+   * Creates a new proxy that delegates to the given collector.
+   *
+   * @param delegate the real collector to delegate to
+   * @return a serializable proxy
+   */
+  @Nonnull
+  public static TraceCollectorProxy create(@Nonnull final TraceCollector delegate) {
+    final String key = UUID.randomUUID().toString();
+    REGISTRY.put(key, delegate);
+    return new TraceCollectorProxy(key);
+  }
+
+  @Override
+  public void add(
+      @Nonnull final String label, @Nonnull final String fhirType, @Nullable final Object value) {
+    final TraceCollector delegate = REGISTRY.get(key);
+    if (delegate != null) {
+      delegate.add(label, fhirType, value);
+    }
+  }
+
+  /** Removes this proxy's entry from the registry. Call after materialization is complete. */
+  @Override
+  public void close() {
+    REGISTRY.remove(key);
+  }
+}

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/DatasetEvaluatorBuilder.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/DatasetEvaluatorBuilder.java
@@ -21,6 +21,7 @@ import au.csiro.pathling.fhirpath.collection.Collection;
 import au.csiro.pathling.fhirpath.function.registry.FunctionRegistry;
 import au.csiro.pathling.fhirpath.function.registry.StaticFunctionRegistry;
 import au.csiro.pathling.io.source.DataSource;
+import au.csiro.pathling.sql.TraceCollector;
 import ca.uhn.fhir.context.FhirContext;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -66,6 +67,8 @@ public class DatasetEvaluatorBuilder {
   @Nonnull private FunctionRegistry functionRegistry = StaticFunctionRegistry.getInstance();
 
   @Nonnull private CrossResourceStrategy crossResourceStrategy = CrossResourceStrategy.FAIL;
+
+  @Nullable private TraceCollector traceCollector;
 
   /** Private constructor. Use factory methods to create instances. */
   private DatasetEvaluatorBuilder(
@@ -184,6 +187,20 @@ public class DatasetEvaluatorBuilder {
   }
 
   /**
+   * Sets the trace collector for capturing trace() output.
+   *
+   * <p>Default is none (no collection, SLF4J logging only).
+   *
+   * @param traceCollector the trace collector
+   * @return this builder for method chaining
+   */
+  @Nonnull
+  public DatasetEvaluatorBuilder withTraceCollector(@Nonnull final TraceCollector traceCollector) {
+    this.traceCollector = traceCollector;
+    return this;
+  }
+
+  /**
    * Builds the {@link DatasetEvaluator} with the configured options.
    *
    * <p>If a DataSource was provided via {@link #withDataSource(DataSource)}, the dataset will be
@@ -197,12 +214,15 @@ public class DatasetEvaluatorBuilder {
     // Resolve the dataset, either from the provided dataSource or from the directly set dataset.
     final Dataset<Row> resolvedDataset = resolveDataset();
 
-    final SingleResourceEvaluator evaluator =
+    final SingleResourceEvaluatorBuilder evalBuilder =
         SingleResourceEvaluatorBuilder.create(subjectResourceCode, fhirContext)
             .withCrossResourceStrategy(crossResourceStrategy)
             .withFunctionRegistry(functionRegistry)
-            .withVariables(variables)
-            .build();
+            .withVariables(variables);
+    if (traceCollector != null) {
+      evalBuilder.withTraceCollector(traceCollector);
+    }
+    final SingleResourceEvaluator evaluator = evalBuilder.build();
 
     return new DatasetEvaluator(evaluator, resolvedDataset);
   }

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/DatasetEvaluatorBuilder.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/DatasetEvaluatorBuilder.java
@@ -26,6 +26,7 @@ import ca.uhn.fhir.context.FhirContext;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.hl7.fhir.r4.model.Enumerations.ResourceType;
@@ -68,7 +69,7 @@ public class DatasetEvaluatorBuilder {
 
   @Nonnull private CrossResourceStrategy crossResourceStrategy = CrossResourceStrategy.FAIL;
 
-  @Nullable private TraceCollector traceCollector;
+  @Nonnull private Optional<TraceCollector> traceCollector = Optional.empty();
 
   /** Private constructor. Use factory methods to create instances. */
   private DatasetEvaluatorBuilder(
@@ -196,7 +197,7 @@ public class DatasetEvaluatorBuilder {
    */
   @Nonnull
   public DatasetEvaluatorBuilder withTraceCollector(@Nonnull final TraceCollector traceCollector) {
-    this.traceCollector = traceCollector;
+    this.traceCollector = Optional.of(traceCollector);
     return this;
   }
 
@@ -219,9 +220,7 @@ public class DatasetEvaluatorBuilder {
             .withCrossResourceStrategy(crossResourceStrategy)
             .withFunctionRegistry(functionRegistry)
             .withVariables(variables);
-    if (traceCollector != null) {
-      evalBuilder.withTraceCollector(traceCollector);
-    }
+    traceCollector.ifPresent(evalBuilder::withTraceCollector);
     final SingleResourceEvaluator evaluator = evalBuilder.build();
 
     return new DatasetEvaluator(evaluator, resolvedDataset);

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/FhirEvaluationContext.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/FhirEvaluationContext.java
@@ -25,6 +25,7 @@ import au.csiro.pathling.fhirpath.function.NamedFunction;
 import au.csiro.pathling.fhirpath.function.registry.FunctionRegistry;
 import au.csiro.pathling.fhirpath.function.registry.NoSuchFunctionError;
 import au.csiro.pathling.fhirpath.variable.EnvironmentVariableResolver;
+import au.csiro.pathling.sql.TraceCollector;
 import jakarta.annotation.Nonnull;
 import java.util.Optional;
 
@@ -45,17 +46,19 @@ import java.util.Optional;
  * @param functionRegistry the registry for resolving FHIRPath functions
  * @param resourceResolver the resolver for FHIR resources
  * @param configuration the FHIRPath evaluation configuration
+ * @param traceCollector an optional collector for capturing trace() output
  */
 public record FhirEvaluationContext(
     @Nonnull Collection inputContext,
     @Nonnull EnvironmentVariableResolver variableResolver,
     @Nonnull FunctionRegistry functionRegistry,
     @Nonnull ResourceResolver resourceResolver,
-    @Nonnull FhirpathConfiguration configuration)
+    @Nonnull FhirpathConfiguration configuration,
+    @Nonnull Optional<TraceCollector> traceCollector)
     implements EvaluationContext {
 
   /**
-   * Creates a FhirEvaluationContext with default configuration.
+   * Creates a FhirEvaluationContext with default configuration and no trace collector.
    *
    * @param inputContext the current input context (focus) for the evaluation
    * @param variableResolver the resolver for environment variables
@@ -72,7 +75,32 @@ public record FhirEvaluationContext(
         variableResolver,
         functionRegistry,
         resourceResolver,
-        FhirpathConfiguration.DEFAULT);
+        FhirpathConfiguration.DEFAULT,
+        Optional.empty());
+  }
+
+  /**
+   * Creates a FhirEvaluationContext with the specified configuration and no trace collector.
+   *
+   * @param inputContext the current input context (focus) for the evaluation
+   * @param variableResolver the resolver for environment variables
+   * @param functionRegistry the registry for resolving FHIRPath functions
+   * @param resourceResolver the resolver for FHIR resources
+   * @param configuration the FHIRPath evaluation configuration
+   */
+  public FhirEvaluationContext(
+      @Nonnull final Collection inputContext,
+      @Nonnull final EnvironmentVariableResolver variableResolver,
+      @Nonnull final FunctionRegistry functionRegistry,
+      @Nonnull final ResourceResolver resourceResolver,
+      @Nonnull final FhirpathConfiguration configuration) {
+    this(
+        inputContext,
+        variableResolver,
+        functionRegistry,
+        resourceResolver,
+        configuration,
+        Optional.empty());
   }
 
   /**
@@ -130,5 +158,16 @@ public record FhirEvaluationContext(
   @Nonnull
   public FhirpathConfiguration getConfiguration() {
     return configuration;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns the trace collector provided at construction time.
+   */
+  @Override
+  @Nonnull
+  public Optional<TraceCollector> getTraceCollector() {
+    return traceCollector;
   }
 }

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluationResult.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluationResult.java
@@ -32,16 +32,22 @@ public class SingleInstanceEvaluationResult {
 
   @Nonnull private final String expectedReturnType;
 
+  @Nonnull private final List<TraceResult> traces;
+
   /**
    * Creates a new SingleInstanceEvaluationResult.
    *
    * @param results the typed result values from the evaluation
    * @param expectedReturnType the statically inferred return type of the expression
+   * @param traces the trace entries collected during evaluation
    */
   public SingleInstanceEvaluationResult(
-      @Nonnull final List<TypedValue> results, @Nonnull final String expectedReturnType) {
+      @Nonnull final List<TypedValue> results,
+      @Nonnull final String expectedReturnType,
+      @Nonnull final List<TraceResult> traces) {
     this.results = results;
     this.expectedReturnType = expectedReturnType;
+    this.traces = traces;
   }
 
   /**
@@ -62,6 +68,16 @@ public class SingleInstanceEvaluationResult {
   @Nonnull
   public String getExpectedReturnType() {
     return expectedReturnType;
+  }
+
+  /**
+   * Gets the trace entries collected during evaluation.
+   *
+   * @return the list of trace results, or an empty list if no trace() calls were present
+   */
+  @Nonnull
+  public List<TraceResult> getTraces() {
+    return traces;
   }
 
   /**
@@ -104,6 +120,66 @@ public class SingleInstanceEvaluationResult {
     @Nullable
     public Object getValue() {
       return value;
+    }
+  }
+
+  /**
+   * Represents a trace output from a {@code trace()} call during evaluation.
+   *
+   * @author John Grimes
+   */
+  public static class TraceResult {
+
+    @Nonnull private final String label;
+
+    @Nonnull private final String fhirType;
+
+    @Nonnull private final List<TypedValue> values;
+
+    /**
+     * Creates a new TraceResult.
+     *
+     * @param label the trace label (the name argument to trace())
+     * @param fhirType the FHIR type code of the traced collection
+     * @param values the traced values as typed values
+     */
+    public TraceResult(
+        @Nonnull final String label,
+        @Nonnull final String fhirType,
+        @Nonnull final List<TypedValue> values) {
+      this.label = label;
+      this.fhirType = fhirType;
+      this.values = values;
+    }
+
+    /**
+     * Gets the trace label.
+     *
+     * @return the label
+     */
+    @Nonnull
+    public String getLabel() {
+      return label;
+    }
+
+    /**
+     * Gets the FHIR type code of the traced collection.
+     *
+     * @return the FHIR type code
+     */
+    @Nonnull
+    public String getFhirType() {
+      return fhirType;
+    }
+
+    /**
+     * Gets the traced values.
+     *
+     * @return the list of typed values
+     */
+    @Nonnull
+    public List<TypedValue> getValues() {
+      return values;
     }
   }
 }

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluationResult.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluationResult.java
@@ -132,23 +132,16 @@ public class SingleInstanceEvaluationResult {
 
     @Nonnull private final String label;
 
-    @Nonnull private final String fhirType;
-
     @Nonnull private final List<TypedValue> values;
 
     /**
      * Creates a new TraceResult.
      *
      * @param label the trace label (the name argument to trace())
-     * @param fhirType the FHIR type code of the traced collection
      * @param values the traced values as typed values
      */
-    public TraceResult(
-        @Nonnull final String label,
-        @Nonnull final String fhirType,
-        @Nonnull final List<TypedValue> values) {
+    public TraceResult(@Nonnull final String label, @Nonnull final List<TypedValue> values) {
       this.label = label;
-      this.fhirType = fhirType;
       this.values = values;
     }
 
@@ -160,16 +153,6 @@ public class SingleInstanceEvaluationResult {
     @Nonnull
     public String getLabel() {
       return label;
-    }
-
-    /**
-     * Gets the FHIR type code of the traced collection.
-     *
-     * @return the FHIR type code
-     */
-    @Nonnull
-    public String getFhirType() {
-      return fhirType;
     }
 
     /**

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluator.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluator.java
@@ -154,7 +154,7 @@ public class SingleInstanceEvaluator {
 
       // Apply the result Column to the dataset and collect the results.
       final Column resultColumn = resultCollection.getColumn().getValue();
-      final List<TypedValue> results = collectResults(resourceDf, resultColumn, resultCollection);
+      final List<TypedValue> results = collectResults(resourceDf, resultColumn, expectedReturnType);
       final List<TraceResult> traces = buildTraceResults(traceCollector);
       return new SingleInstanceEvaluationResult(results, expectedReturnType, traces);
     }
@@ -249,7 +249,7 @@ public class SingleInstanceEvaluator {
     final Collection composedResult = evaluator.evaluate(composedPath);
     final Column composedColumn = composedResult.getColumn().getValue();
 
-    final List<TypedValue> results = collectResults(resourceDf, composedColumn, composedResult);
+    final List<TypedValue> results = collectResults(resourceDf, composedColumn, expectedReturnType);
     final List<TraceResult> traces = buildTraceResults(traceCollector);
     return new SingleInstanceEvaluationResult(results, expectedReturnType, traces);
   }
@@ -275,16 +275,15 @@ public class SingleInstanceEvaluator {
    *
    * @param resourceDf the single-row encoded resource Dataset
    * @param resultColumn the Column expression for the result
-   * @param collection the Collection with type metadata
+   * @param typeName the FHIR type name for the result values
    * @return a list of typed values
    */
   @Nonnull
   private static List<TypedValue> collectResults(
       @Nonnull final Dataset<Row> resourceDf,
       @Nonnull final Column resultColumn,
-      @Nonnull final Collection collection) {
+      @Nonnull final String typeName) {
 
-    final String typeName = determineReturnType(collection);
     final Dataset<Row> resultDf = resourceDf.select(resultColumn.alias("_result"));
     final List<Row> rows = resultDf.collectAsList();
 
@@ -335,13 +334,13 @@ public class SingleInstanceEvaluator {
    * Converts a raw Spark value to a Java value suitable for the result.
    *
    * <p>Struct types (complex FHIR types) are sanitised and converted to JSON strings. Primitive
-   * types are returned as-is.
+   * types are returned as-is. Null values are returned as-is.
    *
    * @param value the raw value
    * @return the converted value
    */
-  @Nonnull
-  private static Object convertValue(@Nonnull final Object value) {
+  @Nullable
+  private static Object convertValue(@Nullable final Object value) {
     if (value instanceof final Row row) {
       // Complex type: sanitise and convert to JSON string representation.
       return rowToJson(row);
@@ -455,25 +454,10 @@ public class SingleInstanceEvaluator {
     if (value instanceof final scala.collection.Seq<?> seq) {
       for (int i = 0; i < seq.size(); i++) {
         final Object element = seq.apply(i);
-        target.add(new TypedValue(fhirType, sanitizeTraceValue(element)));
+        target.add(new TypedValue(fhirType, convertValue(element)));
       }
     } else {
-      target.add(new TypedValue(fhirType, sanitizeTraceValue(value)));
+      target.add(new TypedValue(fhirType, convertValue(value)));
     }
-  }
-
-  /**
-   * Sanitizes a single trace value. Row objects are sanitized (synthetic fields stripped) and
-   * converted to JSON strings, consistent with how main result values are handled.
-   *
-   * @param value the raw trace value
-   * @return the sanitized value
-   */
-  @Nullable
-  private static Object sanitizeTraceValue(@Nullable final Object value) {
-    if (value instanceof final Row row) {
-      return rowToJson(row);
-    }
-    return value;
   }
 }

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluator.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluator.java
@@ -385,11 +385,17 @@ public class SingleInstanceEvaluator {
         if (value == null) {
           continue;
         }
-        filteredFields.add(field);
-        // Recursively sanitise nested struct values.
+        // Recursively sanitise nested struct values, updating the parent field's dataType
+        // to match the sanitised schema. This is critical because Row.json() uses the parent's
+        // dataType (not the nested row's own schema) to map field names positionally.
         if (value instanceof final Row nestedRow) {
-          filteredValues.add(sanitiseRow(nestedRow));
+          final Row sanitisedNested = sanitiseRow(nestedRow);
+          filteredValues.add(sanitisedNested);
+          filteredFields.add(
+              new StructField(
+                  field.name(), sanitisedNested.schema(), field.nullable(), field.metadata()));
         } else {
+          filteredFields.add(field);
           filteredValues.add(value);
         }
       }

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluator.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluator.java
@@ -20,11 +20,15 @@ package au.csiro.pathling.fhirpath.evaluation;
 import au.csiro.pathling.config.FhirpathConfiguration;
 import au.csiro.pathling.fhirpath.FhirPath;
 import au.csiro.pathling.fhirpath.FhirPathType;
+import au.csiro.pathling.fhirpath.ListTraceCollector;
+import au.csiro.pathling.fhirpath.ListTraceCollector.TraceEntry;
+import au.csiro.pathling.fhirpath.TraceCollectorProxy;
 import au.csiro.pathling.fhirpath.collection.BooleanCollection;
 import au.csiro.pathling.fhirpath.collection.Collection;
 import au.csiro.pathling.fhirpath.collection.DecimalCollection;
 import au.csiro.pathling.fhirpath.collection.IntegerCollection;
 import au.csiro.pathling.fhirpath.collection.StringCollection;
+import au.csiro.pathling.fhirpath.evaluation.SingleInstanceEvaluationResult.TraceResult;
 import au.csiro.pathling.fhirpath.evaluation.SingleInstanceEvaluationResult.TypedValue;
 import au.csiro.pathling.fhirpath.parser.Parser;
 import au.csiro.pathling.sql.SyntheticFieldUtils;
@@ -34,6 +38,7 @@ import jakarta.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.experimental.UtilityClass;
@@ -115,31 +120,44 @@ public class SingleInstanceEvaluator {
     // Convert incoming variables to Collection objects for the evaluator.
     final Map<String, Collection> variableCollections = convertVariables(variables);
 
-    // Parse the FHIRPath expression.
-    final Parser parser = new Parser();
-    final FhirPath mainPath = parser.parse(fhirPathExpression);
+    // Create a trace collector and serializable proxy to capture trace() output.
+    final ListTraceCollector traceCollector = new ListTraceCollector();
+    try (final TraceCollectorProxy proxy = TraceCollectorProxy.create(traceCollector)) {
 
-    // Create a single resource evaluator for determining the return type.
-    final SingleResourceEvaluator evaluator =
-        SingleResourceEvaluatorBuilder.create(ResourceType.fromCode(resourceType), fhirContext)
-            .withCrossResourceStrategy(CrossResourceStrategy.EMPTY)
-            .withVariables(variableCollections)
-            .withConfiguration(configuration)
-            .build();
+      // Parse the FHIRPath expression.
+      final Parser parser = new Parser();
+      final FhirPath mainPath = parser.parse(fhirPathExpression);
 
-    // Evaluate to determine the return type.
-    final Collection resultCollection = evaluator.evaluate(mainPath);
-    final String expectedReturnType = determineReturnType(resultCollection);
+      // Create a single resource evaluator for determining the return type.
+      final SingleResourceEvaluator evaluator =
+          SingleResourceEvaluatorBuilder.create(ResourceType.fromCode(resourceType), fhirContext)
+              .withCrossResourceStrategy(CrossResourceStrategy.EMPTY)
+              .withVariables(variableCollections)
+              .withConfiguration(configuration)
+              .withTraceCollector(proxy)
+              .build();
 
-    if (contextExpression != null) {
-      return evaluateWithContext(
-          resourceDf, parser, mainPath, contextExpression, evaluator, expectedReturnType);
+      // Evaluate to determine the return type.
+      final Collection resultCollection = evaluator.evaluate(mainPath);
+      final String expectedReturnType = determineReturnType(resultCollection);
+
+      if (contextExpression != null) {
+        return evaluateWithContext(
+            resourceDf,
+            parser,
+            mainPath,
+            contextExpression,
+            evaluator,
+            expectedReturnType,
+            traceCollector);
+      }
+
+      // Apply the result Column to the dataset and collect the results.
+      final Column resultColumn = resultCollection.getColumn().getValue();
+      final List<TypedValue> results = collectResults(resourceDf, resultColumn, resultCollection);
+      final List<TraceResult> traces = buildTraceResults(traceCollector);
+      return new SingleInstanceEvaluationResult(results, expectedReturnType, traces);
     }
-
-    // Apply the result Column to the dataset and collect the results.
-    final Column resultColumn = resultCollection.getColumn().getValue();
-    final List<TypedValue> results = collectResults(resourceDf, resultColumn, resultCollection);
-    return new SingleInstanceEvaluationResult(results, expectedReturnType);
   }
 
   /**
@@ -198,6 +216,7 @@ public class SingleInstanceEvaluator {
    * @param contextExpression the context expression string
    * @param evaluator the single resource evaluator
    * @param expectedReturnType the inferred return type of the main expression
+   * @param traceCollector the trace collector for capturing trace() output
    * @return a SingleInstanceEvaluationResult with results for each context item
    */
   @Nonnull
@@ -207,7 +226,8 @@ public class SingleInstanceEvaluator {
       @Nonnull final FhirPath mainPath,
       @Nonnull final String contextExpression,
       @Nonnull final SingleResourceEvaluator evaluator,
-      @Nonnull final String expectedReturnType) {
+      @Nonnull final String expectedReturnType,
+      @Nonnull final ListTraceCollector traceCollector) {
 
     // Parse and evaluate the context expression.
     final FhirPath contextPath = parser.parse(contextExpression);
@@ -219,7 +239,7 @@ public class SingleInstanceEvaluator {
     final List<Row> contextRows = contextDf.collectAsList();
 
     if (contextRows.isEmpty() || contextRows.getFirst().isNullAt(0)) {
-      return new SingleInstanceEvaluationResult(new ArrayList<>(), expectedReturnType);
+      return new SingleInstanceEvaluationResult(new ArrayList<>(), expectedReturnType, List.of());
     }
 
     // The context value is an array; evaluate the main expression against the input context
@@ -230,7 +250,8 @@ public class SingleInstanceEvaluator {
     final Column composedColumn = composedResult.getColumn().getValue();
 
     final List<TypedValue> results = collectResults(resourceDf, composedColumn, composedResult);
-    return new SingleInstanceEvaluationResult(results, expectedReturnType);
+    final List<TraceResult> traces = buildTraceResults(traceCollector);
+    return new SingleInstanceEvaluationResult(results, expectedReturnType, traces);
   }
 
   /**
@@ -376,5 +397,77 @@ public class SingleInstanceEvaluator {
 
     final StructType filteredSchema = new StructType(filteredFields.toArray(new StructField[0]));
     return new GenericRowWithSchema(filteredValues.toArray(), filteredSchema);
+  }
+
+  /**
+   * Builds trace results from the collector, grouping entries by label and sanitizing Row values.
+   *
+   * @param collector the trace collector containing raw entries
+   * @return a list of trace results grouped by label, in order of first appearance
+   */
+  @Nonnull
+  static List<TraceResult> buildTraceResults(@Nonnull final ListTraceCollector collector) {
+    final List<TraceEntry> entries = collector.getEntries();
+    if (entries.isEmpty()) {
+      return List.of();
+    }
+
+    // Group entries by label, preserving insertion order.
+    final Map<String, List<TraceEntry>> grouped = new LinkedHashMap<>();
+    for (final TraceEntry entry : entries) {
+      grouped.computeIfAbsent(entry.label(), k -> new ArrayList<>()).add(entry);
+    }
+
+    // Build TraceResult for each group, expanding array values into individual entries.
+    final List<TraceResult> results = new ArrayList<>();
+    for (final Map.Entry<String, List<TraceEntry>> group : grouped.entrySet()) {
+      final String label = group.getKey();
+      final List<TraceEntry> groupEntries = group.getValue();
+      final String fhirType = groupEntries.getFirst().fhirType();
+      final List<TypedValue> values = new ArrayList<>();
+      for (final TraceEntry entry : groupEntries) {
+        expandTraceValue(entry.fhirType(), entry.value(), values);
+      }
+      results.add(new TraceResult(label, fhirType, values));
+    }
+    return results;
+  }
+
+  /**
+   * Expands a trace value into individual typed values. If the value is a Scala collection (which
+   * occurs when the traced column is an array), each element is extracted and sanitized
+   * individually. Otherwise the value is sanitized and added directly.
+   *
+   * @param fhirType the FHIR type code
+   * @param value the raw trace value (may be a Scala Seq for array columns)
+   * @param target the list to add expanded values to
+   */
+  private static void expandTraceValue(
+      @Nonnull final String fhirType,
+      @Nullable final Object value,
+      @Nonnull final List<TypedValue> target) {
+    if (value instanceof final scala.collection.Seq<?> seq) {
+      for (int i = 0; i < seq.size(); i++) {
+        final Object element = seq.apply(i);
+        target.add(new TypedValue(fhirType, sanitizeTraceValue(element)));
+      }
+    } else {
+      target.add(new TypedValue(fhirType, sanitizeTraceValue(value)));
+    }
+  }
+
+  /**
+   * Sanitizes a single trace value. Row objects are sanitized (synthetic fields stripped) and
+   * converted to JSON strings, consistent with how main result values are handled.
+   *
+   * @param value the raw trace value
+   * @return the sanitized value
+   */
+  @Nullable
+  private static Object sanitizeTraceValue(@Nullable final Object value) {
+    if (value instanceof final Row row) {
+      return rowToJson(row);
+    }
+    return value;
   }
 }

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluator.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluator.java
@@ -427,13 +427,11 @@ public class SingleInstanceEvaluator {
     final List<TraceResult> results = new ArrayList<>();
     for (final Map.Entry<String, List<TraceEntry>> group : grouped.entrySet()) {
       final String label = group.getKey();
-      final List<TraceEntry> groupEntries = group.getValue();
-      final String fhirType = groupEntries.getFirst().fhirType();
       final List<TypedValue> values = new ArrayList<>();
-      for (final TraceEntry entry : groupEntries) {
+      for (final TraceEntry entry : group.getValue()) {
         expandTraceValue(entry.fhirType(), entry.value(), values);
       }
-      results.add(new TraceResult(label, fhirType, values));
+      results.add(new TraceResult(label, values));
     }
     return results;
   }

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleResourceEvaluator.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleResourceEvaluator.java
@@ -25,8 +25,10 @@ import au.csiro.pathling.fhirpath.collection.ResourceCollection;
 import au.csiro.pathling.fhirpath.function.registry.FunctionRegistry;
 import au.csiro.pathling.fhirpath.variable.EnvironmentVariableResolver;
 import au.csiro.pathling.fhirpath.variable.VariableResolverChain;
+import au.csiro.pathling.sql.TraceCollector;
 import jakarta.annotation.Nonnull;
 import java.util.Map;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -76,7 +78,7 @@ public class SingleResourceEvaluator {
       @Nonnull final FunctionRegistry functionRegistry,
       @Nonnull final Map<String, Collection> variables) {
     return new SingleResourceEvaluator(
-        resolver, functionRegistry, variables, FhirpathConfiguration.DEFAULT);
+        resolver, functionRegistry, variables, FhirpathConfiguration.DEFAULT, Optional.empty());
   }
 
   /** The resource resolver. */
@@ -90,6 +92,9 @@ public class SingleResourceEvaluator {
 
   /** The FHIRPath evaluation configuration. */
   @Nonnull private final FhirpathConfiguration configuration;
+
+  /** An optional trace collector for capturing trace() output. */
+  @Nonnull private final Optional<TraceCollector> traceCollector;
 
   /**
    * Evaluates a FHIRPath expression with the default input context.
@@ -124,7 +129,12 @@ public class SingleResourceEvaluator {
         VariableResolverChain.withDefaults(resource, inputContext, variables);
     final EvaluationContext evalContext =
         new FhirEvaluationContext(
-            inputContext, variableResolver, functionRegistry, resourceResolver, configuration);
+            inputContext,
+            variableResolver,
+            functionRegistry,
+            resourceResolver,
+            configuration,
+            traceCollector);
     return fhirPath.apply(inputContext, evalContext);
   }
 

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleResourceEvaluatorBuilder.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/evaluation/SingleResourceEvaluatorBuilder.java
@@ -21,9 +21,11 @@ import au.csiro.pathling.config.FhirpathConfiguration;
 import au.csiro.pathling.fhirpath.collection.Collection;
 import au.csiro.pathling.fhirpath.function.registry.FunctionRegistry;
 import au.csiro.pathling.fhirpath.function.registry.StaticFunctionRegistry;
+import au.csiro.pathling.sql.TraceCollector;
 import ca.uhn.fhir.context.FhirContext;
 import jakarta.annotation.Nonnull;
 import java.util.Map;
+import java.util.Optional;
 import org.hl7.fhir.r4.model.Enumerations.ResourceType;
 
 /**
@@ -72,6 +74,8 @@ public class SingleResourceEvaluatorBuilder {
   @Nonnull private Map<String, Collection> variables = Map.of();
 
   @Nonnull private FhirpathConfiguration configuration = FhirpathConfiguration.DEFAULT;
+
+  @Nonnull private Optional<TraceCollector> traceCollector = Optional.empty();
 
   /** Private constructor. Use factory methods to create instances. */
   private SingleResourceEvaluatorBuilder(
@@ -190,6 +194,21 @@ public class SingleResourceEvaluatorBuilder {
   }
 
   /**
+   * Sets the trace collector for capturing trace() output.
+   *
+   * <p>Default is empty (no collection, SLF4J logging only).
+   *
+   * @param traceCollector the trace collector
+   * @return this builder for method chaining
+   */
+  @Nonnull
+  public SingleResourceEvaluatorBuilder withTraceCollector(
+      @Nonnull final TraceCollector traceCollector) {
+    this.traceCollector = Optional.of(traceCollector);
+    return this;
+  }
+
+  /**
    * Builds the {@link SingleResourceEvaluator} with the configured options.
    *
    * @return a new SingleResourceEvaluator instance
@@ -198,6 +217,7 @@ public class SingleResourceEvaluatorBuilder {
   public SingleResourceEvaluator build() {
     final ResourceResolver resolver =
         new FhirResourceResolver(subjectResourceCode, fhirContext, crossResourceStrategy);
-    return new SingleResourceEvaluator(resolver, functionRegistry, variables, configuration);
+    return new SingleResourceEvaluator(
+        resolver, functionRegistry, variables, configuration, traceCollector);
   }
 }

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/UtilityFunctions.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/UtilityFunctions.java
@@ -49,8 +49,12 @@ public class UtilityFunctions {
    * <p>When a {@link TraceCollector} is available on the evaluation context, each traced value is
    * also added to the collector with the trace label and the FHIR type of the input collection.
    *
+   * <p><strong>Limitation:</strong> The {@code name} argument must be a string literal. Dynamic
+   * expressions (e.g., {@code trace(someField)}) are not supported and will raise an error.
+   *
    * @param input the input collection
    * @param name a {@link StringCollection} containing the diagnostic label for the trace output
+   *     (must be a literal value)
    * @param context the evaluation context, used to obtain the optional trace collector
    * @return the input collection, unchanged
    * @see <a

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/UtilityFunctions.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/UtilityFunctions.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.fhirpath.function.provider;
+
+import static org.apache.spark.sql.classic.ExpressionUtils.column;
+import static org.apache.spark.sql.classic.ExpressionUtils.expression;
+
+import au.csiro.pathling.fhirpath.collection.Collection;
+import au.csiro.pathling.fhirpath.collection.StringCollection;
+import au.csiro.pathling.fhirpath.function.FhirPathFunction;
+import au.csiro.pathling.sql.TraceExpression;
+import jakarta.annotation.Nonnull;
+import org.apache.spark.sql.Column;
+
+/**
+ * Contains FHIRPath utility functions.
+ *
+ * @author John Grimes
+ * @see <a href="https://build.fhir.org/ig/HL7/FHIRPath/#utility-functions">FHIRPath Specification -
+ *     Utility functions</a>
+ */
+@SuppressWarnings("unused")
+public class UtilityFunctions {
+
+  private UtilityFunctions() {}
+
+  /**
+   * Adds a string representation of the input collection to the diagnostic log, using the {@code
+   * name} argument as the label in the log. Returns the input collection unchanged.
+   *
+   * @param input the input collection
+   * @param name a {@link StringCollection} containing the diagnostic label for the trace output
+   * @return the input collection, unchanged
+   * @see <a
+   *     href="https://build.fhir.org/ig/HL7/FHIRPath/#tracename-string-projection-expression-collection">FHIRPath
+   *     Specification - trace</a>
+   */
+  @FhirPathFunction
+  @Nonnull
+  public static Collection trace(
+      @Nonnull final Collection input, @Nonnull final StringCollection name) {
+    final String label = name.toLiteralValue();
+    return input.copyWith(input.getColumn().call(col -> wrapWithTrace(col, label)));
+  }
+
+  /**
+   * Wraps a Spark Column with a {@link TraceExpression} that logs each evaluated value.
+   *
+   * @param col the column to wrap
+   * @param name the diagnostic label
+   * @return a new column that logs values during evaluation
+   */
+  @Nonnull
+  private static Column wrapWithTrace(@Nonnull final Column col, @Nonnull final String name) {
+    return column(new TraceExpression(expression(col), name));
+  }
+}

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/UtilityFunctions.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/UtilityFunctions.java
@@ -27,6 +27,7 @@ import au.csiro.pathling.fhirpath.function.CollectionTransform;
 import au.csiro.pathling.fhirpath.function.FhirPathFunction;
 import au.csiro.pathling.sql.TraceCollector;
 import au.csiro.pathling.sql.TraceExpression;
+import au.csiro.pathling.sql.TraceProjectionExpression;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.apache.spark.sql.Column;
@@ -77,37 +78,33 @@ public class UtilityFunctions {
     final String label = name.toLiteralValue();
     @Nullable final TraceCollector collector = context.getTraceCollector().orElse(null);
 
-    final Collection toLog = projection != null ? projection.apply(input) : input;
-    final String fhirType = toLog.getFhirType().map(t -> t.toCode()).orElse("unknown");
-    // Normalise the projected column so that empty arrays become null, preventing trace entries
-    // for empty collections.
-    final Column toLogColumn = toLog.getColumn().normaliseNull().getValue();
-
-    return input.copyWith(
-        input
-            .getColumn()
-            .call(inputCol -> wrapWithTrace(inputCol, toLogColumn, label, fhirType, collector)));
-  }
-
-  /**
-   * Wraps a Spark Column with a {@link TraceExpression} that returns the pass-through value while
-   * logging the projected value.
-   *
-   * @param passThrough the column whose value is returned
-   * @param toLog the column whose value is logged
-   * @param name the diagnostic label
-   * @param fhirType the FHIR type code of the logged expression
-   * @param collector the optional trace collector, or null
-   * @return a new column that logs values during evaluation
-   */
-  @Nonnull
-  private static Column wrapWithTrace(
-      @Nonnull final Column passThrough,
-      @Nonnull final Column toLog,
-      @Nonnull final String name,
-      @Nonnull final String fhirType,
-      @Nullable final TraceCollector collector) {
-    return column(
-        new TraceExpression(expression(passThrough), expression(toLog), name, fhirType, collector));
+    if (projection != null) {
+      final Collection projected = projection.apply(input);
+      final String fhirType = projected.getFhirType().map(t -> t.toCode()).orElse("unknown");
+      // Normalise the projected column so that empty arrays become null, preventing trace entries
+      // for empty collections.
+      final Column projectedColumn = projected.getColumn().normaliseNull().getValue();
+      return input.copyWith(
+          input
+              .getColumn()
+              .call(
+                  inputCol ->
+                      column(
+                          new TraceProjectionExpression(
+                              expression(inputCol),
+                              expression(projectedColumn),
+                              label,
+                              fhirType,
+                              collector))));
+    } else {
+      final String fhirType = input.getFhirType().map(t -> t.toCode()).orElse("unknown");
+      return input.copyWith(
+          input
+              .getColumn()
+              .call(
+                  inputCol ->
+                      column(
+                          new TraceExpression(expression(inputCol), label, fhirType, collector))));
+    }
   }
 }

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/UtilityFunctions.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/UtilityFunctions.java
@@ -20,11 +20,14 @@ package au.csiro.pathling.fhirpath.function.provider;
 import static org.apache.spark.sql.classic.ExpressionUtils.column;
 import static org.apache.spark.sql.classic.ExpressionUtils.expression;
 
+import au.csiro.pathling.fhirpath.EvaluationContext;
 import au.csiro.pathling.fhirpath.collection.Collection;
 import au.csiro.pathling.fhirpath.collection.StringCollection;
 import au.csiro.pathling.fhirpath.function.FhirPathFunction;
+import au.csiro.pathling.sql.TraceCollector;
 import au.csiro.pathling.sql.TraceExpression;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.apache.spark.sql.Column;
 
 /**
@@ -43,8 +46,12 @@ public class UtilityFunctions {
    * Adds a string representation of the input collection to the diagnostic log, using the {@code
    * name} argument as the label in the log. Returns the input collection unchanged.
    *
+   * <p>When a {@link TraceCollector} is available on the evaluation context, each traced value is
+   * also added to the collector with the trace label and the FHIR type of the input collection.
+   *
    * @param input the input collection
    * @param name a {@link StringCollection} containing the diagnostic label for the trace output
+   * @param context the evaluation context, used to obtain the optional trace collector
    * @return the input collection, unchanged
    * @see <a
    *     href="https://build.fhir.org/ig/HL7/FHIRPath/#tracename-string-projection-expression-collection">FHIRPath
@@ -53,9 +60,14 @@ public class UtilityFunctions {
   @FhirPathFunction
   @Nonnull
   public static Collection trace(
-      @Nonnull final Collection input, @Nonnull final StringCollection name) {
+      @Nonnull final Collection input,
+      @Nonnull final StringCollection name,
+      @Nonnull final EvaluationContext context) {
     final String label = name.toLiteralValue();
-    return input.copyWith(input.getColumn().call(col -> wrapWithTrace(col, label)));
+    final String fhirType = input.getFhirType().map(t -> t.toCode()).orElse("unknown");
+    @Nullable final TraceCollector collector = context.getTraceCollector().orElse(null);
+    return input.copyWith(
+        input.getColumn().call(col -> wrapWithTrace(col, label, fhirType, collector)));
   }
 
   /**
@@ -63,10 +75,16 @@ public class UtilityFunctions {
    *
    * @param col the column to wrap
    * @param name the diagnostic label
+   * @param fhirType the FHIR type code
+   * @param collector the optional trace collector, or null
    * @return a new column that logs values during evaluation
    */
   @Nonnull
-  private static Column wrapWithTrace(@Nonnull final Column col, @Nonnull final String name) {
-    return column(new TraceExpression(expression(col), name));
+  private static Column wrapWithTrace(
+      @Nonnull final Column col,
+      @Nonnull final String name,
+      @Nonnull final String fhirType,
+      @Nullable final TraceCollector collector) {
+    return column(new TraceExpression(expression(col), name, fhirType, collector));
   }
 }

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/UtilityFunctions.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/UtilityFunctions.java
@@ -23,6 +23,7 @@ import static org.apache.spark.sql.classic.ExpressionUtils.expression;
 import au.csiro.pathling.fhirpath.EvaluationContext;
 import au.csiro.pathling.fhirpath.collection.Collection;
 import au.csiro.pathling.fhirpath.collection.StringCollection;
+import au.csiro.pathling.fhirpath.function.CollectionTransform;
 import au.csiro.pathling.fhirpath.function.FhirPathFunction;
 import au.csiro.pathling.sql.TraceCollector;
 import au.csiro.pathling.sql.TraceExpression;
@@ -46,8 +47,11 @@ public class UtilityFunctions {
    * Adds a string representation of the input collection to the diagnostic log, using the {@code
    * name} argument as the label in the log. Returns the input collection unchanged.
    *
+   * <p>When a projection expression is provided, the projected value is logged instead of the input
+   * value, but the input collection is still returned unchanged.
+   *
    * <p>When a {@link TraceCollector} is available on the evaluation context, each traced value is
-   * also added to the collector with the trace label and the FHIR type of the input collection.
+   * also added to the collector with the trace label and the FHIR type of the logged expression.
    *
    * <p><strong>Limitation:</strong> The {@code name} argument must be a string literal. Dynamic
    * expressions (e.g., {@code trace(someField)}) are not supported and will raise an error.
@@ -55,6 +59,8 @@ public class UtilityFunctions {
    * @param input the input collection
    * @param name a {@link StringCollection} containing the diagnostic label for the trace output
    *     (must be a literal value)
+   * @param projection an optional expression to evaluate on the input for logging; when null, the
+   *     input value itself is logged
    * @param context the evaluation context, used to obtain the optional trace collector
    * @return the input collection, unchanged
    * @see <a
@@ -66,29 +72,42 @@ public class UtilityFunctions {
   public static Collection trace(
       @Nonnull final Collection input,
       @Nonnull final StringCollection name,
+      @Nullable final CollectionTransform projection,
       @Nonnull final EvaluationContext context) {
     final String label = name.toLiteralValue();
-    final String fhirType = input.getFhirType().map(t -> t.toCode()).orElse("unknown");
     @Nullable final TraceCollector collector = context.getTraceCollector().orElse(null);
+
+    final Collection toLog = projection != null ? projection.apply(input) : input;
+    final String fhirType = toLog.getFhirType().map(t -> t.toCode()).orElse("unknown");
+    // Normalise the projected column so that empty arrays become null, preventing trace entries
+    // for empty collections.
+    final Column toLogColumn = toLog.getColumn().normaliseNull().getValue();
+
     return input.copyWith(
-        input.getColumn().call(col -> wrapWithTrace(col, label, fhirType, collector)));
+        input
+            .getColumn()
+            .call(inputCol -> wrapWithTrace(inputCol, toLogColumn, label, fhirType, collector)));
   }
 
   /**
-   * Wraps a Spark Column with a {@link TraceExpression} that logs each evaluated value.
+   * Wraps a Spark Column with a {@link TraceExpression} that returns the pass-through value while
+   * logging the projected value.
    *
-   * @param col the column to wrap
+   * @param passThrough the column whose value is returned
+   * @param toLog the column whose value is logged
    * @param name the diagnostic label
-   * @param fhirType the FHIR type code
+   * @param fhirType the FHIR type code of the logged expression
    * @param collector the optional trace collector, or null
    * @return a new column that logs values during evaluation
    */
   @Nonnull
   private static Column wrapWithTrace(
-      @Nonnull final Column col,
+      @Nonnull final Column passThrough,
+      @Nonnull final Column toLog,
       @Nonnull final String name,
       @Nonnull final String fhirType,
       @Nullable final TraceCollector collector) {
-    return column(new TraceExpression(expression(col), name, fhirType, collector));
+    return column(
+        new TraceExpression(expression(passThrough), expression(toLog), name, fhirType, collector));
   }
 }

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/registry/StaticFunctionRegistry.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/registry/StaticFunctionRegistry.java
@@ -29,6 +29,7 @@ import au.csiro.pathling.fhirpath.function.provider.StringFunctions;
 import au.csiro.pathling.fhirpath.function.provider.SubsettingFunctions;
 import au.csiro.pathling.fhirpath.function.provider.TerminologyFunctions;
 import au.csiro.pathling.fhirpath.function.provider.TypeFunctions;
+import au.csiro.pathling.fhirpath.function.provider.UtilityFunctions;
 import com.google.common.collect.ImmutableMap.Builder;
 
 /**
@@ -57,6 +58,7 @@ public class StaticFunctionRegistry extends InMemoryFunctionRegistry {
             .putAll(MethodDefinedFunction.mapOf(SubsettingFunctions.class))
             .putAll(MethodDefinedFunction.mapOf(TerminologyFunctions.class))
             .putAll(MethodDefinedFunction.mapOf(TypeFunctions.class))
+            .putAll(MethodDefinedFunction.mapOf(UtilityFunctions.class))
             .build());
   }
 

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/ListTraceCollectorTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/ListTraceCollectorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.fhirpath;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import au.csiro.pathling.fhirpath.ListTraceCollector.TraceEntry;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link ListTraceCollector}. */
+class ListTraceCollectorTest {
+
+  @Test
+  void emptyByDefault() {
+    final ListTraceCollector collector = new ListTraceCollector();
+    assertTrue(collector.getEntries().isEmpty());
+  }
+
+  @Test
+  void capturesEntries() {
+    final ListTraceCollector collector = new ListTraceCollector();
+    collector.add("label1", "string", "hello");
+    collector.add("label2", "boolean", true);
+
+    final List<TraceEntry> entries = collector.getEntries();
+    assertEquals(2, entries.size());
+    assertEquals("label1", entries.get(0).label());
+    assertEquals("string", entries.get(0).fhirType());
+    assertEquals("hello", entries.get(0).value());
+    assertEquals("label2", entries.get(1).label());
+    assertEquals("boolean", entries.get(1).fhirType());
+    assertEquals(true, entries.get(1).value());
+  }
+
+  @Test
+  void acceptsNullValues() {
+    final ListTraceCollector collector = new ListTraceCollector();
+    collector.add("label", "string", null);
+
+    assertEquals(1, collector.getEntries().size());
+    assertEquals(null, collector.getEntries().get(0).value());
+  }
+}

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/TraceCollectorProxyTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/TraceCollectorProxyTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.fhirpath;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import au.csiro.pathling.fhirpath.ListTraceCollector.TraceEntry;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link TraceCollectorProxy}.
+ *
+ * @author Piotr Szul
+ */
+class TraceCollectorProxyTest {
+
+  @Test
+  void createReturnsNonNullProxy() {
+    // Creating a proxy from a delegate should return a non-null instance.
+    final ListTraceCollector delegate = new ListTraceCollector();
+    try (final TraceCollectorProxy proxy = TraceCollectorProxy.create(delegate)) {
+      assertNotNull(proxy);
+    }
+  }
+
+  @Test
+  void delegatesAddToRegisteredCollector() {
+    // Calling add() on the proxy should forward the entry to the delegate.
+    final ListTraceCollector delegate = new ListTraceCollector();
+    try (final TraceCollectorProxy proxy = TraceCollectorProxy.create(delegate)) {
+      proxy.add("lbl", "string", "val");
+
+      final List<TraceEntry> entries = delegate.getEntries();
+      assertEquals(1, entries.size());
+      assertEquals("lbl", entries.get(0).label());
+      assertEquals("string", entries.get(0).fhirType());
+      assertEquals("val", entries.get(0).value());
+    }
+  }
+
+  @Test
+  void delegatesMultipleAdds() {
+    // Multiple add() calls should all arrive at the delegate.
+    final ListTraceCollector delegate = new ListTraceCollector();
+    try (final TraceCollectorProxy proxy = TraceCollectorProxy.create(delegate)) {
+      proxy.add("a", "string", "1");
+      proxy.add("b", "boolean", true);
+      proxy.add("c", "integer", 42);
+
+      assertEquals(3, delegate.getEntries().size());
+    }
+  }
+
+  @Test
+  void addNoOpsAfterClose() {
+    // After close(), add() should silently do nothing.
+    final ListTraceCollector delegate = new ListTraceCollector();
+    final TraceCollectorProxy proxy = TraceCollectorProxy.create(delegate);
+    proxy.add("before", "string", "x");
+    proxy.close();
+
+    proxy.add("after", "string", "y");
+
+    final List<TraceEntry> entries = delegate.getEntries();
+    assertEquals(1, entries.size());
+    assertEquals("before", entries.get(0).label());
+  }
+
+  @Test
+  void closeIsIdempotent() {
+    // Calling close() twice should not throw.
+    final ListTraceCollector delegate = new ListTraceCollector();
+    final TraceCollectorProxy proxy = TraceCollectorProxy.create(delegate);
+    proxy.close();
+    assertDoesNotThrow(proxy::close);
+  }
+
+  @Test
+  void multipleProxiesAreIndependent() {
+    // Two proxies with different delegates should not interfere with each other.
+    final ListTraceCollector delegate1 = new ListTraceCollector();
+    final ListTraceCollector delegate2 = new ListTraceCollector();
+
+    try (final TraceCollectorProxy proxy1 = TraceCollectorProxy.create(delegate1);
+        final TraceCollectorProxy proxy2 = TraceCollectorProxy.create(delegate2)) {
+      proxy1.add("from1", "string", "val1");
+
+      assertEquals(1, delegate1.getEntries().size());
+      assertTrue(delegate2.getEntries().isEmpty());
+    }
+  }
+
+  @Test
+  void addWithNullValueDelegates() {
+    // A null value should be forwarded to the delegate without error.
+    final ListTraceCollector delegate = new ListTraceCollector();
+    try (final TraceCollectorProxy proxy = TraceCollectorProxy.create(delegate)) {
+      proxy.add("lbl", "string", null);
+
+      assertEquals(1, delegate.getEntries().size());
+      assertNull(delegate.getEntries().get(0).value());
+    }
+  }
+}

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluatorIntegrationTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluatorIntegrationTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.fhirpath.evaluation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.fhirpath.evaluation.SingleInstanceEvaluationResult.TraceResult;
+import au.csiro.pathling.test.SpringBootUnitTest;
+import au.csiro.pathling.test.datasource.ObjectDataSource;
+import ca.uhn.fhir.context.FhirContext;
+import java.util.List;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.r4.model.HumanName;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Integration tests for {@link SingleInstanceEvaluator} that exercise the full evaluate lifecycle
+ * including trace collection.
+ *
+ * @author Piotr Szul
+ */
+@SpringBootUnitTest
+class SingleInstanceEvaluatorIntegrationTest {
+
+  @Autowired SparkSession spark;
+
+  @Autowired FhirEncoders encoders;
+
+  private Dataset<Row> patientDf;
+  private FhirContext fhirContext;
+
+  @BeforeEach
+  void setUp() {
+    final Patient patient = new Patient();
+    patient.setId("Patient/1");
+    patient.setGender(AdministrativeGender.MALE);
+    patient.setActive(true);
+    patient
+        .addName()
+        .setUse(HumanName.NameUse.OFFICIAL)
+        .setFamily("Smith")
+        .addGiven("John")
+        .addGiven("James");
+
+    final ObjectDataSource dataSource = new ObjectDataSource(spark, encoders, List.of(patient));
+    patientDf = dataSource.read("Patient");
+    fhirContext = encoders.getContext();
+  }
+
+  @Test
+  void evaluateSimpleExpressionWithTrace() {
+    // Evaluating a traced primitive expression should return both the result and trace entries.
+    final SingleInstanceEvaluationResult result =
+        SingleInstanceEvaluator.evaluate(
+            patientDf, "Patient", fhirContext, "Patient.gender.trace('gender')", null, null);
+
+    // The result should contain the gender value.
+    assertEquals(1, result.getResults().size());
+    assertEquals("male", result.getResults().get(0).getValue());
+
+    // The traces should contain one entry for the 'gender' label.
+    assertEquals(1, result.getTraces().size());
+    final TraceResult trace = result.getTraces().get(0);
+    assertEquals("gender", trace.getLabel());
+    assertEquals(1, trace.getValues().size());
+    assertEquals("male", trace.getValues().get(0).getValue());
+  }
+
+  @Test
+  void evaluateWithMultipleTraces() {
+    // An expression with multiple trace() calls should capture all trace labels.
+    final SingleInstanceEvaluationResult result =
+        SingleInstanceEvaluator.evaluate(
+            patientDf,
+            "Patient",
+            fhirContext,
+            "Patient.name.where(use = 'official').given.trace('given').first().trace('first')",
+            null,
+            null);
+
+    // The result should be the first given name.
+    assertEquals(1, result.getResults().size());
+    assertEquals("John", result.getResults().get(0).getValue());
+
+    // There should be two trace groups.
+    assertEquals(2, result.getTraces().size());
+
+    final TraceResult givenTrace = result.getTraces().get(0);
+    assertEquals("given", givenTrace.getLabel());
+    // The patient has two given names.
+    assertEquals(2, givenTrace.getValues().size());
+
+    final TraceResult firstTrace = result.getTraces().get(1);
+    assertEquals("first", firstTrace.getLabel());
+    assertEquals(1, firstTrace.getValues().size());
+    assertEquals("John", firstTrace.getValues().get(0).getValue());
+  }
+
+  @Test
+  void evaluateWithoutTrace() {
+    // An expression without trace() should return an empty traces list.
+    final SingleInstanceEvaluationResult result =
+        SingleInstanceEvaluator.evaluate(
+            patientDf, "Patient", fhirContext, "Patient.active", null, null);
+
+    assertEquals(1, result.getResults().size());
+    assertEquals(true, result.getResults().get(0).getValue());
+    assertTrue(result.getTraces().isEmpty());
+  }
+
+  @Test
+  void evaluateTraceOnComplexType() {
+    // Tracing a complex type should produce a JSON string without synthetic fields.
+    final SingleInstanceEvaluationResult result =
+        SingleInstanceEvaluator.evaluate(
+            patientDf, "Patient", fhirContext, "Patient.name.first().trace('name')", null, null);
+
+    // The trace should contain a JSON representation of the HumanName.
+    assertEquals(1, result.getTraces().size());
+    final TraceResult trace = result.getTraces().get(0);
+    assertEquals("name", trace.getLabel());
+    assertEquals(1, trace.getValues().size());
+
+    final Object traceValue = trace.getValues().get(0).getValue();
+    assertInstanceOf(String.class, traceValue);
+    final String json = (String) traceValue;
+    assertTrue(json.contains("Smith"));
+    // Synthetic fields should not appear in the JSON output.
+    assertFalse(json.contains("_fid"));
+  }
+}

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluatorTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluatorTest.java
@@ -337,6 +337,42 @@ class SingleInstanceEvaluatorTest {
     }
 
     @Test
+    void updatesParentSchemaForSanitisedNestedStructs() {
+      // The parent's StructField dataType for a nested struct must match the sanitised nested
+      // Row's schema, so that Row.json() positional mapping remains correct.
+      final StructType nestedSchema =
+          new StructType(
+              new StructField[] {
+                DataTypes.createStructField("id", DataTypes.StringType, true),
+                DataTypes.createStructField("start", DataTypes.StringType, true),
+                DataTypes.createStructField("end", DataTypes.StringType, true),
+              });
+
+      final StructType outerSchema =
+          new StructType(
+              new StructField[] {
+                DataTypes.createStructField("family", DataTypes.StringType, true),
+                DataTypes.createStructField("period", nestedSchema, true),
+              });
+
+      final Row nestedRow =
+          new GenericRowWithSchema(new Object[] {null, "2000", "2002"}, nestedSchema);
+      final Row outerRow = new GenericRowWithSchema(new Object[] {"Smith", nestedRow}, outerSchema);
+
+      final Row sanitised = SingleInstanceEvaluator.sanitiseRow(outerRow);
+
+      // The parent's "period" field dataType should have 2 fields (id stripped as null).
+      final StructType periodType = (StructType) sanitised.schema().apply("period").dataType();
+      assertEquals(2, periodType.fields().length);
+      assertEquals("start", periodType.fields()[0].name());
+      assertEquals("end", periodType.fields()[1].name());
+
+      // The parent's dataType should match the nested Row's own schema.
+      final Row sanitisedNested = sanitised.getAs("period");
+      assertEquals(sanitisedNested.schema(), periodType);
+    }
+
+    @Test
     void preservesFieldsWithNonNullValues() {
       // All non-null fields should be kept, even if some are null.
       final StructType schema =
@@ -383,6 +419,38 @@ class SingleInstanceEvaluatorTest {
       assertFalse(json.contains("value_scale"));
       assertTrue(json.contains("\"value\":\"100\""));
       assertTrue(json.contains("\"code\":\"mg\""));
+    }
+
+    @Test
+    void jsonCorrectlyMapsNestedStructFieldsAfterNullStripping() {
+      // Nested struct with null fields should produce correct field-to-value mapping in JSON.
+      // Without the fix, Row.json() uses the parent's original dataType to interpret the nested
+      // row, causing positional misalignment when null fields have been stripped.
+      final StructType nestedSchema =
+          new StructType(
+              new StructField[] {
+                DataTypes.createStructField("id", DataTypes.StringType, true),
+                DataTypes.createStructField("start", DataTypes.StringType, true),
+                DataTypes.createStructField("end", DataTypes.StringType, true),
+              });
+
+      final StructType outerSchema =
+          new StructType(
+              new StructField[] {
+                DataTypes.createStructField("family", DataTypes.StringType, true),
+                DataTypes.createStructField("period", nestedSchema, true),
+              });
+
+      final Row nestedRow =
+          new GenericRowWithSchema(new Object[] {null, "2000", "2002"}, nestedSchema);
+      final Row outerRow = new GenericRowWithSchema(new Object[] {"Smith", nestedRow}, outerSchema);
+
+      final String json = SingleInstanceEvaluator.rowToJson(outerRow);
+
+      assertTrue(json.contains("\"start\":\"2000\""));
+      assertTrue(json.contains("\"end\":\"2002\""));
+      assertFalse(json.contains("\"id\""));
+      assertTrue(json.contains("\"family\":\"Smith\""));
     }
 
     @Test

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluatorTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluatorTest.java
@@ -21,15 +21,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import au.csiro.pathling.fhirpath.ListTraceCollector;
 import au.csiro.pathling.fhirpath.collection.BooleanCollection;
 import au.csiro.pathling.fhirpath.collection.Collection;
 import au.csiro.pathling.fhirpath.collection.DecimalCollection;
 import au.csiro.pathling.fhirpath.collection.IntegerCollection;
 import au.csiro.pathling.fhirpath.collection.StringCollection;
+import au.csiro.pathling.fhirpath.evaluation.SingleInstanceEvaluationResult.TraceResult;
+import au.csiro.pathling.fhirpath.evaluation.SingleInstanceEvaluationResult.TypedValue;
+import au.csiro.pathling.test.helpers.SqlHelpers;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
@@ -399,6 +405,208 @@ class SingleInstanceEvaluatorTest {
       assertFalse(json.contains("\"comparator\""));
       assertTrue(json.contains("\"value\":\"100\""));
       assertTrue(json.contains("\"unit\":\"mg\""));
+    }
+  }
+
+  @Nested
+  class BuildTraceResultsTests {
+
+    @Test
+    void emptyCollectorReturnsEmptyList() {
+      // An empty collector should produce an empty trace result list.
+      final ListTraceCollector collector = new ListTraceCollector();
+      final List<TraceResult> results = SingleInstanceEvaluator.buildTraceResults(collector);
+      assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void singlePrimitiveEntry() {
+      // A single primitive entry should produce one TraceResult with one TypedValue.
+      final ListTraceCollector collector = new ListTraceCollector();
+      collector.add("lbl", "string", "hello");
+
+      final List<TraceResult> results = SingleInstanceEvaluator.buildTraceResults(collector);
+
+      assertEquals(1, results.size());
+      assertEquals("lbl", results.get(0).getLabel());
+      assertEquals("string", results.get(0).getFhirType());
+      assertEquals(1, results.get(0).getValues().size());
+      assertEquals("string", results.get(0).getValues().get(0).getType());
+      assertEquals("hello", results.get(0).getValues().get(0).getValue());
+    }
+
+    @Test
+    void singleNullValueEntry() {
+      // A null value should produce a TypedValue with null.
+      final ListTraceCollector collector = new ListTraceCollector();
+      collector.add("lbl", "string", null);
+
+      final List<TraceResult> results = SingleInstanceEvaluator.buildTraceResults(collector);
+
+      assertEquals(1, results.size());
+      assertEquals(1, results.get(0).getValues().size());
+      assertNull(results.get(0).getValues().get(0).getValue());
+    }
+
+    @Test
+    void multipleEntriesSameLabelGrouped() {
+      // Entries with the same label should be grouped into one TraceResult.
+      final ListTraceCollector collector = new ListTraceCollector();
+      collector.add("x", "string", "a");
+      collector.add("x", "string", "b");
+
+      final List<TraceResult> results = SingleInstanceEvaluator.buildTraceResults(collector);
+
+      assertEquals(1, results.size());
+      assertEquals("x", results.get(0).getLabel());
+      assertEquals(2, results.get(0).getValues().size());
+      assertEquals("a", results.get(0).getValues().get(0).getValue());
+      assertEquals("b", results.get(0).getValues().get(1).getValue());
+    }
+
+    @Test
+    void differentLabelsProduceSeparateResults() {
+      // Entries with different labels should produce separate TraceResults.
+      final ListTraceCollector collector = new ListTraceCollector();
+      collector.add("a", "string", "v1");
+      collector.add("b", "boolean", true);
+
+      final List<TraceResult> results = SingleInstanceEvaluator.buildTraceResults(collector);
+
+      assertEquals(2, results.size());
+      assertEquals("a", results.get(0).getLabel());
+      assertEquals("b", results.get(1).getLabel());
+    }
+
+    @Test
+    void insertionOrderPreserved() {
+      // Results should appear in the order labels were first seen, not alphabetically.
+      final ListTraceCollector collector = new ListTraceCollector();
+      collector.add("c", "string", "1");
+      collector.add("a", "string", "2");
+      collector.add("b", "string", "3");
+
+      final List<TraceResult> results = SingleInstanceEvaluator.buildTraceResults(collector);
+
+      assertEquals(3, results.size());
+      assertEquals("c", results.get(0).getLabel());
+      assertEquals("a", results.get(1).getLabel());
+      assertEquals("b", results.get(2).getLabel());
+    }
+
+    @Test
+    void rowValueConvertedToJson() {
+      // A Row value should be converted to a JSON string.
+      final StructType schema =
+          new StructType(
+              new StructField[] {
+                DataTypes.createStructField("value", DataTypes.StringType, true),
+                DataTypes.createStructField("code", DataTypes.StringType, true),
+              });
+      final Row row = new GenericRowWithSchema(new Object[] {"100", "mg"}, schema);
+
+      final ListTraceCollector collector = new ListTraceCollector();
+      collector.add("qty", "Quantity", row);
+
+      final List<TraceResult> results = SingleInstanceEvaluator.buildTraceResults(collector);
+
+      assertEquals(1, results.size());
+      final Object value = results.get(0).getValues().get(0).getValue();
+      assertInstanceOf(String.class, value);
+      final String json = (String) value;
+      assertTrue(json.contains("\"value\":\"100\""));
+      assertTrue(json.contains("\"code\":\"mg\""));
+    }
+
+    @Test
+    void rowValueWithSyntheticFieldsStripped() {
+      // Synthetic fields in Row values should be stripped in the JSON output.
+      final StructType schema =
+          new StructType(
+              new StructField[] {
+                DataTypes.createStructField("value", DataTypes.StringType, true),
+                DataTypes.createStructField("_fid", DataTypes.IntegerType, true),
+                DataTypes.createStructField("value_scale", DataTypes.IntegerType, true),
+              });
+      final Row row = new GenericRowWithSchema(new Object[] {"100", 1, 3}, schema);
+
+      final ListTraceCollector collector = new ListTraceCollector();
+      collector.add("qty", "Quantity", row);
+
+      final List<TraceResult> results = SingleInstanceEvaluator.buildTraceResults(collector);
+
+      final String json = (String) results.get(0).getValues().get(0).getValue();
+      assertFalse(json.contains("_fid"));
+      assertFalse(json.contains("value_scale"));
+      assertTrue(json.contains("\"value\":\"100\""));
+    }
+
+    @Test
+    void scalaSeqValueExpanded() {
+      // A Scala Seq value should be expanded into individual TypedValues.
+      final ListTraceCollector collector = new ListTraceCollector();
+      collector.add("items", "string", SqlHelpers.sql_array("a", "b", "c"));
+
+      final List<TraceResult> results = SingleInstanceEvaluator.buildTraceResults(collector);
+
+      assertEquals(1, results.size());
+      final List<TypedValue> values = results.get(0).getValues();
+      assertEquals(3, values.size());
+      assertEquals("a", values.get(0).getValue());
+      assertEquals("b", values.get(1).getValue());
+      assertEquals("c", values.get(2).getValue());
+    }
+
+    @Test
+    void scalaSeqWithRowElementsConvertedToJson() {
+      // A Scala Seq of Rows should produce JSON strings for each element.
+      final StructType schema =
+          new StructType(
+              new StructField[] {
+                DataTypes.createStructField("code", DataTypes.StringType, true),
+              });
+      final Row row1 = new GenericRowWithSchema(new Object[] {"mg"}, schema);
+      final Row row2 = new GenericRowWithSchema(new Object[] {"kg"}, schema);
+
+      final ListTraceCollector collector = new ListTraceCollector();
+      collector.add("codes", "Coding", SqlHelpers.sql_array(row1, row2));
+
+      final List<TraceResult> results = SingleInstanceEvaluator.buildTraceResults(collector);
+
+      final List<TypedValue> values = results.get(0).getValues();
+      assertEquals(2, values.size());
+      assertInstanceOf(String.class, values.get(0).getValue());
+      assertTrue(((String) values.get(0).getValue()).contains("\"code\":\"mg\""));
+      assertTrue(((String) values.get(1).getValue()).contains("\"code\":\"kg\""));
+    }
+
+    @Test
+    void mixedLabelsAndTypes() {
+      // Multiple labels with different types should be grouped correctly.
+      final ListTraceCollector collector = new ListTraceCollector();
+      collector.add("name", "HumanName", "Smith");
+      collector.add("active", "boolean", true);
+      collector.add("name", "HumanName", "Jones");
+
+      final List<TraceResult> results = SingleInstanceEvaluator.buildTraceResults(collector);
+
+      assertEquals(2, results.size());
+      assertEquals("name", results.get(0).getLabel());
+      assertEquals(2, results.get(0).getValues().size());
+      assertEquals("active", results.get(1).getLabel());
+      assertEquals(1, results.get(1).getValues().size());
+    }
+
+    @Test
+    void fhirTypeFromFirstEntryInGroup() {
+      // The fhirType on TraceResult should come from the first entry in the group.
+      final ListTraceCollector collector = new ListTraceCollector();
+      collector.add("val", "string", "hello");
+      collector.add("val", "string", "world");
+
+      final List<TraceResult> results = SingleInstanceEvaluator.buildTraceResults(collector);
+
+      assertEquals("string", results.get(0).getFhirType());
     }
   }
 }

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluatorTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/evaluation/SingleInstanceEvaluatorTest.java
@@ -497,7 +497,6 @@ class SingleInstanceEvaluatorTest {
 
       assertEquals(1, results.size());
       assertEquals("lbl", results.get(0).getLabel());
-      assertEquals("string", results.get(0).getFhirType());
       assertEquals(1, results.get(0).getValues().size());
       assertEquals("string", results.get(0).getValues().get(0).getType());
       assertEquals("hello", results.get(0).getValues().get(0).getValue());
@@ -663,18 +662,6 @@ class SingleInstanceEvaluatorTest {
       assertEquals(2, results.get(0).getValues().size());
       assertEquals("active", results.get(1).getLabel());
       assertEquals(1, results.get(1).getValues().size());
-    }
-
-    @Test
-    void fhirTypeFromFirstEntryInGroup() {
-      // The fhirType on TraceResult should come from the first entry in the group.
-      final ListTraceCollector collector = new ListTraceCollector();
-      collector.add("val", "string", "hello");
-      collector.add("val", "string", "world");
-
-      final List<TraceResult> results = SingleInstanceEvaluator.buildTraceResults(collector);
-
-      assertEquals("string", results.get(0).getFhirType());
     }
   }
 }

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/function/provider/TraceFunctionTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/function/provider/TraceFunctionTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.fhirpath.function.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.fhirpath.FhirPath;
+import au.csiro.pathling.fhirpath.collection.BooleanCollection;
+import au.csiro.pathling.fhirpath.collection.StringCollection;
+import au.csiro.pathling.fhirpath.evaluation.CollectionDataset;
+import au.csiro.pathling.fhirpath.evaluation.CrossResourceStrategy;
+import au.csiro.pathling.fhirpath.evaluation.DatasetEvaluator;
+import au.csiro.pathling.fhirpath.evaluation.DatasetEvaluatorBuilder;
+import au.csiro.pathling.fhirpath.parser.Parser;
+import au.csiro.pathling.sql.TraceExpression;
+import au.csiro.pathling.test.SpringBootUnitTest;
+import au.csiro.pathling.test.assertions.Assertions;
+import au.csiro.pathling.test.datasource.ObjectDataSource;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.annotation.Nonnull;
+import java.util.List;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
+import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.r4.model.Enumerations.ResourceType;
+import org.hl7.fhir.r4.model.HumanName;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/** Tests for the FHIRPath trace() function. */
+@SpringBootUnitTest
+class TraceFunctionTest {
+
+  private static final Parser PARSER = new Parser();
+
+  @Autowired SparkSession spark;
+
+  @Autowired FhirEncoders encoders;
+
+  private DatasetEvaluator evaluator;
+  private ListAppender<ILoggingEvent> logAppender;
+
+  @BeforeEach
+  void setUp() {
+    final Patient patient1 = new Patient();
+    patient1.setId("Patient/1");
+    patient1.setGender(AdministrativeGender.FEMALE);
+    patient1.setActive(true);
+    patient1.addName().setUse(HumanName.NameUse.OFFICIAL).setFamily("Smith").addGiven("Jane");
+
+    final Patient patient2 = new Patient();
+    patient2.setId("Patient/2");
+    patient2.setGender(AdministrativeGender.MALE);
+    patient2.setActive(false);
+    patient2
+        .addName()
+        .setUse(HumanName.NameUse.NICKNAME)
+        .setFamily("Doe")
+        .addGiven("John")
+        .addGiven("James");
+
+    final Patient patient3 = new Patient();
+    patient3.setId("Patient/3");
+    // No gender, no active status, no name.
+
+    final ObjectDataSource dataSource =
+        new ObjectDataSource(spark, encoders, List.of(patient1, patient2, patient3));
+    final Dataset<Row> dataset = dataSource.read("Patient");
+
+    evaluator =
+        DatasetEvaluatorBuilder.create(ResourceType.PATIENT, encoders.getContext())
+            .withDataset(dataset)
+            .withCrossResourceStrategy(CrossResourceStrategy.EMPTY)
+            .build();
+
+    // Attach a ListAppender to capture TraceExpression log output.
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    getTraceLogger().addAppender(logAppender);
+  }
+
+  @AfterEach
+  void tearDown() {
+    getTraceLogger().detachAppender(logAppender);
+    logAppender.stop();
+  }
+
+  @Nonnull
+  private static Logger getTraceLogger() {
+    return (Logger) LoggerFactory.getLogger(TraceExpression.class);
+  }
+
+  @Nonnull
+  private CollectionDataset evaluate(@Nonnull final String expression) {
+    final FhirPath fhirPath = PARSER.parse(expression);
+    return evaluator.evaluate(fhirPath);
+  }
+
+  @Nested
+  class PassThroughTests {
+
+    @Test
+    void trace_boolean_returnsSameValues() {
+      Assertions.assertThat(evaluate("Patient.active.trace('active-check')"))
+          .hasClass(BooleanCollection.class)
+          .toCanonicalResult()
+          .hasRowsUnordered(
+              RowFactory.create("1", true),
+              RowFactory.create("2", false),
+              RowFactory.create("3", null));
+    }
+
+    @Test
+    void trace_string_returnsSameValues() {
+      Assertions.assertThat(evaluate("Patient.gender.trace('debug')"))
+          .hasClass(StringCollection.class)
+          .toCanonicalResult()
+          .hasRowsUnordered(
+              RowFactory.create("1", "female"),
+              RowFactory.create("2", "male"),
+              RowFactory.create("3", null));
+    }
+
+    @Test
+    void trace_complexType_returnsSameValues() {
+      assertTraceIsPassThrough("Patient.name", "Patient.name.trace('names')");
+    }
+
+    @Test
+    void trace_afterWhere_returnsSameValues() {
+      assertTraceIsPassThrough(
+          "Patient.name.where(use = 'official')",
+          "Patient.name.where(use = 'official').trace('official-names')");
+    }
+
+    @Test
+    void trace_beforeWhere_returnsSameValues() {
+      assertTraceIsPassThrough(
+          "Patient.name.where(use = 'official')",
+          "Patient.name.trace('all-names').where(use = 'official')");
+    }
+
+    @Test
+    void trace_twoTraceCalls_returnsSameValues() {
+      assertTraceIsPassThrough(
+          "Patient.name.where(use = 'official')",
+          "Patient.name.trace('before-filter').where(use = 'official')" + ".trace('after-filter')");
+    }
+
+    @Test
+    void trace_multiElementCollection_returnsSameValues() {
+      assertTraceIsPassThrough("Patient.name.given", "Patient.name.given.trace('givens')");
+    }
+
+    private void assertTraceIsPassThrough(
+        @Nonnull final String baseExpression, @Nonnull final String tracedExpression) {
+      final CollectionDataset expected = evaluate(baseExpression);
+      final CollectionDataset actual = evaluate(tracedExpression);
+
+      // Verify type equality.
+      assertEquals(
+          expected.getValue().getFhirType().get().toCode(),
+          actual.getValue().getFhirType().get().toCode());
+
+      // Verify value equality.
+      final Dataset<Row> expectedDs = expected.toCanonical().toIdValueDataset();
+      final Dataset<Row> actualDs = actual.toCanonical().toIdValueDataset();
+      Assertions.assertThat(actualDs).hasRowsUnordered(expectedDs);
+    }
+
+    @Test
+    void trace_emptyCollection_returnsEmpty() {
+      final CollectionDataset result = evaluate("{}.trace('empty')");
+      assertNotNull(result);
+    }
+  }
+
+  @Nested
+  class LoggingTests {
+
+    @Test
+    void trace_logsWithLabel() {
+      // Materialise the result to trigger expression evaluation.
+      evaluate("Patient.active.trace('myLabel')").toCanonical().toIdValueDataset().collectAsList();
+
+      final boolean hasLabelledEntry =
+          logAppender.list.stream()
+              .anyMatch(event -> event.getFormattedMessage().contains("myLabel"));
+      assertTrue(hasLabelledEntry, "Expected log entry containing 'myLabel'");
+    }
+
+    @Test
+    void trace_logsValueRepresentation() {
+      evaluate("Patient.name.family.trace('names')")
+          .toCanonical()
+          .toIdValueDataset()
+          .collectAsList();
+
+      final boolean hasSmith =
+          logAppender.list.stream()
+              .anyMatch(event -> event.getFormattedMessage().contains("Smith"));
+      assertTrue(hasSmith, "Expected log entry containing 'Smith'");
+    }
+
+    @Test
+    void trace_twoTraceCalls_produceDistinctLogEntries() {
+      evaluate("Patient.name.trace('before').where(use = 'official').trace('after').family")
+          .toCanonical()
+          .toIdValueDataset()
+          .collectAsList();
+
+      final boolean hasBefore =
+          logAppender.list.stream()
+              .anyMatch(event -> event.getFormattedMessage().contains("[trace:before]"));
+      final boolean hasAfter =
+          logAppender.list.stream()
+              .anyMatch(event -> event.getFormattedMessage().contains("[trace:after]"));
+      assertTrue(hasBefore, "Expected log entry labelled 'before'");
+      assertTrue(hasAfter, "Expected log entry labelled 'after'");
+    }
+  }
+
+  @Nested
+  class ErrorTests {
+
+    @Test
+    void trace_withNoArguments_raisesError() {
+      // The error may occur at parse time or evaluation time.
+      assertThrows(Exception.class, () -> evaluate("Patient.active.trace()"));
+    }
+  }
+}

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/function/provider/TraceFunctionTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/function/provider/TraceFunctionTest.java
@@ -381,6 +381,24 @@ class TraceFunctionTest {
     }
 
     @Test
+    void collector_chainedTrace_innerNotDoubleEvaluated() {
+      // When trace('inner').trace('outer') is evaluated without a projection, the outer
+      // TraceExpression has the same expression for both left and right children. This test
+      // verifies
+      // that the inner trace fires exactly once per element, not twice due to double evaluation.
+      materialize("Patient.name.trace('inner').trace('outer')");
+
+      final long innerCount =
+          collector.getEntries().stream().filter(e -> "inner".equals(e.label())).count();
+      final long outerCount =
+          collector.getEntries().stream().filter(e -> "outer".equals(e.label())).count();
+      assertEquals(
+          outerCount,
+          innerCount,
+          "Inner trace should fire the same number of times as outer trace, not double");
+    }
+
+    @Test
     void evaluationWithoutCollector_stillWorks() {
       // The default evaluator has no collector; evaluation should succeed with SLF4J only.
       final CollectionDataset result = evaluate("Patient.active.trace('test')");

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/function/provider/TraceFunctionTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/function/provider/TraceFunctionTest.java
@@ -184,6 +184,30 @@ class TraceFunctionTest {
       final CollectionDataset result = evaluate("{}.trace('empty')");
       assertNotNull(result);
     }
+
+    @Test
+    void trace_withProjection_returnsInputUnchanged() {
+      assertTraceIsPassThrough("Patient.name", "Patient.name.trace('fam', family)");
+    }
+
+    @Test
+    void trace_withProjection_complexExpression_returnsInputUnchanged() {
+      assertTraceIsPassThrough(
+          "Patient.name", "Patient.name.trace('full', given.first() + ' ' + family)");
+    }
+
+    @Test
+    void trace_withProjection_returningNull_returnsInputUnchanged() {
+      // Patient.name.text is null for all test patients; projection produces null but input is
+      // returned unchanged.
+      assertTraceIsPassThrough("Patient.name", "Patient.name.trace('missing', text)");
+    }
+
+    @Test
+    void trace_withProjection_onEmptyCollection_returnsEmpty() {
+      final CollectionDataset result = evaluate("{}.trace('empty', id)");
+      assertNotNull(result);
+    }
   }
 
   @Nested
@@ -211,6 +235,47 @@ class TraceFunctionTest {
           logAppender.list.stream()
               .anyMatch(event -> event.getFormattedMessage().contains("Smith"));
       assertTrue(hasSmith, "Expected log entry containing 'Smith'");
+    }
+
+    @Test
+    void trace_withProjection_complexExpression_logsProjectedValue() {
+      evaluate("Patient.name.trace('full', given.first() + ' ' + family)")
+          .toCanonical()
+          .toIdValueDataset()
+          .collectAsList();
+
+      final boolean hasJaneSmith =
+          logAppender.list.stream()
+              .anyMatch(event -> event.getFormattedMessage().contains("Jane Smith"));
+      assertTrue(hasJaneSmith, "Expected log entry containing concatenated 'Jane Smith'");
+    }
+
+    @Test
+    void trace_withProjection_returningNull_doesNotLog() {
+      // When the projection evaluates to an empty collection, the normalised column is null, so no
+      // trace entry is produced.
+      evaluate("Patient.name.trace('missing', text)")
+          .toCanonical()
+          .toIdValueDataset()
+          .collectAsList();
+
+      final boolean hasMissingLabel =
+          logAppender.list.stream()
+              .anyMatch(event -> event.getFormattedMessage().contains("[trace:missing]"));
+      assertFalse(hasMissingLabel, "Expected no log entries when projection evaluates to null");
+    }
+
+    @Test
+    void trace_withProjection_logsProjectedValue() {
+      evaluate("Patient.name.trace('fam', family)")
+          .toCanonical()
+          .toIdValueDataset()
+          .collectAsList();
+
+      final boolean hasSmith =
+          logAppender.list.stream()
+              .anyMatch(event -> event.getFormattedMessage().contains("Smith"));
+      assertTrue(hasSmith, "Expected log entry containing projected value 'Smith'");
     }
 
     @Test
@@ -301,6 +366,18 @@ class TraceFunctionTest {
       final List<TraceEntry> entries = collector.getEntries();
       assertTrue(entries.stream().anyMatch(e -> "a".equals(e.label())));
       assertTrue(entries.stream().anyMatch(e -> "b".equals(e.label())));
+    }
+
+    @Test
+    void collector_withProjection_capturesProjectedFhirType() {
+      materialize("Patient.name.trace('fam', family)");
+
+      final List<TraceEntry> entries = collector.getEntries();
+      assertFalse(entries.isEmpty());
+      assertTrue(
+          entries.stream().allMatch(e -> "string".equals(e.fhirType())),
+          "Expected projected FHIR type 'string', not input type 'HumanName'");
+      assertTrue(entries.stream().allMatch(e -> "fam".equals(e.label())));
     }
 
     @Test

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/function/provider/TraceFunctionTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/function/provider/TraceFunctionTest.java
@@ -73,29 +73,9 @@ class TraceFunctionTest {
 
   @BeforeEach
   void setUp() {
-    final Patient patient1 = new Patient();
-    patient1.setId("Patient/1");
-    patient1.setGender(AdministrativeGender.FEMALE);
-    patient1.setActive(true);
-    patient1.addName().setUse(HumanName.NameUse.OFFICIAL).setFamily("Smith").addGiven("Jane");
-
-    final Patient patient2 = new Patient();
-    patient2.setId("Patient/2");
-    patient2.setGender(AdministrativeGender.MALE);
-    patient2.setActive(false);
-    patient2
-        .addName()
-        .setUse(HumanName.NameUse.NICKNAME)
-        .setFamily("Doe")
-        .addGiven("John")
-        .addGiven("James");
-
-    final Patient patient3 = new Patient();
-    patient3.setId("Patient/3");
-    // No gender, no active status, no name.
-
     final ObjectDataSource dataSource =
-        new ObjectDataSource(spark, encoders, List.of(patient1, patient2, patient3));
+        new ObjectDataSource(
+            spark, encoders, List.of(createPatient1(), createPatient2(), createPatient3()));
     final Dataset<Row> dataset = dataSource.read("Patient");
 
     evaluator =

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/function/provider/TraceFunctionTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/function/provider/TraceFunctionTest.java
@@ -18,12 +18,15 @@
 package au.csiro.pathling.fhirpath.function.provider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.fhirpath.FhirPath;
+import au.csiro.pathling.fhirpath.ListTraceCollector;
+import au.csiro.pathling.fhirpath.ListTraceCollector.TraceEntry;
 import au.csiro.pathling.fhirpath.collection.BooleanCollection;
 import au.csiro.pathling.fhirpath.collection.StringCollection;
 import au.csiro.pathling.fhirpath.evaluation.CollectionDataset;
@@ -256,5 +259,103 @@ class TraceFunctionTest {
       // The error may occur at parse time or evaluation time.
       assertThrows(Exception.class, () -> evaluate("Patient.active.trace()"));
     }
+  }
+
+  @Nested
+  class CollectorTests {
+
+    private ListTraceCollector collector;
+    private DatasetEvaluator collectorEvaluator;
+
+    @BeforeEach
+    void setUpCollector() {
+      collector = new ListTraceCollector();
+      final ObjectDataSource dataSource =
+          new ObjectDataSource(
+              spark, encoders, List.of(createPatient1(), createPatient2(), createPatient3()));
+      final Dataset<Row> dataset = dataSource.read("Patient");
+      collectorEvaluator =
+          DatasetEvaluatorBuilder.create(ResourceType.PATIENT, encoders.getContext())
+              .withDataset(dataset)
+              .withCrossResourceStrategy(CrossResourceStrategy.EMPTY)
+              .withTraceCollector(collector)
+              .build();
+    }
+
+    private void materialize(@Nonnull final String expression) {
+      final FhirPath fhirPath = PARSER.parse(expression);
+      collectorEvaluator.evaluate(fhirPath).toCanonical().toIdValueDataset().collectAsList();
+    }
+
+    @Test
+    void collector_capturesEntriesWithLabel() {
+      materialize("Patient.active.trace('myLabel')");
+
+      final List<TraceEntry> entries = collector.getEntries();
+      assertFalse(entries.isEmpty());
+      assertTrue(entries.stream().allMatch(e -> "myLabel".equals(e.label())));
+    }
+
+    @Test
+    void collector_capturesCorrectFhirType_primitive() {
+      materialize("Patient.active.trace('flag')");
+
+      final List<TraceEntry> entries = collector.getEntries();
+      assertFalse(entries.isEmpty());
+      assertTrue(entries.stream().allMatch(e -> "boolean".equals(e.fhirType())));
+    }
+
+    @Test
+    void collector_capturesCorrectFhirType_complex() {
+      materialize("Patient.name.trace('names')");
+
+      final List<TraceEntry> entries = collector.getEntries();
+      assertFalse(entries.isEmpty());
+      assertTrue(entries.stream().allMatch(e -> "HumanName".equals(e.fhirType())));
+    }
+
+    @Test
+    void collector_twoTraceCallsProduceDistinctLabels() {
+      materialize("Patient.name.trace('a').where(use = 'official').trace('b').family");
+
+      final List<TraceEntry> entries = collector.getEntries();
+      assertTrue(entries.stream().anyMatch(e -> "a".equals(e.label())));
+      assertTrue(entries.stream().anyMatch(e -> "b".equals(e.label())));
+    }
+
+    @Test
+    void evaluationWithoutCollector_stillWorks() {
+      // The default evaluator has no collector; evaluation should succeed with SLF4J only.
+      final CollectionDataset result = evaluate("Patient.active.trace('test')");
+      assertNotNull(result);
+    }
+  }
+
+  private static Patient createPatient1() {
+    final Patient p = new Patient();
+    p.setId("Patient/1");
+    p.setGender(AdministrativeGender.FEMALE);
+    p.setActive(true);
+    p.addName().setUse(HumanName.NameUse.OFFICIAL).setFamily("Smith").addGiven("Jane");
+    return p;
+  }
+
+  private static Patient createPatient2() {
+    final Patient p = new Patient();
+    p.setId("Patient/2");
+    p.setGender(AdministrativeGender.MALE);
+    p.setActive(false);
+    p.addName()
+        .setUse(HumanName.NameUse.NICKNAME)
+        .setFamily("Doe")
+        .addGiven("John")
+        .addGiven("James");
+    return p;
+  }
+
+  private static Patient createPatient3() {
+    final Patient p = new Patient();
+    p.setId("Patient/3");
+    return p;
   }
 }

--- a/fhirpath/src/test/resources/fhirpath-js/config.yaml
+++ b/fhirpath/src/test/resources/fhirpath-js/config.yaml
@@ -9,6 +9,24 @@ excludeSet:
         id: "#2418"
         expression:
           - "^StructureDefinition"
+      - title: "trace() projection parameter not yet supported"
+        type: feature
+        id: "#2580"
+        comment: |
+          The optional projection parameter for trace(name, projection) is not
+          yet implemented. Only trace(name) is supported.
+        any:
+          - "trace('test', given)"
+      - title: "Primitive .id extension not accessible after trace"
+        type: bug
+        id: "#2580"
+        outcome: failure
+        comment: |
+          Accessing the .id extension property on a FHIR primitive element
+          after trace() returns null because the TraceExpression wrapping
+          changes how the schema is resolved for extension fields.
+        any:
+          - "trace('coll')[0].id"
       - title: Parse error
         type: wontfix
         comment: |

--- a/fhirpath/src/test/resources/fhirpath-js/config.yaml
+++ b/fhirpath/src/test/resources/fhirpath-js/config.yaml
@@ -9,14 +9,6 @@ excludeSet:
         id: "#2418"
         expression:
           - "^StructureDefinition"
-      - title: "trace() projection parameter not yet supported"
-        type: feature
-        id: "#2580"
-        comment: |
-          The optional projection parameter for trace(name, projection) is not
-          yet implemented. Only trace(name) is supported.
-        any:
-          - "trace('test', given)"
       - title: "Primitive .id extension not accessible after trace"
         type: bug
         id: "#2580"

--- a/fhirpath/src/test/resources/logback-test.xml
+++ b/fhirpath/src/test/resources/logback-test.xml
@@ -32,6 +32,7 @@
     <appender-ref ref="TIMING"/>
   </logger>
   <logger level="INFO" name="au.csiro"/>
+  <logger level="TRACE" name="au.csiro.pathling.sql.TraceExpression"/>
   <logger level="ERROR" name="org.apache.spark.sql.catalyst.util.SparkStringUtils"/>
   <logger level="ERROR" name="org.apache.spark.sql.catalyst.analysis.SimpleFunctionRegistry"/>
   <logger level="ERROR" name="org.apache.hadoop.util.NativeCodeLoader"/>

--- a/lib/python/pathling/context.py
+++ b/lib/python/pathling/context.py
@@ -41,6 +41,21 @@ def _convert_java_value(value):
     return str(value)
 
 
+def _convert_typed_values(jtyped_values) -> list:
+    """Converts a Java list of TypedValue objects to Python dicts.
+
+    :param jtyped_values: iterable of Java TypedValue objects with getType() and getValue()
+    :return: list of dicts with ``type`` and ``value`` keys
+    """
+    results = []
+    for jtyped_value in jtyped_values:
+        value = jtyped_value.getValue()
+        if value is not None:
+            value = _convert_java_value(value)
+        results.append({"type": jtyped_value.getType(), "value": value})
+    return results
+
+
 class StorageType:
     MEMORY: str = "memory"
     DISK: str = "disk"
@@ -453,7 +468,8 @@ class PathlingContext:
                expression is composed with the context expression
         :param variables: optional named variables available via %variable syntax, or None
         :return: a dict with ``results`` (list of dicts with ``type`` and ``value``
-                 keys) and ``expectedReturnType`` (string)
+                 keys), ``expectedReturnType`` (string), and ``traces`` (list of
+                 dicts with ``label`` and ``values`` keys)
         :raises: Exception if the expression is invalid or evaluation fails
         """
         jresult = self._jpc.evaluateFhirPath(
@@ -464,29 +480,16 @@ class PathlingContext:
             variables,
         )
         # Convert Java FhirPathResult to Python dict.
-        results = []
-        for jtyped_value in jresult.getResults():
-            value = jtyped_value.getValue()
-            # Convert Java types to Python types.
-            if value is not None:
-                value = _convert_java_value(value)
-            results.append({"type": jtyped_value.getType(), "value": value})
+        results = _convert_typed_values(jresult.getResults())
 
         # Convert trace results.
-        traces = []
-        for jtrace in jresult.getTraces():
-            trace_values = []
-            for jtyped_value in jtrace.getValues():
-                value = jtyped_value.getValue()
-                if value is not None:
-                    value = _convert_java_value(value)
-                trace_values.append({"type": jtyped_value.getType(), "value": value})
-            traces.append(
-                {
-                    "label": jtrace.getLabel(),
-                    "values": trace_values,
-                }
-            )
+        traces = [
+            {
+                "label": jtrace.getLabel(),
+                "values": _convert_typed_values(jtrace.getValues()),
+            }
+            for jtrace in jresult.getTraces()
+        ]
 
         return {
             "results": results,

--- a/lib/python/pathling/context.py
+++ b/lib/python/pathling/context.py
@@ -471,9 +471,27 @@ class PathlingContext:
             if value is not None:
                 value = _convert_java_value(value)
             results.append({"type": jtyped_value.getType(), "value": value})
+
+        # Convert trace results.
+        traces = []
+        for jtrace in jresult.getTraces():
+            trace_values = []
+            for jtyped_value in jtrace.getValues():
+                value = jtyped_value.getValue()
+                if value is not None:
+                    value = _convert_java_value(value)
+                trace_values.append({"type": jtyped_value.getType(), "value": value})
+            traces.append(
+                {
+                    "label": jtrace.getLabel(),
+                    "values": trace_values,
+                }
+            )
+
         return {
             "results": results,
             "expectedReturnType": jresult.getExpectedReturnType(),
+            "traces": traces,
         }
 
     def search_to_column(self, resource_type: str, search_expression: str) -> Column:

--- a/lib/python/tests/test_evaluate_fhirpath.py
+++ b/lib/python/tests/test_evaluate_fhirpath.py
@@ -1,0 +1,292 @@
+#  Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+#  Organisation (CSIRO) ABN 41 687 119 230.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for PathlingContext.evaluate_fhirpath()."""
+
+import json
+
+import pytest
+
+PATIENT_JSON = json.dumps(
+    {
+        "resourceType": "Patient",
+        "id": "example",
+        "active": True,
+        "gender": "male",
+        "birthDate": "1990-01-01",
+        "name": [
+            {"use": "official", "family": "Smith", "given": ["John", "James"]},
+            {"use": "nickname", "family": "Smith", "given": ["Johnny"]},
+        ],
+        "telecom": [{"system": "phone", "value": "555-1234"}],
+        "address": [{"city": "Melbourne", "state": "VIC"}],
+    }
+)
+
+
+# ========== Basic result evaluation ==========
+
+
+def test_string_result(pathling_ctx):
+    """Evaluating a string path returns typed string values."""
+    result = pathling_ctx.evaluate_fhirpath("Patient", PATIENT_JSON, "gender")
+
+    assert result == {
+        "results": [{"type": "code", "value": "male"}],
+        "expectedReturnType": "code",
+        "traces": [],
+    }
+
+
+def test_boolean_result(pathling_ctx):
+    """Evaluating a boolean path returns typed boolean values."""
+    result = pathling_ctx.evaluate_fhirpath("Patient", PATIENT_JSON, "active")
+
+    assert result == {
+        "results": [{"type": "boolean", "value": True}],
+        "expectedReturnType": "boolean",
+        "traces": [],
+    }
+
+
+def test_date_result(pathling_ctx):
+    """Evaluating a date path returns typed date values."""
+    result = pathling_ctx.evaluate_fhirpath("Patient", PATIENT_JSON, "birthDate")
+
+    assert result == {
+        "results": [{"type": "date", "value": "1990-01-01"}],
+        "expectedReturnType": "date",
+        "traces": [],
+    }
+
+
+def test_integer_result(pathling_ctx):
+    """Evaluating count() returns a typed integer value."""
+    result = pathling_ctx.evaluate_fhirpath("Patient", PATIENT_JSON, "name.count()")
+
+    assert result == {
+        "results": [{"type": "integer", "value": 2}],
+        "expectedReturnType": "integer",
+        "traces": [],
+    }
+
+
+def test_multiple_results(pathling_ctx):
+    """Evaluating a path that matches multiple elements returns all values."""
+    result = pathling_ctx.evaluate_fhirpath("Patient", PATIENT_JSON, "name.given")
+
+    assert result["expectedReturnType"] == "string"
+    assert result["traces"] == []
+    values = {r["value"] for r in result["results"]}
+    assert values == {"John", "James", "Johnny"}
+    assert all(r["type"] == "string" for r in result["results"])
+
+
+def test_empty_result(pathling_ctx):
+    """Evaluating a path that matches nothing returns an empty list."""
+    result = pathling_ctx.evaluate_fhirpath(
+        "Patient", PATIENT_JSON, "multipleBirthBoolean"
+    )
+
+    assert result == {
+        "results": [],
+        "expectedReturnType": "boolean",
+        "traces": [],
+    }
+
+
+def test_complex_type_result(pathling_ctx):
+    """Evaluating a complex type path returns typed values with string
+    representations."""
+    result = pathling_ctx.evaluate_fhirpath("Patient", PATIENT_JSON, "name")
+
+    assert result["expectedReturnType"] == "HumanName"
+    assert result["traces"] == []
+    assert len(result["results"]) == 2
+    assert all(r["type"] == "HumanName" for r in result["results"])
+    assert all(isinstance(r["value"], str) for r in result["results"])
+
+
+# ========== Expected return type ==========
+
+
+def test_primitive_return_type(pathling_ctx):
+    """The return type for a string expression is correctly reported."""
+    result = pathling_ctx.evaluate_fhirpath("Patient", PATIENT_JSON, "name.family")
+
+    assert result["expectedReturnType"] == "string"
+
+
+def test_boolean_return_type(pathling_ctx):
+    """The return type for a boolean expression is correctly reported."""
+    result = pathling_ctx.evaluate_fhirpath("Patient", PATIENT_JSON, "active")
+
+    assert result["expectedReturnType"] == "boolean"
+
+
+def test_complex_return_type(pathling_ctx):
+    """The return type for a complex type expression is correctly reported."""
+    result = pathling_ctx.evaluate_fhirpath("Patient", PATIENT_JSON, "name")
+
+    assert result["expectedReturnType"] == "HumanName"
+
+
+# ========== Context expression ==========
+
+
+def test_with_context_expression(pathling_ctx):
+    """A context expression composes with the main expression."""
+    result = pathling_ctx.evaluate_fhirpath(
+        "Patient", PATIENT_JSON, "given", context_expression="name"
+    )
+
+    assert result["expectedReturnType"] == "unknown"
+    assert result["traces"] == []
+    values = {r["value"] for r in result["results"]}
+    assert values == {"John", "James", "Johnny"}
+
+
+def test_without_context_expression(pathling_ctx):
+    """Omitting context_expression evaluates the main expression directly."""
+    result = pathling_ctx.evaluate_fhirpath("Patient", PATIENT_JSON, "active")
+
+    assert result == {
+        "results": [{"type": "boolean", "value": True}],
+        "expectedReturnType": "boolean",
+        "traces": [],
+    }
+
+
+# ========== Variables ==========
+
+
+def test_with_string_variable(pathling_ctx):
+    """A string variable is resolvable in the expression."""
+    result = pathling_ctx.evaluate_fhirpath(
+        "Patient", PATIENT_JSON, "%greeting", variables={"greeting": "hello"}
+    )
+
+    assert result == {
+        "results": [{"type": "string", "value": "hello"}],
+        "expectedReturnType": "string",
+        "traces": [],
+    }
+
+
+def test_with_integer_variable(pathling_ctx):
+    """An integer variable is resolvable in the expression."""
+    result = pathling_ctx.evaluate_fhirpath(
+        "Patient", PATIENT_JSON, "%count", variables={"count": 42}
+    )
+
+    assert result == {
+        "results": [{"type": "integer", "value": 42}],
+        "expectedReturnType": "integer",
+        "traces": [],
+    }
+
+
+def test_with_boolean_variable(pathling_ctx):
+    """A boolean variable is resolvable in the expression."""
+    result = pathling_ctx.evaluate_fhirpath(
+        "Patient", PATIENT_JSON, "%flag", variables={"flag": True}
+    )
+
+    assert result == {
+        "results": [{"type": "boolean", "value": True}],
+        "expectedReturnType": "boolean",
+        "traces": [],
+    }
+
+
+def test_without_variables(pathling_ctx):
+    """Omitting variables evaluates normally."""
+    result = pathling_ctx.evaluate_fhirpath("Patient", PATIENT_JSON, "active")
+
+    assert result == {
+        "results": [{"type": "boolean", "value": True}],
+        "expectedReturnType": "boolean",
+        "traces": [],
+    }
+
+
+# ========== Trace output ==========
+
+
+def test_trace_boolean(pathling_ctx):
+    """Tracing a boolean expression returns the traced value with correct
+    label and type."""
+    result = pathling_ctx.evaluate_fhirpath(
+        "Patient", PATIENT_JSON, "active.trace('flag')"
+    )
+
+    assert result == {
+        "results": [{"type": "boolean", "value": True}],
+        "expectedReturnType": "boolean",
+        "traces": [
+            {
+                "label": "flag",
+                "values": [{"type": "boolean", "value": True}],
+            }
+        ],
+    }
+
+
+def test_trace_entry_has_no_type_key(pathling_ctx):
+    """Each trace entry has label and values keys, but no top-level type key."""
+    result = pathling_ctx.evaluate_fhirpath(
+        "Patient", PATIENT_JSON, "active.trace('flag')"
+    )
+
+    for trace in result["traces"]:
+        assert set(trace.keys()) == {"label", "values"}
+
+
+def test_multiple_trace_calls(pathling_ctx):
+    """Multiple trace() calls produce distinct trace entries with correct
+    labels."""
+    result = pathling_ctx.evaluate_fhirpath(
+        "Patient",
+        PATIENT_JSON,
+        "name.trace('before').where(use = 'official').trace('after').family",
+    )
+
+    assert result["expectedReturnType"] == "string"
+    assert result["results"] == [{"type": "string", "value": "Smith"}]
+    labels = [t["label"] for t in result["traces"]]
+    assert "before" in labels
+    assert "after" in labels
+
+
+def test_no_trace_returns_empty_list(pathling_ctx):
+    """An expression without trace() returns an empty traces list."""
+    result = pathling_ctx.evaluate_fhirpath("Patient", PATIENT_JSON, "active")
+
+    assert result["traces"] == []
+
+
+# ========== Error handling ==========
+
+
+def test_invalid_expression(pathling_ctx):
+    """An invalid FHIRPath expression raises an exception."""
+    with pytest.raises(Exception):
+        pathling_ctx.evaluate_fhirpath("Patient", PATIENT_JSON, "!!invalid!!")
+
+
+def test_malformed_json(pathling_ctx):
+    """Malformed JSON resource raises an exception."""
+    with pytest.raises(Exception):
+        pathling_ctx.evaluate_fhirpath("Patient", "{not valid json}", "active")

--- a/openspec/changes/archive/2026-03-30-fhirpath-trace-function/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-30-fhirpath-trace-function/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-29

--- a/openspec/changes/archive/2026-03-30-fhirpath-trace-function/design.md
+++ b/openspec/changes/archive/2026-03-30-fhirpath-trace-function/design.md
@@ -1,0 +1,118 @@
+## Context
+
+Pathling translates FHIRPath expressions into Spark SQL column expressions.
+The `trace()` function is a diagnostic utility that must produce a logging side
+effect during Spark execution while returning the input value unchanged. Spark's
+execution model is lazy and distributed, so the logging mechanism must operate
+within Catalyst expression evaluation.
+
+The codebase already has a precedent for custom Catalyst expressions:
+`PruneSyntheticFields` in the `encoders` module is a `UnaryExpression` with
+`CodegenFallback` that transforms values at evaluation time. The same pattern
+applies to `trace()`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Implement `trace(name : String)` that logs each evaluated value via SLF4J and
+  returns the input collection unchanged.
+- Pass existing YAML reference tests for `trace()`, with exclusions only for
+  the unsupported projection parameter and the known `.id` extension limitation
+  after trace wrapping.
+- Provide a testable implementation where log output can be verified in tests.
+
+**Non-Goals:**
+
+- The optional `projection` parameter (deferred to a follow-up).
+- FHIR-aware serialisation of logged values (raw `toString()` is sufficient
+  initially).
+- Performance optimisation of the logging path.
+
+## Decisions
+
+### 1. Custom Catalyst expression over UDF
+
+**Decision:** Implement `TraceExpression` as a Scala `UnaryExpression` with
+`CodegenFallback` in the `encoders` module.
+
+**Alternatives considered:**
+
+- **Spark UDF:** UDFs are boxed, lose type information, and require explicit
+  registration with the SparkSession. A Catalyst expression preserves the
+  child's `dataType` exactly and follows the `PruneSyntheticFields` precedent.
+- **No-op pass-through:** Would satisfy the return-value contract but provides
+  no diagnostic value to users.
+
+**Rationale:** The Catalyst expression runs inside Spark's evaluation loop,
+receives the actual runtime value in `nullSafeEval`, and can log it before
+returning unchanged. It preserves the child's data type and nullability without
+any conversion overhead.
+
+### 2. Logging via SLF4J on a dedicated logger
+
+**Decision:** Log at `INFO` level using a logger named after the
+`TraceExpression` class (e.g.,
+`au.csiro.pathling.sql.TraceExpression`).
+
+**Rationale:** SLF4J is already on the classpath. A dedicated logger allows
+users to control trace output independently via logback configuration. `INFO`
+level is appropriate for diagnostic output that is opt-in by expression authors.
+
+### 3. JSON-like string representation via CatalystTypeConverters
+
+**Decision:** Convert Spark internal values to external Scala types using
+`CatalystTypeConverters.createToScalaConverter`, then format as JSON-like
+output: `Row.json` for structs, quoted strings for primitives, and recursive
+formatting for arrays.
+
+**Alternatives considered:**
+
+- **Raw `toString()`:** Spark internal types (`UnsafeRow`, `ArrayData`) produce
+  binary or unhelpful output for complex types, making diagnostics useless.
+- **`prettyJson`:** More readable but multi-line output is noisy in logs.
+
+**Rationale:** Compact JSON gives readable, single-line output for all types
+including nested FHIR structs. The converter is created lazily and reused per
+partition, so the overhead is minimal for a diagnostic function.
+
+### 4. New `UtilityFunctions` provider class
+
+**Decision:** Create `UtilityFunctions.java` in the `function/provider` package,
+following the same pattern as `ExistenceFunctions`, `StringFunctions`, etc.
+
+**Rationale:** The FHIRPath spec groups `trace()` under "Utility functions".
+A dedicated provider keeps it separate from unrelated function groups and
+provides a natural home for future utility functions (e.g., `now()`,
+`timeOfDay()`).
+
+### 5. Testing via DatasetEvaluator with ListAppender
+
+**Decision:** Write tests using the `DatasetEvaluator` pattern (as in
+`DatasetEvaluatorTest`) which materialises data through Spark. Verify logging
+by attaching a Logback `ListAppender` to the `TraceExpression` logger.
+
+**Alternatives considered:**
+
+- **DSL tests only:** Cannot assert on log output without extending the DSL
+  builder framework.
+- **Unit test on `nullSafeEval` directly:** Would work but doesn't test
+  integration through the full FHIRPath → Spark pipeline.
+- **SingleResourceEvaluatorTest:** Only builds Column expressions without
+  materialising — `nullSafeEval` is never called.
+
+**Rationale:** `DatasetEvaluator` tests run in local Spark mode (single JVM),
+so executor logging goes to the same logger and is capturable via
+`ListAppender`. This tests both the pass-through semantics and the logging
+side effect end-to-end.
+
+## Risks / Trade-offs
+
+- **Distributed logging:** In cluster mode, trace output goes to executor logs,
+  not the driver. This is inherent to Spark and acceptable for a diagnostic
+  function. → Users can aggregate executor logs or use local mode for debugging.
+- **Verbose output for complex types:** Mitigated by using
+  `CatalystTypeConverters` with compact JSON serialisation (see Decision #3).
+  Deeply nested FHIR structs may still produce long single-line output.
+- **Performance:** Logging on every row adds overhead. → `trace()` is
+  explicitly a diagnostic function; users choose when to use it.

--- a/openspec/changes/archive/2026-03-30-fhirpath-trace-function/proposal.md
+++ b/openspec/changes/archive/2026-03-30-fhirpath-trace-function/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The FHIRPath `trace()` function is defined in the specification as a diagnostic
+utility that logs intermediate collection values during expression evaluation.
+Pathling does not currently support it, causing expressions that use `trace()`
+to fail. Implementing it improves spec compliance and gives users a debugging
+tool for complex FHIRPath expressions. See GitHub issue #2580.
+
+## What Changes
+
+- Add a custom Spark Catalyst expression (`TraceExpression`) that logs the
+  string representation of each evaluated value via SLF4J, then returns the
+  value unchanged.
+- Add a new `UtilityFunctions` function provider class exposing `trace()` as a
+  `@FhirPathFunction`, registered in the `StaticFunctionRegistry`.
+- The initial implementation supports the `name` parameter only; the optional
+  `projection` parameter is deferred to a follow-up.
+
+## Capabilities
+
+### New Capabilities
+
+- `fhirpath-trace`: The FHIRPath `trace(name)` function that logs a string
+  representation of the input collection under the given label, then returns
+  the input unchanged.
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- `encoders` module: new Scala file `TraceExpression.scala` in
+  `au.csiro.pathling.sql`.
+- `fhirpath` module: new `UtilityFunctions.java` provider, registration in
+  `StaticFunctionRegistry`.
+- `fhirpath` module (test): new tests in `DatasetEvaluatorTest` or a dedicated
+  test class verifying pass-through semantics and log output via
+  `ListAppender`.
+- Existing YAML reference tests for `trace()` should pass without exclusions.

--- a/openspec/changes/archive/2026-03-30-fhirpath-trace-function/specs/fhirpath-trace/spec.md
+++ b/openspec/changes/archive/2026-03-30-fhirpath-trace-function/specs/fhirpath-trace/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: trace returns input collection unchanged
+
+The `trace(name)` function SHALL return the input collection without
+modification. The result collection SHALL have the same type, cardinality, and
+values as the input collection.
+
+#### Scenario: trace on a singleton string
+
+- **WHEN** evaluating `Patient.name.family.trace('debug')`
+- **THEN** the result SHALL be identical to evaluating `Patient.name.family`
+
+#### Scenario: trace on a boolean value
+
+- **WHEN** evaluating `Patient.active.trace('active-check')`
+- **THEN** the result SHALL be identical to evaluating `Patient.active`
+
+#### Scenario: trace on an empty collection
+
+- **WHEN** evaluating `{}.trace('empty')`
+- **THEN** the result SHALL be an empty collection
+
+#### Scenario: trace on a collection with null values
+
+- **WHEN** evaluating a path that produces null values followed by `.trace('label')`
+- **THEN** null values SHALL be preserved in the output
+
+#### Scenario: trace on a complex type
+
+- **WHEN** evaluating `Patient.name.trace('names')` where name is a HumanName
+  complex type
+- **THEN** the result SHALL be identical to evaluating `Patient.name`
+
+#### Scenario: trace after a where filter
+
+- **WHEN** evaluating `Patient.name.where(use = 'official').trace('official-names')`
+- **THEN** the result SHALL be identical to evaluating
+  `Patient.name.where(use = 'official')`
+
+#### Scenario: trace before a where filter
+
+- **WHEN** evaluating `Patient.name.trace('all-names').where(use = 'official')`
+- **THEN** the result SHALL be identical to evaluating
+  `Patient.name.where(use = 'official')`
+
+#### Scenario: two trace calls in a single expression
+
+- **WHEN** evaluating
+  `Patient.name.trace('before-filter').where(use = 'official').trace('after-filter')`
+- **THEN** the result SHALL be identical to evaluating
+  `Patient.name.where(use = 'official')`
+
+#### Scenario: trace on a multi-element collection
+
+- **WHEN** evaluating `Patient.name.given.trace('givens')` where the Patient
+  has multiple given names
+- **THEN** the result SHALL contain all given names unchanged
+
+### Requirement: trace logs values via SLF4J
+
+The `trace(name)` function SHALL log a string representation of each evaluated
+value using an SLF4J logger. The log message SHALL include the `name` argument
+as a label to identify the trace point.
+
+#### Scenario: trace produces log output with label
+
+- **WHEN** evaluating `Patient.active.trace('myLabel')` and materialising the
+  result
+- **THEN** the SLF4J logger for `TraceExpression` SHALL emit at least one log
+  entry containing the string `myLabel`
+
+#### Scenario: trace logs the value representation
+
+- **WHEN** evaluating `Patient.name.family.trace('names')` against a Patient
+  with family name `Smith` and materialising the result
+- **THEN** the log output SHALL contain a representation of `Smith`
+
+#### Scenario: two trace calls produce distinct log entries
+
+- **WHEN** evaluating
+  `Patient.name.trace('before').where(use = 'official').trace('after')` and
+  materialising the result
+- **THEN** the log output SHALL contain entries labelled `before` and entries
+  labelled `after`
+
+### Requirement: trace is a recognised FHIRPath function
+
+The `trace` function SHALL be registered in the `StaticFunctionRegistry` and
+recognised by the FHIRPath parser. Expressions containing `trace()` SHALL NOT
+produce parse errors or "unknown function" errors.
+
+#### Scenario: trace function is callable
+
+- **WHEN** parsing and evaluating the expression `Patient.active.trace('test')`
+- **THEN** no error SHALL be raised
+
+#### Scenario: trace with missing name argument is an error
+
+- **WHEN** parsing the expression `Patient.active.trace()`
+- **THEN** an error SHALL be raised indicating a missing required argument

--- a/openspec/changes/archive/2026-03-30-fhirpath-trace-function/tasks.md
+++ b/openspec/changes/archive/2026-03-30-fhirpath-trace-function/tasks.md
@@ -1,0 +1,24 @@
+## 1. Catalyst Expression
+
+- [x] 1.1 Create `TraceExpression` Scala case class in `encoders/src/main/scala/au/csiro/pathling/sql/TraceExpression.scala` extending `UnaryExpression` with `CodegenFallback`
+- [x] 1.2 Implement `nullSafeEval` to log the value via SLF4J and return it unchanged
+- [x] 1.3 Preserve child's `dataType` and `nullable` properties
+
+## 2. Function Provider
+
+- [x] 2.1 Create `UtilityFunctions.java` in `fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/`
+- [x] 2.2 Implement `trace(Collection input, StringCollection name)` method annotated with `@FhirPathFunction`
+- [x] 2.3 Wrap the input column with `TraceExpression` and return via `copyWithColumn`
+
+## 3. Registry
+
+- [x] 3.1 Register `UtilityFunctions` in `StaticFunctionRegistry`
+
+## 4. Tests
+
+- [x] 4.1 Create trace function test class using `DatasetEvaluator` pattern with `@SpringBootUnitTest`
+- [x] 4.2 Test pass-through: `trace()` returns the same values as the input for strings, booleans, and complex types
+- [x] 4.3 Test logging: attach `ListAppender` and verify log entries contain the trace label and value representation
+- [x] 4.4 Test empty collection: `{}.trace('label')` returns empty
+- [x] 4.5 Test error: `trace()` with no arguments raises an error
+- [x] 4.6 Verify existing YAML reference tests for `trace()` pass (2 exclusions added for unsupported projection parameter and primitive .id extension after trace)

--- a/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-30

--- a/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/design.md
+++ b/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/design.md
@@ -1,0 +1,183 @@
+## Context
+
+The `trace()` function (issue #2580) currently logs values to SLF4J via
+`TraceExpression` but discards them. The fhirpath-lab web service needs to
+return trace data alongside evaluation results. The evaluation chain is:
+
+```
+fhirpath-lab API (Python web service)
+  → PathlingContext.evaluate_fhirpath() [Python, py4j]
+    → PathlingContext.evaluateFhirPath() [Java, library-api]
+      → SingleInstanceEvaluator.evaluate() [Java, fhirpath]
+        → TraceExpression.nullSafeEval() [Scala, encoders]
+```
+
+The `FunctionParameterResolver` already auto-injects `EvaluationContext` into
+`@FhirPathFunction` methods (see `repeat()` for precedent). The
+`EvaluationContext` carries `FhirpathConfiguration` which is accessible from
+all evaluation participants.
+
+`SingleInstanceEvaluator` always operates on a single-row dataset in local Spark
+mode — no distributed serialization concerns.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a `TraceCollector` interface for programmatic capture of trace entries
+  during evaluation.
+- Thread the collector through the existing `EvaluationContext` so
+  `UtilityFunctions.trace()` can populate it.
+- Enrich `SingleInstanceEvaluationResult` with collected trace data.
+- Preserve existing SLF4J logging behaviour — collection is additive, not a
+  replacement.
+
+**Non-Goals:**
+
+- Accumulator-backed implementation for distributed mode (future work).
+- Formatting trace data as FHIR Parameters (fhirpath-lab-api responsibility).
+- Changes to the fhirpath-lab-api Python web service.
+- Support for the `projection` parameter of `trace()`.
+
+## Decisions
+
+### 1. TraceCollector as an interface
+
+**Decision:** Define `TraceCollector` as an interface with a
+`ListTraceCollector` implementation backed by a plain `ArrayList`.
+
+**Alternatives considered:**
+
+- **Concrete class only:** Less flexible, harder to swap for an
+  accumulator-backed implementation later.
+- **Spark AccumulatorV2:** Proper Spark pattern for collecting side-effect data,
+  but requires SparkContext for registration and adds serialization ceremony.
+  Overkill for the single-row local-mode use case.
+
+**Rationale:** An interface allows swapping in an `AccumulatorV2`-backed
+implementation in the future without changing callers. The list-backed
+implementation is intentionally not serializable — it will fail fast with a
+clear error if used in a distributed context, rather than silently losing data.
+
+### 2. Collector lives on EvaluationContext
+
+**Decision:** Add an `Optional<TraceCollector> getTraceCollector()` method to
+`EvaluationContext` with a default returning `Optional.empty()`.
+`FhirEvaluationContext` accepts an optional collector at construction.
+
+**Alternatives considered:**
+
+- **On FhirpathConfiguration:** Configuration is a data class (Lombok
+  `@Builder`). Adding a mutable collector to an immutable configuration object
+  is semantically wrong.
+- **Thread-local global:** Works but invisible coupling, hard to test, lifecycle
+  management issues.
+
+**Rationale:** `EvaluationContext` is already the injection mechanism for
+contextual state into function providers. The `FunctionParameterResolver`
+auto-injects it into `@FhirPathFunction` methods that declare it as a
+parameter. The collector naturally belongs with other evaluation-scoped state.
+
+### 3. TraceExpression receives fhirType and collector
+
+**Decision:** Extend `TraceExpression` with two new parameters:
+
+```scala
+case class TraceExpression(
+  child: Expression,
+  name: String,
+  fhirType: String,
+  collector: TraceCollector
+)
+```
+
+`UtilityFunctions.trace()` extracts the FHIR type from `input.getFhirType()`
+and the collector from `EvaluationContext`. If no collector is present, create
+the expression without one (or use a no-op implementation) and rely on SLF4J
+logging only.
+
+**Rationale:** The FHIR type is only known at the `Collection` level (not at
+the Catalyst expression level). Passing it into the expression at construction
+time is the simplest way to propagate it. The collector reference is not
+serializable, which is intentional — see Decision #1.
+
+### 4. TraceEntry carries label, FHIR type, and typed values
+
+**Decision:** Each `TraceEntry` contains:
+
+- `label` (String) — the trace name argument
+- `fhirType` (String) — the FHIR type code (e.g., `"HumanName"`, `"string"`)
+- `values` (List&lt;Object&gt;) — the converted Scala values (Row for structs,
+  String/Integer/etc. for primitives)
+
+Multiple `nullSafeEval` calls with the same label accumulate values into a
+single entry (grouped by label).
+
+**Rationale:** This mirrors the response format needed by fhirpath-lab, where
+each trace part groups values under a label. The fhirpath-lab-api converts
+these to FHIR Parameters parts.
+
+### 5. SingleInstanceEvaluator creates and reads the collector
+
+**Decision:** `SingleInstanceEvaluator.evaluate()` creates a
+`ListTraceCollector` before evaluation, passes it through the
+`FhirEvaluationContext` constructor, and reads collected traces after
+materialization. The traces are included in `SingleInstanceEvaluationResult`.
+
+**Rationale:** This scopes the collector lifecycle to a single evaluation call.
+No global state, no cleanup needed. The caller (PathlingContext, Python API)
+just reads traces from the result DTO.
+
+### 6. Row sanitization and JSON conversion on the Java side
+
+**Decision:** Trace values that are `Row` objects are sanitized using the
+existing `SingleInstanceEvaluator.sanitiseRow()` logic (strips synthetic fields
+and null values) and then converted to JSON strings via `rowToJson()`, consistent
+with how main result values are handled.
+
+**Alternatives considered:**
+
+- **Raw Rows:** Would expose internal fields like `_fid`, `_value_scale`, etc.
+- **Sanitized Rows without JSON:** Would require consumers to call `Row.json()`
+  across the Py4J bridge, which is fragile.
+
+**Rationale:** Converting to JSON strings on the Java side means the Python API
+receives plain strings that can be directly included in the FHIR Parameters
+response. This is consistent with how `convertValue()` handles main result Rows.
+
+### 7. TraceCollectorProxy for Spark serialization
+
+**Decision:** Introduce `TraceCollectorProxy`, a serializable `TraceCollector`
+implementation that delegates to a real collector via a static
+`ConcurrentHashMap` registry keyed by UUID. The proxy holds only the UUID string
+(serializable). `SingleInstanceEvaluator` creates a `ListTraceCollector` and
+wraps it in a proxy before passing it into the evaluation context. After
+materialization, the proxy is closed (deregistered).
+
+**Alternatives considered:**
+
+- **`@transient` collector field on TraceExpression:** Would silently lose trace
+  data after deserialization rather than collecting it.
+- **Making ListTraceCollector serializable:** The deserialized copy would be a
+  different object than the caller reads from — collected entries would be lost.
+- **Spark AccumulatorV2:** Correct Spark pattern but requires SparkContext
+  registration and is overkill for local mode.
+
+**Rationale:** Spark serializes expression plans even in local mode (for closure
+cleaning). The proxy pattern keeps the real collector on the driver JVM and
+survives serialization by holding only a registry key. The `AutoCloseable`
+interface ensures cleanup after each evaluation.
+
+## Risks / Trade-offs
+
+- **Non-serializable collector behind proxy:** The `ListTraceCollector` itself is
+  not serializable, but it is never passed directly into Spark expressions. The
+  `TraceCollectorProxy` handles serialization transparently. If someone bypasses
+  the proxy and passes `ListTraceCollector` directly, Spark will fail with a
+  clear serialization error.
+  → Accumulator implementation can be added later behind the same interface.
+- **Memory usage:** All trace values are held in memory during evaluation.
+  → Acceptable for single-resource evaluation. Not intended for batch use.
+- **Breaking change to TraceExpression constructor:** Adding parameters changes
+  the case class signature.
+  → Internal API, not user-facing. All call sites are in `UtilityFunctions`.

--- a/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/proposal.md
+++ b/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+The FHIRPath `trace()` function currently logs to SLF4J but discards the traced
+values. The primary consumer — fhirpath-lab — needs to return trace data
+alongside evaluation results so users can inspect intermediate collections in the
+web UI. The `SingleInstanceEvaluationResult` DTO must carry trace entries back
+through the Python API to the fhirpath-lab web service.
+
+## What Changes
+
+- Introduce a `TraceCollector` interface with a simple list-backed
+  implementation for capturing trace entries (label, FHIR type, values) during
+  expression evaluation.
+- Thread the collector through `EvaluationContext` so `UtilityFunctions.trace()`
+  can write to it alongside the existing SLF4J logging.
+- Pass the FHIR type from the input `Collection` into `TraceExpression` so
+  collected entries carry type metadata.
+- Extend `SingleInstanceEvaluationResult` with a list of trace entries, each
+  containing the trace label, FHIR type, and list of typed values.
+- Update `SingleInstanceEvaluator` to create a collector before evaluation,
+  attach it to the configuration/context, and fold the collected traces into
+  the result DTO after materialization.
+
+## Capabilities
+
+### New Capabilities
+
+- `fhirpath-trace-collector`: The `TraceCollector` interface, its list-backed
+  implementation, the `TraceEntry` data class, and the wiring through
+  `EvaluationContext` into `TraceExpression`.
+
+### Modified Capabilities
+
+- `fhirpath-trace`: Trace now supports programmatic collection via
+  `TraceCollector` in addition to SLF4J logging. `TraceExpression` gains
+  `fhirType` and `collector` parameters.
+- `fhirpath-evaluation-api`: `SingleInstanceEvaluationResult` gains a `traces`
+  field containing collected trace entries with label, type, and values.
+
+## Impact
+
+- `encoders` module: `TraceExpression.scala` gains `fhirType` and `collector`
+  parameters.
+- `fhirpath` module: new `TraceCollector` interface and `ListTraceCollector`
+  implementation; changes to `EvaluationContext`, `FhirpathConfiguration` or
+  `FhirEvaluationContext`; changes to `UtilityFunctions.trace()`;
+  changes to `SingleInstanceEvaluator` and `SingleInstanceEvaluationResult`.
+- `library-api` module: `PathlingContext.evaluateFhirPath()` returns the
+  enriched result.
+- `lib/python` module: `evaluate_fhirpath()` returns trace data in the result
+  dict.
+- Downstream: fhirpath-lab-api can read trace entries from the result and build
+  the FHIR Parameters response.

--- a/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/specs/fhirpath-evaluation-api/spec.md
+++ b/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/specs/fhirpath-evaluation-api/spec.md
@@ -1,4 +1,4 @@
-## ADDED Requirements
+## MODIFIED Requirements
 
 ### Requirement: Evaluate FHIRPath expression against a single resource
 
@@ -77,55 +77,6 @@ included in the result alongside the typed values.
 
 - **WHEN** the method is called with an expression that does not use `trace()`
 - **THEN** the result SHALL include an empty trace list
-
-### Requirement: Return type metadata with evaluation results
-
-The library API evaluation method SHALL return type information alongside each
-result value, indicating the FHIR data type of the result (e.g., `string`,
-`boolean`, `integer`, `Patient`, `HumanName`).
-
-#### Scenario: Primitive type identification
-
-- **WHEN** evaluating the expression `name.family` against a Patient resource
-- **THEN** each result value is annotated with the type `string`
-
-#### Scenario: Complex type identification
-
-- **WHEN** evaluating the expression `name` against a Patient resource
-- **THEN** each result value is annotated with the type `HumanName`
-
-#### Scenario: Boolean type identification
-
-- **WHEN** evaluating the expression `active` against a Patient resource
-- **THEN** the result value is annotated with the type `boolean`
-
-### Requirement: Provide expression parsing metadata
-
-The library API evaluation method SHALL return the parsed abstract syntax tree
-(AST) of the expression as a JSON string, and the statically inferred return
-type of the expression.
-
-#### Scenario: AST available after evaluation
-
-- **WHEN** a FHIRPath expression is evaluated
-- **THEN** the result includes a JSON representation of the parsed expression
-  tree
-
-#### Scenario: Return type inference
-
-- **WHEN** the expression `name.family` is evaluated against a Patient resource
-- **THEN** the result includes `string` as the expected return type
-
-### Requirement: Support environment variables
-
-The library API evaluation method SHALL accept optional named variables that are
-available to the expression via the `%variable` syntax.
-
-#### Scenario: Variable substitution
-
-- **WHEN** the method is called with a variable `myVar` set to `"test"` and the
-  expression `%myVar`
-- **THEN** the method returns a result containing the string `"test"`
 
 ### Requirement: Python bindings for evaluation method
 

--- a/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/specs/fhirpath-trace-collector/spec.md
+++ b/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/specs/fhirpath-trace-collector/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: TraceCollector interface for programmatic trace capture
+
+The system SHALL provide a `TraceCollector` interface that accepts trace data
+during FHIRPath expression evaluation. The interface SHALL accept a label
+(String), a FHIR type (String), and a value (Object) for each traced element.
+How the implementation stores, groups, or retrieves these entries is not
+prescribed by the interface.
+
+#### Scenario: Collector is called during trace evaluation
+
+- **WHEN** an expression containing `trace('myLabel')` is evaluated with a
+  `TraceCollector` attached to the evaluation context and the result is
+  materialised
+- **THEN** the collector's add method SHALL be called with the label `myLabel`,
+  the FHIR type of the traced collection, and the traced value
+
+### Requirement: List-backed collector implementation
+
+The system SHALL provide a `ListTraceCollector` implementation of
+`TraceCollector` backed by a plain list. This implementation is not serializable.
+A `TraceCollectorProxy` SHALL wrap the list collector for use in Spark
+expressions, delegating via a static registry keyed by UUID. The proxy SHALL be
+serializable and SHALL implement `AutoCloseable` for registry cleanup.
+
+#### Scenario: ListTraceCollector captures entries
+
+- **WHEN** a `ListTraceCollector` is used during evaluation (via proxy)
+- **THEN** all trace entries are captured and retrievable after materialisation
+
+#### Scenario: Proxy survives Spark plan serialization
+
+- **WHEN** a `TraceCollectorProxy` wrapping a `ListTraceCollector` is serialized
+  during Spark closure cleaning
+- **THEN** the proxy SHALL deserialize successfully and continue delegating to
+  the original collector via the registry
+
+### Requirement: Trace entries carry FHIR type metadata
+
+Each trace entry SHALL include the FHIR type code of the traced collection
+(e.g., `"HumanName"`, `"string"`, `"boolean"`), derived from the input
+collection's type information at the point where `trace()` is invoked.
+
+#### Scenario: Trace entry for a complex type
+
+- **WHEN** `Patient.name.trace('names')` is evaluated with a collector
+- **THEN** each trace entry SHALL have FHIR type `"HumanName"`
+
+#### Scenario: Trace entry for a primitive type
+
+- **WHEN** `Patient.active.trace('flag')` is evaluated with a collector
+- **THEN** each trace entry SHALL have FHIR type `"boolean"`
+
+### Requirement: Trace collector is optional on EvaluationContext
+
+The `EvaluationContext` SHALL provide an optional `TraceCollector`. When no
+collector is present, `trace()` SHALL still log via SLF4J but SHALL NOT attempt
+to collect entries.
+
+#### Scenario: No collector attached
+
+- **WHEN** an expression containing `trace()` is evaluated without a collector
+  on the context
+- **THEN** the expression SHALL evaluate successfully with SLF4J logging only
+
+#### Scenario: Collector attached
+
+- **WHEN** an expression containing `trace()` is evaluated with a collector on
+  the context
+- **THEN** both SLF4J logging and collector capture SHALL occur
+
+### Requirement: Trace values are sanitized
+
+Trace values that are complex types (Spark `Row` objects) SHALL be sanitized
+before being stored in the collector. Sanitization SHALL strip synthetic fields
+and null-valued fields, consistent with the existing
+`SingleInstanceEvaluator.sanitiseRow()` logic.
+
+#### Scenario: Synthetic fields stripped from trace values
+
+- **WHEN** tracing a complex type that contains synthetic fields (e.g., `_fid`)
+- **THEN** the collected trace value SHALL NOT contain synthetic fields

--- a/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/specs/fhirpath-trace/spec.md
+++ b/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/specs/fhirpath-trace/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: trace logs values via SLF4J
+
+The `trace(name)` function SHALL log a string representation of each evaluated
+value using an SLF4J logger. The log message SHALL include the `name` argument
+as a label to identify the trace point.
+
+When a `TraceCollector` is available on the `EvaluationContext`, the function
+SHALL additionally add each traced value to the collector with the trace label
+and the FHIR type of the input collection.
+
+#### Scenario: trace produces log output with label
+
+- **WHEN** evaluating `Patient.active.trace('myLabel')` and materialising the
+  result
+- **THEN** the SLF4J logger for `TraceExpression` SHALL emit at least one log
+  entry containing the string `myLabel`
+
+#### Scenario: trace logs the value representation
+
+- **WHEN** evaluating `Patient.name.family.trace('names')` against a Patient
+  with family name `Smith` and materialising the result
+- **THEN** the log output SHALL contain a representation of `Smith`
+
+#### Scenario: two trace calls produce distinct log entries
+
+- **WHEN** evaluating
+  `Patient.name.trace('before').where(use = 'official').trace('after')` and
+  materialising the result
+- **THEN** the log output SHALL contain entries labelled `before` and entries
+  labelled `after`
+
+#### Scenario: trace populates collector when present
+
+- **WHEN** evaluating `Patient.name.trace('names')` with a `TraceCollector`
+  attached to the evaluation context and materialising the result
+- **THEN** the collector SHALL contain entries under label `names` with FHIR
+  type `HumanName`

--- a/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/tasks.md
+++ b/openspec/changes/archive/2026-03-31-fhirpath-trace-collector/tasks.md
@@ -1,0 +1,45 @@
+## 1. TraceCollector Interface and Implementation
+
+- [x] 1.1 Create `TraceCollector` interface in `encoders` module (`au.csiro.pathling.sql` package) with `add(String label, String fhirType, Object value)` method
+- [x] 1.2 Create `ListTraceCollector` implementation backed by `ArrayList` (not serializable)
+- [x] 1.3 Write unit tests for `ListTraceCollector`
+
+## 2. EvaluationContext Wiring
+
+- [x] 2.1 Add `Optional<TraceCollector> getTraceCollector()` default method to `EvaluationContext` returning `Optional.empty()`
+- [x] 2.2 Add optional `TraceCollector` parameter to `FhirEvaluationContext` record and override `getTraceCollector()`
+- [x] 2.3 Thread the collector through `SingleResourceEvaluator` and `SingleResourceEvaluatorBuilder`
+
+## 3. TraceExpression Changes
+
+- [x] 3.1 Add `fhirType: String` and `collector: TraceCollector` parameters to `TraceExpression` case class
+- [x] 3.2 Update `nullSafeEval` to call `collector.add()` alongside SLF4J logging (null-safe for when no collector is provided)
+- [x] 3.3 Update `withNewChildInternal` to preserve the new parameters (handled by case class `copy`)
+
+## 4. UtilityFunctions Changes
+
+- [x] 4.1 Add `EvaluationContext` parameter to `UtilityFunctions.trace()`
+- [x] 4.2 Extract FHIR type from input collection and pass to `TraceExpression`
+- [x] 4.3 Extract optional `TraceCollector` from context and pass to `TraceExpression`
+
+## 5. SingleInstanceEvaluator Integration
+
+- [x] 5.1 Create `ListTraceCollector` in `SingleInstanceEvaluator.evaluate()` before evaluation
+- [x] 5.2 Pass the collector through to the evaluator context
+- [x] 5.3 Add `traces` field to `SingleInstanceEvaluationResult` (list of trace entries with label, type, and typed values)
+- [x] 5.4 Read collected traces after materialisation and fold into the result DTO
+- [x] 5.5 Sanitize `Row` values in trace entries using existing `sanitiseRow()` logic
+
+## 6. Python Bindings
+
+- [x] 6.1 Update `PathlingContext.evaluate_fhirpath()` in Python to read trace data from the Java result
+- [x] 6.2 Include `traces` key in the returned Python dict with label, type, and values
+
+## 7. Tests
+
+- [x] 7.1 Test trace collection end-to-end via `DatasetEvaluator` with a `ListTraceCollector`
+- [x] 7.2 Test that collector receives correct FHIR types for complex and primitive traced collections
+- [x] 7.3 Test that two trace calls produce entries with distinct labels
+- [x] 7.4 Test that evaluation without a collector still works (SLF4J only)
+- [x] 7.5 Test that `SingleInstanceEvaluationResult` includes trace data (tested via collector integration)
+- [x] 7.6 Verify existing `TraceFunctionTest` and YAML reference tests still pass

--- a/openspec/changes/archive/2026-04-09-trace-projection-argument/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-09-trace-projection-argument/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/archive/2026-04-09-trace-projection-argument/design.md
+++ b/openspec/changes/archive/2026-04-09-trace-projection-argument/design.md
@@ -1,0 +1,83 @@
+## Context
+
+The `trace()` function is implemented as a unary Spark Catalyst expression
+(`TraceExpression`) that logs and returns its single child. The FHIRPath spec
+defines an optional second argument (`projection: Expression`) that allows
+logging a derived value while still returning the original input. The function
+argument infrastructure (`CollectionTransform`) already supports expression-type
+parameters, used by `where()`, `select()`, `exists()`, etc.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Support the optional projection argument: `trace(name, projection)`
+- Ensure the logged value and FHIR type reflect the projection result when
+  provided
+- Fix existing issue: mark `TraceExpression` as `Nondeterministic` to prevent
+  Catalyst from optimizing away side effects
+
+**Non-Goals:**
+
+- Dynamic name expressions (name must remain a string literal)
+- Changes to `TraceCollector` interface or `ListTraceCollector`
+- Changes to library-api, Python, or R bindings
+
+## Decisions
+
+### 1. Single binary expression (always binary)
+
+Convert `TraceExpression` from `UnaryExpression` to `BinaryExpression`. The
+first child (`left`) is the pass-through value; the second child (`right`) is
+the value to log.
+
+When no projection is provided, both children reference the same column. When a
+projection is provided, `right` is the projected column.
+
+**Alternatives considered:**
+
+- **Two separate expressions (unary + binary)**: Avoids double-evaluation of the
+  same column when no projection is provided, but duplicates logging/formatting
+  logic across two classes.
+- **Single expression with `Option[Expression]`**: Cannot extend
+  `UnaryExpression` or `BinaryExpression`; requires manual `children` and
+  `withNewChildren` management.
+
+**Rationale:** Minimal code duplication. The shared logging, formatting, and
+collector logic stays in one place. Double-evaluation of the same column in the
+no-projection case is negligible for a diagnostic function.
+
+### 2. Mark TraceExpression as Nondeterministic
+
+`TraceExpression` has side effects (SLF4J logging, collector accumulation).
+Without the `Nondeterministic` trait, Catalyst could theoretically eliminate
+duplicate trace expressions via common subexpression elimination.
+
+### 3. Custom eval() instead of nullSafeEval for binary form
+
+`BinaryExpression.nullSafeEval` skips evaluation if either child is null. We
+need asymmetric null handling:
+
+- If the pass-through value (left) is null, return null (no logging).
+- If the projected value (right) is null, skip logging but still return the
+  pass-through value.
+
+Override `eval()` directly to implement this.
+
+### 4. Projection evaluated at FHIRPath level
+
+The `trace()` function evaluates the `CollectionTransform` projection on the
+input collection at the FHIRPath level, extracting the resulting column and FHIR
+type. These are passed to `TraceExpression` as constructor arguments. The
+Catalyst expression does not know about FHIRPath.
+
+## Risks / Trade-offs
+
+- **Double evaluation when no projection**: When both children are the same
+  column expression, Spark evaluates it twice per row. Mitigated by the fact
+  that trace is a diagnostic tool, not performance-critical. Can refactor to two
+  expression classes later if profiling shows impact.
+- **Nondeterministic disables CSE**: Marking the expression nondeterministic
+  prevents Catalyst from caching results across duplicate trace expressions.
+  This is the correct behavior (each trace should fire its side effects) but
+  worth noting.

--- a/openspec/changes/archive/2026-04-09-trace-projection-argument/proposal.md
+++ b/openspec/changes/archive/2026-04-09-trace-projection-argument/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+The FHIRPath `trace()` function supports an optional second argument
+(`projection: Expression`) that allows logging a derived value instead of the
+full input collection. This is part of the FHIRPath specification but was
+explicitly out of scope in #2580. Adding it completes the trace implementation.
+
+## What Changes
+
+- Modify `TraceExpression` from a unary to a binary Spark Catalyst expression
+  that returns the first child (input) and logs the second child (projected
+  value). When no projection is provided, both children are the same column.
+- Mark `TraceExpression` as `Nondeterministic` to prevent Spark from optimizing
+  away its logging side effects.
+- Add an optional `CollectionTransform` parameter to the `trace()` function in
+  `UtilityFunctions` for the projection expression.
+- When a projection is provided, the logged FHIR type is the projected
+  collection's type, not the input's type.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `fhirpath-trace`: Add support for the optional projection argument. The trace
+  function accepts a second expression argument that is evaluated against the
+  input and logged, while the input is still returned unchanged.
+- `fhirpath-trace-collector`: The FHIR type captured in trace entries reflects
+  the type of the expression being logged (projected type when projection is
+  used).
+
+## Impact
+
+- `encoders` module: `TraceExpression.scala` changes from unary to binary
+  expression, marked nondeterministic.
+- `fhirpath` module: `UtilityFunctions.trace()` gains an optional
+  `CollectionTransform` parameter.
+- `fhirpath` module: New tests for projection behavior.
+- No changes to `library-api`, Python, or R bindings (projection is a FHIRPath
+  syntax feature, transparent to callers).

--- a/openspec/changes/archive/2026-04-09-trace-projection-argument/specs/fhirpath-trace-collector/spec.md
+++ b/openspec/changes/archive/2026-04-09-trace-projection-argument/specs/fhirpath-trace-collector/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Trace entries carry FHIR type metadata
+
+Each trace entry SHALL include the FHIR type code of the expression being
+logged. When no projection is provided, this is the FHIR type of the input
+collection. When a projection is provided, this is the FHIR type of the
+projected result (e.g., `"string"` for a `family` projection on a `HumanName`
+input).
+
+#### Scenario: Trace entry for a complex type
+
+- **WHEN** `Patient.name.trace('names')` is evaluated with a collector
+- **THEN** each trace entry SHALL have FHIR type `"HumanName"`
+
+#### Scenario: Trace entry for a primitive type
+
+- **WHEN** `Patient.active.trace('flag')` is evaluated with a collector
+- **THEN** each trace entry SHALL have FHIR type `"boolean"`
+
+#### Scenario: Trace entry type reflects projection
+
+- **WHEN** `Patient.name.trace('fam', family)` is evaluated with a collector
+- **THEN** each trace entry SHALL have FHIR type `"string"` (the projected
+  type), not `"HumanName"` (the input type)

--- a/openspec/changes/archive/2026-04-09-trace-projection-argument/specs/fhirpath-trace/spec.md
+++ b/openspec/changes/archive/2026-04-09-trace-projection-argument/specs/fhirpath-trace/spec.md
@@ -1,3 +1,52 @@
+## ADDED Requirements
+
+### Requirement: trace with projection logs projected value and returns input unchanged
+
+The `trace(name, projection)` function SHALL evaluate the projection expression
+against the input collection and log the projected result. The function SHALL
+return the input collection unchanged, regardless of the projection result.
+
+#### Scenario: trace with projection on a primitive path
+
+- **WHEN** evaluating `Patient.name.trace('ids', id)` where `id` is a valid
+  path on HumanName
+- **THEN** the result SHALL be identical to evaluating `Patient.name`
+- **AND** the logged value SHALL be the result of evaluating `id` on each
+  HumanName element
+
+#### Scenario: trace with projection on a complex expression
+
+- **WHEN** evaluating `Patient.name.trace('full', given.first() + ' ' + family)`
+- **THEN** the result SHALL be identical to evaluating `Patient.name`
+- **AND** the logged value SHALL be the concatenated string
+
+#### Scenario: trace with projection returning empty
+
+- **WHEN** evaluating `Patient.name.trace('missing', deceased)` where `deceased`
+  does not exist on HumanName
+- **THEN** the result SHALL be identical to evaluating `Patient.name`
+- **AND** no value SHALL be logged for that element
+
+#### Scenario: trace with projection on an empty input collection
+
+- **WHEN** evaluating `{}.trace('empty', id)`
+- **THEN** the result SHALL be an empty collection
+
+### Requirement: trace is a nondeterministic expression
+
+The Spark Catalyst expression underlying `trace()` SHALL be marked as
+nondeterministic to prevent the query optimizer from eliminating trace
+expressions or caching their results via common subexpression elimination. Each
+`trace()` call SHALL execute its logging side effect independently.
+
+#### Scenario: duplicate trace calls both execute
+
+- **WHEN** evaluating an expression where the same `trace()` call appears in
+  two branches of a computation
+- **THEN** both trace calls SHALL produce log output independently
+
+## MODIFIED Requirements
+
 ### Requirement: trace returns input collection unchanged
 
 The `trace(name [, projection])` function SHALL return the input collection
@@ -136,48 +185,3 @@ two arguments SHALL NOT produce parse errors or "unknown function" errors.
 
 - **WHEN** parsing the expression `Patient.active.trace()`
 - **THEN** an error SHALL be raised indicating a missing required argument
-
-### Requirement: trace with projection logs projected value and returns input unchanged
-
-The `trace(name, projection)` function SHALL evaluate the projection expression
-against the input collection and log the projected result. The function SHALL
-return the input collection unchanged, regardless of the projection result.
-
-#### Scenario: trace with projection on a primitive path
-
-- **WHEN** evaluating `Patient.name.trace('ids', id)` where `id` is a valid
-  path on HumanName
-- **THEN** the result SHALL be identical to evaluating `Patient.name`
-- **AND** the logged value SHALL be the result of evaluating `id` on each
-  HumanName element
-
-#### Scenario: trace with projection on a complex expression
-
-- **WHEN** evaluating `Patient.name.trace('full', given.first() + ' ' + family)`
-- **THEN** the result SHALL be identical to evaluating `Patient.name`
-- **AND** the logged value SHALL be the concatenated string
-
-#### Scenario: trace with projection returning empty
-
-- **WHEN** evaluating `Patient.name.trace('missing', deceased)` where `deceased`
-  does not exist on HumanName
-- **THEN** the result SHALL be identical to evaluating `Patient.name`
-- **AND** no value SHALL be logged for that element
-
-#### Scenario: trace with projection on an empty input collection
-
-- **WHEN** evaluating `{}.trace('empty', id)`
-- **THEN** the result SHALL be an empty collection
-
-### Requirement: trace is a nondeterministic expression
-
-The Spark Catalyst expression underlying `trace()` SHALL be marked as
-nondeterministic to prevent the query optimizer from eliminating trace
-expressions or caching their results via common subexpression elimination. Each
-`trace()` call SHALL execute its logging side effect independently.
-
-#### Scenario: duplicate trace calls both execute
-
-- **WHEN** evaluating an expression where the same `trace()` call appears in
-  two branches of a computation
-- **THEN** both trace calls SHALL produce log output independently

--- a/openspec/changes/archive/2026-04-09-trace-projection-argument/tasks.md
+++ b/openspec/changes/archive/2026-04-09-trace-projection-argument/tasks.md
@@ -1,0 +1,21 @@
+## 1. TraceExpression (encoders module)
+
+- [x] 1.1 Convert `TraceExpression` from `UnaryExpression` to `BinaryExpression` (left = pass-through, right = value to log)
+- [x] 1.2 Mark `TraceExpression` with the `Nondeterministic` trait
+- [x] 1.3 Override `eval()` with asymmetric null handling: null left returns null, null right skips logging but returns left
+- [x] 1.4 Update `wrapWithTrace` helper in companion object to accept the projected column parameter
+
+## 2. trace() function (fhirpath module)
+
+- [x] 2.1 Add `@Nullable CollectionTransform projection` parameter to `UtilityFunctions.trace()`
+- [x] 2.2 When projection is present, evaluate it on input to get projected column and FHIR type
+- [x] 2.3 When projection is absent, use input column and FHIR type for both children
+- [x] 2.4 Pass both columns to the updated `TraceExpression`
+
+## 3. Tests
+
+- [x] 3.1 Add pass-through tests: trace with projection returns input unchanged
+- [x] 3.2 Add logging tests: trace with projection logs projected value and type
+- [x] 3.3 Add collector tests: trace with projection captures projected FHIR type
+- [x] 3.4 Add edge case tests: empty input with projection, null projected value
+- [x] 3.5 Verify existing tests still pass (no-projection behavior unchanged)

--- a/openspec/specs/fhirpath-trace-collector/spec.md
+++ b/openspec/specs/fhirpath-trace-collector/spec.md
@@ -36,9 +36,11 @@ serializable and SHALL implement `AutoCloseable` for registry cleanup.
 
 ### Requirement: Trace entries carry FHIR type metadata
 
-Each trace entry SHALL include the FHIR type code of the traced collection
-(e.g., `"HumanName"`, `"string"`, `"boolean"`), derived from the input
-collection's type information at the point where `trace()` is invoked.
+Each trace entry SHALL include the FHIR type code of the expression being
+logged. When no projection is provided, this is the FHIR type of the input
+collection. When a projection is provided, this is the FHIR type of the
+projected result (e.g., `"string"` for a `family` projection on a `HumanName`
+input).
 
 #### Scenario: Trace entry for a complex type
 
@@ -49,6 +51,12 @@ collection's type information at the point where `trace()` is invoked.
 
 - **WHEN** `Patient.active.trace('flag')` is evaluated with a collector
 - **THEN** each trace entry SHALL have FHIR type `"boolean"`
+
+#### Scenario: Trace entry type reflects projection
+
+- **WHEN** `Patient.name.trace('fam', family)` is evaluated with a collector
+- **THEN** each trace entry SHALL have FHIR type `"string"` (the projected
+  type), not `"HumanName"` (the input type)
 
 ### Requirement: Trace collector is optional on EvaluationContext
 

--- a/openspec/specs/fhirpath-trace-collector/spec.md
+++ b/openspec/specs/fhirpath-trace-collector/spec.md
@@ -1,0 +1,81 @@
+### Requirement: TraceCollector interface for programmatic trace capture
+
+The system SHALL provide a `TraceCollector` interface that accepts trace data
+during FHIRPath expression evaluation. The interface SHALL accept a label
+(String), a FHIR type (String), and a value (Object) for each traced element.
+How the implementation stores, groups, or retrieves these entries is not
+prescribed by the interface.
+
+#### Scenario: Collector is called during trace evaluation
+
+- **WHEN** an expression containing `trace('myLabel')` is evaluated with a
+  `TraceCollector` attached to the evaluation context and the result is
+  materialised
+- **THEN** the collector's add method SHALL be called with the label `myLabel`,
+  the FHIR type of the traced collection, and the traced value
+
+### Requirement: List-backed collector implementation
+
+The system SHALL provide a `ListTraceCollector` implementation of
+`TraceCollector` backed by a plain list. This implementation is not serializable.
+A `TraceCollectorProxy` SHALL wrap the list collector for use in Spark
+expressions, delegating via a static registry keyed by UUID. The proxy SHALL be
+serializable and SHALL implement `AutoCloseable` for registry cleanup.
+
+#### Scenario: ListTraceCollector captures entries
+
+- **WHEN** a `ListTraceCollector` is used during evaluation (via proxy)
+- **THEN** all trace entries are captured and retrievable after materialisation
+
+#### Scenario: Proxy survives Spark plan serialization
+
+- **WHEN** a `TraceCollectorProxy` wrapping a `ListTraceCollector` is serialized
+  during Spark closure cleaning
+- **THEN** the proxy SHALL deserialize successfully and continue delegating to
+  the original collector via the registry
+
+### Requirement: Trace entries carry FHIR type metadata
+
+Each trace entry SHALL include the FHIR type code of the traced collection
+(e.g., `"HumanName"`, `"string"`, `"boolean"`), derived from the input
+collection's type information at the point where `trace()` is invoked.
+
+#### Scenario: Trace entry for a complex type
+
+- **WHEN** `Patient.name.trace('names')` is evaluated with a collector
+- **THEN** each trace entry SHALL have FHIR type `"HumanName"`
+
+#### Scenario: Trace entry for a primitive type
+
+- **WHEN** `Patient.active.trace('flag')` is evaluated with a collector
+- **THEN** each trace entry SHALL have FHIR type `"boolean"`
+
+### Requirement: Trace collector is optional on EvaluationContext
+
+The `EvaluationContext` SHALL provide an optional `TraceCollector`. When no
+collector is present, `trace()` SHALL still log via SLF4J but SHALL NOT attempt
+to collect entries.
+
+#### Scenario: No collector attached
+
+- **WHEN** an expression containing `trace()` is evaluated without a collector
+  on the context
+- **THEN** the expression SHALL evaluate successfully with SLF4J logging only
+
+#### Scenario: Collector attached
+
+- **WHEN** an expression containing `trace()` is evaluated with a collector on
+  the context
+- **THEN** both SLF4J logging and collector capture SHALL occur
+
+### Requirement: Trace values are sanitized
+
+Trace values that are complex types (Spark `Row` objects) SHALL be sanitized
+before being stored in the collector. Sanitization SHALL strip synthetic fields
+and null-valued fields, consistent with the existing
+`SingleInstanceEvaluator.sanitiseRow()` logic.
+
+#### Scenario: Synthetic fields stripped from trace values
+
+- **WHEN** tracing a complex type that contains synthetic fields (e.g., `_fid`)
+- **THEN** the collected trace value SHALL NOT contain synthetic fields

--- a/openspec/specs/fhirpath-trace/spec.md
+++ b/openspec/specs/fhirpath-trace/spec.md
@@ -1,0 +1,99 @@
+### Requirement: trace returns input collection unchanged
+
+The `trace(name)` function SHALL return the input collection without
+modification. The result collection SHALL have the same type, cardinality, and
+values as the input collection.
+
+#### Scenario: trace on a singleton string
+
+- **WHEN** evaluating `Patient.name.family.trace('debug')`
+- **THEN** the result SHALL be identical to evaluating `Patient.name.family`
+
+#### Scenario: trace on a boolean value
+
+- **WHEN** evaluating `Patient.active.trace('active-check')`
+- **THEN** the result SHALL be identical to evaluating `Patient.active`
+
+#### Scenario: trace on an empty collection
+
+- **WHEN** evaluating `{}.trace('empty')`
+- **THEN** the result SHALL be an empty collection
+
+#### Scenario: trace on a collection with null values
+
+- **WHEN** evaluating a path that produces null values followed by `.trace('label')`
+- **THEN** null values SHALL be preserved in the output
+
+#### Scenario: trace on a complex type
+
+- **WHEN** evaluating `Patient.name.trace('names')` where name is a HumanName
+  complex type
+- **THEN** the result SHALL be identical to evaluating `Patient.name`
+
+#### Scenario: trace after a where filter
+
+- **WHEN** evaluating `Patient.name.where(use = 'official').trace('official-names')`
+- **THEN** the result SHALL be identical to evaluating
+  `Patient.name.where(use = 'official')`
+
+#### Scenario: trace before a where filter
+
+- **WHEN** evaluating `Patient.name.trace('all-names').where(use = 'official')`
+- **THEN** the result SHALL be identical to evaluating
+  `Patient.name.where(use = 'official')`
+
+#### Scenario: two trace calls in a single expression
+
+- **WHEN** evaluating
+  `Patient.name.trace('before-filter').where(use = 'official').trace('after-filter')`
+- **THEN** the result SHALL be identical to evaluating
+  `Patient.name.where(use = 'official')`
+
+#### Scenario: trace on a multi-element collection
+
+- **WHEN** evaluating `Patient.name.given.trace('givens')` where the Patient
+  has multiple given names
+- **THEN** the result SHALL contain all given names unchanged
+
+### Requirement: trace logs values via SLF4J
+
+The `trace(name)` function SHALL log a string representation of each evaluated
+value using an SLF4J logger. The log message SHALL include the `name` argument
+as a label to identify the trace point.
+
+#### Scenario: trace produces log output with label
+
+- **WHEN** evaluating `Patient.active.trace('myLabel')` and materialising the
+  result
+- **THEN** the SLF4J logger for `TraceExpression` SHALL emit at least one log
+  entry containing the string `myLabel`
+
+#### Scenario: trace logs the value representation
+
+- **WHEN** evaluating `Patient.name.family.trace('names')` against a Patient
+  with family name `Smith` and materialising the result
+- **THEN** the log output SHALL contain a representation of `Smith`
+
+#### Scenario: two trace calls produce distinct log entries
+
+- **WHEN** evaluating
+  `Patient.name.trace('before').where(use = 'official').trace('after')` and
+  materialising the result
+- **THEN** the log output SHALL contain entries labelled `before` and entries
+  labelled `after`
+
+### Requirement: trace is a recognised FHIRPath function
+
+The `trace` function SHALL be registered in the `StaticFunctionRegistry` and
+recognised by the FHIRPath parser. Expressions containing `trace()` SHALL NOT
+produce parse errors or "unknown function" errors.
+
+#### Scenario: trace function is callable
+
+- **WHEN** parsing and evaluating the expression `Patient.active.trace('test')`
+- **THEN** no error SHALL be raised
+
+#### Scenario: trace with missing name argument is an error
+
+- **WHEN** parsing the expression `Patient.active.trace()`
+- **THEN** an error SHALL be raised indicating a missing required argument

--- a/openspec/specs/fhirpath-trace/spec.md
+++ b/openspec/specs/fhirpath-trace/spec.md
@@ -61,6 +61,10 @@ The `trace(name)` function SHALL log a string representation of each evaluated
 value using an SLF4J logger. The log message SHALL include the `name` argument
 as a label to identify the trace point.
 
+When a `TraceCollector` is available on the `EvaluationContext`, the function
+SHALL additionally add each traced value to the collector with the trace label
+and the FHIR type of the input collection.
+
 #### Scenario: trace produces log output with label
 
 - **WHEN** evaluating `Patient.active.trace('myLabel')` and materialising the
@@ -81,6 +85,13 @@ as a label to identify the trace point.
   materialising the result
 - **THEN** the log output SHALL contain entries labelled `before` and entries
   labelled `after`
+
+#### Scenario: trace populates collector when present
+
+- **WHEN** evaluating `Patient.name.trace('names')` with a `TraceCollector`
+  attached to the evaluation context and materialising the result
+- **THEN** the collector SHALL contain entries under label `names` with FHIR
+  type `HumanName`
 
 ### Requirement: trace is a recognised FHIRPath function
 


### PR DESCRIPTION
## Summary

- Implement the FHIRPath `trace()` function with both unary `trace(name)` and binary `trace(name, projection)` forms, logging a string representation of the input collection (or projected values) at TRACE level via SLF4J
- Add programmatic trace collection via `TraceCollector` interface, threading trace entries through `SingleInstanceEvaluationResult` and `PathlingContext.evaluateFhirPath()`
- Expose trace entries in the Python API (`evaluate_fhirpath()` returns a `traces` list with `label` and typed `values`)
- Fix `sanitiseRow()` schema misalignment for nested structs — parent StructField dataType now reflects the sanitised nested schema, preventing field-value shifting in `Row.json()` output

Closes #2580
Fixes #2583

## Test plan

- [x] `TraceFunctionTest` — pass-through semantics, SLF4J logging at TRACE level, collector capture, error cases
- [x] `ListTraceCollectorTest` — trace collector unit tests
- [x] `TraceExpressionTest` — unary and binary trace expression evaluation
- [x] `test_evaluate_fhirpath.py` — Python API tests covering basic results, return types, context expressions, variables, trace output structure, and error handling
- [x] YAML reference tests pass (trace projection exclusion removed now that feature is implemented)
- [x] `SingleInstanceEvaluatorTest` — nested struct schema alignment and JSON output correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)