### PR TITLE
Enable FHIR extensions in FHIRPath Lab API context

### DIFF
--- a/fhirpath-lab-api/src/fhirpath_lab_api/app.py
+++ b/fhirpath-lab-api/src/fhirpath_lab_api/app.py
@@ -67,7 +67,7 @@ def create_app(pathling_context=None) -> Flask:
             from pathling import PathlingContext
 
             logger.info("Initialising PathlingContext...")
-            ctx = PathlingContext.create()
+            ctx = PathlingContext.create(enable_extensions=True)
             app.config["pathling_context"] = ctx
             logger.info("PathlingContext initialised.")
         return ctx


### PR DESCRIPTION
Closes #2590.

Pass `enable_extensions=True` when constructing the `PathlingContext` in the FHIRPath Lab API so that FHIRPath expressions can traverse the `extension` element on FHIR resources.