### PR TITLE
Implement caching for DynamicDeltaSource

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -56,7 +56,6 @@
     <pathling.awsSdkVersion>2.40.3</pathling.awsSdkVersion>
     <pathling.bulkExportVersion>1.0.4</pathling.bulkExportVersion>
     <pathling.fhirAuthVersion>1.0.0</pathling.fhirAuthVersion>
-    <pathling.testcontainersVersion>1.21.3</pathling.testcontainersVersion>
   </properties>
 
   <repositories>
@@ -318,18 +317,6 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>5.13.4</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers</artifactId>
-      <version>${pathling.testcontainersVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${pathling.testcontainersVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -56,6 +56,7 @@
     <pathling.awsSdkVersion>2.40.3</pathling.awsSdkVersion>
     <pathling.bulkExportVersion>1.0.4</pathling.bulkExportVersion>
     <pathling.fhirAuthVersion>1.0.0</pathling.fhirAuthVersion>
+    <pathling.testcontainersVersion>1.21.3</pathling.testcontainersVersion>
   </properties>
 
   <repositories>
@@ -317,6 +318,18 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>5.13.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>${pathling.testcontainersVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${pathling.testcontainersVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/server/src/main/java/au/csiro/pathling/Dependencies.java
+++ b/server/src/main/java/au/csiro/pathling/Dependencies.java
@@ -89,7 +89,8 @@ public class Dependencies {
         baseSource,
         pathlingContext.getSpark(),
         databaseLocation,
-        pathlingContext.getFhirEncoders());
+        pathlingContext.getFhirEncoders(),
+        serverConfiguration.getStorage());
   }
 
   @Bean

--- a/server/src/main/java/au/csiro/pathling/config/StorageConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/StorageConfiguration.java
@@ -62,4 +62,11 @@ public class StorageConfiguration {
   @Min(1)
   @Builder.Default
   private int compactionThreshold = 10;
+
+  /**
+   * When enabled, Delta Lake merge operations will automatically evolve the table schema to
+   * accommodate new columns present in the incoming data. This is useful when the FHIR encoder adds
+   * new fields (e.g. synthetic columns) that are not yet present in an existing table.
+   */
+  @NotNull @Builder.Default private Boolean schemaAutoMerge = false;
 }

--- a/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
@@ -18,6 +18,7 @@
 package au.csiro.pathling.io;
 
 import au.csiro.pathling.QueryHelpers;
+import au.csiro.pathling.config.StorageConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.io.source.DataSource;
 import au.csiro.pathling.library.io.FileSystemPersistence;
@@ -56,6 +57,8 @@ public class DynamicDeltaSource implements QueryableDataSource {
 
   @Nonnull private final FhirEncoders fhirEncoders;
 
+  private final boolean cacheDatasets;
+
   @Nonnull private final Set<String> dynamicallyDiscoveredTypes = ConcurrentHashMap.newKeySet();
 
   /**
@@ -65,16 +68,19 @@ public class DynamicDeltaSource implements QueryableDataSource {
    * @param spark the Spark session for Delta table operations
    * @param databasePath the path to the Delta database
    * @param fhirEncoders the FHIR encoders for creating empty datasets
+   * @param storageConfiguration the storage configuration
    */
   public DynamicDeltaSource(
       @Nonnull final QueryableDataSource delegate,
       @Nonnull final SparkSession spark,
       @Nonnull final String databasePath,
-      @Nonnull final FhirEncoders fhirEncoders) {
+      @Nonnull final FhirEncoders fhirEncoders,
+      @Nonnull final StorageConfiguration storageConfiguration) {
     this.delegate = delegate;
     this.spark = spark;
     this.databasePath = databasePath;
     this.fhirEncoders = fhirEncoders;
+    this.cacheDatasets = storageConfiguration.getCacheDatasets();
   }
 
   @Override
@@ -86,12 +92,12 @@ public class DynamicDeltaSource implements QueryableDataSource {
 
     // If delegate knows about this type, use it.
     if (delegate.getResourceTypes().contains(resourceCode)) {
-      return delegate.read(resourceCode);
+      return cacheIfEnabled(delegate.read(resourceCode));
     }
 
     // If we've already discovered this type dynamically, read from Delta.
     if (dynamicallyDiscoveredTypes.contains(resourceCode)) {
-      return readFromDelta(resourceCode);
+      return cacheIfEnabled(readFromDelta(resourceCode));
     }
 
     // Try to discover the Delta table.
@@ -99,7 +105,7 @@ public class DynamicDeltaSource implements QueryableDataSource {
     if (DeltaTable.isDeltaTable(spark, tablePath)) {
       log.debug("Dynamically discovered Delta table for resource type: {}", resourceCode);
       dynamicallyDiscoveredTypes.add(resourceCode);
-      return readFromDelta(resourceCode);
+      return cacheIfEnabled(readFromDelta(resourceCode));
     }
 
     // No data found - return an empty dataset with the correct schema.
@@ -151,6 +157,14 @@ public class DynamicDeltaSource implements QueryableDataSource {
   @Nonnull
   public DataSource cache() {
     return delegate.cache();
+  }
+
+  @Nonnull
+  private Dataset<Row> cacheIfEnabled(@Nonnull final Dataset<Row> dataset) {
+    if (cacheDatasets) {
+      return dataset.cache();
+    }
+    return dataset;
   }
 
   @Nonnull

--- a/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
@@ -134,7 +134,8 @@ public class UpdateExecutor {
     final String tablePath = getTablePath(resourceCode);
 
     if (deltaTableExists(spark, tablePath)) {
-      if (schemaAutoMerge) {
+      if (schemaAutoMerge
+          && !updates.schema().equals(spark.read().format("delta").load(tablePath).schema())) {
         // Delta's MERGE — even with spark.databricks.delta.schema.autoMerge.enabled=true —
         // does not support adding new fields to nested structs inside arrays. This is the exact
         // failure mode when the FHIR encoder gains new value-type columns (e.g. valueDecimal,
@@ -147,6 +148,10 @@ public class UpdateExecutor {
         // any missing nested fields to the target table schema (with null for existing rows)
         // without inserting any data. The MERGE that follows then sees compatible schemas and
         // succeeds.
+        //
+        // The schema-equality guard above ensures this second transaction is only paid when the
+        // encoder schema has actually drifted from the table schema; in the steady-state case
+        // where they already match, the warmup is skipped and the update is a single transaction.
         updates
             .limit(0)
             .write()

--- a/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
@@ -53,6 +53,8 @@ public class UpdateExecutor {
 
   @Nonnull private final CacheableDatabase cacheableDatabase;
 
+  private final boolean schemaAutoMerge;
+
   /**
    * Constructs a new UpdateExecutor.
    *
@@ -60,17 +62,20 @@ public class UpdateExecutor {
    * @param fhirEncoders encoders for converting FHIR resources to Spark Datasets
    * @param databasePath the path to the Delta database
    * @param cacheableDatabase the cacheable database for cache invalidation
+   * @param schemaAutoMerge whether to enable Delta Lake schema auto-merge during merge operations
    */
   public UpdateExecutor(
       @Nonnull final PathlingContext pathlingContext,
       @Nonnull final FhirEncoders fhirEncoders,
       @Value("${pathling.storage.warehouseUrl}/${pathling.storage.databaseName}") @Nonnull
           final String databasePath,
-      @Nonnull final CacheableDatabase cacheableDatabase) {
+      @Nonnull final CacheableDatabase cacheableDatabase,
+      @Value("${pathling.storage.schemaAutoMerge:false}") final boolean schemaAutoMerge) {
     this.pathlingContext = pathlingContext;
     this.fhirEncoders = fhirEncoders;
     this.databasePath = databasePath;
     this.cacheableDatabase = cacheableDatabase;
+    this.schemaAutoMerge = schemaAutoMerge;
   }
 
   /**
@@ -129,16 +134,27 @@ public class UpdateExecutor {
     final String tablePath = getTablePath(resourceCode);
 
     if (deltaTableExists(spark, tablePath)) {
-      // Perform a merge operation on the existing table.
-      final DeltaTable table = DeltaTable.forPath(spark, tablePath);
-      table
-          .as("original")
-          .merge(updates.as("updates"), "original.id = updates.id")
-          .whenMatched()
-          .updateAll()
-          .whenNotMatched()
-          .insertAll()
-          .execute();
+      if (schemaAutoMerge) {
+        // Enable automatic schema merging so that tables created with an older encoder schema can
+        // accept resources encoded with a newer schema (e.g. additional synthetic fields).
+        spark.conf().set("spark.databricks.delta.schema.autoMerge.enabled", "true");
+      }
+      try {
+        // Perform a merge operation on the existing table.
+        final DeltaTable table = DeltaTable.forPath(spark, tablePath);
+        table
+            .as("original")
+            .merge(updates.as("updates"), "original.id = updates.id")
+            .whenMatched()
+            .updateAll()
+            .whenNotMatched()
+            .insertAll()
+            .execute();
+      } finally {
+        if (schemaAutoMerge) {
+          spark.conf().set("spark.databricks.delta.schema.autoMerge.enabled", "false");
+        }
+      }
     } else {
       // Create a new table with the resources.
       log.debug("Creating new Delta table for resource type: {}", resourceCode);

--- a/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
@@ -135,26 +135,37 @@ public class UpdateExecutor {
 
     if (deltaTableExists(spark, tablePath)) {
       if (schemaAutoMerge) {
-        // Enable automatic schema merging so that tables created with an older encoder schema can
-        // accept resources encoded with a newer schema (e.g. additional synthetic fields).
-        spark.conf().set("spark.databricks.delta.schema.autoMerge.enabled", "true");
+        // Delta's MERGE — even with spark.databricks.delta.schema.autoMerge.enabled=true —
+        // does not support adding new fields to nested structs inside arrays. This is the exact
+        // failure mode when the FHIR encoder gains new value-type columns (e.g. valueDecimal,
+        // valueDecimal_scale inside the extension element struct): the MERGE planner throws
+        // DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION because it cannot cast the richer source struct
+        // to the narrower target struct.
+        //
+        // A regular write with mergeSchema=true DOES support nested-struct field evolution.
+        // Writing limit(0) — zero rows, same schema as the encoder output — causes Delta to add
+        // any missing nested fields to the target table schema (with null for existing rows)
+        // without inserting any data. The MERGE that follows then sees compatible schemas and
+        // succeeds.
+        updates
+            .limit(0)
+            .write()
+            .format("delta")
+            .mode(SaveMode.Append)
+            .option("mergeSchema", "true")
+            .save(tablePath);
       }
-      try {
-        // Perform a merge operation on the existing table.
-        final DeltaTable table = DeltaTable.forPath(spark, tablePath);
-        table
-            .as("original")
-            .merge(updates.as("updates"), "original.id = updates.id")
-            .whenMatched()
-            .updateAll()
-            .whenNotMatched()
-            .insertAll()
-            .execute();
-      } finally {
-        if (schemaAutoMerge) {
-          spark.conf().set("spark.databricks.delta.schema.autoMerge.enabled", "false");
-        }
-      }
+
+      // Perform a merge operation on the existing table.
+      final DeltaTable table = DeltaTable.forPath(spark, tablePath);
+      table
+          .as("original")
+          .merge(updates.as("updates"), "original.id = updates.id")
+          .whenMatched()
+          .updateAll()
+          .whenNotMatched()
+          .insertAll()
+          .execute();
     } else {
       // Create a new table with the resources.
       log.debug("Creating new Delta table for resource type: {}", resourceCode);

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -53,6 +53,11 @@ pathling:
     # prevents large numbers of small updates causing poor subsequent query performance.
     compactionThreshold: 10
 
+    # When enabled, Delta Lake merge operations will automatically evolve the table schema to
+    # accommodate new columns present in the incoming data. This is useful when the FHIR encoder
+    # adds new fields (e.g. synthetic columns) that are not yet present in an existing table.
+    schemaAutoMerge: false
+
   query:
     # Setting this option to true will enable additional logging relating to the query plan used to
     # execute queries.

--- a/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
@@ -19,6 +19,7 @@ package au.csiro.pathling.io;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import au.csiro.pathling.config.StorageConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
@@ -57,7 +58,8 @@ class DynamicDeltaSourceTest {
         Path.of("src/test/resources/test-data/bulk/fhir/delta").toAbsolutePath().toString();
     final QueryableDataSource baseSource = pathlingContext.read().delta(databasePath);
     dynamicDeltaSource =
-        new DynamicDeltaSource(baseSource, sparkSession, databasePath, fhirEncoders);
+        new DynamicDeltaSource(
+            baseSource, sparkSession, databasePath, fhirEncoders, new StorageConfiguration());
   }
 
   // Verifies that reading a resource type that doesn't exist in the database returns an empty

--- a/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
@@ -25,10 +25,12 @@ import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import au.csiro.pathling.util.FhirServerTestConfiguration;
+import jakarta.annotation.Nonnull;
 import java.nio.file.Path;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.storage.StorageLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +45,9 @@ import org.springframework.context.annotation.Import;
 @SpringBootUnitTest
 class DynamicDeltaSourceTest {
 
+  private static final String DATABASE_PATH =
+      Path.of("src/test/resources/test-data/bulk/fhir/delta").toAbsolutePath().toString();
+
   @Autowired private SparkSession sparkSession;
 
   @Autowired private PathlingContext pathlingContext;
@@ -53,13 +58,7 @@ class DynamicDeltaSourceTest {
 
   @BeforeEach
   void setUp() {
-    // Use an empty directory as the database path to simulate no data.
-    final String databasePath =
-        Path.of("src/test/resources/test-data/bulk/fhir/delta").toAbsolutePath().toString();
-    final QueryableDataSource baseSource = pathlingContext.read().delta(databasePath);
-    dynamicDeltaSource =
-        new DynamicDeltaSource(
-            baseSource, sparkSession, databasePath, fhirEncoders, new StorageConfiguration());
+    dynamicDeltaSource = newDynamicDeltaSource(true);
   }
 
   // Verifies that reading a resource type that doesn't exist in the database returns an empty
@@ -74,5 +73,42 @@ class DynamicDeltaSourceTest {
     assertThat(result.count()).isZero();
     // Verify the schema has the expected structure for an ImmunizationEvaluation resource.
     assertThat(result.schema().fieldNames()).contains("id", "status");
+  }
+
+  // Verifies that when StorageConfiguration.cacheDatasets is true, datasets returned by read()
+  // are marked for caching. Guards against accidental changes to the caching contract introduced
+  // by cacheIfEnabled().
+  @Test
+  void readCachesDatasetWhenCachingEnabled() {
+    final DynamicDeltaSource source = newDynamicDeltaSource(true);
+
+    final Dataset<Row> result = source.read("Patient");
+
+    try {
+      assertThat(result.storageLevel()).isNotEqualTo(StorageLevel.NONE());
+    } finally {
+      result.unpersist();
+    }
+  }
+
+  // Verifies that when StorageConfiguration.cacheDatasets is false, datasets returned by read()
+  // are not cached. Pairs with readCachesDatasetWhenCachingEnabled() to lock in cacheIfEnabled()
+  // behaviour for both configuration values.
+  @Test
+  void readDoesNotCacheDatasetWhenCachingDisabled() {
+    final DynamicDeltaSource source = newDynamicDeltaSource(false);
+
+    final Dataset<Row> result = source.read("Patient");
+
+    assertThat(result.storageLevel()).isEqualTo(StorageLevel.NONE());
+  }
+
+  @Nonnull
+  private DynamicDeltaSource newDynamicDeltaSource(final boolean cacheDatasets) {
+    final StorageConfiguration storageConfiguration = new StorageConfiguration();
+    storageConfiguration.setCacheDatasets(cacheDatasets);
+    final QueryableDataSource baseSource = pathlingContext.read().delta(DATABASE_PATH);
+    return new DynamicDeltaSource(
+        baseSource, sparkSession, DATABASE_PATH, fhirEncoders, storageConfiguration);
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/create/CreateProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/create/CreateProviderTest.java
@@ -87,7 +87,8 @@ class CreateProviderTest {
             pathlingContext,
             fhirEncoders,
             tempDatabasePath.toAbsolutePath().toString(),
-            cacheableDatabase);
+            cacheableDatabase,
+            false);
 
     // Create the CreateProvider.
     createProvider = new CreateProvider(updateExecutor, fhirContext, Patient.class);

--- a/server/src/test/java/au/csiro/pathling/operations/delete/DeleteProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/delete/DeleteProviderTest.java
@@ -84,7 +84,8 @@ class DeleteProviderTest {
             pathlingContext,
             fhirEncoders,
             tempDatabasePath.toAbsolutePath().toString(),
-            cacheableDatabase);
+            cacheableDatabase,
+            false);
 
     // Create DeleteExecutor with the temp database path.
     final DeleteExecutor deleteExecutor =

--- a/server/src/test/java/au/csiro/pathling/operations/update/BatchProviderCreateTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/BatchProviderCreateTest.java
@@ -86,7 +86,8 @@ class BatchProviderCreateTest {
             pathlingContext,
             fhirEncoders,
             tempDatabasePath.toAbsolutePath().toString(),
-            cacheableDatabase);
+            cacheableDatabase,
+            false);
 
     // Create DeleteExecutor with the temp database path.
     deleteExecutor =

--- a/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorSchemaAutoMergeTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorSchemaAutoMergeTest.java
@@ -142,11 +142,16 @@ class UpdateExecutorSchemaAutoMergeTest {
     final ViewDefinitionResource initial = createViewDefinition(VIEW_ID, "initial_view", "Patient");
     seed.merge("ViewDefinition", initial);
 
-    final Path deltaLogDir =
-        tempDatabasePath.resolve("ViewDefinition.parquet").resolve("_delta_log");
+    final Path tablePath = tempDatabasePath.resolve("ViewDefinition.parquet");
+    final Path deltaLogDir = tablePath.resolve("_delta_log");
     downgradeDeltaSchema(deltaLogDir);
+    invalidateDeltaMetadataCache(tablePath);
   }
 
+  private void invalidateDeltaMetadataCache(@Nonnull final Path tablePath) {
+    pathlingContext.getSpark().catalog().clearCache();
+    pathlingContext.getSpark().catalog().refreshByPath(tablePath.toAbsolutePath().toString());
+  }
   @Nonnull
   private UpdateExecutor newExecutor(final boolean schemaAutoMerge) {
     return new UpdateExecutor(

--- a/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorSchemaAutoMergeTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorSchemaAutoMergeTest.java
@@ -152,6 +152,7 @@ class UpdateExecutorSchemaAutoMergeTest {
     pathlingContext.getSpark().catalog().clearCache();
     pathlingContext.getSpark().catalog().refreshByPath(tablePath.toAbsolutePath().toString());
   }
+
   @Nonnull
   private UpdateExecutor newExecutor(final boolean schemaAutoMerge) {
     return new UpdateExecutor(

--- a/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorSchemaAutoMergeTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorSchemaAutoMergeTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import au.csiro.pathling.cache.CacheableDatabase;
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.encoders.ViewDefinitionResource;
+import au.csiro.pathling.encoders.ViewDefinitionResource.ColumnComponent;
+import au.csiro.pathling.encoders.ViewDefinitionResource.SelectComponent;
+import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.test.SpringBootUnitTest;
+import au.csiro.pathling.util.FhirServerTestConfiguration;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+/**
+ * In-process regression tests for the {@code schemaAutoMerge} workaround in {@link UpdateExecutor}.
+ *
+ * <p>Reproduces the {@code DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION} failure that occurs when a
+ * Delta table's persisted schema lags the current FHIR encoder schema in the specific way that
+ * Delta's MERGE cannot reconcile: missing fields inside nested struct types. A target struct with
+ * fewer fields than the corresponding source struct cannot be implicitly cast by Delta's MERGE
+ * planner, even with {@code spark.databricks.delta.schema.autoMerge.enabled=true}.
+ *
+ * <p>Setup: a Delta table is created via {@link UpdateExecutor} so it has the full encoder schema,
+ * then the {@code schemaString} in the initial Delta log commit is rewritten in place to remove the
+ * {@code forEach} and {@code forEachOrNull} fields from every nested struct. The CRC side-cars are
+ * deleted so checksum validation does not reject the modified commit. The result looks like a Delta
+ * table that was written by an older encoder version that lacked those fields.
+ *
+ * <p>Replaces the container-based regression coverage previously provided by {@code
+ * ViewDefinitionInstallContainerIT}, runs in-process without Docker, and validates the
+ * locally-built {@code UpdateExecutor} directly rather than the published Pathling image.
+ */
+@Import(FhirServerTestConfiguration.class)
+@SpringBootUnitTest
+class UpdateExecutorSchemaAutoMergeTest {
+
+  private static final String VIEW_ID = "schema-compat-test";
+
+  @Autowired private PathlingContext pathlingContext;
+
+  @Autowired private FhirEncoders fhirEncoders;
+
+  @Autowired private CacheableDatabase cacheableDatabase;
+
+  private Path tempDatabasePath;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    tempDatabasePath = Files.createTempDirectory("schema-automerge-test-");
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    if (tempDatabasePath != null && Files.exists(tempDatabasePath)) {
+      Files.walk(tempDatabasePath)
+          .sorted(Comparator.reverseOrder())
+          .map(Path::toFile)
+          .forEach(File::delete);
+    }
+  }
+
+  /**
+   * With {@code schemaAutoMerge=false} a merge into a table whose nested-struct schema has been
+   * downgraded must fail with {@code DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION} because Delta cannot
+   * cast the richer source struct into the narrower target struct on the {@code
+   * whenMatched().updateAll()} path.
+   */
+  @Test
+  void mergeIntoOldSchemaTable_withoutAutoMerge_throwsSchemaMismatch() throws Exception {
+    seedTableAndDowngradeSchema();
+
+    final UpdateExecutor executor = newExecutor(false);
+    final ViewDefinitionResource update = createViewDefinition(VIEW_ID, "updated_view", "Patient");
+
+    assertThatThrownBy(() -> executor.merge("ViewDefinition", update))
+        .hasMessageContaining("DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION");
+  }
+
+  /**
+   * With {@code schemaAutoMerge=true} the warmup write evolves the table schema to match the
+   * encoder's current shape before the MERGE runs, so the merge succeeds and the matched row is
+   * updated.
+   */
+  @Test
+  void mergeIntoOldSchemaTable_withAutoMerge_succeeds() throws Exception {
+    seedTableAndDowngradeSchema();
+
+    final UpdateExecutor executor = newExecutor(true);
+    final ViewDefinitionResource update = createViewDefinition(VIEW_ID, "updated_view", "Patient");
+
+    assertThatNoException().isThrownBy(() -> executor.merge("ViewDefinition", update));
+  }
+
+  // ---- helpers ----
+
+  /**
+   * Two-stage setup: write a ViewDefinition through {@link UpdateExecutor} so the Delta log is
+   * created in the correct format, then rewrite the {@code schemaString} on disk to simulate an
+   * older encoder version.
+   */
+  private void seedTableAndDowngradeSchema() throws IOException {
+    final UpdateExecutor seed = newExecutor(true);
+    final ViewDefinitionResource initial = createViewDefinition(VIEW_ID, "initial_view", "Patient");
+    seed.merge("ViewDefinition", initial);
+
+    final Path deltaLogDir =
+        tempDatabasePath.resolve("ViewDefinition.parquet").resolve("_delta_log");
+    downgradeDeltaSchema(deltaLogDir);
+  }
+
+  @Nonnull
+  private UpdateExecutor newExecutor(final boolean schemaAutoMerge) {
+    return new UpdateExecutor(
+        pathlingContext,
+        fhirEncoders,
+        tempDatabasePath.toAbsolutePath().toString(),
+        cacheableDatabase,
+        schemaAutoMerge);
+  }
+
+  /**
+   * Rewrites the {@code metaData} action in the first Delta log commit to remove the {@code
+   * forEach} and {@code forEachOrNull} fields from all nested struct definitions in the table's
+   * {@code schemaString}. Also removes the Delta and Hadoop CRC side-cars so checksum validation
+   * does not reject the modified commit.
+   *
+   * <p>Why struct-level removal rather than a wholesale schema replacement: Delta 4.x {@code
+   * updateAll()} silently ignores extra top-level columns in the source, so a target with only
+   * {@code {id}} does not trigger {@code DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION}. The error only
+   * fires when a struct-typed column in the target has fewer fields than the corresponding struct
+   * in the source.
+   */
+  private static void downgradeDeltaSchema(@Nonnull final Path deltaLogDir) throws IOException {
+    final Path logFile = deltaLogDir.resolve("00000000000000000000.json");
+    assertThat(logFile).exists();
+
+    final ObjectMapper mapper = new ObjectMapper();
+    final List<String> original = Files.readAllLines(logFile);
+    final List<String> patched = new ArrayList<>(original.size());
+
+    for (final String line : original) {
+      final JsonNode node = mapper.readTree(line);
+      if (node.has("metaData")) {
+        final String schemaString = node.get("metaData").get("schemaString").asText();
+        final JsonNode schema = mapper.readTree(schemaString);
+        removeStructFields(schema, Set.of("forEach", "forEachOrNull"));
+        ((ObjectNode) node.get("metaData")).put("schemaString", mapper.writeValueAsString(schema));
+        patched.add(mapper.writeValueAsString(node));
+      } else {
+        patched.add(line);
+      }
+    }
+
+    Files.write(logFile, patched);
+
+    Files.deleteIfExists(deltaLogDir.resolve("00000000000000000000.crc"));
+    Files.deleteIfExists(deltaLogDir.resolve(".00000000000000000000.json.crc"));
+  }
+
+  /**
+   * Recursively removes fields with the given names from all struct-type definitions within a Spark
+   * schema JSON node (as serialised by Delta Lake). Struct nodes are identified by having a {@code
+   * fields} array; array-type nodes by having an {@code elementType} object.
+   */
+  private static void removeStructFields(
+      @Nonnull final JsonNode node, @Nonnull final Set<String> fieldNames) {
+    if (!node.isObject()) {
+      return;
+    }
+    if (node.has("fields")) {
+      final ArrayNode fields = (ArrayNode) node.get("fields");
+      for (int i = fields.size() - 1; i >= 0; i--) {
+        if (fieldNames.contains(fields.get(i).get("name").asText())) {
+          fields.remove(i);
+        }
+      }
+      for (final JsonNode field : fields) {
+        removeStructFields(field.get("type"), fieldNames);
+      }
+    } else if (node.has("elementType")) {
+      removeStructFields(node.get("elementType"), fieldNames);
+    }
+  }
+
+  @Nonnull
+  private ViewDefinitionResource createViewDefinition(
+      @Nonnull final String id, @Nonnull final String name, @Nonnull final String resource) {
+    final ViewDefinitionResource viewDef = new ViewDefinitionResource();
+    viewDef.setId(id);
+    viewDef.setName(new StringType(name));
+    viewDef.setResource(new CodeType(resource));
+    viewDef.setStatus(new CodeType("active"));
+
+    final SelectComponent select = new SelectComponent();
+    final ColumnComponent column = new ColumnComponent();
+    column.setName(new StringType("id"));
+    column.setPath(new StringType("id"));
+    select.getColumn().add(column);
+    viewDef.getSelect().add(select);
+
+    return viewDef;
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionCreateTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionCreateTest.java
@@ -77,13 +77,14 @@ class ViewDefinitionCreateTest {
     // Create a temporary directory for the Delta Lake database.
     tempDatabasePath = Files.createTempDirectory("viewdefinition-create-test-");
 
-    // Create UpdateExecutor with the temp database path.
+    // Create UpdateExecutor with the temp database path (schema auto-merge disabled by default).
     final UpdateExecutor updateExecutor =
         new UpdateExecutor(
             pathlingContext,
             fhirEncoders,
             tempDatabasePath.toAbsolutePath().toString(),
-            cacheableDatabase);
+            cacheableDatabase,
+            false);
 
     // Create the CreateProvider for ViewDefinition.
     createProvider = new CreateProvider(updateExecutor, fhirContext, ViewDefinitionResource.class);
@@ -184,6 +185,56 @@ class ViewDefinitionCreateTest {
     final String tablePath = tempDatabasePath.resolve("ViewDefinition.parquet").toString();
     final Dataset<Row> dataset = sparkSession.read().format("delta").load(tablePath);
     assertThat(dataset.count()).isEqualTo(2);
+  }
+
+  @Test
+  void createViewDefinitionSucceedsWhenDeltaTableHasOlderSchema() {
+    // Given: a provider with schema auto-merge enabled.
+    final UpdateExecutor autoMergeExecutor =
+        new UpdateExecutor(
+            pathlingContext,
+            fhirEncoders,
+            tempDatabasePath.toAbsolutePath().toString(),
+            cacheableDatabase,
+            true);
+    final CreateProvider autoMergeProvider =
+        new CreateProvider(autoMergeExecutor, fhirContext, ViewDefinitionResource.class);
+
+    // Create a ViewDefinition, establishing a Delta table.
+    final ViewDefinitionResource viewDef1 = createViewDefinition(null, "view_1", "Patient");
+    autoMergeProvider.create(viewDef1);
+
+    final String tablePath = tempDatabasePath.resolve("ViewDefinition.parquet").toString();
+    assertThat(DeltaTable.isDeltaTable(sparkSession, tablePath)).isTrue();
+
+    // Simulate an older schema by dropping a column from the existing Delta table.
+    // This reproduces the real-world scenario where the encoder adds new fields
+    // (e.g. valueDecimal, valueDecimal_scale) but the persisted table lacks them.
+    final Dataset<Row> original = sparkSession.read().format("delta").load(tablePath);
+    final String columnToDrop = original.columns()[original.columns().length - 1];
+    final Dataset<Row> narrowed = original.drop(columnToDrop);
+    narrowed
+        .write()
+        .format("delta")
+        .mode("overwrite")
+        .option("overwriteSchema", "true")
+        .save(tablePath);
+
+    // Verify the column was actually dropped.
+    final Dataset<Row> reloaded = sparkSession.read().format("delta").load(tablePath);
+    assertThat(reloaded.schema().fieldNames()).doesNotContain(columnToDrop);
+
+    // When: creating another ViewDefinition (which uses the full current schema).
+    final ViewDefinitionResource viewDef2 = createViewDefinition(null, "view_2", "Observation");
+    final MethodOutcome outcome2 = autoMergeProvider.create(viewDef2);
+
+    // Then: it should succeed despite the schema mismatch.
+    assertThat(outcome2.getId()).isNotNull();
+    assertThat(outcome2.getCreated()).isTrue();
+
+    // And both rows should be present.
+    final Dataset<Row> result = sparkSession.read().format("delta").load(tablePath);
+    assertThat(result.count()).isEqualTo(2);
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionCreateTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionCreateTest.java
@@ -207,11 +207,12 @@ class ViewDefinitionCreateTest {
     final String tablePath = tempDatabasePath.resolve("ViewDefinition.parquet").toString();
     assertThat(DeltaTable.isDeltaTable(sparkSession, tablePath)).isTrue();
 
-    // Simulate an older schema by dropping a column from the existing Delta table.
-    // This reproduces the real-world scenario where the encoder adds new fields
+    // Simulate an older schema by dropping a known non-key column from the existing Delta
+    // table. This reproduces the real-world scenario where the encoder adds new fields
     // (e.g. valueDecimal, valueDecimal_scale) but the persisted table lacks them.
     final Dataset<Row> original = sparkSession.read().format("delta").load(tablePath);
-    final String columnToDrop = original.columns()[original.columns().length - 1];
+    final String columnToDrop = "valueDecimal_scale";
+    assertThat(java.util.Arrays.asList(original.columns())).contains(columnToDrop);
     final Dataset<Row> narrowed = original.drop(columnToDrop);
     narrowed
         .write()

--- a/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionCreateTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionCreateTest.java
@@ -208,10 +208,12 @@ class ViewDefinitionCreateTest {
     assertThat(DeltaTable.isDeltaTable(sparkSession, tablePath)).isTrue();
 
     // Simulate an older schema by dropping a known non-key column from the existing Delta
-    // table. This reproduces the real-world scenario where the encoder adds new fields
-    // (e.g. valueDecimal, valueDecimal_scale) but the persisted table lacks them.
+    // table. This reproduces the real-world scenario where the encoder adds new fields not
+    // present in the persisted table. Use a stable, named column rather than a positional
+    // pick so the test does not depend on Spark column ordering or accidentally drop "id".
     final Dataset<Row> original = sparkSession.read().format("delta").load(tablePath);
-    final String columnToDrop = "valueDecimal_scale";
+    final String columnToDrop = "name";
+    assertThat(columnToDrop).isNotEqualTo("id");
     assertThat(java.util.Arrays.asList(original.columns())).contains(columnToDrop);
     final Dataset<Row> narrowed = original.drop(columnToDrop);
     narrowed


### PR DESCRIPTION
This pull request introduces support for automatic schema evolution during Delta Lake merge operations, addressing issues that arise when the FHIR encoder adds new nested fields not present in existing tables. The main change is the addition of a `schemaAutoMerge` configuration option, which enables a workaround for Delta Lake's inability to merge nested struct fields during updates. The implementation includes updates to configuration, the `UpdateExecutor`, and comprehensive regression tests.

**Delta Lake Schema Evolution Support:**

* Added a new `schemaAutoMerge` option to `StorageConfiguration`, configuration files, and constructor parameters. This allows enabling or disabling automatic schema evolution during Delta Lake merge operations. [[1]](diffhunk://#diff-5e35ccdf0be1f4e27e0ce9523e1b69f89fccd095474a907a240170dcedbee8c8R65-R71) [[2]](diffhunk://#diff-48ae60541b4c8a3d7f7c50b6b692f5acffa37d8f427c726f9ff92e6efab18092R56-R60) [[3]](diffhunk://#diff-345ad39805e305d2a16fd196107343b5b04f5a13f2932a0f365d23e925812e31R56-R78)
* Updated `UpdateExecutor` to perform a zero-row write with `mergeSchema=true` before a merge if `schemaAutoMerge` is enabled and the encoder schema differs from the table schema. This ensures that new nested struct fields are added to the table schema, preventing `DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION` errors during merges.

**Codebase and Dependency Updates:**

* Propagated the new `schemaAutoMerge` and `StorageConfiguration` parameters through constructors and dependency injection in relevant classes and tests. [[1]](diffhunk://#diff-0c125ba7f94f173d1e77f966ebdfc847b7ca0b85e991cf40d00f53f43fcd819eL92-R93) [[2]](diffhunk://#diff-58f4dec20e5ca7deb14a6940be1bab9bfbd7737781ada76626205289e520e3a3R22) [[3]](diffhunk://#diff-58f4dec20e5ca7deb14a6940be1bab9bfbd7737781ada76626205289e520e3a3L60-R62) [[4]](diffhunk://#diff-53cf8151e71e210f1b5aff55dd1650025a49f0eaff8f91e3e13410cfd6ae88a6L90-R91) [[5]](diffhunk://#diff-20809287fbcd73195c10118550f564bc786e8604b4cb38497c514a17e8903431L87-R88) [[6]](diffhunk://#diff-3eae151b358e5c307fbf6147afc2d52a02ee3431fc370422c0c20fc22ff7532eL89-R90) [[7]](diffhunk://#diff-c89b337876a715d1656268067e273633ee49e5be3042b2851a82bb94b4a7194fR21) [[8]](diffhunk://#diff-c89b337876a715d1656268067e273633ee49e5be3042b2851a82bb94b4a7194fR60-R61) [[9]](diffhunk://#diff-c89b337876a715d1656268067e273633ee49e5be3042b2851a82bb94b4a7194fR71-R83)

**Testing Improvements:**

* Added a comprehensive regression test (`UpdateExecutorSchemaAutoMergeTest`) that simulates schema drift in nested struct fields and verifies both the failure and success cases of merges with and without `schemaAutoMerge` enabled. This replaces previous container-based tests and ensures robust coverage of the new behavior.

**Performance and Behavior:**

* Ensured that dataset caching behavior in `DynamicDeltaSource` is controlled via configuration, aligning with other storage-related options. [[1]](diffhunk://#diff-c89b337876a715d1656268067e273633ee49e5be3042b2851a82bb94b4a7194fR60-R61) [[2]](diffhunk://#diff-c89b337876a715d1656268067e273633ee49e5be3042b2851a82bb94b4a7194fR71-R83) [[3]](diffhunk://#diff-c89b337876a715d1656268067e273633ee49e5be3042b2851a82bb94b4a7194fL89-R108) [[4]](diffhunk://#diff-c89b337876a715d1656268067e273633ee49e5be3042b2851a82bb94b4a7194fR162-R169)

These changes make schema evolution during updates more robust and configurable, particularly for complex nested FHIR resource types.