### PR TITLE
FHIRPath Lab context expression grouping and trace support

### DIFF
--- a/fhirpath-lab-api/README.md
+++ b/fhirpath-lab-api/README.md
@@ -118,6 +118,76 @@ Response (FHIR Parameters):
 }
 ```
 
+#### Trace entries
+
+Each invocation of the FHIRPath `trace()` function inside the expression
+contributes an additional part inside the `result` part. The trace part is
+named `trace`, its `valueString` is the trace label, and its `part` list
+contains the typed values that flowed through the trace. Trace parts appear
+after the typed result values within the same `result` part.
+
+For an expression such as `name.given.trace('all-given').first()`:
+
+```json
+{
+    "name": "result",
+    "part": [
+        { "name": "string", "valueString": "John" },
+        {
+            "name": "trace",
+            "valueString": "all-given",
+            "part": [
+                { "name": "string", "valueString": "John" },
+                { "name": "string", "valueString": "Jim" }
+            ]
+        }
+    ]
+}
+```
+
+#### Grouped responses (with `context`)
+
+When a `context` parameter is supplied, the main expression is evaluated once
+per element of the context. The response then contains one `result` part per
+context element, in order. Each result part carries a `valueString` label of
+the form `"<context>[i]"` identifying the element it relates to, and its
+`part` list contains the typed values (and any `trace` parts) produced by
+that iteration.
+
+For an expression of `given.first()` with a context of `name` against a
+patient with two names:
+
+```json
+{
+    "resourceType": "Parameters",
+    "parameter": [
+        {
+            "name": "parameters",
+            "part": [
+                { "name": "evaluator", "valueString": "Pathling 9.6.0 (R4)" },
+                { "name": "expression", "valueString": "given.first()" },
+                { "name": "context", "valueString": "name" },
+                { "name": "expectedReturnType", "valueString": "string" }
+            ]
+        },
+        {
+            "name": "result",
+            "valueString": "name[0]",
+            "part": [{ "name": "string", "valueString": "Peter" }]
+        },
+        {
+            "name": "result",
+            "valueString": "name[1]",
+            "part": [{ "name": "string", "valueString": "Jim" }]
+        }
+    ]
+}
+```
+
+A context that yields zero elements produces a successful response with no
+`result` parts. A context that yields more than `MAX_CONTEXT_ELEMENTS`
+elements is rejected with HTTP 400 - see the configuration section above.
+
 ## Docker
 
 Build the image:

--- a/fhirpath-lab-api/README.md
+++ b/fhirpath-lab-api/README.md
@@ -38,13 +38,20 @@ uv run pytest -v
 
 The server is configured via environment variables:
 
-| Variable               | Description                             | Default |
-| ---------------------- | --------------------------------------- | ------- |
-| `PORT`                 | HTTP port to listen on                  | `8080`  |
-| `CORS_ALLOWED_ORIGINS` | Comma-separated list of allowed origins | (none)  |
+| Variable               | Description                                                        | Default |
+| ---------------------- | ------------------------------------------------------------------ | ------- |
+| `PORT`                 | HTTP port to listen on                                             | `8080`  |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated list of allowed origins                            | (none)  |
+| `MAX_CONTEXT_ELEMENTS` | Upper bound on the number of context elements in a grouped request | `100`   |
 
 CORS is disabled unless `CORS_ALLOWED_ORIGINS` is set. The Helm chart provides
 default origins for production deployments.
+
+Requests whose `context` expression yields more than `MAX_CONTEXT_ELEMENTS`
+elements are rejected with HTTP 400 (`OperationOutcome` issue code
+`too-costly`). Each element triggers an additional round-trip through the
+Pathling engine, so the cap protects against denial-of-service via large
+contexts such as `Bundle.entry`.
 
 ## API
 

--- a/fhirpath-lab-api/pyproject.toml
+++ b/fhirpath-lab-api/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "flask>=3.1,<4",
   "flask-cors>=6.0,<7",
   "gunicorn>=23,<26",
-  "pathling>=9.5.0,<10",
+  "pathling>=9.6.0,<10",
 ]
 
 [project.optional-dependencies]

--- a/fhirpath-lab-api/src/fhirpath_lab_api/app.py
+++ b/fhirpath-lab-api/src/fhirpath_lab_api/app.py
@@ -33,12 +33,32 @@ from flask_cors import CORS
 from py4j.protocol import Py4JJavaError
 
 from fhirpath_lab_api.parameters import (
+    InputParameters,
     build_operation_outcome,
     build_response_parameters,
     parse_input_parameters,
 )
 
 logger = logging.getLogger(__name__)
+
+# Upper bound on the number of context elements permitted in a grouped
+# evaluation. Evaluating the main expression once per context element requires
+# N additional round-trips through the Pathling engine, so a sanity cap
+# prevents accidental denial-of-service on contexts like ``Bundle.entry``.
+MAX_CONTEXT_ELEMENTS = 100
+
+
+class _ContextTooLargeError(Exception):
+    """Raised when the context expression yields more elements than
+    MAX_CONTEXT_ELEMENTS."""
+
+    def __init__(self, count: int, limit: int):
+        super().__init__(
+            f"Context expression produced {count} elements, exceeding the "
+            f"limit of {limit}. Please narrow the context expression."
+        )
+        self.count = count
+        self.limit = limit
 
 
 def create_app(pathling_context=None) -> Flask:
@@ -133,15 +153,21 @@ def _handle_evaluate(get_context) -> Response:
         )
 
     # Evaluate the expression.
+    use_grouped = params.context is not None and params.context.strip() != ""
     try:
         pc = get_context()
-        result = pc.evaluate_fhirpath(
-            resource_type=params.resource_type,
-            resource_json=json.dumps(params.resource),
-            fhirpath_expression=params.expression,
-            context_expression=params.context,
-            variables=params.variables,
-        )
+        if use_grouped:
+            grouped = _evaluate_grouped(pc, params)
+        else:
+            result = pc.evaluate_fhirpath(
+                resource_type=params.resource_type,
+                resource_json=json.dumps(params.resource),
+                fhirpath_expression=params.expression,
+                context_expression=params.context,
+                variables=params.variables,
+            )
+    except _ContextTooLargeError as e:
+        return _error_response(400, "too-costly", str(e))
     except Py4JJavaError as e:
         full_message = str(e)
         logger.exception("Error evaluating FHIRPath expression")
@@ -155,21 +181,89 @@ def _handle_evaluate(get_context) -> Response:
 
     # Build the response.
     evaluator_string = f"Pathling {pc.version()} (R4)"
-    response_body = build_response_parameters(
-        evaluator_string=evaluator_string,
-        expression=params.expression,
-        resource=params.resource,
-        expected_return_type=result["expectedReturnType"],
-        results=result["results"],
-        context=params.context,
-        traces=result.get("traces", []),
-    )
+    if use_grouped:
+        response_body = build_response_parameters(
+            evaluator_string=evaluator_string,
+            expression=params.expression,
+            resource=params.resource,
+            expected_return_type=grouped["expected_return_type"],
+            context=params.context,
+            grouped_results=grouped["groups"],
+        )
+    else:
+        response_body = build_response_parameters(
+            evaluator_string=evaluator_string,
+            expression=params.expression,
+            resource=params.resource,
+            expected_return_type=result["expectedReturnType"],
+            results=result["results"],
+            context=params.context,
+            traces=result.get("traces", []),
+        )
 
     return Response(
         json.dumps(response_body),
         status=200,
         content_type="application/fhir+json",
     )
+
+
+def _evaluate_grouped(pc, params: InputParameters) -> dict:
+    """Evaluates the main expression once per element of the context expression.
+
+    First evaluates the context expression alone to determine its cardinality,
+    then evaluates the main expression N times, each time scoping the context
+    to a single element using the FHIRPath indexer ``(context)[i]``. Each
+    iteration's results and trace entries are collected into a separate group
+    labelled ``"<context>[i]"``.
+
+    This results in 1 + N calls through the Pathling engine. The cardinality
+    is capped by :data:`MAX_CONTEXT_ELEMENTS`.
+
+    :param pc: the PathlingContext to use for evaluation
+    :param params: the parsed input parameters; ``params.context`` must be
+        non-empty
+    :return: a dict with keys ``groups`` (list of
+        ``(label, results, traces)`` tuples), ``expected_return_type`` (string,
+        taken from the first iteration or empty when the context yields no
+        elements), and ``context_count`` (int)
+    :raises _ContextTooLargeError: if the context expression yields more than
+        :data:`MAX_CONTEXT_ELEMENTS` elements
+    """
+    resource_json = json.dumps(params.resource)
+
+    count_result = pc.evaluate_fhirpath(
+        resource_type=params.resource_type,
+        resource_json=resource_json,
+        fhirpath_expression=params.context,
+        context_expression=None,
+        variables=params.variables,
+    )
+    context_count = len(count_result["results"])
+
+    if context_count > MAX_CONTEXT_ELEMENTS:
+        raise _ContextTooLargeError(context_count, MAX_CONTEXT_ELEMENTS)
+
+    groups: list[tuple[str, list[dict], list[dict]]] = []
+    expected_return_type = ""
+    for i in range(context_count):
+        iter_result = pc.evaluate_fhirpath(
+            resource_type=params.resource_type,
+            resource_json=resource_json,
+            fhirpath_expression=params.expression,
+            context_expression=f"({params.context})[{i}]",
+            variables=params.variables,
+        )
+        label = f"{params.context}[{i}]"
+        groups.append((label, iter_result["results"], iter_result.get("traces", [])))
+        if i == 0:
+            expected_return_type = iter_result["expectedReturnType"]
+
+    return {
+        "groups": groups,
+        "expected_return_type": expected_return_type,
+        "context_count": context_count,
+    }
 
 
 # Module-level WSGI application instance for use by production WSGI servers

--- a/fhirpath-lab-api/src/fhirpath_lab_api/app.py
+++ b/fhirpath-lab-api/src/fhirpath_lab_api/app.py
@@ -34,6 +34,7 @@ from py4j.protocol import Py4JJavaError
 
 from fhirpath_lab_api.parameters import (
     InputParameters,
+    build_grouped_response_parameters,
     build_operation_outcome,
     build_response_parameters,
     parse_input_parameters,
@@ -41,24 +42,20 @@ from fhirpath_lab_api.parameters import (
 
 logger = logging.getLogger(__name__)
 
-# Upper bound on the number of context elements permitted in a grouped
-# evaluation. Evaluating the main expression once per context element requires
-# N additional round-trips through the Pathling engine, so a sanity cap
-# prevents accidental denial-of-service on contexts like ``Bundle.entry``.
+# Cap context cardinality: each element triggers an extra Pathling round-trip,
+# so an unbounded context like ``Bundle.entry`` could be used to exhaust the
+# server.
 MAX_CONTEXT_ELEMENTS = 100
 
 
 class _ContextTooLargeError(Exception):
-    """Raised when the context expression yields more elements than
-    MAX_CONTEXT_ELEMENTS."""
+    """Raised when the context yields more elements than MAX_CONTEXT_ELEMENTS."""
 
     def __init__(self, count: int, limit: int):
         super().__init__(
             f"Context expression produced {count} elements, exceeding the "
             f"limit of {limit}. Please narrow the context expression."
         )
-        self.count = count
-        self.limit = limit
 
 
 def create_app(pathling_context=None) -> Flask:
@@ -157,7 +154,7 @@ def _handle_evaluate(get_context) -> Response:
     try:
         pc = get_context()
         if use_grouped:
-            grouped = _evaluate_grouped(pc, params)
+            groups, grouped_return_type = _evaluate_grouped(pc, params)
         else:
             result = pc.evaluate_fhirpath(
                 resource_type=params.resource_type,
@@ -182,13 +179,13 @@ def _handle_evaluate(get_context) -> Response:
     # Build the response.
     evaluator_string = f"Pathling {pc.version()} (R4)"
     if use_grouped:
-        response_body = build_response_parameters(
+        response_body = build_grouped_response_parameters(
             evaluator_string=evaluator_string,
             expression=params.expression,
             resource=params.resource,
-            expected_return_type=grouped["expected_return_type"],
+            expected_return_type=grouped_return_type,
             context=params.context,
-            grouped_results=grouped["groups"],
+            grouped_results=groups,
         )
     else:
         response_body = build_response_parameters(
@@ -208,7 +205,9 @@ def _handle_evaluate(get_context) -> Response:
     )
 
 
-def _evaluate_grouped(pc, params: InputParameters) -> dict:
+def _evaluate_grouped(
+    pc, params: InputParameters
+) -> tuple[list[tuple[str, list[dict], list[dict]]], str]:
     """Evaluates the main expression once per element of the context expression.
 
     First evaluates the context expression alone to determine its cardinality,
@@ -223,10 +222,10 @@ def _evaluate_grouped(pc, params: InputParameters) -> dict:
     :param pc: the PathlingContext to use for evaluation
     :param params: the parsed input parameters; ``params.context`` must be
         non-empty
-    :return: a dict with keys ``groups`` (list of
-        ``(label, results, traces)`` tuples), ``expected_return_type`` (string,
-        taken from the first iteration or empty when the context yields no
-        elements), and ``context_count`` (int)
+    :return: a tuple of ``(groups, expected_return_type)`` where ``groups`` is
+        an ordered list of ``(label, results, traces)`` tuples and
+        ``expected_return_type`` is taken from the first iteration (empty
+        string when the context yields no elements)
     :raises _ContextTooLargeError: if the context expression yields more than
         :data:`MAX_CONTEXT_ELEMENTS` elements
     """
@@ -256,14 +255,11 @@ def _evaluate_grouped(pc, params: InputParameters) -> dict:
         )
         label = f"{params.context}[{i}]"
         groups.append((label, iter_result["results"], iter_result.get("traces", [])))
-        if i == 0:
+        # The static return type is identical across iterations; capture it once.
+        if not expected_return_type:
             expected_return_type = iter_result["expectedReturnType"]
 
-    return {
-        "groups": groups,
-        "expected_return_type": expected_return_type,
-        "context_count": context_count,
-    }
+    return groups, expected_return_type
 
 
 # Module-level WSGI application instance for use by production WSGI servers

--- a/fhirpath-lab-api/src/fhirpath_lab_api/app.py
+++ b/fhirpath-lab-api/src/fhirpath_lab_api/app.py
@@ -162,6 +162,7 @@ def _handle_evaluate(get_context) -> Response:
         expected_return_type=result["expectedReturnType"],
         results=result["results"],
         context=params.context,
+        traces=result.get("traces", []),
     )
 
     return Response(

--- a/fhirpath-lab-api/src/fhirpath_lab_api/app.py
+++ b/fhirpath-lab-api/src/fhirpath_lab_api/app.py
@@ -44,8 +44,8 @@ logger = logging.getLogger(__name__)
 
 # Cap context cardinality: each element triggers an extra Pathling round-trip,
 # so an unbounded context like ``Bundle.entry`` could be used to exhaust the
-# server.
-MAX_CONTEXT_ELEMENTS = 100
+# server. Override via the ``MAX_CONTEXT_ELEMENTS`` environment variable.
+MAX_CONTEXT_ELEMENTS = int(os.environ.get("MAX_CONTEXT_ELEMENTS", "100"))
 
 
 class _ContextTooLargeError(Exception):
@@ -253,6 +253,10 @@ def _evaluate_grouped(
             context_expression=f"({params.context})[{i}]",
             variables=params.variables,
         )
+        # Label uses the unparenthesised context for readability; the eval
+        # expression is parenthesised to handle low-precedence operators. This
+        # asymmetry matches other FHIRPath Lab implementations (e.g. Aidbox,
+        # fhirpath-py).
         label = f"{params.context}[{i}]"
         groups.append((label, iter_result["results"], iter_result.get("traces", [])))
         # The static return type is identical across iterations; capture it once.

--- a/fhirpath-lab-api/src/fhirpath_lab_api/parameters.py
+++ b/fhirpath-lab-api/src/fhirpath_lab_api/parameters.py
@@ -184,21 +184,34 @@ def build_response_parameters(
     expression: str,
     resource: dict,
     expected_return_type: str,
-    results: list[dict],
+    results: Optional[list[dict]] = None,
     context: Optional[str] = None,
     traces: Optional[list[dict]] = None,
+    grouped_results: Optional[list[tuple[str, list[dict], list[dict]]]] = None,
 ) -> dict:
     """Constructs a FHIR Parameters response from evaluation results.
+
+    Callers must supply either ``results`` (for a flat single-collection
+    response) or ``grouped_results`` (for a per-context-element response with
+    one ``result`` part per group), but not both.
 
     :param evaluator_string: the evaluator identification string
     :param expression: the original expression
     :param resource: the original resource
     :param expected_return_type: the statically inferred return type
-    :param results: the list of typed result values
+    :param results: the flat list of typed result values
     :param context: the optional context expression
-    :param traces: the list of trace entries from trace() calls
+    :param traces: the flat list of trace entries (only used with ``results``)
+    :param grouped_results: an ordered list of ``(label, results, traces)``
+        tuples, one per context element. When supplied, each tuple produces a
+        separate ``result`` part with ``valueString`` set to the label.
     :return: a FHIR Parameters resource dict
+    :raises ValueError: if both ``results`` and ``grouped_results`` are
+        provided
     """
+    if results is not None and grouped_results is not None:
+        raise ValueError("results and grouped_results are mutually exclusive")
+
     # Build the parameters metadata part.
     params_parts = [
         {"name": "evaluator", "valueString": evaluator_string},
@@ -215,12 +228,17 @@ def build_response_parameters(
 
     output_parameters: list[dict] = [{"name": "parameters", "part": params_parts}]
 
-    # Build result and trace parts.
-    if results or traces:
-        result_parts = []
-        for typed_value in results:
-            result_part = _build_result_part(typed_value)
-            result_parts.append(result_part)
+    if grouped_results is not None:
+        # One result part per context element, labelled via valueString.
+        for label, group_results, group_traces in grouped_results:
+            part_list = [_build_result_part(tv) for tv in group_results]
+            part_list.extend(_build_trace_part(t) for t in group_traces)
+            output_parameters.append(
+                {"name": "result", "valueString": label, "part": part_list}
+            )
+    elif results or traces:
+        # Flat result part containing all typed values and trace entries.
+        result_parts = [_build_result_part(tv) for tv in results or []]
         for trace_entry in traces or []:
             result_parts.append(_build_trace_part(trace_entry))
         output_parameters.append({"name": "result", "part": result_parts})

--- a/fhirpath-lab-api/src/fhirpath_lab_api/parameters.py
+++ b/fhirpath-lab-api/src/fhirpath_lab_api/parameters.py
@@ -184,16 +184,11 @@ def build_response_parameters(
     expression: str,
     resource: dict,
     expected_return_type: str,
-    results: Optional[list[dict]] = None,
+    results: list[dict],
     context: Optional[str] = None,
     traces: Optional[list[dict]] = None,
-    grouped_results: Optional[list[tuple[str, list[dict], list[dict]]]] = None,
 ) -> dict:
-    """Constructs a FHIR Parameters response from evaluation results.
-
-    Callers must supply either ``results`` (for a flat single-collection
-    response) or ``grouped_results`` (for a per-context-element response with
-    one ``result`` part per group), but not both.
+    """Constructs a FHIR Parameters response with a single flat result part.
 
     :param evaluator_string: the evaluator identification string
     :param expression: the original expression
@@ -201,49 +196,91 @@ def build_response_parameters(
     :param expected_return_type: the statically inferred return type
     :param results: the flat list of typed result values
     :param context: the optional context expression
-    :param traces: the flat list of trace entries (only used with ``results``)
-    :param grouped_results: an ordered list of ``(label, results, traces)``
-        tuples, one per context element. When supplied, each tuple produces a
-        separate ``result`` part with ``valueString`` set to the label.
+    :param traces: the flat list of trace entries
     :return: a FHIR Parameters resource dict
-    :raises ValueError: if both ``results`` and ``grouped_results`` are
-        provided
     """
-    if results is not None and grouped_results is not None:
-        raise ValueError("results and grouped_results are mutually exclusive")
+    output_parameters: list[dict] = [
+        {
+            "name": "parameters",
+            "part": _build_metadata_parts(
+                evaluator_string, expression, resource, expected_return_type, context
+            ),
+        }
+    ]
 
-    # Build the parameters metadata part.
-    params_parts = [
+    if results or traces:
+        output_parameters.append(
+            {"name": "result", "part": _build_part_list(results, traces or [])}
+        )
+
+    return {"resourceType": "Parameters", "parameter": output_parameters}
+
+
+def build_grouped_response_parameters(
+    evaluator_string: str,
+    expression: str,
+    resource: dict,
+    expected_return_type: str,
+    grouped_results: list[tuple[str, list[dict], list[dict]]],
+    context: Optional[str] = None,
+) -> dict:
+    """Constructs a FHIR Parameters response with one result part per context element.
+
+    :param evaluator_string: the evaluator identification string
+    :param expression: the original expression
+    :param resource: the original resource
+    :param expected_return_type: the statically inferred return type
+    :param grouped_results: an ordered list of ``(label, results, traces)``
+        tuples, one per context element. Each tuple produces a separate
+        ``result`` part with ``valueString`` set to the label.
+    :param context: the optional context expression
+    :return: a FHIR Parameters resource dict
+    """
+    output_parameters: list[dict] = [
+        {
+            "name": "parameters",
+            "part": _build_metadata_parts(
+                evaluator_string, expression, resource, expected_return_type, context
+            ),
+        }
+    ]
+
+    for label, group_results, group_traces in grouped_results:
+        output_parameters.append(
+            {
+                "name": "result",
+                "valueString": label,
+                "part": _build_part_list(group_results, group_traces),
+            }
+        )
+
+    return {"resourceType": "Parameters", "parameter": output_parameters}
+
+
+def _build_metadata_parts(
+    evaluator_string: str,
+    expression: str,
+    resource: dict,
+    expected_return_type: str,
+    context: Optional[str],
+) -> list[dict]:
+    """Builds the metadata ``parameters`` part list shared by both response shapes."""
+    parts = [
         {"name": "evaluator", "valueString": evaluator_string},
         {"name": "expression", "valueString": expression},
         {"name": "resource", "resource": resource},
     ]
-
     if context is not None:
-        params_parts.append({"name": "context", "valueString": context})
+        parts.append({"name": "context", "valueString": context})
+    parts.append({"name": "expectedReturnType", "valueString": expected_return_type})
+    return parts
 
-    params_parts.append(
-        {"name": "expectedReturnType", "valueString": expected_return_type}
-    )
 
-    output_parameters: list[dict] = [{"name": "parameters", "part": params_parts}]
-
-    if grouped_results is not None:
-        # One result part per context element, labelled via valueString.
-        for label, group_results, group_traces in grouped_results:
-            part_list = [_build_result_part(tv) for tv in group_results]
-            part_list.extend(_build_trace_part(t) for t in group_traces)
-            output_parameters.append(
-                {"name": "result", "valueString": label, "part": part_list}
-            )
-    elif results or traces:
-        # Flat result part containing all typed values and trace entries.
-        result_parts = [_build_result_part(tv) for tv in results or []]
-        for trace_entry in traces or []:
-            result_parts.append(_build_trace_part(trace_entry))
-        output_parameters.append({"name": "result", "part": result_parts})
-
-    return {"resourceType": "Parameters", "parameter": output_parameters}
+def _build_part_list(results: list[dict], traces: list[dict]) -> list[dict]:
+    """Builds a result part list combining typed values and trace entries."""
+    parts = [_build_result_part(tv) for tv in results]
+    parts.extend(_build_trace_part(t) for t in traces)
+    return parts
 
 
 def _build_trace_part(trace_entry: dict) -> dict:

--- a/fhirpath-lab-api/src/fhirpath_lab_api/parameters.py
+++ b/fhirpath-lab-api/src/fhirpath_lab_api/parameters.py
@@ -186,6 +186,7 @@ def build_response_parameters(
     expected_return_type: str,
     results: list[dict],
     context: Optional[str] = None,
+    traces: Optional[list[dict]] = None,
 ) -> dict:
     """Constructs a FHIR Parameters response from evaluation results.
 
@@ -195,6 +196,7 @@ def build_response_parameters(
     :param expected_return_type: the statically inferred return type
     :param results: the list of typed result values
     :param context: the optional context expression
+    :param traces: the list of trace entries from trace() calls
     :return: a FHIR Parameters resource dict
     """
     # Build the parameters metadata part.
@@ -213,15 +215,27 @@ def build_response_parameters(
 
     output_parameters: list[dict] = [{"name": "parameters", "part": params_parts}]
 
-    # Build result parts.
-    if results:
+    # Build result and trace parts.
+    if results or traces:
         result_parts = []
         for typed_value in results:
             result_part = _build_result_part(typed_value)
             result_parts.append(result_part)
+        for trace_entry in traces or []:
+            result_parts.append(_build_trace_part(trace_entry))
         output_parameters.append({"name": "result", "part": result_parts})
 
     return {"resourceType": "Parameters", "parameter": output_parameters}
+
+
+def _build_trace_part(trace_entry: dict) -> dict:
+    """Builds a trace part from a trace entry.
+
+    :param trace_entry: a dict with 'label' and 'values' keys
+    :return: a FHIR Parameters part dict with the trace name and typed values
+    """
+    value_parts = [_build_result_part(tv) for tv in trace_entry["values"]]
+    return {"name": "trace", "valueString": trace_entry["label"], "part": value_parts}
 
 
 def _build_result_part(typed_value: dict) -> dict:

--- a/fhirpath-lab-api/tests/test_app.py
+++ b/fhirpath-lab-api/tests/test_app.py
@@ -709,6 +709,36 @@ def test_grouped_context_exceeds_limit_returns_400(client, mock_context):
     assert mock_context.evaluate_fhirpath.call_count == 1
 
 
+def test_grouped_context_at_limit_succeeds(client, mock_context):
+    """A context whose cardinality exactly equals MAX_CONTEXT_ELEMENTS is
+    accepted (the limit is inclusive)."""
+    at_limit = [{"type": "HumanName", "value": "{}"}] * 2
+    iter_response = {
+        "results": [{"type": "string", "value": "John"}],
+        "expectedReturnType": "string",
+        "traces": [],
+    }
+    mock_context.evaluate_fhirpath.side_effect = [
+        {"results": at_limit, "expectedReturnType": "HumanName", "traces": []},
+        iter_response,
+        iter_response,
+    ]
+
+    with patch.object(app_module, "MAX_CONTEXT_ELEMENTS", 2):
+        response = client.post(
+            "/fhir/$fhirpath",
+            data=json.dumps(_grouped_request_body()),
+            content_type="application/json",
+        )
+
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    result_parts = [p for p in data["parameter"] if p["name"] == "result"]
+    assert len(result_parts) == 2
+    # Count call plus one call per element.
+    assert mock_context.evaluate_fhirpath.call_count == 3
+
+
 def test_grouped_context_expected_return_type_from_first_iteration(
     client, mock_context
 ):

--- a/fhirpath-lab-api/tests/test_app.py
+++ b/fhirpath-lab-api/tests/test_app.py
@@ -346,7 +346,7 @@ def test_cors_multiple_origins(mock_context, valid_request_body):
                 ), f"Expected CORS header for {origin}"
 
 
-def test_traces_included_in_response(mock_context, valid_request_body):
+def test_traces_included_in_response(client, mock_context, valid_request_body):
     """Trace entries from evaluation appear inside the result part."""
     mock_context.evaluate_fhirpath.return_value = {
         "results": [{"type": "boolean", "value": True}],
@@ -359,15 +359,11 @@ def test_traces_included_in_response(mock_context, valid_request_body):
         ],
     }
 
-    with patch.dict(os.environ, {"CORS_ALLOWED_ORIGINS": TEST_CORS_ORIGINS}):
-        app = create_app(pathling_context=mock_context)
-        app.config["TESTING"] = True
-        with app.test_client() as c:
-            response = c.post(
-                "/fhir/$fhirpath",
-                data=json.dumps(valid_request_body),
-                content_type="application/json",
-            )
+    response = client.post(
+        "/fhir/$fhirpath",
+        data=json.dumps(valid_request_body),
+        content_type="application/json",
+    )
 
     assert response.status_code == 200
     data = json.loads(response.data)

--- a/fhirpath-lab-api/tests/test_app.py
+++ b/fhirpath-lab-api/tests/test_app.py
@@ -42,6 +42,7 @@ def mock_context():
     ctx.evaluate_fhirpath.return_value = {
         "results": [{"type": "string", "value": "Smith"}],
         "expectedReturnType": "string",
+        "traces": [],
     }
     return ctx
 
@@ -342,6 +343,40 @@ def test_cors_multiple_origins(mock_context, valid_request_body):
                 assert (
                     response.headers.get("Access-Control-Allow-Origin") is not None
                 ), f"Expected CORS header for {origin}"
+
+
+def test_traces_included_in_response(mock_context, valid_request_body):
+    """Trace entries from evaluation appear inside the result part."""
+    mock_context.evaluate_fhirpath.return_value = {
+        "results": [{"type": "boolean", "value": True}],
+        "expectedReturnType": "boolean",
+        "traces": [
+            {
+                "label": "flag",
+                "values": [{"type": "boolean", "value": True}],
+            },
+        ],
+    }
+
+    with patch.dict(os.environ, {"CORS_ALLOWED_ORIGINS": TEST_CORS_ORIGINS}):
+        app = create_app(pathling_context=mock_context)
+        app.config["TESTING"] = True
+        with app.test_client() as c:
+            response = c.post(
+                "/fhir/$fhirpath",
+                data=json.dumps(valid_request_body),
+                content_type="application/json",
+            )
+
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    result_part = data["parameter"][1]
+    assert result_part["name"] == "result"
+
+    trace_parts = [p for p in result_part["part"] if p["name"] == "trace"]
+    assert len(trace_parts) == 1
+    assert trace_parts[0]["valueString"] == "flag"
+    assert trace_parts[0]["part"] == [{"name": "boolean", "valueBoolean": True}]
 
 
 def test_context_expression_passed_to_evaluator(client, mock_context):

--- a/fhirpath-lab-api/tests/test_app.py
+++ b/fhirpath-lab-api/tests/test_app.py
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from py4j.protocol import Py4JJavaError
 
+from fhirpath_lab_api import app as app_module
 from fhirpath_lab_api.app import _extract_friendly_message, create_app
 
 TEST_CORS_ORIGINS = "https://fhirpath-lab.azurewebsites.net,http://localhost:3000"
@@ -379,17 +380,386 @@ def test_traces_included_in_response(mock_context, valid_request_body):
     assert trace_parts[0]["part"] == [{"name": "boolean", "valueBoolean": True}]
 
 
-def test_context_expression_passed_to_evaluator(client, mock_context):
-    """A context expression is passed through to the evaluator."""
+# ========== Context-grouped evaluation tests ==========
+
+
+def _resource_example():
+    """Returns the canonical Patient resource used in grouped-context tests."""
+    return {"resourceType": "Patient", "id": "example"}
+
+
+def _grouped_request_body(context="name", expression="given.first()"):
+    """Builds a request body with the given context and expression."""
+    return {
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "expression", "valueString": expression},
+            {"name": "resource", "resource": _resource_example()},
+            {"name": "context", "valueString": context},
+        ],
+    }
+
+
+def test_grouped_context_multi_element(client, mock_context):
+    """Multi-element context produces one result part per element, with
+    per-call results isolated to the matching group."""
+    mock_context.evaluate_fhirpath.side_effect = [
+        # Count call: context "name" returns 2 elements.
+        {
+            "results": [
+                {"type": "HumanName", "value": '{"family": "Chalmers"}'},
+                {"type": "HumanName", "value": '{"family": "Windsor"}'},
+            ],
+            "expectedReturnType": "HumanName",
+            "traces": [],
+        },
+        # Index 0 evaluation.
+        {
+            "results": [{"type": "string", "value": "Peter"}],
+            "expectedReturnType": "string",
+            "traces": [],
+        },
+        # Index 1 evaluation.
+        {
+            "results": [{"type": "string", "value": "Jim"}],
+            "expectedReturnType": "string",
+            "traces": [],
+        },
+    ]
+
+    response = client.post(
+        "/fhir/$fhirpath",
+        data=json.dumps(_grouped_request_body()),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    result_parts = [p for p in data["parameter"] if p["name"] == "result"]
+    assert len(result_parts) == 2
+    assert result_parts[0]["valueString"] == "name[0]"
+    assert result_parts[0]["part"] == [{"name": "string", "valueString": "Peter"}]
+    assert result_parts[1]["valueString"] == "name[1]"
+    assert result_parts[1]["part"] == [{"name": "string", "valueString": "Jim"}]
+
+    # Three calls in order: count, index 0, index 1.
+    calls = mock_context.evaluate_fhirpath.call_args_list
+    assert len(calls) == 3
+    assert calls[0].kwargs["fhirpath_expression"] == "name"
+    assert calls[0].kwargs["context_expression"] is None
+    assert calls[1].kwargs["fhirpath_expression"] == "given.first()"
+    assert calls[1].kwargs["context_expression"] == "(name)[0]"
+    assert calls[2].kwargs["context_expression"] == "(name)[1]"
+
+
+def test_grouped_context_single_element(client, mock_context):
+    """A single-element context still produces a grouped result (labelled
+    ``name[0]``), not a flattened one."""
+    mock_context.evaluate_fhirpath.side_effect = [
+        {
+            "results": [{"type": "HumanName", "value": '{"family": "Smith"}'}],
+            "expectedReturnType": "HumanName",
+            "traces": [],
+        },
+        {
+            "results": [{"type": "string", "value": "John"}],
+            "expectedReturnType": "string",
+            "traces": [],
+        },
+    ]
+
+    response = client.post(
+        "/fhir/$fhirpath",
+        data=json.dumps(_grouped_request_body()),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    result_parts = [p for p in data["parameter"] if p["name"] == "result"]
+    assert len(result_parts) == 1
+    assert result_parts[0]["valueString"] == "name[0]"
+    assert result_parts[0]["part"] == [{"name": "string", "valueString": "John"}]
+
+
+def test_grouped_context_zero_elements(client, mock_context):
+    """A zero-element context produces no result parts and issues no per-index
+    calls to the evaluator."""
+    mock_context.evaluate_fhirpath.side_effect = [
+        {"results": [], "expectedReturnType": "HumanName", "traces": []},
+    ]
+
+    response = client.post(
+        "/fhir/$fhirpath",
+        data=json.dumps(_grouped_request_body()),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    result_parts = [p for p in data["parameter"] if p["name"] == "result"]
+    assert result_parts == []
+    # Only the count call was made.
+    assert mock_context.evaluate_fhirpath.call_count == 1
+
+
+def test_grouped_context_with_traces(client, mock_context):
+    """Per-iteration trace entries appear inside the matching result part
+    only, not across groups."""
+    mock_context.evaluate_fhirpath.side_effect = [
+        # Count: 2 elements.
+        {
+            "results": [
+                {"type": "HumanName", "value": "{}"},
+                {"type": "HumanName", "value": "{}"},
+            ],
+            "expectedReturnType": "HumanName",
+            "traces": [],
+        },
+        # Index 0.
+        {
+            "results": [{"type": "string", "value": "Peter James, Chalmers"}],
+            "expectedReturnType": "string",
+            "traces": [
+                {
+                    "label": "trc",
+                    "values": [
+                        {"type": "HumanName", "value": '{"family": "Chalmers"}'}
+                    ],
+                }
+            ],
+        },
+        # Index 1.
+        {
+            "results": [{"type": "string", "value": "Peter James, Windsor"}],
+            "expectedReturnType": "string",
+            "traces": [
+                {
+                    "label": "trc",
+                    "values": [{"type": "HumanName", "value": '{"family": "Windsor"}'}],
+                }
+            ],
+        },
+    ]
+
+    body = _grouped_request_body(
+        expression="trace('trc').given.join(' ').combine(family).join(', ')"
+    )
+    response = client.post(
+        "/fhir/$fhirpath",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    result_parts = [p for p in data["parameter"] if p["name"] == "result"]
+
+    trace0 = next(p for p in result_parts[0]["part"] if p["name"] == "trace")
+    assert "Chalmers" in trace0["part"][0]["extension"][0]["valueString"]
+    assert "Windsor" not in trace0["part"][0]["extension"][0]["valueString"]
+
+    trace1 = next(p for p in result_parts[1]["part"] if p["name"] == "trace")
+    assert "Windsor" in trace1["part"][0]["extension"][0]["valueString"]
+    assert "Chalmers" not in trace1["part"][0]["extension"][0]["valueString"]
+
+
+def test_grouped_context_with_variables(client, mock_context):
+    """Variables are passed through to every call (count + per-index)."""
+    mock_context.evaluate_fhirpath.side_effect = [
+        {
+            "results": [{"type": "HumanName", "value": "{}"}],
+            "expectedReturnType": "HumanName",
+            "traces": [],
+        },
+        {
+            "results": [{"type": "boolean", "value": True}],
+            "expectedReturnType": "boolean",
+            "traces": [],
+        },
+    ]
+
     body = {
         "resourceType": "Parameters",
         "parameter": [
-            {"name": "expression", "valueString": "given.first()"},
-            {
-                "name": "resource",
-                "resource": {"resourceType": "Patient", "id": "example"},
-            },
+            {"name": "expression", "valueString": "given = %target"},
+            {"name": "resource", "resource": _resource_example()},
             {"name": "context", "valueString": "name"},
+            {
+                "name": "variables",
+                "part": [{"name": "target", "valueString": "John"}],
+            },
+        ],
+    }
+    response = client.post(
+        "/fhir/$fhirpath",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    calls = mock_context.evaluate_fhirpath.call_args_list
+    assert len(calls) == 2
+    for call in calls:
+        assert call.kwargs["variables"] == {"target": "John"}
+
+
+def test_grouped_context_complex_expression(client, mock_context):
+    """A complex context is parenthesised in the per-index call but not in
+    the response label."""
+    mock_context.evaluate_fhirpath.side_effect = [
+        {
+            "results": [{"type": "HumanName", "value": "{}"}],
+            "expectedReturnType": "HumanName",
+            "traces": [],
+        },
+        {
+            "results": [{"type": "string", "value": "John"}],
+            "expectedReturnType": "string",
+            "traces": [],
+        },
+    ]
+
+    context_expr = "name.where(use='official')"
+    response = client.post(
+        "/fhir/$fhirpath",
+        data=json.dumps(_grouped_request_body(context=context_expr)),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    result_parts = [p for p in data["parameter"] if p["name"] == "result"]
+    assert result_parts[0]["valueString"] == "name.where(use='official')[0]"
+
+    calls = mock_context.evaluate_fhirpath.call_args_list
+    assert calls[1].kwargs["context_expression"] == "(name.where(use='official'))[0]"
+
+
+def test_grouped_context_error_in_iteration_returns_500(client, mock_context):
+    """An error during a per-index iteration surfaces as a 500 via the
+    existing error pipeline."""
+    mock_context.evaluate_fhirpath.side_effect = [
+        {
+            "results": [{"type": "HumanName", "value": "{}"}],
+            "expectedReturnType": "HumanName",
+            "traces": [],
+        },
+        RuntimeError("Evaluation failed on index 0"),
+    ]
+
+    response = client.post(
+        "/fhir/$fhirpath",
+        data=json.dumps(_grouped_request_body()),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 500
+    data = json.loads(response.data)
+    assert data["resourceType"] == "OperationOutcome"
+    assert "Evaluation failed on index 0" in data["issue"][0]["details"]["text"]
+
+
+def test_grouped_context_empty_expression_short_circuits(client, mock_context):
+    """An empty expression short-circuits even when a context is supplied,
+    and no Pathling calls are issued."""
+    body = {
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "expression", "valueString": ""},
+            {"name": "resource", "resource": _resource_example()},
+            {"name": "context", "valueString": "name"},
+        ],
+    }
+    response = client.post(
+        "/fhir/$fhirpath",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    # Only the parameters part, no result parts.
+    assert len(data["parameter"]) == 1
+    assert data["parameter"][0]["name"] == "parameters"
+    # Context is still echoed in the metadata.
+    context_parts = [p for p in data["parameter"][0]["part"] if p["name"] == "context"]
+    assert context_parts[0]["valueString"] == "name"
+    mock_context.evaluate_fhirpath.assert_not_called()
+
+
+def test_grouped_context_exceeds_limit_returns_400(client, mock_context):
+    """A context that yields more than MAX_CONTEXT_ELEMENTS elements returns
+    400 with an OperationOutcome naming the limit."""
+    oversized = [{"type": "HumanName", "value": "{}"}] * 3
+
+    mock_context.evaluate_fhirpath.side_effect = [
+        {"results": oversized, "expectedReturnType": "HumanName", "traces": []},
+    ]
+
+    with patch.object(app_module, "MAX_CONTEXT_ELEMENTS", 2):
+        response = client.post(
+            "/fhir/$fhirpath",
+            data=json.dumps(_grouped_request_body()),
+            content_type="application/json",
+        )
+
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert data["resourceType"] == "OperationOutcome"
+    assert "3 elements" in data["issue"][0]["details"]["text"]
+    assert "limit of 2" in data["issue"][0]["details"]["text"]
+    # No per-index calls were made.
+    assert mock_context.evaluate_fhirpath.call_count == 1
+
+
+def test_grouped_context_expected_return_type_from_first_iteration(
+    client, mock_context
+):
+    """The metadata expectedReturnType is taken from the first per-index
+    iteration."""
+    mock_context.evaluate_fhirpath.side_effect = [
+        {
+            "results": [
+                {"type": "HumanName", "value": "{}"},
+                {"type": "HumanName", "value": "{}"},
+            ],
+            "expectedReturnType": "HumanName",
+            "traces": [],
+        },
+        {
+            "results": [{"type": "string", "value": "John"}],
+            "expectedReturnType": "string",
+            "traces": [],
+        },
+        {
+            "results": [{"type": "string", "value": "Jim"}],
+            "expectedReturnType": "string",
+            "traces": [],
+        },
+    ]
+
+    response = client.post(
+        "/fhir/$fhirpath",
+        data=json.dumps(_grouped_request_body()),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    params_part = data["parameter"][0]["part"]
+    ert = next(p for p in params_part if p["name"] == "expectedReturnType")
+    assert ert["valueString"] == "string"
+
+
+def test_flat_context_no_longer_passed_through_in_flat_path(client, mock_context):
+    """Requests without a context parameter still use the flat single-call
+    path with ``context_expression=None``."""
+    body = {
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "expression", "valueString": "name.family"},
+            {"name": "resource", "resource": _resource_example()},
         ],
     }
     response = client.post(
@@ -401,9 +771,9 @@ def test_context_expression_passed_to_evaluator(client, mock_context):
     assert response.status_code == 200
     mock_context.evaluate_fhirpath.assert_called_once_with(
         resource_type="Patient",
-        resource_json=json.dumps({"resourceType": "Patient", "id": "example"}),
-        fhirpath_expression="given.first()",
-        context_expression="name",
+        resource_json=json.dumps(_resource_example()),
+        fhirpath_expression="name.family",
+        context_expression=None,
         variables=None,
     )
 

--- a/fhirpath-lab-api/tests/test_parameters.py
+++ b/fhirpath-lab-api/tests/test_parameters.py
@@ -253,6 +253,92 @@ def test_build_response_includes_expected_return_type():
     assert return_type_parts[0]["valueString"] == "boolean"
 
 
+# ========== Trace rendering tests ==========
+
+
+def test_build_response_with_traces():
+    """Trace entries appear inside the result part with label and typed values."""
+    traces = [
+        {
+            "label": "myLabel",
+            "values": [
+                {"type": "string", "value": "id1"},
+                {"type": "string", "value": "id2"},
+            ],
+        },
+    ]
+    response = build_response_parameters(
+        evaluator_string="Pathling 9.6.0 (R4)",
+        expression="name.given.trace('myLabel')",
+        resource={"resourceType": "Patient", "id": "example"},
+        expected_return_type="string",
+        results=[{"type": "string", "value": "John"}],
+        traces=traces,
+    )
+
+    result_part = response["parameter"][1]
+    assert result_part["name"] == "result"
+
+    # First part is the result value, second is the trace.
+    assert result_part["part"][0] == {"name": "string", "valueString": "John"}
+
+    trace_part = result_part["part"][1]
+    assert trace_part["name"] == "trace"
+    assert trace_part["valueString"] == "myLabel"
+    assert trace_part["part"] == [
+        {"name": "string", "valueString": "id1"},
+        {"name": "string", "valueString": "id2"},
+    ]
+
+
+def test_build_response_with_empty_traces():
+    """No trace parts appear when the traces list is empty."""
+    response = build_response_parameters(
+        evaluator_string="Pathling 9.6.0 (R4)",
+        expression="active",
+        resource={"resourceType": "Patient", "id": "example"},
+        expected_return_type="boolean",
+        results=[{"type": "boolean", "value": True}],
+        traces=[],
+    )
+
+    result_part = response["parameter"][1]
+    trace_parts = [p for p in result_part["part"] if p["name"] == "trace"]
+    assert trace_parts == []
+
+
+def test_build_response_with_complex_trace_values():
+    """Complex trace values use the json-value extension."""
+    traces = [
+        {
+            "label": "names",
+            "values": [
+                {"type": "HumanName", "value": '{"family": "Smith"}'},
+            ],
+        },
+    ]
+    response = build_response_parameters(
+        evaluator_string="Pathling 9.6.0 (R4)",
+        expression="name.trace('names')",
+        resource={"resourceType": "Patient", "id": "example"},
+        expected_return_type="HumanName",
+        results=[],
+        traces=traces,
+    )
+
+    # Traces present even when results are empty.
+    result_part = response["parameter"][1]
+    assert result_part["name"] == "result"
+
+    trace_part = result_part["part"][0]
+    assert trace_part["name"] == "trace"
+    assert trace_part["valueString"] == "names"
+    value_part = trace_part["part"][0]
+    assert value_part["name"] == "HumanName"
+    assert value_part["extension"][0]["url"] == JSON_VALUE_EXTENSION_URL
+    assert "Smith" in value_part["extension"][0]["valueString"]
+
+
 # ========== OperationOutcome construction tests ==========
 
 

--- a/fhirpath-lab-api/tests/test_parameters.py
+++ b/fhirpath-lab-api/tests/test_parameters.py
@@ -26,6 +26,7 @@ import pytest
 
 from fhirpath_lab_api.parameters import (
     JSON_VALUE_EXTENSION_URL,
+    build_grouped_response_parameters,
     build_operation_outcome,
     build_response_parameters,
     parse_input_parameters,
@@ -344,7 +345,7 @@ def test_build_response_with_complex_trace_values():
 
 def test_build_response_grouped_empty():
     """A zero-element grouped response emits only the parameters part."""
-    response = build_response_parameters(
+    response = build_grouped_response_parameters(
         evaluator_string="Pathling 9.6.0 (R4)",
         expression="given.first()",
         resource={"resourceType": "Patient", "id": "example"},
@@ -359,7 +360,7 @@ def test_build_response_grouped_empty():
 
 def test_build_response_grouped_single_group():
     """A single-group grouped response emits one labelled result part."""
-    response = build_response_parameters(
+    response = build_grouped_response_parameters(
         evaluator_string="Pathling 9.6.0 (R4)",
         expression="given.first()",
         resource={"resourceType": "Patient", "id": "example"},
@@ -392,7 +393,7 @@ def test_build_response_grouped_multiple_groups():
             [{"label": "trc", "values": [{"type": "string", "value": "hit1"}]}],
         ),
     ]
-    response = build_response_parameters(
+    response = build_grouped_response_parameters(
         evaluator_string="Pathling 9.6.0 (R4)",
         expression="given.first().trace('trc')",
         resource={"resourceType": "Patient", "id": "example"},
@@ -433,7 +434,7 @@ def test_build_response_grouped_complex_trace_value():
             ],
         ),
     ]
-    response = build_response_parameters(
+    response = build_grouped_response_parameters(
         evaluator_string="Pathling 9.6.0 (R4)",
         expression="trace('trc')",
         resource={"resourceType": "Patient", "id": "example"},
@@ -453,7 +454,7 @@ def test_build_response_grouped_complex_trace_value():
 
 def test_build_response_grouped_preserves_metadata():
     """The parameters metadata part is present and correct in grouped responses."""
-    response = build_response_parameters(
+    response = build_grouped_response_parameters(
         evaluator_string="Pathling 9.6.0 (R4)",
         expression="given.first()",
         resource={"resourceType": "Patient", "id": "example"},
@@ -476,7 +477,7 @@ def test_build_response_grouped_preserves_metadata():
 def test_build_response_grouped_empty_group_still_emitted():
     """A group with no results and no traces still produces a labelled result
     part with an empty part list, preserving index continuity."""
-    response = build_response_parameters(
+    response = build_grouped_response_parameters(
         evaluator_string="Pathling 9.6.0 (R4)",
         expression="given.first()",
         resource={"resourceType": "Patient", "id": "example"},
@@ -493,21 +494,6 @@ def test_build_response_grouped_empty_group_still_emitted():
     labels = [p["valueString"] for p in result_parts]
     assert labels == ["name[0]", "name[1]", "name[2]"]
     assert result_parts[1]["part"] == []
-
-
-def test_build_response_results_and_grouped_mutually_exclusive():
-    """Supplying both results and grouped_results raises ValueError."""
-    with pytest.raises(ValueError, match="mutually exclusive"):
-        build_response_parameters(
-            evaluator_string="Pathling 9.6.0 (R4)",
-            expression="given.first()",
-            resource={"resourceType": "Patient", "id": "example"},
-            expected_return_type="string",
-            results=[{"type": "string", "value": "John"}],
-            grouped_results=[
-                ("name[0]", [{"type": "string", "value": "John"}], []),
-            ],
-        )
 
 
 # ========== OperationOutcome construction tests ==========

--- a/fhirpath-lab-api/tests/test_parameters.py
+++ b/fhirpath-lab-api/tests/test_parameters.py
@@ -339,6 +339,177 @@ def test_build_response_with_complex_trace_values():
     assert "Smith" in value_part["extension"][0]["valueString"]
 
 
+# ========== Grouped response construction tests ==========
+
+
+def test_build_response_grouped_empty():
+    """A zero-element grouped response emits only the parameters part."""
+    response = build_response_parameters(
+        evaluator_string="Pathling 9.6.0 (R4)",
+        expression="given.first()",
+        resource={"resourceType": "Patient", "id": "example"},
+        expected_return_type="",
+        context="name",
+        grouped_results=[],
+    )
+
+    assert len(response["parameter"]) == 1
+    assert response["parameter"][0]["name"] == "parameters"
+
+
+def test_build_response_grouped_single_group():
+    """A single-group grouped response emits one labelled result part."""
+    response = build_response_parameters(
+        evaluator_string="Pathling 9.6.0 (R4)",
+        expression="given.first()",
+        resource={"resourceType": "Patient", "id": "example"},
+        expected_return_type="string",
+        context="name",
+        grouped_results=[
+            ("name[0]", [{"type": "string", "value": "John"}], []),
+        ],
+    )
+
+    assert len(response["parameter"]) == 2
+    result_part = response["parameter"][1]
+    assert result_part["name"] == "result"
+    assert result_part["valueString"] == "name[0]"
+    assert result_part["part"] == [{"name": "string", "valueString": "John"}]
+
+
+def test_build_response_grouped_multiple_groups():
+    """Multiple groups each produce their own labelled result part; per-group
+    traces do not bleed across groups."""
+    grouped_results = [
+        (
+            "name[0]",
+            [{"type": "string", "value": "John"}],
+            [{"label": "trc", "values": [{"type": "string", "value": "hit0"}]}],
+        ),
+        (
+            "name[1]",
+            [{"type": "string", "value": "Jane"}],
+            [{"label": "trc", "values": [{"type": "string", "value": "hit1"}]}],
+        ),
+    ]
+    response = build_response_parameters(
+        evaluator_string="Pathling 9.6.0 (R4)",
+        expression="given.first().trace('trc')",
+        resource={"resourceType": "Patient", "id": "example"},
+        expected_return_type="string",
+        context="name",
+        grouped_results=grouped_results,
+    )
+
+    result_parts = [p for p in response["parameter"] if p["name"] == "result"]
+    assert len(result_parts) == 2
+
+    assert result_parts[0]["valueString"] == "name[0]"
+    assert result_parts[0]["part"][0] == {"name": "string", "valueString": "John"}
+    trace0 = result_parts[0]["part"][1]
+    assert trace0["name"] == "trace"
+    assert trace0["valueString"] == "trc"
+    assert trace0["part"] == [{"name": "string", "valueString": "hit0"}]
+
+    assert result_parts[1]["valueString"] == "name[1]"
+    assert result_parts[1]["part"][0] == {"name": "string", "valueString": "Jane"}
+    trace1 = result_parts[1]["part"][1]
+    assert trace1["part"] == [{"name": "string", "valueString": "hit1"}]
+
+
+def test_build_response_grouped_complex_trace_value():
+    """Complex trace values inside a group use the json-value extension."""
+    grouped_results = [
+        (
+            "name[0]",
+            [],
+            [
+                {
+                    "label": "trc",
+                    "values": [
+                        {"type": "HumanName", "value": '{"family": "Chalmers"}'}
+                    ],
+                }
+            ],
+        ),
+    ]
+    response = build_response_parameters(
+        evaluator_string="Pathling 9.6.0 (R4)",
+        expression="trace('trc')",
+        resource={"resourceType": "Patient", "id": "example"},
+        expected_return_type="HumanName",
+        context="name",
+        grouped_results=grouped_results,
+    )
+
+    result_part = response["parameter"][1]
+    trace_part = result_part["part"][0]
+    assert trace_part["name"] == "trace"
+    value_part = trace_part["part"][0]
+    assert value_part["name"] == "HumanName"
+    assert value_part["extension"][0]["url"] == JSON_VALUE_EXTENSION_URL
+    assert "Chalmers" in value_part["extension"][0]["valueString"]
+
+
+def test_build_response_grouped_preserves_metadata():
+    """The parameters metadata part is present and correct in grouped responses."""
+    response = build_response_parameters(
+        evaluator_string="Pathling 9.6.0 (R4)",
+        expression="given.first()",
+        resource={"resourceType": "Patient", "id": "example"},
+        expected_return_type="string",
+        context="name",
+        grouped_results=[
+            ("name[0]", [{"type": "string", "value": "John"}], []),
+        ],
+    )
+
+    params_part = response["parameter"][0]
+    assert params_part["name"] == "parameters"
+    names = {p["name"]: p for p in params_part["part"]}
+    assert names["evaluator"]["valueString"] == "Pathling 9.6.0 (R4)"
+    assert names["expression"]["valueString"] == "given.first()"
+    assert names["context"]["valueString"] == "name"
+    assert names["expectedReturnType"]["valueString"] == "string"
+
+
+def test_build_response_grouped_empty_group_still_emitted():
+    """A group with no results and no traces still produces a labelled result
+    part with an empty part list, preserving index continuity."""
+    response = build_response_parameters(
+        evaluator_string="Pathling 9.6.0 (R4)",
+        expression="given.first()",
+        resource={"resourceType": "Patient", "id": "example"},
+        expected_return_type="string",
+        context="name",
+        grouped_results=[
+            ("name[0]", [{"type": "string", "value": "John"}], []),
+            ("name[1]", [], []),
+            ("name[2]", [{"type": "string", "value": "Peter"}], []),
+        ],
+    )
+
+    result_parts = [p for p in response["parameter"] if p["name"] == "result"]
+    labels = [p["valueString"] for p in result_parts]
+    assert labels == ["name[0]", "name[1]", "name[2]"]
+    assert result_parts[1]["part"] == []
+
+
+def test_build_response_results_and_grouped_mutually_exclusive():
+    """Supplying both results and grouped_results raises ValueError."""
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        build_response_parameters(
+            evaluator_string="Pathling 9.6.0 (R4)",
+            expression="given.first()",
+            resource={"resourceType": "Patient", "id": "example"},
+            expected_return_type="string",
+            results=[{"type": "string", "value": "John"}],
+            grouped_results=[
+                ("name[0]", [{"type": "string", "value": "John"}], []),
+            ],
+        )
+
+
 # ========== OperationOutcome construction tests ==========
 
 

--- a/fhirpath-lab-api/uv.lock
+++ b/fhirpath-lab-api/uv.lock
@@ -101,7 +101,7 @@ requires-dist = [
     { name = "flask", specifier = ">=3.1,<4" },
     { name = "flask-cors", specifier = ">=6.0,<7" },
     { name = "gunicorn", specifier = ">=23,<26" },
-    { name = "pathling", specifier = ">=9.5.0,<10" },
+    { name = "pathling", specifier = ">=9.6.0,<10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3,<9" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9,<1" },
 ]
@@ -333,15 +333,15 @@ wheels = [
 
 [[package]]
 name = "pathling"
-version = "9.5.0"
+version = "9.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "pyspark" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/71/ec47720c168728d51e3e0091fc2174e75a6b5af0a2676fb69473b70fbe50/pathling-9.5.0.tar.gz", hash = "sha256:a8004cd8d015c8ae9ba58c130ea2b0f34105d591b93c707b36f12a5840177a7e", size = 53753, upload-time = "2026-03-17T03:04:12.38Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/b2/c089f65da23819bf7df45aa0c0850674c54738d272aea73c3867c665acb6/pathling-9.6.0.tar.gz", hash = "sha256:047de6bb94f240414d88c1e3cfcc258f35e75b0ea23ac2687db78b9fdf129bcb", size = 53922, upload-time = "2026-04-23T06:04:51.306Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/f5/d58ecf3a576ef3a52f992bf147d7948fb64bc9b3ed9274f796c686872712/pathling-9.5.0-py3-none-any.whl", hash = "sha256:f2e155e1d7ff136a1845f80b8243dc80c556aa8c1549ae4e4ebb91dc5555d869", size = 73627, upload-time = "2026-03-17T03:04:11.033Z" },
+    { url = "https://files.pythonhosted.org/packages/76/49/01592bb0dcf7e1bfb3635600b921d37c86dc233caae2110e88e1fa8be8b7/pathling-9.6.0-py3-none-any.whl", hash = "sha256:51240ca9b9257ea5325535501f2ee12be46e8b52e5e6e3b660e5dae1d147bdaa", size = 73774, upload-time = "2026-04-23T06:04:50.269Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Group FHIRPath Lab results by context element so the main expression is evaluated per context item (#2586).
- Include `trace()` entries in the FHIR Parameters response so they can be surfaced in the FHIRPath Lab UI (#2585).
- Bump `fhirpath-lab-api` to pathling 9.6.0.

Closes #2585, closes #2586.

## Test plan
- [x] `uv run pytest` in `fhirpath-lab-api`
- [x] Smoke test a FHIRPath Lab request with a Context Expression and verify per-context grouping
- [x] Smoke test an expression using `trace()` (unary and binary) and verify trace parts in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)