### PR TITLE
Implement $sqlquery-run operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ server/client-tests
 
 *-local.yml
 *-local.properties
+lib/import/lib
+lib/js/lib

--- a/openspec/changes/add-sqlquery-run-ui/.openspec.yaml
+++ b/openspec/changes/add-sqlquery-run-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/add-sqlquery-run-ui/design.md
+++ b/openspec/changes/add-sqlquery-run-ui/design.md
@@ -1,0 +1,251 @@
+## Context
+
+The admin UI exposes ViewDefinition execution at `/sql-on-fhir`. The page
+follows a familiar pattern across the admin UI: a left-hand `Card` form
+that triggers an action, and a right-hand column of result cards
+(`ViewCard`), one per submitted job, each managing its own lifecycle
+through TanStack Query.
+
+The server now offers a second SQL on FHIR operation - `$sqlquery-run` -
+which takes a Library resource conforming to the `SQLQuery` profile. The
+Library wraps Base64-encoded SQL, references one or more ViewDefinitions
+via `relatedArtifact` (whose `label` becomes the table name in the SQL),
+declares typed runtime parameters, and supports five output formats
+(`csv`, `ndjson`, `json`, `parquet`, `fhir`). The HTTP request supplies
+the Library either inline (`queryResource`) or by reference
+(`queryReference`) and binds runtime parameters via a nested
+`parameters` Parameters resource.
+
+The `feature/sql-run-operation` branch already implements the operation
+on the server, so this change is wholly UI-side. The user has asked for
+wireframes (lo-fi HTML wireframes co-located with the change) and
+adherence to the project's Radix Themes conventions.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a "SQL query" mode to the existing SQL on FHIR page using a top
+  segmented control, sharing the same page chrome and authentication
+  guards as the ViewDefinition flow.
+- Let users author a SQLQuery Library inline (SQL text + related
+  ViewDefinitions + parameter declarations), or pick a stored Library
+  conforming to the SQLQuery profile.
+- Render results in a `Table` for tabular formats (`csv`, `ndjson`,
+  `json`, `fhir`) and offer a download for `parquet`.
+- Surface server-side validation errors (e.g. disallowed SQL operations,
+  missing parameter bindings) in a `Callout`.
+- Provide a "Save to server" path that POSTs the assembled Library and
+  flips to "stored" mode pointing at the new resource, mirroring the
+  ViewDefinition flow.
+
+**Non-Goals:**
+
+- Async export of SQL query results. The operation is synchronous-only;
+  there is no `$sqlquery-export` to mirror `$viewdefinition-export`.
+- A SQL syntax-highlighting editor. We keep the existing `TextArea`
+  monospace pattern - sufficient at this stage and consistent with the
+  ViewDefinition JSON editor.
+- Editing or deleting stored SQLQuery Libraries (the existing UI does
+  not offer this for ViewDefinitions either).
+- Server-side changes. The operation, profile and output formats are
+  already implemented on `feature/sql-run-operation`.
+- Authoring the `parameter` definitions on a stored Library; the user
+  binds against parameters declared by an existing Library, but inline
+  Libraries declare parameters in the same form.
+
+## Decisions
+
+### Single page, mode-toggled form
+
+The SQL on FHIR page hosts both `$viewdefinition-run` and
+`$sqlquery-run` behind a `SegmentedControl` ("View definition" vs "SQL
+query") at the top of the form card. Switching modes swaps the form
+body but keeps the result column visible, so cards from either mode can
+coexist.
+
+**Rationale:** Both operations are SQL on FHIR primitives that operate
+on ViewDefinitions; users will naturally compare results. A single
+page is simpler than two routes, avoids navigation friction during query
+development, and keeps the existing left-form/right-results layout intact.
+
+**Alternatives considered:**
+
+- Separate `/sql-query` route - rejected because it duplicates the auth
+  guard, capabilities check and result column wiring without a
+  meaningful UX gain.
+- Tabs (`Tabs.Root`) inside the form card - the existing form already
+  uses `Tabs` to switch between "Select view definition" and "Provide
+  JSON" within the ViewDefinition flow. Reusing `Tabs` for the
+  outer mode would visually clash with the inner `Tabs`. A
+  `SegmentedControl` reads as a higher-level mode switch.
+
+### Form structure in SQL query mode
+
+The SQL query form uses the same outer `Card` as the ViewDefinition
+form, with the following sections (top to bottom):
+
+1. `Tabs.Root` to switch between "Select Library" (stored) and
+   "Provide Library" (inline) - mirrors the ViewDefinition flow.
+2. **Stored tab:** `Select.Root` listing Libraries with
+   `type.coding.code = sql-query`. Below the picker, a read-only
+   `TextArea` previews the decoded SQL with a copy-to-clipboard
+   icon, plus a read-only summary of `relatedArtifact` and declared
+   parameters.
+3. **Inline tab:**
+    - SQL `TextArea` (monospace, ~16 rows) for editing the query.
+    - "Tables" section: a list of related-artifact rows. Each row is a
+      `label` `TextField` (the table name used in the SQL) paired with
+      a `Select.Root` listing stored ViewDefinitions; an "Add table"
+      button appends rows and a `TrashIcon` `IconButton` removes them.
+    - "Parameters" section: a list of declared-parameter rows
+      (`name` `TextField`, `type` `Select.Root` from the FHIR primitive
+      types we support, `default` `TextField`); same add/remove pattern.
+4. **Common, below tabs:**
+    - "Runtime parameter values" section: one row per declared parameter
+      (whether the Library is stored or inline), with a typed input
+      appropriate to the declared FHIR type (string, integer, decimal,
+      boolean, date, dateTime, code).
+    - "Output format" `Select.Root` (csv / ndjson / json / parquet /
+      fhir) and a `_limit` `TextField` (numeric). When the format is
+      `csv`, a `_header` `Switch` appears.
+5. Action row: "Execute" (primary) and, in inline mode only, "Save to
+   server" (soft variant), matching the ViewDefinition form.
+
+**Rationale:** Reusing the existing two-tab pattern keeps the page
+visually coherent. Pulling the runtime parameter values out of the
+"inline" tab matches the server's request shape (parameter declarations
+live on the Library; runtime bindings live on the request) and means
+the same controls work for stored and inline queries.
+
+### Library construction and persistence
+
+Inline SQLQuery Libraries are assembled client-side from the form
+state and shaped to match the SQLQuery profile:
+
+- `resourceType: "Library"`, `status: "active"`,
+  `meta.profile: ["https://sql-on-fhir.org/ig/StructureDefinition/SQLQuery"]`.
+- `type.coding[0]`:
+  `{system: ".../LibraryTypesCodes", code: "sql-query"}`.
+- `content[0]`:
+  `{contentType: "application/sql", data: <Base64(SQL)>}`. We add the
+  `sql-text` extension carrying the plain SQL too, matching the
+  examples in the operation definition.
+- `relatedArtifact`: `{type: "depends-on", label, resource: "ViewDefinition/<id>"}`
+  per row.
+- `parameter`: declared parameters mapped to FHIR
+  `ParameterDefinition` (`name`, `use: "in"`, `type`, optional default
+  via `extension` if needed).
+
+The "Save to server" button POSTs this Library to `/Library` (mirroring
+`useSaveViewDefinition`) and switches to the stored tab, pre-selecting
+the new ID. Stored Libraries are listed via
+`/Library?type=https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes|sql-query`
+through a new `useSqlQueryLibraries` hook that mirrors
+`useViewDefinitions`.
+
+### Runtime parameter binding
+
+Runtime parameter values are submitted as a `parameters` Parameters
+resource nested in the request:
+
+```json
+{
+    "name": "parameters",
+    "resource": {
+        "resourceType": "Parameters",
+        "parameter": [{ "name": "patient_id", "valueString": "Patient/123" }]
+    }
+}
+```
+
+The form maps each declared parameter's FHIR type to a typed input and
+to the appropriate `value[x]` slot at submission time. We do **not**
+support the alternative repeated-`parameter`-with-parts form shown in
+the operation definition examples; the nested-Parameters form is
+unambiguously typed and matches the canonical example.
+
+### Result rendering
+
+Result rendering branches on the requested output format:
+
+- `csv` / `ndjson` / `json`: parsed into rows + columns and rendered
+  in `Table` (reusing the same NDJSON parsing utilities as
+  `useViewRun`; CSV uses a small new parser; JSON is a single array).
+- `fhir`: the response is a Parameters resource where each `row`
+  parameter has typed `part`s. We flatten each row into a
+  `{column: stringified value}` map and render the same `Table`,
+  adding a "FHIR types" badge on each column header to distinguish it
+  from the binary formats.
+- `parquet`: binary - we render a download button instead of a table,
+  with a row showing file size and timestamp.
+
+This logic lives in a new `SqlQueryCard` component, parallel to
+`ViewCard`. Both consume the existing close-button / multi-card
+pattern in `SqlOnFhir.tsx`.
+
+### Error handling
+
+The server returns `OperationOutcome` for invalid input (SQL
+validation, missing bindings, unresolved Library, etc.). Error messages
+are surfaced in a red `Callout.Root` inside the result card. We do not
+attempt client-side SQL validation - the server's reject-list is
+authoritative and would be brittle to mirror.
+
+### State, not effects, for derived data
+
+The runtime-parameter input list is derived from the active Library's
+declared parameters: when the user picks a stored Library, we read its
+`parameter` array; when they edit the inline declarations, the runtime
+inputs follow. This is computed during render from the form state, not
+synced via an effect, in line with the project React rules.
+
+### Wireframes
+
+Lo-fi HTML wireframes are produced via the wireframing skill and
+written to `wireframes/` under this change directory. They cover:
+
+1. SQL on FHIR page - SQL query mode, "Provide Library" tab,
+   parameters declared, runtime values bound, ready to execute.
+2. SQL on FHIR page - SQL query mode, "Select Library" tab, with a
+   stored Library selected.
+3. Result card - tabular result rendered after execution, with a
+   format badge and download (when applicable).
+4. Result card - error state showing an `OperationOutcome` callout.
+
+## Risks / Trade-offs
+
+- **Form complexity:** the inline form mixes SQL, related artefacts and
+  parameter declarations. → Mitigation: keep each section in its own
+  `Box` with a `FieldLabel` and `FieldGuidance`, and lean on the
+  existing `Tabs` to keep stored vs inline visually separated.
+- **Output-format result divergence:** different formats produce
+  different shapes (text vs Parameters vs binary). → Mitigation:
+  branch on format in `SqlQueryCard` and gate the table on
+  parsability; binary formats fall back to a download.
+- **No syntax highlighting:** plain `TextArea` for SQL is uglier than a
+  proper editor. → Mitigation: deferred; see Non-Goals. We already
+  ship JSON in a plain `TextArea` for ViewDefinitions and have not
+  hit pushback.
+- **FHIR-format flattening:** turning typed `part`s into strings drops
+  type info from the rendered table. → Mitigation: include a
+  per-column type indicator above the table; users who need exact
+  types can switch to `_format=ndjson` or download `parquet`.
+- **Library round-trip on save:** assembling a Library client-side
+  risks producing an invalid resource that the server rejects on
+  save. → Mitigation: surface server validation errors in the same
+  Callout as the execute path, and (a) require a non-empty SQL,
+  (b) require at least one related artefact, (c) require a label per
+  related artefact in the form before enabling the save button.
+
+## Open Questions
+
+- Should "Save to server" require a `name` and `url` on the Library, or
+  should we let the server reject incomplete saves? Leaning towards a
+  required `name` field for usability and storing it as
+  `Library.name`, with `url` left optional.
+- Should the parameter editor support FHIR `Quantity` and `Coding`
+  declared types? The server's parser handles them; the UI would need
+  composite inputs. Initial scope: primitives only (string, integer,
+  decimal, boolean, date, dateTime, code), with a follow-up issue if
+  users need composites.

--- a/openspec/changes/add-sqlquery-run-ui/design.md
+++ b/openspec/changes/add-sqlquery-run-ui/design.md
@@ -59,34 +59,39 @@ adherence to the project's Radix Themes conventions.
 ### Single page, mode-toggled form
 
 The SQL on FHIR page hosts both `$viewdefinition-run` and
-`$sqlquery-run` behind a `SegmentedControl` ("View definition" vs "SQL
-query") at the top of the form card. Switching modes swaps the form
-body but keeps the result column visible, so cards from either mode can
+`$sqlquery-run` behind a top-level `Tabs.Root` ("View definition" vs
+"SQL query") above the form card. Switching tabs swaps the form body
+but keeps the result column visible, so cards from either mode can
 coexist.
 
 **Rationale:** Both operations are SQL on FHIR primitives that operate
 on ViewDefinitions; users will naturally compare results. A single
 page is simpler than two routes, avoids navigation friction during query
-development, and keeps the existing left-form/right-results layout intact.
+development, and keeps the existing left-form/right-results layout
+intact. The Import page already uses a top-level `Tabs.Root` to switch
+between "Import from URLs" and "Import from FHIR server"; reusing that
+pattern keeps page-level mode switches visually consistent across the
+admin UI.
 
 **Alternatives considered:**
 
 - Separate `/sql-query` route - rejected because it duplicates the auth
   guard, capabilities check and result column wiring without a
   meaningful UX gain.
-- Tabs (`Tabs.Root`) inside the form card - the existing form already
-  uses `Tabs` to switch between "Select view definition" and "Provide
-  JSON" within the ViewDefinition flow. Reusing `Tabs` for the
-  outer mode would visually clash with the inner `Tabs`. A
-  `SegmentedControl` reads as a higher-level mode switch.
+- A `SegmentedControl` for the outer mode - inconsistent with the rest
+  of the admin UI, which uses tabs at the page level (e.g. the Import
+  page). The inner ViewDefinition form already uses `Tabs.Root` for
+  "Select view definition" / "Provide JSON"; nesting tabs inside tabs
+  is acceptable here because the inner tabs sit inside their own card
+  with distinct styling.
 
 ### Form structure in SQL query mode
 
 The SQL query form uses the same outer `Card` as the ViewDefinition
 form, with the following sections (top to bottom):
 
-1. `Tabs.Root` to switch between "Select Library" (stored) and
-   "Provide Library" (inline) - mirrors the ViewDefinition flow.
+1. `Tabs.Root` to switch between "Select query" (stored) and
+   "Provide SQL" (inline) - mirrors the ViewDefinition flow.
 2. **Stored tab:** `Select.Root` listing Libraries with
    `type.coding.code = sql-query`. Below the picker, a read-only
    `TextArea` previews the decoded SQL with a copy-to-clipboard
@@ -205,9 +210,9 @@ synced via an effect, in line with the project React rules.
 Lo-fi HTML wireframes are produced via the wireframing skill and
 written to `wireframes/` under this change directory. They cover:
 
-1. SQL on FHIR page - SQL query mode, "Provide Library" tab,
+1. SQL on FHIR page - SQL query mode, "Provide SQL" tab,
    parameters declared, runtime values bound, ready to execute.
-2. SQL on FHIR page - SQL query mode, "Select Library" tab, with a
+2. SQL on FHIR page - SQL query mode, "Select query" tab, with a
    stored Library selected.
 3. Result card - tabular result rendered after execution, with a
    format badge and download (when applicable).

--- a/openspec/changes/add-sqlquery-run-ui/proposal.md
+++ b/openspec/changes/add-sqlquery-run-ui/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+The Pathling server now implements the SQL on FHIR `$sqlquery-run` operation,
+which lets users execute ad-hoc SQL against ViewDefinition tables via a
+SQLQuery Library resource. The admin UI currently only exposes
+`$viewdefinition-run`, so there is no interactive way to author SQL, bind
+runtime parameters, pick output formats and inspect results. Adding this to
+the SQL on FHIR page closes the gap between the server capability and the
+operator experience, and gives users a place to develop and test SQL
+queries against their FHIR data without leaving the admin UI.
+
+## What Changes
+
+- Add a new "SQL query" mode to the existing SQL on FHIR page so the user can
+  choose between running a ViewDefinition (`$viewdefinition-run`) and running
+  a SQL query (`$sqlquery-run`).
+- In SQL query mode, allow the user to:
+    - Either select a stored Library that conforms to the SQLQuery profile, or
+      author an inline query.
+    - Edit the SQL text in a monospace text area (round-tripped through Base64
+      in the Library `content`).
+    - Pick depended-on ViewDefinitions from the server and assign each a
+      `label` (the table name used in the SQL), backed by `relatedArtifact`.
+    - Declare and bind runtime parameters (name, FHIR type, value), submitted
+      as the `parameters` Parameters resource.
+    - Choose an output format (`ndjson`, `csv`, `json`, `parquet`, `fhir`) and
+      optional row limit / CSV header toggle.
+- Execute the request and render the result in a card alongside the existing
+  ViewDefinition result cards, with the same close / multi-card behaviour.
+  Tabular formats render in a `Table`; the `fhir` Parameters response is
+  flattened into rows; binary formats (`parquet`) offer a download.
+- Surface validation errors from the server (e.g. disallowed SQL operations,
+  missing parameter bindings, unresolved Library) in a Callout.
+- Add a "Save to server" action in inline mode that POSTs the assembled
+  SQLQuery Library and switches the form to "stored" mode pointing at the
+  new resource, mirroring the existing ViewDefinition flow.
+- Add a new client-side API module and TanStack Query hook for invoking
+  `$sqlquery-run`, plus a hook for listing stored SQLQuery Libraries
+  (Library resources with `type.coding.code = sql-query`).
+- The existing `SqlOnFhirForm` is generalised to host both modes via a top
+  segmented control; the ViewDefinition flow keeps its existing behaviour.
+
+## Capabilities
+
+### New Capabilities
+
+- `sqlquery-run-ui`: UI support for authoring, parameterising, executing and
+  inspecting SQL queries through the server's `$sqlquery-run` operation,
+  including stored-Library selection, inline-Library authoring, runtime
+  parameter binding, output-format selection and result rendering.
+
+### Modified Capabilities
+
+(none - the existing SQL on FHIR ViewDefinition page does not have a
+dedicated capability spec; new behaviour is wholly contained in the new
+capability.)
+
+## Impact
+
+- `ui/src/pages/SqlOnFhir.tsx` - hosts the new mode toggle and a second
+  result-card type alongside the existing `ViewCard`.
+- `ui/src/components/sqlOnFhir/` - new components for the SQL query form,
+  related-artifact picker, parameter editor and result card.
+- `ui/src/api/` - new `sqlQuery.ts` module for `$sqlquery-run` and listing
+  SQLQuery Libraries.
+- `ui/src/hooks/` - new `useSqlQueryRun.ts` and `useSqlQueryLibraries.ts`
+  hooks; a new `useSaveSqlQueryLibrary.ts` mirroring
+  `useSaveViewDefinition.ts`.
+- `ui/src/types/` - new `sqlQuery.ts` type module covering the SQLQuery
+  Library shape, parameter declarations and request/result types.
+- No server changes: the operation, profile and output formats already
+  exist on `feature/sql-run-operation`.
+- No new runtime dependencies; the form is built with the existing Radix
+  Themes / Radix Primitives stack already used by the admin UI.

--- a/openspec/changes/add-sqlquery-run-ui/specs/sqlquery-run-ui/spec.md
+++ b/openspec/changes/add-sqlquery-run-ui/specs/sqlquery-run-ui/spec.md
@@ -1,0 +1,377 @@
+## ADDED Requirements
+
+### Requirement: SQL on FHIR mode selector
+
+The SQL on FHIR page SHALL render a top-level mode selector that switches
+between two operations: "View definition" (which invokes
+`$viewdefinition-run`, the existing behaviour) and "SQL query" (which
+invokes `$sqlquery-run`). The selector SHALL be visible at the top of the
+page above the form card and SHALL persist for the lifetime of the page.
+The selector SHALL be implemented as a Radix Themes `SegmentedControl`
+component.
+
+#### Scenario: Page renders with View definition mode active by default
+
+- **WHEN** the SQL on FHIR page is rendered
+- **THEN** the mode selector SHALL be visible with two options "View
+  definition" and "SQL query"
+- **AND** the "View definition" option SHALL be selected by default
+- **AND** the existing ViewDefinition form SHALL be displayed in the form
+  card
+
+#### Scenario: User switches to SQL query mode
+
+- **WHEN** the user selects "SQL query" in the mode selector
+- **THEN** the form card SHALL replace its body with the SQL query form
+- **AND** any result cards already in the result column SHALL remain
+  visible
+- **AND** the page SHALL not navigate to a different route
+
+#### Scenario: User switches back to View definition mode
+
+- **WHEN** the user selects "View definition" after having been in "SQL
+  query" mode
+- **THEN** the form card SHALL display the ViewDefinition form
+- **AND** SQL query result cards already in the result column SHALL remain
+  visible alongside any ViewDefinition result cards
+
+### Requirement: SQL query Library source tabs
+
+The SQL query form SHALL provide two tabs that select the source of the
+SQLQuery Library: "Select Library" (a stored Library is referenced by
+ID) and "Provide Library" (the Library is authored inline). The tabs
+SHALL be implemented as a Radix Themes `Tabs.Root` component nested
+inside the form card.
+
+#### Scenario: Tabs are visible in SQL query mode
+
+- **WHEN** the user is in SQL query mode
+- **THEN** the form card SHALL display two tabs: "Select Library" and
+  "Provide Library"
+
+#### Scenario: Switching tabs preserves runtime input values
+
+- **WHEN** the user has entered runtime parameter values, an output
+  format and a row limit, and switches between the "Select Library" and
+  "Provide Library" tabs
+- **THEN** the runtime parameter values, output format and row limit
+  SHALL be retained
+
+### Requirement: Stored SQLQuery Library selection
+
+In the "Select Library" tab, the form SHALL display a `Select.Root`
+populated with stored Library resources whose
+`type.coding[].code = sql-query` (queried from the FHIR server). When
+the user selects a Library, the form SHALL display:
+
+- a read-only `TextArea` showing the Base64-decoded SQL from
+  `Library.content[0].data`, with a copy-to-clipboard `IconButton`
+  positioned over the top-right corner;
+- a read-only summary listing each `relatedArtifact` (label and
+  ViewDefinition reference);
+- a read-only summary listing each declared parameter (name and FHIR
+  type from `Library.parameter[]`);
+- the runtime parameter values section (one input per declared
+  parameter).
+
+#### Scenario: Library list is empty
+
+- **WHEN** the FHIR server has no Library resources matching the
+  SQLQuery type code
+- **THEN** the `Select.Root` SHALL not render
+- **AND** the form SHALL display guidance prompting the user to use the
+  "Provide Library" tab
+
+#### Scenario: User selects a stored Library
+
+- **WHEN** the user selects a Library from the picker
+- **THEN** the SQL preview SHALL display the decoded SQL text
+- **AND** the related-artifact summary SHALL list each artefact's label
+  and ViewDefinition reference
+- **AND** the declared-parameters summary SHALL list each parameter's
+  name and type
+- **AND** the runtime parameter values section SHALL render an input
+  per declared parameter
+
+#### Scenario: User copies the previewed SQL
+
+- **WHEN** the user clicks the copy `IconButton` over the SQL preview
+- **THEN** the decoded SQL text SHALL be written to the system
+  clipboard
+
+### Requirement: Inline SQLQuery Library authoring
+
+In the "Provide Library" tab, the form SHALL allow the user to author a
+SQLQuery Library inline, comprising:
+
+- a `TextArea` for the SQL text rendered with a monospace font;
+- a "Tables" section listing related-artifact rows; each row contains a
+  label `TextField`, a `Select.Root` of stored ViewDefinitions, and a
+  remove `IconButton`. An "Add table" button appends rows;
+- a "Parameters" section listing declared-parameter rows; each row
+  contains a name `TextField`, a type `Select.Root` (the supported FHIR
+  primitives: string, integer, decimal, boolean, date, dateTime, code),
+  an optional default `TextField`, and a remove `IconButton`. An "Add
+  parameter" button appends rows;
+- the runtime parameter values section (one input per declared
+  parameter).
+
+#### Scenario: Adding a table row
+
+- **WHEN** the user clicks "Add table"
+- **THEN** a new row SHALL be appended with empty label and unselected
+  ViewDefinition
+
+#### Scenario: Removing a table row
+
+- **WHEN** the user clicks the remove `IconButton` on a table row
+- **THEN** the row SHALL be removed from the form
+
+#### Scenario: Adding a parameter row updates runtime inputs
+
+- **WHEN** the user adds a parameter row with name `patient_id` and
+  type `string`
+- **THEN** the runtime parameter values section SHALL render an input
+  for `patient_id` typed as string
+
+#### Scenario: Renaming a declared parameter
+
+- **WHEN** the user changes the name of a declared parameter
+- **THEN** the runtime parameter values section SHALL render an input
+  with the new name
+- **AND** any value previously entered for the old name SHALL be
+  discarded
+
+### Requirement: Runtime parameter input typing
+
+Each runtime parameter input SHALL match the declared parameter type:
+
+- string and code SHALL render a `TextField`;
+- integer SHALL render a numeric `TextField` accepting integers only;
+- decimal SHALL render a numeric `TextField` accepting decimal values;
+- boolean SHALL render a `Switch`;
+- date SHALL render a date `TextField` (ISO 8601 date);
+- dateTime SHALL render a dateTime `TextField` (ISO 8601 dateTime).
+
+The user SHALL be able to leave runtime values empty, in which case the
+parameter SHALL be omitted from the request's nested `parameters`
+Parameters resource.
+
+#### Scenario: Boolean parameter renders a switch
+
+- **WHEN** a parameter is declared with type `boolean`
+- **THEN** the runtime input SHALL render as a `Switch` defaulting to
+  off
+- **AND** the bound value submitted on the request SHALL be a
+  `valueBoolean`
+
+#### Scenario: Integer parameter rejects non-integer input
+
+- **WHEN** the user types a non-integer value into an integer
+  parameter input
+- **THEN** the form SHALL not allow execution
+- **AND** SHALL display field-level guidance indicating the expected
+  type
+
+### Requirement: Output format and execution options
+
+The SQL query form SHALL provide:
+
+- a `Select.Root` for the output format with values `csv`, `ndjson`,
+  `json`, `parquet` and `fhir`;
+- a numeric `TextField` for `_limit`;
+- a `Switch` for `_header`, visible only when the output format is
+  `csv`.
+
+#### Scenario: Switching output format to non-csv hides the header switch
+
+- **WHEN** the user changes the output format from `csv` to any other
+  value
+- **THEN** the `_header` `Switch` SHALL no longer render
+
+#### Scenario: Empty limit submits without a row cap
+
+- **WHEN** the user leaves the `_limit` field empty and clicks Execute
+- **THEN** the request SHALL omit the `_limit` parameter
+
+### Requirement: Execute action submits a $sqlquery-run request
+
+When the user clicks the Execute button, the form SHALL submit a POST
+to the FHIR server's `$sqlquery-run` operation with a Parameters body
+containing:
+
+- exactly one of `queryReference` (in "Select Library" tab) or
+  `queryResource` (in "Provide Library" tab);
+- the `_format` parameter when an output format is selected;
+- the `_limit` parameter when a numeric limit is provided;
+- the `_header` parameter when output format is `csv`;
+- a `parameters` parameter holding a Parameters resource that lists
+  one entry per declared parameter with a non-empty runtime value,
+  using the `value[x]` slot matching the declared FHIR type.
+
+The Execute button SHALL be disabled while a request is in flight or
+when required inputs are missing (no Library selected in the "Select
+Library" tab, or empty SQL or zero tables in the "Provide Library"
+tab).
+
+#### Scenario: Execute is disabled when SQL is empty in inline mode
+
+- **WHEN** the user is in the "Provide Library" tab with an empty SQL
+  text area
+- **THEN** the Execute button SHALL be disabled
+
+#### Scenario: Execute is disabled when no Library is selected in stored mode
+
+- **WHEN** the user is in the "Select Library" tab and has not
+  selected a Library
+- **THEN** the Execute button SHALL be disabled
+
+#### Scenario: Execute submits queryResource for an inline Library
+
+- **WHEN** the user clicks Execute in the "Provide Library" tab with
+  a non-empty SQL, at least one table row and a runtime value for each
+  declared parameter
+- **THEN** the form SHALL POST to `/$sqlquery-run` with a Parameters
+  body containing exactly one `queryResource` parameter whose
+  resource is a Library conforming to the SQLQuery profile, the
+  selected output format under `_format`, and a `parameters`
+  Parameters resource with the runtime bindings
+
+#### Scenario: Execute submits queryReference for a stored Library
+
+- **WHEN** the user clicks Execute in the "Select Library" tab with a
+  Library selected
+- **THEN** the form SHALL POST to `/$sqlquery-run` with a Parameters
+  body containing exactly one `queryReference` parameter whose value
+  is a relative reference of the form `Library/<id>`
+
+### Requirement: Save inline SQLQuery Library to server
+
+In the "Provide Library" tab, the form SHALL display a "Save to server"
+button alongside the Execute button. Clicking it SHALL POST the
+assembled SQLQuery Library to `/Library` and, on success, switch the
+form to the "Select Library" tab with the new Library's ID
+pre-selected. On failure, the form SHALL display the server-returned
+error message in a `Callout`. The button SHALL be hidden in the
+"Select Library" tab.
+
+#### Scenario: Successful save switches to stored mode
+
+- **WHEN** the user clicks "Save to server" in the "Provide Library"
+  tab and the server responds with `201 Created`
+- **THEN** the form SHALL switch to the "Select Library" tab
+- **AND** the new Library's ID SHALL be the selected value in the
+  Library picker
+
+#### Scenario: Failed save surfaces server error
+
+- **WHEN** the user clicks "Save to server" and the server responds
+  with a 4xx or 5xx status
+- **THEN** the form SHALL display a red `Callout` containing the
+  server error message
+- **AND** the form SHALL remain in the "Provide Library" tab with the
+  user's input intact
+
+### Requirement: SQL query result card
+
+Each Execute click SHALL append a result card to the right-hand result
+column. The card SHALL be implemented as a Radix Themes `Card` and
+SHALL include:
+
+- a header with the title "SQL query", the requested output format as
+  a `Badge`, and a job ID and timestamp;
+- a close `Button` once the request has terminated (success or
+  failure);
+- a body that depends on the response:
+    - while the request is pending, a `Spinner` and "Executing SQL
+      query…" message;
+    - on success with a tabular format (`csv`, `ndjson`, `json`,
+      `fhir`), a `Table` listing parsed rows, a row count `Badge` and a
+      download button that streams the original response body;
+    - on success with `parquet`, a download button only;
+    - on failure, a red `Callout` with the server error message and the
+      submitted SQL displayed in a monospace block above it.
+
+Multiple result cards SHALL be supported in the result column. The
+most recent SHALL appear at the top.
+
+#### Scenario: Pending request shows a spinner
+
+- **WHEN** the request is in flight
+- **THEN** the result card body SHALL display a spinner and the message
+  "Executing SQL query…"
+
+#### Scenario: Successful CSV response renders a table
+
+- **WHEN** the request succeeds with a `text/csv` response body
+- **THEN** the card body SHALL render a `Table` with one column per
+  CSV column and one row per data row
+- **AND** SHALL display a row count badge
+- **AND** SHALL display a download button labelled "Download .csv"
+
+#### Scenario: Successful FHIR-format response is flattened
+
+- **WHEN** the request succeeds with `_format=fhir` and an
+  `application/fhir+json` Parameters resource as the body
+- **THEN** the card body SHALL render a `Table` whose columns are the
+  unique `part.name` values across all `row` parameters
+- **AND** the cells SHALL display the part's `value[x]` rendered as a
+  string
+
+#### Scenario: Successful parquet response is download-only
+
+- **WHEN** the request succeeds with `_format=parquet`
+- **THEN** the card body SHALL not render a `Table`
+- **AND** SHALL render a download button labelled "Download .parquet"
+
+#### Scenario: Failed response surfaces the OperationOutcome
+
+- **WHEN** the server responds with a 4xx or 5xx status and an
+  `OperationOutcome` body
+- **THEN** the card body SHALL display the submitted SQL in a monospace
+  block
+- **AND** the issue's diagnostics or details text SHALL be displayed
+  inside a red `Callout`
+
+#### Scenario: User closes a result card
+
+- **WHEN** the user clicks the close button on a terminated result
+  card
+- **THEN** the card SHALL be removed from the result column
+- **AND** other result cards SHALL be unaffected
+
+### Requirement: SQL query API client and TanStack Query hooks
+
+A new `sqlQuery.ts` module under `ui/src/api/` SHALL expose typed
+functions for invoking `$sqlquery-run` (returning a streamed response)
+and for listing Library resources whose
+`type.coding[].code = sql-query`. New TanStack Query hooks SHALL wrap
+these functions:
+
+- `useSqlQueryRun` SHALL provide an imperative `execute` function and
+  expose status, result and error values, mirroring the API of
+  `useViewRun`.
+- `useSqlQueryLibraries` SHALL fetch and cache the list of stored
+  SQLQuery Libraries.
+- `useSaveSqlQueryLibrary` SHALL POST a Library and return the
+  created resource's ID, mirroring `useSaveViewDefinition`.
+
+#### Scenario: useSqlQueryRun parses CSV responses into rows
+
+- **WHEN** the form invokes `useSqlQueryRun` with `_format=csv` and the
+  server returns CSV text
+- **THEN** the hook SHALL resolve a result with a columns array and a
+  rows array parsed from the CSV body
+
+#### Scenario: useSqlQueryLibraries scopes the search by type code
+
+- **WHEN** `useSqlQueryLibraries` runs
+- **THEN** it SHALL issue a GET to `/Library` with a `type` search
+  parameter constraining the value to the canonical SQLQuery type
+  coding system and code `sql-query`
+
+#### Scenario: useSqlQueryRun returns a stream for parquet
+
+- **WHEN** the form invokes `useSqlQueryRun` with `_format=parquet`
+- **THEN** the hook SHALL resolve with a binary blob suitable for
+  download instead of attempting to parse rows

--- a/openspec/changes/add-sqlquery-run-ui/specs/sqlquery-run-ui/spec.md
+++ b/openspec/changes/add-sqlquery-run-ui/specs/sqlquery-run-ui/spec.md
@@ -7,8 +7,9 @@ between two operations: "View definition" (which invokes
 `$viewdefinition-run`, the existing behaviour) and "SQL query" (which
 invokes `$sqlquery-run`). The selector SHALL be visible at the top of the
 page above the form card and SHALL persist for the lifetime of the page.
-The selector SHALL be implemented as a Radix Themes `SegmentedControl`
-component.
+The selector SHALL be implemented as a Radix Themes `Tabs.Root`
+component, mirroring the top-level mode-switch pattern used on the
+Import page.
 
 #### Scenario: Page renders with View definition mode active by default
 
@@ -38,28 +39,28 @@ component.
 ### Requirement: SQL query Library source tabs
 
 The SQL query form SHALL provide two tabs that select the source of the
-SQLQuery Library: "Select Library" (a stored Library is referenced by
-ID) and "Provide Library" (the Library is authored inline). The tabs
+SQLQuery Library: "Select query" (a stored Library is referenced by
+ID) and "Provide SQL" (the Library is authored inline). The tabs
 SHALL be implemented as a Radix Themes `Tabs.Root` component nested
 inside the form card.
 
 #### Scenario: Tabs are visible in SQL query mode
 
 - **WHEN** the user is in SQL query mode
-- **THEN** the form card SHALL display two tabs: "Select Library" and
-  "Provide Library"
+- **THEN** the form card SHALL display two tabs: "Select query" and
+  "Provide SQL"
 
 #### Scenario: Switching tabs preserves runtime input values
 
 - **WHEN** the user has entered runtime parameter values, an output
-  format and a row limit, and switches between the "Select Library" and
-  "Provide Library" tabs
+  format and a row limit, and switches between the "Select query" and
+  "Provide SQL" tabs
 - **THEN** the runtime parameter values, output format and row limit
   SHALL be retained
 
 ### Requirement: Stored SQLQuery Library selection
 
-In the "Select Library" tab, the form SHALL display a `Select.Root`
+In the "Select query" tab, the form SHALL display a `Select.Root`
 populated with stored Library resources whose
 `type.coding[].code = sql-query` (queried from the FHIR server). When
 the user selects a Library, the form SHALL display:
@@ -80,7 +81,7 @@ the user selects a Library, the form SHALL display:
   SQLQuery type code
 - **THEN** the `Select.Root` SHALL not render
 - **AND** the form SHALL display guidance prompting the user to use the
-  "Provide Library" tab
+  "Provide SQL" tab
 
 #### Scenario: User selects a stored Library
 
@@ -101,7 +102,7 @@ the user selects a Library, the form SHALL display:
 
 ### Requirement: Inline SQLQuery Library authoring
 
-In the "Provide Library" tab, the form SHALL allow the user to author a
+In the "Provide SQL" tab, the form SHALL allow the user to author a
 SQLQuery Library inline, comprising:
 
 - a `TextArea` for the SQL text rendered with a monospace font;
@@ -200,8 +201,8 @@ When the user clicks the Execute button, the form SHALL submit a POST
 to the FHIR server's `$sqlquery-run` operation with a Parameters body
 containing:
 
-- exactly one of `queryReference` (in "Select Library" tab) or
-  `queryResource` (in "Provide Library" tab);
+- exactly one of `queryReference` (in "Select query" tab) or
+  `queryResource` (in "Provide SQL" tab);
 - the `_format` parameter when an output format is selected;
 - the `_limit` parameter when a numeric limit is provided;
 - the `_header` parameter when output format is `csv`;
@@ -211,24 +212,24 @@ containing:
 
 The Execute button SHALL be disabled while a request is in flight or
 when required inputs are missing (no Library selected in the "Select
-Library" tab, or empty SQL or zero tables in the "Provide Library"
+Library" tab, or empty SQL or zero tables in the "Provide SQL"
 tab).
 
 #### Scenario: Execute is disabled when SQL is empty in inline mode
 
-- **WHEN** the user is in the "Provide Library" tab with an empty SQL
+- **WHEN** the user is in the "Provide SQL" tab with an empty SQL
   text area
 - **THEN** the Execute button SHALL be disabled
 
 #### Scenario: Execute is disabled when no Library is selected in stored mode
 
-- **WHEN** the user is in the "Select Library" tab and has not
+- **WHEN** the user is in the "Select query" tab and has not
   selected a Library
 - **THEN** the Execute button SHALL be disabled
 
 #### Scenario: Execute submits queryResource for an inline Library
 
-- **WHEN** the user clicks Execute in the "Provide Library" tab with
+- **WHEN** the user clicks Execute in the "Provide SQL" tab with
   a non-empty SQL, at least one table row and a runtime value for each
   declared parameter
 - **THEN** the form SHALL POST to `/$sqlquery-run` with a Parameters
@@ -239,7 +240,7 @@ tab).
 
 #### Scenario: Execute submits queryReference for a stored Library
 
-- **WHEN** the user clicks Execute in the "Select Library" tab with a
+- **WHEN** the user clicks Execute in the "Select query" tab with a
   Library selected
 - **THEN** the form SHALL POST to `/$sqlquery-run` with a Parameters
   body containing exactly one `queryReference` parameter whose value
@@ -247,19 +248,19 @@ tab).
 
 ### Requirement: Save inline SQLQuery Library to server
 
-In the "Provide Library" tab, the form SHALL display a "Save to server"
+In the "Provide SQL" tab, the form SHALL display a "Save to server"
 button alongside the Execute button. Clicking it SHALL POST the
 assembled SQLQuery Library to `/Library` and, on success, switch the
-form to the "Select Library" tab with the new Library's ID
+form to the "Select query" tab with the new Library's ID
 pre-selected. On failure, the form SHALL display the server-returned
 error message in a `Callout`. The button SHALL be hidden in the
-"Select Library" tab.
+"Select query" tab.
 
 #### Scenario: Successful save switches to stored mode
 
-- **WHEN** the user clicks "Save to server" in the "Provide Library"
+- **WHEN** the user clicks "Save to server" in the "Provide SQL"
   tab and the server responds with `201 Created`
-- **THEN** the form SHALL switch to the "Select Library" tab
+- **THEN** the form SHALL switch to the "Select query" tab
 - **AND** the new Library's ID SHALL be the selected value in the
   Library picker
 
@@ -269,7 +270,7 @@ error message in a `Callout`. The button SHALL be hidden in the
   with a 4xx or 5xx status
 - **THEN** the form SHALL display a red `Callout` containing the
   server error message
-- **AND** the form SHALL remain in the "Provide Library" tab with the
+- **AND** the form SHALL remain in the "Provide SQL" tab with the
   user's input intact
 
 ### Requirement: SQL query result card

--- a/openspec/changes/add-sqlquery-run-ui/tasks.md
+++ b/openspec/changes/add-sqlquery-run-ui/tasks.md
@@ -1,0 +1,130 @@
+## 1. Types and shared utilities
+
+- [ ] 1.1 Add a new `ui/src/types/sqlQuery.ts` module defining
+      `SqlQueryLibrary` (Library shape conforming to the SQLQuery profile),
+      `SqlQueryRelatedArtifact`, `SqlQueryParameterDeclaration` (FHIR
+      primitive types we support), `SqlQueryRuntimeBindings`,
+      `SqlQueryRequest` (mode `stored` | `inline`, request payload) and
+      `SqlQueryOutputFormat`.
+- [ ] 1.2 Add a small CSV parser utility in
+      `ui/src/utils/csv.ts` with unit tests covering quoted values,
+      embedded commas, CRLF and empty cells; mirror the public API of
+      `parseNdjsonResponse` from `utils/ndjson.ts`.
+- [ ] 1.3 Add a Library-flattener utility that turns a `_format=fhir`
+      Parameters response into `{columns, rows}` matching the existing
+      `ViewDefinitionResult` shape, with unit tests for typed and missing
+      parts and zero-row responses.
+- [ ] 1.4 Add a Base64 SQL helper (encode plus decode) in
+      `ui/src/utils/sqlBase64.ts` using browser `btoa`/`atob` with a
+      Unicode-safe wrapper, plus unit tests.
+
+## 2. API client
+
+- [ ] 2.1 Create `ui/src/api/sqlQuery.ts` exporting `sqlQueryRun` (POST
+      `/$sqlquery-run` with `queryReference` or `queryResource`) and
+      `listSqlQueryLibraries` (GET `/Library?type=…|sql-query`),
+      following the `view.ts` style and reusing
+      `buildHeaders`/`buildUrl`/`checkResponse`.
+- [ ] 2.2 Re-export the new functions from `ui/src/api/index.ts`.
+- [ ] 2.3 Add unit tests in `ui/src/api/__tests__/sqlQuery.test.ts`
+      covering: 200 with body for inline and stored modes, request shape
+      assertions (Parameters body, `_format`, `_limit`, `_header`,
+      nested `parameters`), 400 with OperationOutcome, 401 throwing
+      `UnauthorizedError`.
+
+## 3. Hooks
+
+- [ ] 3.1 Add `ui/src/hooks/useSqlQueryLibraries.ts` (TanStack Query
+      `useQuery` that calls `listSqlQueryLibraries`); export from
+      `ui/src/hooks/index.ts`.
+- [ ] 3.2 Add `ui/src/hooks/useSaveSqlQueryLibrary.ts` mirroring
+      `useSaveViewDefinition.ts`; export from the hooks index.
+- [ ] 3.3 Add `ui/src/hooks/useSqlQueryRun.ts` providing imperative
+      `execute`, `reset` and `status`/`result`/`error` similar to
+      `useViewRun`; branch on `_format` to either parse rows
+      (csv/ndjson/json/fhir) or return a binary blob (parquet); export
+      from the hooks index.
+- [ ] 3.4 Unit-test pure helpers used by the hook (request-body
+      assembly, response branching) with Vitest. Hooks themselves stay
+      thin per the project's React rules.
+
+## 4. Form components
+
+- [ ] 4.1 Add a top-level `SegmentedControl` to
+      `ui/src/components/sqlOnFhir/SqlOnFhirForm.tsx` (or extract the
+      existing form into `ViewDefinitionForm` and create a new
+      `SqlOnFhirForm` shell that switches between `ViewDefinitionForm`
+      and a new `SqlQueryForm`).
+- [ ] 4.2 Implement `ui/src/components/sqlOnFhir/SqlQueryForm.tsx` with
+      the inner `Tabs.Root` for "Select Library" vs "Provide Library"
+      and the runtime-values + output-options section shared below the
+      tabs. Wire it up to the new hooks and types.
+- [ ] 4.3 Implement `SqlQueryStoredTab.tsx` (Library picker, decoded
+      SQL preview with copy `IconButton`, related-artifact summary,
+      declared-parameters summary).
+- [ ] 4.4 Implement `SqlQueryInlineTab.tsx` (SQL `TextArea`, "Tables"
+      list with add/remove rows, "Parameters" list with add/remove
+      rows).
+- [ ] 4.5 Implement `SqlQueryRuntimeBindings.tsx` rendering one input
+      per declared parameter using the type-to-input mapping (string,
+      integer, decimal, boolean, date, dateTime, code).
+- [ ] 4.6 Implement `SqlQueryOutputControls.tsx` with the
+      `Select.Root` for output format, the numeric `_limit` field and
+      the `_header` `Switch` (visible only when format is csv).
+- [ ] 4.7 Wire the Execute and Save-to-server actions; disable Execute
+      when required inputs are missing; hide Save in the stored tab.
+
+## 5. Result card
+
+- [ ] 5.1 Implement `ui/src/components/sqlOnFhir/SqlQueryCard.tsx`
+      mirroring `ViewCard` (Card chrome, job ID, timestamp, format
+      `Badge`, close button when terminated).
+- [ ] 5.2 Render the pending state (`Spinner` + "Executing SQL
+      query…") and route to the right body based on output format:
+      `Table` for tabular formats, download-only for parquet, error
+      `Callout` with submitted SQL on failure.
+- [ ] 5.3 Implement the download action by streaming the cached
+      response body to a Blob and triggering a download with a
+      filename derived from the format.
+- [ ] 5.4 Add a `SqlQueryJob` type to
+      `ui/src/types/sqlQuery.ts` for the in-page job list (ID, mode,
+      request, createdAt) - parallel to `ViewJob`.
+
+## 6. Page wiring
+
+- [ ] 6.1 Update `ui/src/pages/SqlOnFhir.tsx` to track both
+      `ViewJob[]` and `SqlQueryJob[]` and to render `SqlQueryCard`
+      alongside `ViewCard` in the result column, sorted by `createdAt`
+      descending.
+- [ ] 6.2 Pipe the Execute and Save callbacks through the new form
+      components, including the auto-switch to "Select Library" with
+      the new Library ID after a successful save.
+- [ ] 6.3 Confirm the existing auth gate, server-capabilities check
+      and `SessionExpiredDialog` continue to apply unchanged.
+
+## 7. Tests
+
+- [ ] 7.1 Unit-test the form submission helpers (Library
+      construction, request assembly, runtime-binding mapping per FHIR
+      type) in `ui/src/components/sqlOnFhir/__tests__/`.
+- [ ] 7.2 Unit-test result branching (CSV / NDJSON / JSON / FHIR /
+      parquet) and OperationOutcome rendering in `SqlQueryCard`'s tests.
+- [ ] 7.3 Add Playwright E2E coverage in `ui/e2e/` for: (a) executing a
+      stored Library, (b) authoring an inline Library and executing
+      it, (c) saving an inline Library and seeing it in the picker,
+      (d) error rendering when the server returns a 400. Mock the FHIR
+      endpoints with `page.route()`.
+
+## 8. Docs and polish
+
+- [ ] 8.1 Update `ui/CONTRIBUTING.md` only if a new pattern is
+      introduced that future contributors need to know about (else
+      skip; the README does not document individual pages).
+- [ ] 8.2 Run `bun run lint`, `bun run lint:duplication`,
+      `bun run test:coverage`, `bun run test:e2e` and `bun run build`
+      from `ui/` and fix any regressions.
+- [ ] 8.3 Manually exercise the page in dev mode (`bun run dev`)
+      against a local Pathling server with the
+      `feature/sql-run-operation` branch deployed; verify each
+      wireframe scenario (`wireframes/index.html`) renders in line
+      with the design.

--- a/openspec/changes/add-sqlquery-run-ui/tasks.md
+++ b/openspec/changes/add-sqlquery-run-ui/tasks.md
@@ -1,32 +1,32 @@
 ## 1. Types and shared utilities
 
-- [ ] 1.1 Add a new `ui/src/types/sqlQuery.ts` module defining
+- [x] 1.1 Add a new `ui/src/types/sqlQuery.ts` module defining
       `SqlQueryLibrary` (Library shape conforming to the SQLQuery profile),
       `SqlQueryRelatedArtifact`, `SqlQueryParameterDeclaration` (FHIR
       primitive types we support), `SqlQueryRuntimeBindings`,
       `SqlQueryRequest` (mode `stored` | `inline`, request payload) and
       `SqlQueryOutputFormat`.
-- [ ] 1.2 Add a small CSV parser utility in
+- [x] 1.2 Add a small CSV parser utility in
       `ui/src/utils/csv.ts` with unit tests covering quoted values,
       embedded commas, CRLF and empty cells; mirror the public API of
       `parseNdjsonResponse` from `utils/ndjson.ts`.
-- [ ] 1.3 Add a Library-flattener utility that turns a `_format=fhir`
+- [x] 1.3 Add a Library-flattener utility that turns a `_format=fhir`
       Parameters response into `{columns, rows}` matching the existing
       `ViewDefinitionResult` shape, with unit tests for typed and missing
       parts and zero-row responses.
-- [ ] 1.4 Add a Base64 SQL helper (encode plus decode) in
+- [x] 1.4 Add a Base64 SQL helper (encode plus decode) in
       `ui/src/utils/sqlBase64.ts` using browser `btoa`/`atob` with a
       Unicode-safe wrapper, plus unit tests.
 
 ## 2. API client
 
-- [ ] 2.1 Create `ui/src/api/sqlQuery.ts` exporting `sqlQueryRun` (POST
+- [x] 2.1 Create `ui/src/api/sqlQuery.ts` exporting `sqlQueryRun` (POST
       `/$sqlquery-run` with `queryReference` or `queryResource`) and
       `listSqlQueryLibraries` (GET `/Library?type=…|sql-query`),
       following the `view.ts` style and reusing
       `buildHeaders`/`buildUrl`/`checkResponse`.
-- [ ] 2.2 Re-export the new functions from `ui/src/api/index.ts`.
-- [ ] 2.3 Add unit tests in `ui/src/api/__tests__/sqlQuery.test.ts`
+- [x] 2.2 Re-export the new functions from `ui/src/api/index.ts`.
+- [x] 2.3 Add unit tests in `ui/src/api/__tests__/sqlQuery.test.ts`
       covering: 200 with body for inline and stored modes, request shape
       assertions (Parameters body, `_format`, `_limit`, `_header`,
       nested `parameters`), 400 with OperationOutcome, 401 throwing
@@ -34,82 +34,82 @@
 
 ## 3. Hooks
 
-- [ ] 3.1 Add `ui/src/hooks/useSqlQueryLibraries.ts` (TanStack Query
+- [x] 3.1 Add `ui/src/hooks/useSqlQueryLibraries.ts` (TanStack Query
       `useQuery` that calls `listSqlQueryLibraries`); export from
       `ui/src/hooks/index.ts`.
-- [ ] 3.2 Add `ui/src/hooks/useSaveSqlQueryLibrary.ts` mirroring
+- [x] 3.2 Add `ui/src/hooks/useSaveSqlQueryLibrary.ts` mirroring
       `useSaveViewDefinition.ts`; export from the hooks index.
-- [ ] 3.3 Add `ui/src/hooks/useSqlQueryRun.ts` providing imperative
+- [x] 3.3 Add `ui/src/hooks/useSqlQueryRun.ts` providing imperative
       `execute`, `reset` and `status`/`result`/`error` similar to
       `useViewRun`; branch on `_format` to either parse rows
       (csv/ndjson/json/fhir) or return a binary blob (parquet); export
       from the hooks index.
-- [ ] 3.4 Unit-test pure helpers used by the hook (request-body
+- [x] 3.4 Unit-test pure helpers used by the hook (request-body
       assembly, response branching) with Vitest. Hooks themselves stay
       thin per the project's React rules.
 
 ## 4. Form components
 
-- [ ] 4.1 Add a top-level `SegmentedControl` to
+- [x] 4.1 Add a top-level `Tabs.Root` to
       `ui/src/components/sqlOnFhir/SqlOnFhirForm.tsx` (or extract the
       existing form into `ViewDefinitionForm` and create a new
       `SqlOnFhirForm` shell that switches between `ViewDefinitionForm`
       and a new `SqlQueryForm`).
-- [ ] 4.2 Implement `ui/src/components/sqlOnFhir/SqlQueryForm.tsx` with
-      the inner `Tabs.Root` for "Select Library" vs "Provide Library"
+- [x] 4.2 Implement `ui/src/components/sqlOnFhir/SqlQueryForm.tsx` with
+      the inner `Tabs.Root` for "Select query" vs "Provide SQL"
       and the runtime-values + output-options section shared below the
       tabs. Wire it up to the new hooks and types.
-- [ ] 4.3 Implement `SqlQueryStoredTab.tsx` (Library picker, decoded
+- [x] 4.3 Implement `SqlQueryStoredTab.tsx` (Library picker, decoded
       SQL preview with copy `IconButton`, related-artifact summary,
       declared-parameters summary).
-- [ ] 4.4 Implement `SqlQueryInlineTab.tsx` (SQL `TextArea`, "Tables"
+- [x] 4.4 Implement `SqlQueryInlineTab.tsx` (SQL `TextArea`, "Tables"
       list with add/remove rows, "Parameters" list with add/remove
       rows).
-- [ ] 4.5 Implement `SqlQueryRuntimeBindings.tsx` rendering one input
+- [x] 4.5 Implement `SqlQueryRuntimeBindings.tsx` rendering one input
       per declared parameter using the type-to-input mapping (string,
       integer, decimal, boolean, date, dateTime, code).
-- [ ] 4.6 Implement `SqlQueryOutputControls.tsx` with the
+- [x] 4.6 Implement `SqlQueryOutputControls.tsx` with the
       `Select.Root` for output format, the numeric `_limit` field and
       the `_header` `Switch` (visible only when format is csv).
-- [ ] 4.7 Wire the Execute and Save-to-server actions; disable Execute
+- [x] 4.7 Wire the Execute and Save-to-server actions; disable Execute
       when required inputs are missing; hide Save in the stored tab.
 
 ## 5. Result card
 
-- [ ] 5.1 Implement `ui/src/components/sqlOnFhir/SqlQueryCard.tsx`
+- [x] 5.1 Implement `ui/src/components/sqlOnFhir/SqlQueryCard.tsx`
       mirroring `ViewCard` (Card chrome, job ID, timestamp, format
       `Badge`, close button when terminated).
-- [ ] 5.2 Render the pending state (`Spinner` + "Executing SQL
+- [x] 5.2 Render the pending state (`Spinner` + "Executing SQL
       query…") and route to the right body based on output format:
       `Table` for tabular formats, download-only for parquet, error
       `Callout` with submitted SQL on failure.
-- [ ] 5.3 Implement the download action by streaming the cached
+- [x] 5.3 Implement the download action by streaming the cached
       response body to a Blob and triggering a download with a
       filename derived from the format.
-- [ ] 5.4 Add a `SqlQueryJob` type to
+- [x] 5.4 Add a `SqlQueryJob` type to
       `ui/src/types/sqlQuery.ts` for the in-page job list (ID, mode,
       request, createdAt) - parallel to `ViewJob`.
 
 ## 6. Page wiring
 
-- [ ] 6.1 Update `ui/src/pages/SqlOnFhir.tsx` to track both
+- [x] 6.1 Update `ui/src/pages/SqlOnFhir.tsx` to track both
       `ViewJob[]` and `SqlQueryJob[]` and to render `SqlQueryCard`
       alongside `ViewCard` in the result column, sorted by `createdAt`
       descending.
-- [ ] 6.2 Pipe the Execute and Save callbacks through the new form
-      components, including the auto-switch to "Select Library" with
+- [x] 6.2 Pipe the Execute and Save callbacks through the new form
+      components, including the auto-switch to "Select query" with
       the new Library ID after a successful save.
-- [ ] 6.3 Confirm the existing auth gate, server-capabilities check
+- [x] 6.3 Confirm the existing auth gate, server-capabilities check
       and `SessionExpiredDialog` continue to apply unchanged.
 
 ## 7. Tests
 
-- [ ] 7.1 Unit-test the form submission helpers (Library
+- [x] 7.1 Unit-test the form submission helpers (Library
       construction, request assembly, runtime-binding mapping per FHIR
       type) in `ui/src/components/sqlOnFhir/__tests__/`.
-- [ ] 7.2 Unit-test result branching (CSV / NDJSON / JSON / FHIR /
+- [x] 7.2 Unit-test result branching (CSV / NDJSON / JSON / FHIR /
       parquet) and OperationOutcome rendering in `SqlQueryCard`'s tests.
-- [ ] 7.3 Add Playwright E2E coverage in `ui/e2e/` for: (a) executing a
+- [x] 7.3 Add Playwright E2E coverage in `ui/e2e/` for: (a) executing a
       stored Library, (b) authoring an inline Library and executing
       it, (c) saving an inline Library and seeing it in the picker,
       (d) error rendering when the server returns a 400. Mock the FHIR
@@ -117,13 +117,13 @@
 
 ## 8. Docs and polish
 
-- [ ] 8.1 Update `ui/CONTRIBUTING.md` only if a new pattern is
+- [x] 8.1 Update `ui/CONTRIBUTING.md` only if a new pattern is
       introduced that future contributors need to know about (else
       skip; the README does not document individual pages).
-- [ ] 8.2 Run `bun run lint`, `bun run lint:duplication`,
+- [x] 8.2 Run `bun run lint`, `bun run lint:duplication`,
       `bun run test:coverage`, `bun run test:e2e` and `bun run build`
       from `ui/` and fix any regressions.
-- [ ] 8.3 Manually exercise the page in dev mode (`bun run dev`)
+- [x] 8.3 Manually exercise the page in dev mode (`bun run dev`)
       against a local Pathling server with the
       `feature/sql-run-operation` branch deployed; verify each
       wireframe scenario (`wireframes/index.html`) renders in line

--- a/openspec/changes/add-sqlquery-run-ui/wireframes/index.html
+++ b/openspec/changes/add-sqlquery-run-ui/wireframes/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Wireframes - $sqlquery-run UI</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: #f0f0f0;
+    color: #333;
+    line-height: 1.5;
+    padding: 2rem;
+  }
+  .container { max-width: 720px; margin: 0 auto; }
+  h1 { font-size: 1.4rem; color: #444; margin-bottom: 0.4rem; }
+  .lede { color: #777; font-size: 0.95rem; margin-bottom: 1.5rem; }
+  ul { list-style: none; }
+  li {
+    background: #fff;
+    border: 2px solid #ccc;
+    border-radius: 6px;
+    margin-bottom: 0.6rem;
+    padding: 1rem 1.2rem;
+  }
+  li a { color: #444; font-weight: 600; text-decoration: none; }
+  li a:hover { text-decoration: underline; }
+  li p { color: #777; font-size: 0.85rem; margin-top: 0.25rem; }
+  small { color: #999; font-size: 0.8rem; }
+</style>
+</head>
+<body>
+  <div class="container">
+    <h1>$sqlquery-run UI wireframes</h1>
+    <p class="lede">Lo-fi wireframes for the new "SQL query" mode of the SQL on FHIR page in the Pathling admin UI.</p>
+    <ul>
+      <li>
+        <a href="./sql-query-inline.html">1. SQL query, inline (Provide Library tab)</a>
+        <p>Authoring a SQLQuery Library inline: SQL text, related ViewDefinitions, declared parameters, runtime values and output options.</p>
+      </li>
+      <li>
+        <a href="./sql-query-stored.html">2. SQL query, stored (Select Library tab)</a>
+        <p>Selecting a stored SQLQuery Library, previewing its SQL and binding runtime parameter values.</p>
+      </li>
+      <li>
+        <a href="./result-card-tabular.html">3. Result card (tabular)</a>
+        <p>Successful query rendered as a Table with format badge, row count and download.</p>
+      </li>
+      <li>
+        <a href="./result-card-error.html">4. Result card (error)</a>
+        <p>Server-side validation error surfaced in a red Callout next to the offending SQL.</p>
+      </li>
+    </ul>
+    <small>Lo-fi monochrome - layout and information density only, not visual design.</small>
+  </div>
+</body>
+</html>

--- a/openspec/changes/add-sqlquery-run-ui/wireframes/result-card-error.html
+++ b/openspec/changes/add-sqlquery-run-ui/wireframes/result-card-error.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Wireframe - SQL query result, error</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f0f0f0; color: #333; line-height: 1.4; }
+  .mono { font-family: "SF Mono", "Menlo", "Consolas", monospace; }
+  .wf-container { max-width: 1280px; margin: 0 auto; background: #fff; min-height: 100vh; display: flex; flex-direction: column; }
+  .wf-header { background: #e8e8e8; border-bottom: 2px solid #bbb; padding: 0.85rem 1.5rem; display: flex; align-items: center; justify-content: space-between; }
+  .wf-logo { font-weight: bold; font-size: 1rem; color: #555; }
+  .wf-nav { display: flex; gap: 1.25rem; }
+  .wf-nav a { color: #666; text-decoration: none; font-size: 0.85rem; padding: 0.25rem 0.4rem; border-radius: 3px; }
+  .wf-nav a.active { background: #d0d0d0; color: #222; font-weight: 600; }
+  .wf-main { padding: 1.5rem; flex: 1; }
+  .wf-page-title { font-size: 1.4rem; font-weight: 600; margin-bottom: 1rem; color: #333; }
+
+  .wf-segmented { display: inline-flex; border: 2px solid #aaa; border-radius: 6px; overflow: hidden; margin-bottom: 1rem; background: #f0f0f0; }
+  .wf-segmented div { padding: 0.45rem 1rem; font-size: 0.85rem; color: #666; border-right: 2px solid #aaa; }
+  .wf-segmented div:last-child { border-right: 0; }
+  .wf-segmented .active { background: #ccc; color: #222; font-weight: 600; }
+
+  .wf-row { display: flex; gap: 1.25rem; align-items: flex-start; }
+  .wf-col { flex: 1; min-width: 0; }
+  .wf-card { background: #fafafa; border: 2px solid #ccc; border-radius: 6px; padding: 1rem; margin-bottom: 1rem; }
+
+  .wf-form-stub { color: #888; font-size: 0.85rem; padding: 1rem; border: 2px dashed #ccc; border-radius: 4px; background: #f5f5f5; }
+
+  .wf-result-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; margin-bottom: 0.6rem; }
+  .wf-result-title { font-weight: 600; color: #333; font-size: 0.95rem; margin-bottom: 0.2rem; }
+  .wf-result-meta { font-size: 0.75rem; color: #888; }
+  .wf-tag { display: inline-block; padding: 0.1rem 0.45rem; background: #e0e0e0; border: 1px solid #bbb; border-radius: 3px; font-size: 0.72rem; color: #555; }
+  .wf-tag.error { background: #f0d6d6; border-color: #c08080; color: #803030; }
+
+  .wf-button { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.4rem 0.7rem; background: #ddd; border: 2px solid #aaa; border-radius: 4px; color: #444; font-size: 0.8rem; }
+  .wf-button.small { padding: 0.25rem 0.55rem; font-size: 0.75rem; }
+  .wf-button.soft { background: #ececec; }
+
+  .wf-callout { border: 2px solid #c08080; background: #f6e3e3; color: #6a2222; padding: 0.7rem 0.9rem; border-radius: 5px; font-size: 0.85rem; }
+  .wf-callout strong { color: #5b1c1c; }
+  .wf-callout .mono { font-size: 0.8rem; }
+
+  .wf-sql-block { background: #f3f3f3; border: 1px solid #ccc; border-radius: 4px; padding: 0.65rem 0.8rem; font-size: 0.82rem; color: #555; margin-bottom: 0.6rem; white-space: pre-wrap; }
+
+  .wf-annotation { font-size: 0.78rem; color: #999; font-style: italic; margin: 0.5rem 0; }
+</style>
+</head>
+<body>
+<div class="wf-container">
+  <header class="wf-header">
+    <div class="wf-logo">Pathling Admin</div>
+    <nav class="wf-nav">
+      <a href="#">Dashboard</a>
+      <a href="#">Resources</a>
+      <a href="#">Import</a>
+      <a href="#">Export</a>
+      <a href="#">Bulk submit</a>
+      <a href="#" class="active">SQL on FHIR</a>
+    </nav>
+  </header>
+
+  <main class="wf-main">
+    <h1 class="wf-page-title">SQL on FHIR</h1>
+
+    <div class="wf-segmented">
+      <div>View definition</div>
+      <div class="active">SQL query</div>
+    </div>
+
+    <div class="wf-row">
+      <div class="wf-col">
+        <div class="wf-card">
+          <div class="wf-form-stub">
+            <strong>SQL query form</strong> (collapsed - see <a href="./sql-query-inline.html">inline</a> wireframe).
+          </div>
+        </div>
+      </div>
+
+      <div class="wf-col">
+        <div class="wf-card">
+          <div class="wf-result-header">
+            <div>
+              <div class="wf-result-title">SQL query <span class="wf-tag error">failed</span></div>
+              <div class="wf-result-meta">Job ID: 9b1c... · 5 May 2026, 14:25 · inline Library</div>
+            </div>
+            <button class="wf-button small soft">× Close</button>
+          </div>
+
+          <div class="wf-section">
+            <div style="font-size: 0.78rem; color: #777; text-transform: uppercase; letter-spacing: 0.04em; font-weight: 600; margin-bottom: 0.3rem;">Submitted SQL</div>
+            <div class="wf-sql-block mono">DROP TABLE conditions</div>
+          </div>
+
+          <div class="wf-callout">
+            <strong>SQL contains a disallowed operation</strong><br>
+            <span style="font-size: 0.8rem;">HTTP 400 - <span class="mono">OperationOutcome</span> issue: <span class="mono">processing.business-rule</span></span><br>
+            <span class="mono" style="display:block; margin-top:0.4rem;">Only SELECT statements are allowed. DDL / DML statements (DROP, INSERT, UPDATE, DELETE, …) are rejected by the SQL validator.</span>
+          </div>
+
+          <p class="wf-annotation">Server-side validation errors are surfaced as a red Callout (Radix Themes red) with the message extracted from OperationOutcome. The submitted SQL is shown above the Callout so the user can correlate the failure with the input.</p>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/openspec/changes/add-sqlquery-run-ui/wireframes/result-card-error.html
+++ b/openspec/changes/add-sqlquery-run-ui/wireframes/result-card-error.html
@@ -31,6 +31,7 @@
   .wf-result-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; margin-bottom: 0.6rem; }
   .wf-result-title { font-weight: 600; color: #333; font-size: 0.95rem; margin-bottom: 0.2rem; }
   .wf-result-meta { font-size: 0.75rem; color: #888; }
+  .wf-result-meta div { margin-bottom: 0.15rem; }
   .wf-tag { display: inline-block; padding: 0.1rem 0.45rem; background: #e0e0e0; border: 1px solid #bbb; border-radius: 3px; font-size: 0.72rem; color: #555; }
   .wf-tag.error { background: #f0d6d6; border-color: #c08080; color: #803030; }
 
@@ -83,7 +84,11 @@
           <div class="wf-result-header">
             <div>
               <div class="wf-result-title">SQL query <span class="wf-tag error">failed</span></div>
-              <div class="wf-result-meta">Job ID: 9b1c... · 5 May 2026, 14:25 · inline Library</div>
+              <div class="wf-result-meta">
+                <div>Job ID: 9b1c...</div>
+                <div>Library ID: inline</div>
+                <div>5 May 2026, 14:25</div>
+              </div>
             </div>
             <button class="wf-button small soft">× Close</button>
           </div>

--- a/openspec/changes/add-sqlquery-run-ui/wireframes/result-card-tabular.html
+++ b/openspec/changes/add-sqlquery-run-ui/wireframes/result-card-tabular.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Wireframe - SQL query result, tabular</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f0f0f0; color: #333; line-height: 1.4; }
+  .mono { font-family: "SF Mono", "Menlo", "Consolas", monospace; }
+  .wf-container { max-width: 1280px; margin: 0 auto; background: #fff; min-height: 100vh; display: flex; flex-direction: column; }
+  .wf-header { background: #e8e8e8; border-bottom: 2px solid #bbb; padding: 0.85rem 1.5rem; display: flex; align-items: center; justify-content: space-between; }
+  .wf-logo { font-weight: bold; font-size: 1rem; color: #555; }
+  .wf-nav { display: flex; gap: 1.25rem; }
+  .wf-nav a { color: #666; text-decoration: none; font-size: 0.85rem; padding: 0.25rem 0.4rem; border-radius: 3px; }
+  .wf-nav a.active { background: #d0d0d0; color: #222; font-weight: 600; }
+  .wf-main { padding: 1.5rem; flex: 1; }
+  .wf-page-title { font-size: 1.4rem; font-weight: 600; margin-bottom: 1rem; color: #333; }
+
+  .wf-segmented { display: inline-flex; border: 2px solid #aaa; border-radius: 6px; overflow: hidden; margin-bottom: 1rem; background: #f0f0f0; }
+  .wf-segmented div { padding: 0.45rem 1rem; font-size: 0.85rem; color: #666; border-right: 2px solid #aaa; }
+  .wf-segmented div:last-child { border-right: 0; }
+  .wf-segmented .active { background: #ccc; color: #222; font-weight: 600; }
+
+  .wf-row { display: flex; gap: 1.25rem; align-items: flex-start; }
+  .wf-col { flex: 1; min-width: 0; }
+  .wf-card { background: #fafafa; border: 2px solid #ccc; border-radius: 6px; padding: 1rem; margin-bottom: 1rem; }
+
+  .wf-form-stub { color: #888; font-size: 0.85rem; padding: 1rem; border: 2px dashed #ccc; border-radius: 4px; background: #f5f5f5; }
+
+  .wf-result-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; }
+  .wf-result-title { font-weight: 600; color: #333; font-size: 0.95rem; margin-bottom: 0.2rem; }
+  .wf-result-meta { font-size: 0.75rem; color: #888; }
+  .wf-tag { display: inline-block; padding: 0.1rem 0.45rem; background: #e0e0e0; border: 1px solid #bbb; border-radius: 3px; font-size: 0.72rem; color: #555; }
+
+  .wf-button { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.4rem 0.7rem; background: #ddd; border: 2px solid #aaa; border-radius: 4px; color: #444; font-size: 0.8rem; }
+  .wf-button.small { padding: 0.25rem 0.55rem; font-size: 0.75rem; }
+  .wf-button.soft { background: #ececec; }
+
+  .wf-result-actions { display: flex; gap: 0.4rem; align-items: center; margin: 0.6rem 0; justify-content: space-between; }
+  .wf-result-controls { display: flex; gap: 0.4rem; }
+
+  .wf-table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
+  .wf-table th, .wf-table td { padding: 0.4rem 0.6rem; border: 1px solid #ccc; text-align: left; white-space: nowrap; }
+  .wf-table th { background: #ececec; font-weight: 600; color: #555; }
+  .wf-table td { color: #555; }
+  .wf-table td.mono { font-family: "SF Mono", "Menlo", monospace; }
+
+  .wf-annotation { font-size: 0.78rem; color: #999; font-style: italic; margin: 0.5rem 0; }
+</style>
+</head>
+<body>
+<div class="wf-container">
+  <header class="wf-header">
+    <div class="wf-logo">Pathling Admin</div>
+    <nav class="wf-nav">
+      <a href="#">Dashboard</a>
+      <a href="#">Resources</a>
+      <a href="#">Import</a>
+      <a href="#">Export</a>
+      <a href="#">Bulk submit</a>
+      <a href="#" class="active">SQL on FHIR</a>
+    </nav>
+  </header>
+
+  <main class="wf-main">
+    <h1 class="wf-page-title">SQL on FHIR</h1>
+
+    <div class="wf-segmented">
+      <div>View definition</div>
+      <div class="active">SQL query</div>
+    </div>
+
+    <div class="wf-row">
+      <div class="wf-col">
+        <div class="wf-card">
+          <div class="wf-form-stub">
+            <strong>SQL query form</strong> (collapsed for brevity - see <a href="./sql-query-inline.html">inline</a> or <a href="./sql-query-stored.html">stored</a> wireframes).
+          </div>
+        </div>
+      </div>
+
+      <!-- Result column -->
+      <div class="wf-col">
+        <div class="wf-card">
+          <div class="wf-result-header">
+            <div>
+              <div class="wf-result-title">SQL query <span class="wf-tag">csv</span></div>
+              <div class="wf-result-meta">Job ID: 7f3e... · 5 May 2026, 14:22 · Library/lib-42</div>
+            </div>
+            <button class="wf-button small soft">× Close</button>
+          </div>
+
+          <div class="wf-result-actions">
+            <span class="wf-tag">4 rows</span>
+            <div class="wf-result-controls">
+              <button class="wf-button small">↓ Download .csv</button>
+            </div>
+          </div>
+
+          <div style="overflow-x: auto;">
+            <table class="wf-table">
+              <thead>
+                <tr>
+                  <th class="mono">given_name</th>
+                  <th class="mono">family_name</th>
+                  <th class="mono">condition_name</th>
+                  <th class="mono">onset_date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>John</td><td>Smith</td><td>Diabetes mellitus</td><td class="mono">2015-03-12</td></tr>
+                <tr><td>John</td><td>Smith</td><td>Hypertension</td><td class="mono">2018-06-01</td></tr>
+                <tr><td>Jane</td><td>Johnson</td><td>Asthma</td><td class="mono">2010-09-20</td></tr>
+                <tr><td>Bob</td><td>Williams</td><td>Diabetes mellitus</td><td class="mono">2020-01-15</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p class="wf-annotation">Tabular formats (csv / ndjson / json / fhir) parse into rows + columns and render in this Table. The "Download" action streams the raw response. For parquet, the Table is replaced by a download-only block.</p>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/openspec/changes/add-sqlquery-run-ui/wireframes/result-card-tabular.html
+++ b/openspec/changes/add-sqlquery-run-ui/wireframes/result-card-tabular.html
@@ -31,11 +31,15 @@
   .wf-result-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; }
   .wf-result-title { font-weight: 600; color: #333; font-size: 0.95rem; margin-bottom: 0.2rem; }
   .wf-result-meta { font-size: 0.75rem; color: #888; }
+  .wf-result-meta div { margin-bottom: 0.15rem; }
   .wf-tag { display: inline-block; padding: 0.1rem 0.45rem; background: #e0e0e0; border: 1px solid #bbb; border-radius: 3px; font-size: 0.72rem; color: #555; }
 
   .wf-button { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.4rem 0.7rem; background: #ddd; border: 2px solid #aaa; border-radius: 4px; color: #444; font-size: 0.8rem; }
   .wf-button.small { padding: 0.25rem 0.55rem; font-size: 0.75rem; }
   .wf-button.soft { background: #ececec; }
+
+  .wf-select.small { display: inline-flex; align-items: center; gap: 0.3rem; padding: 0.25rem 0.45rem; border: 2px solid #bbb; border-radius: 4px; background: #fff; font-size: 0.75rem; color: #555; }
+  .wf-select.small::after { content: "▾"; color: #888; }
 
   .wf-result-actions { display: flex; gap: 0.4rem; align-items: center; margin: 0.6rem 0; justify-content: space-between; }
   .wf-result-controls { display: flex; gap: 0.4rem; }
@@ -86,7 +90,11 @@
           <div class="wf-result-header">
             <div>
               <div class="wf-result-title">SQL query <span class="wf-tag">csv</span></div>
-              <div class="wf-result-meta">Job ID: 7f3e... · 5 May 2026, 14:22 · Library/lib-42</div>
+              <div class="wf-result-meta">
+                <div>Job ID: 7f3e...</div>
+                <div>Library ID: lib-42</div>
+                <div>5 May 2026, 14:22</div>
+              </div>
             </div>
             <button class="wf-button small soft">× Close</button>
           </div>
@@ -94,7 +102,8 @@
           <div class="wf-result-actions">
             <span class="wf-tag">4 rows</span>
             <div class="wf-result-controls">
-              <button class="wf-button small">↓ Download .csv</button>
+              <div class="wf-select small">CSV</div>
+              <button class="wf-button small">↓ Export</button>
             </div>
           </div>
 
@@ -117,7 +126,7 @@
             </table>
           </div>
 
-          <p class="wf-annotation">Tabular formats (csv / ndjson / json / fhir) parse into rows + columns and render in this Table. The "Download" action streams the raw response. For parquet, the Table is replaced by a download-only block.</p>
+          <p class="wf-annotation">Tabular formats (csv / ndjson / json / fhir) parse into rows + columns and render in this Table. The format selector chooses the export format (csv / ndjson / json / parquet / fhir) and "Export" streams the raw response in that format. For parquet, the Table is replaced by a download-only block.</p>
         </div>
       </div>
     </div>

--- a/openspec/changes/add-sqlquery-run-ui/wireframes/sql-query-inline.html
+++ b/openspec/changes/add-sqlquery-run-ui/wireframes/sql-query-inline.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Wireframe - SQL query, inline</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f0f0f0; color: #333; line-height: 1.4; }
+  .mono { font-family: "SF Mono", "Menlo", "Consolas", monospace; }
+  .wf-container { max-width: 1280px; margin: 0 auto; background: #fff; min-height: 100vh; display: flex; flex-direction: column; }
+  .wf-header { background: #e8e8e8; border-bottom: 2px solid #bbb; padding: 0.85rem 1.5rem; display: flex; align-items: center; justify-content: space-between; }
+  .wf-logo { font-weight: bold; font-size: 1rem; color: #555; }
+  .wf-nav { display: flex; gap: 1.25rem; }
+  .wf-nav a { color: #666; text-decoration: none; font-size: 0.85rem; padding: 0.25rem 0.4rem; border-radius: 3px; }
+  .wf-nav a.active { background: #d0d0d0; color: #222; font-weight: 600; }
+  .wf-main { padding: 1.5rem; flex: 1; }
+  .wf-page-title { font-size: 1.4rem; font-weight: 600; margin-bottom: 1rem; color: #333; }
+
+  .wf-segmented { display: inline-flex; border: 2px solid #aaa; border-radius: 6px; overflow: hidden; margin-bottom: 1rem; background: #f0f0f0; }
+  .wf-segmented div { padding: 0.45rem 1rem; font-size: 0.85rem; color: #666; cursor: pointer; border-right: 2px solid #aaa; }
+  .wf-segmented div:last-child { border-right: 0; }
+  .wf-segmented .active { background: #ccc; color: #222; font-weight: 600; }
+
+  .wf-row { display: flex; gap: 1.25rem; align-items: flex-start; }
+  .wf-col { flex: 1; min-width: 0; }
+
+  .wf-card { background: #fafafa; border: 2px solid #ccc; border-radius: 6px; padding: 1rem; margin-bottom: 1rem; }
+  .wf-card h2 { font-size: 1.1rem; color: #444; margin-bottom: 0.85rem; }
+
+  .wf-tabs { display: flex; border-bottom: 2px solid #ccc; margin-bottom: 1rem; }
+  .wf-tab { padding: 0.5rem 0.85rem; font-size: 0.85rem; color: #777; border-bottom: 3px solid transparent; margin-bottom: -2px; cursor: pointer; }
+  .wf-tab.active { color: #222; border-bottom-color: #555; font-weight: 600; }
+
+  .wf-section { margin-bottom: 1rem; }
+  .wf-section-title { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; color: #777; margin-bottom: 0.4rem; font-weight: 600; }
+  .wf-help { font-size: 0.78rem; color: #999; margin-top: 0.3rem; }
+
+  .wf-label { display: block; font-size: 0.82rem; color: #555; margin-bottom: 0.25rem; font-weight: 500; }
+  .wf-input { width: 100%; padding: 0.45rem 0.55rem; border: 2px solid #bbb; border-radius: 4px; background: #fff; font-size: 0.85rem; color: #555; }
+  .wf-input.short { width: 6rem; }
+  .wf-textarea { width: 100%; padding: 0.55rem; border: 2px solid #bbb; border-radius: 4px; background: #fff; font-size: 0.82rem; color: #555; min-height: 7rem; resize: vertical; }
+  .wf-select { display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.45rem 0.6rem; border: 2px solid #bbb; border-radius: 4px; background: #fff; font-size: 0.85rem; color: #555; min-width: 12rem; justify-content: space-between; }
+  .wf-select::after { content: "▾"; color: #888; }
+
+  .wf-button { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.55rem 0.95rem; background: #ddd; border: 2px solid #aaa; border-radius: 4px; color: #444; font-size: 0.88rem; cursor: pointer; }
+  .wf-button.primary { background: #c4c4c4; border-color: #777; color: #222; font-weight: 600; }
+  .wf-button.icon { padding: 0.3rem 0.4rem; min-width: auto; font-size: 0.8rem; }
+  .wf-icon-btn { width: 1.6rem; height: 1.6rem; display: inline-flex; align-items: center; justify-content: center; border: 1px solid #bbb; border-radius: 3px; background: #fff; color: #888; cursor: pointer; }
+
+  .wf-row-of-fields { display: flex; gap: 0.5rem; align-items: flex-end; margin-bottom: 0.4rem; }
+  .wf-row-of-fields .wf-col { flex: 1; }
+  .wf-row-of-fields .wf-col.narrow { flex: 0 0 8rem; }
+  .wf-row-of-fields .wf-col.label { flex: 0 0 7rem; }
+
+  .wf-switch { display: inline-flex; align-items: center; gap: 0.45rem; }
+  .wf-switch .knob { width: 2.2rem; height: 1.1rem; background: #bbb; border-radius: 999px; position: relative; }
+  .wf-switch .knob::after { content: ""; width: 0.85rem; height: 0.85rem; background: #fff; border-radius: 50%; position: absolute; top: 0.12rem; left: 0.12rem; }
+  .wf-switch.on .knob { background: #888; }
+  .wf-switch.on .knob::after { left: 1.2rem; }
+
+  .wf-actions { display: flex; gap: 0.6rem; margin-top: 0.5rem; }
+  .wf-actions .wf-button { flex: 1; justify-content: center; }
+
+  .wf-empty-results { background: #f5f5f5; border: 2px dashed #ccc; border-radius: 6px; padding: 2rem; color: #999; font-size: 0.85rem; text-align: center; }
+  .wf-annotation { font-size: 0.78rem; color: #999; font-style: italic; margin: 0.4rem 0 0.4rem 0; }
+</style>
+</head>
+<body>
+<div class="wf-container">
+  <header class="wf-header">
+    <div class="wf-logo">Pathling Admin</div>
+    <nav class="wf-nav">
+      <a href="#">Dashboard</a>
+      <a href="#">Resources</a>
+      <a href="#">Import</a>
+      <a href="#">Export</a>
+      <a href="#">Bulk submit</a>
+      <a href="#" class="active">SQL on FHIR</a>
+    </nav>
+  </header>
+
+  <main class="wf-main">
+    <h1 class="wf-page-title">SQL on FHIR</h1>
+
+    <div class="wf-segmented" role="tablist" aria-label="SQL on FHIR mode">
+      <div>View definition</div>
+      <div class="active">SQL query</div>
+    </div>
+    <p class="wf-annotation">SegmentedControl chooses between $viewdefinition-run and $sqlquery-run. SQL query mode is selected.</p>
+
+    <div class="wf-row">
+      <!-- Form column -->
+      <div class="wf-col">
+        <div class="wf-card">
+          <h2>SQL query</h2>
+
+          <div class="wf-tabs" role="tablist" aria-label="Library source">
+            <div class="wf-tab">Select Library</div>
+            <div class="wf-tab active">Provide Library</div>
+          </div>
+
+          <!-- SQL editor -->
+          <div class="wf-section">
+            <label class="wf-label">SQL</label>
+            <textarea class="wf-textarea mono" rows="9" spellcheck="false">SELECT p.given_name, p.family_name, c.condition_name, c.onset_date
+FROM patients p
+JOIN conditions c
+  ON concat('Patient/', p.patient_id) = c.patient_ref
+WHERE p.patient_id = :patient_id
+ORDER BY c.onset_date</textarea>
+            <div class="wf-help">Plain SQL text. Encoded as Base64 into Library.content[0].data on submit; the raw text is preserved in the sql-text extension.</div>
+          </div>
+
+          <!-- Tables (related artifacts) -->
+          <div class="wf-section">
+            <div class="wf-section-title">Tables</div>
+            <div class="wf-row-of-fields">
+              <div class="wf-col label">
+                <label class="wf-label">Label</label>
+                <input class="wf-input mono" value="patients">
+              </div>
+              <div class="wf-col">
+                <label class="wf-label">View definition</label>
+                <div class="wf-select">patients <span style="color:#999">(Patient)</span></div>
+              </div>
+              <button class="wf-icon-btn" aria-label="Remove">×</button>
+            </div>
+            <div class="wf-row-of-fields">
+              <div class="wf-col label">
+                <input class="wf-input mono" value="conditions">
+              </div>
+              <div class="wf-col">
+                <div class="wf-select">conditions <span style="color:#999">(Condition)</span></div>
+              </div>
+              <button class="wf-icon-btn" aria-label="Remove">×</button>
+            </div>
+            <button class="wf-button">+ Add table</button>
+            <div class="wf-help">Each table becomes Library.relatedArtifact[*]. The label is the name used to reference the view in SQL.</div>
+          </div>
+
+          <!-- Declared parameters -->
+          <div class="wf-section">
+            <div class="wf-section-title">Parameters</div>
+            <div class="wf-row-of-fields">
+              <div class="wf-col label">
+                <label class="wf-label">Name</label>
+                <input class="wf-input mono" value="patient_id">
+              </div>
+              <div class="wf-col narrow">
+                <label class="wf-label">Type</label>
+                <div class="wf-select">string</div>
+              </div>
+              <div class="wf-col">
+                <label class="wf-label">Default</label>
+                <input class="wf-input" placeholder="(none)">
+              </div>
+              <button class="wf-icon-btn" aria-label="Remove">×</button>
+            </div>
+            <button class="wf-button">+ Add parameter</button>
+            <div class="wf-help">Maps to Library.parameter[*] (use=in). The runtime value goes below.</div>
+          </div>
+
+          <!-- Runtime values -->
+          <div class="wf-section">
+            <div class="wf-section-title">Runtime parameter values</div>
+            <div class="wf-row-of-fields">
+              <div class="wf-col label">
+                <label class="wf-label mono">patient_id</label>
+              </div>
+              <div class="wf-col">
+                <input class="wf-input" value="Patient/pat-1">
+              </div>
+            </div>
+            <div class="wf-help">Submitted as a Parameters resource under the request's "parameters" parameter. Inputs are typed against the declared parameter type.</div>
+          </div>
+
+          <!-- Output / limit / header -->
+          <div class="wf-section">
+            <div class="wf-row-of-fields">
+              <div class="wf-col">
+                <label class="wf-label">Output format</label>
+                <div class="wf-select">csv</div>
+              </div>
+              <div class="wf-col narrow">
+                <label class="wf-label">Limit</label>
+                <input class="wf-input short" value="100">
+              </div>
+              <div class="wf-col">
+                <label class="wf-label">Header row</label>
+                <div class="wf-switch on"><span class="knob"></span><span style="font-size:0.82rem;color:#555">on</span></div>
+              </div>
+            </div>
+            <div class="wf-help">Output format is one of csv / ndjson / json / parquet / fhir. Header switch only shown for csv.</div>
+          </div>
+
+          <!-- Actions -->
+          <div class="wf-actions">
+            <button class="wf-button primary">▶ Execute</button>
+            <button class="wf-button">↥ Save to server</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Results column -->
+      <div class="wf-col">
+        <div class="wf-empty-results">
+          Execute a query to see results here.<br>
+          <small>Each execution adds a card to this column; cards are independent and closable.</small>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/openspec/changes/add-sqlquery-run-ui/wireframes/sql-query-inline.html
+++ b/openspec/changes/add-sqlquery-run-ui/wireframes/sql-query-inline.html
@@ -112,31 +112,31 @@ ORDER BY c.onset_date</textarea>
             <div class="wf-help">Plain SQL text. Encoded as Base64 into Library.content[0].data on submit; the raw text is preserved in the sql-text extension.</div>
           </div>
 
-          <!-- Tables (related artifacts) -->
+          <!-- Dependencies (related artifacts) -->
           <div class="wf-section">
-            <div class="wf-section-title">Tables</div>
+            <div class="wf-section-title">Dependencies</div>
             <div class="wf-row-of-fields">
-              <div class="wf-col label">
+              <div class="wf-col" style="flex:1;">
                 <label class="wf-label">Label</label>
                 <input class="wf-input mono" value="patients">
               </div>
-              <div class="wf-col">
+              <div class="wf-col" style="flex:1;">
                 <label class="wf-label">View definition</label>
-                <div class="wf-select">patients <span style="color:#999">(Patient)</span></div>
+                <div class="wf-select" style="width:100%; min-width:0;"><span>patients <span style="color:#999">(Patient)</span></span></div>
               </div>
               <button class="wf-icon-btn" aria-label="Remove">×</button>
             </div>
             <div class="wf-row-of-fields">
-              <div class="wf-col label">
+              <div class="wf-col" style="flex:1;">
                 <input class="wf-input mono" value="conditions">
               </div>
-              <div class="wf-col">
-                <div class="wf-select">conditions <span style="color:#999">(Condition)</span></div>
+              <div class="wf-col" style="flex:1;">
+                <div class="wf-select" style="width:100%; min-width:0;"><span>conditions <span style="color:#999">(Condition)</span></span></div>
               </div>
               <button class="wf-icon-btn" aria-label="Remove">×</button>
             </div>
-            <button class="wf-button">+ Add table</button>
-            <div class="wf-help">Each table becomes Library.relatedArtifact[*]. The label is the name used to reference the view in SQL.</div>
+            <button class="wf-button">+ Add dependency</button>
+            <div class="wf-help">Each dependency becomes Library.relatedArtifact[*]. The label is the name used to reference the view in SQL.</div>
           </div>
 
           <!-- Declared parameters -->
@@ -149,7 +149,7 @@ ORDER BY c.onset_date</textarea>
               </div>
               <div class="wf-col narrow">
                 <label class="wf-label">Type</label>
-                <div class="wf-select">string</div>
+                <div class="wf-select" style="width:100%; min-width:0;">string</div>
               </div>
               <div class="wf-col">
                 <label class="wf-label">Default</label>

--- a/openspec/changes/add-sqlquery-run-ui/wireframes/sql-query-stored.html
+++ b/openspec/changes/add-sqlquery-run-ui/wireframes/sql-query-stored.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Wireframe - SQL query, stored</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f0f0f0; color: #333; line-height: 1.4; }
+  .mono { font-family: "SF Mono", "Menlo", "Consolas", monospace; }
+  .wf-container { max-width: 1280px; margin: 0 auto; background: #fff; min-height: 100vh; display: flex; flex-direction: column; }
+  .wf-header { background: #e8e8e8; border-bottom: 2px solid #bbb; padding: 0.85rem 1.5rem; display: flex; align-items: center; justify-content: space-between; }
+  .wf-logo { font-weight: bold; font-size: 1rem; color: #555; }
+  .wf-nav { display: flex; gap: 1.25rem; }
+  .wf-nav a { color: #666; text-decoration: none; font-size: 0.85rem; padding: 0.25rem 0.4rem; border-radius: 3px; }
+  .wf-nav a.active { background: #d0d0d0; color: #222; font-weight: 600; }
+  .wf-main { padding: 1.5rem; flex: 1; }
+  .wf-page-title { font-size: 1.4rem; font-weight: 600; margin-bottom: 1rem; color: #333; }
+
+  .wf-segmented { display: inline-flex; border: 2px solid #aaa; border-radius: 6px; overflow: hidden; margin-bottom: 1rem; background: #f0f0f0; }
+  .wf-segmented div { padding: 0.45rem 1rem; font-size: 0.85rem; color: #666; border-right: 2px solid #aaa; }
+  .wf-segmented div:last-child { border-right: 0; }
+  .wf-segmented .active { background: #ccc; color: #222; font-weight: 600; }
+
+  .wf-row { display: flex; gap: 1.25rem; align-items: flex-start; }
+  .wf-col { flex: 1; min-width: 0; }
+
+  .wf-card { background: #fafafa; border: 2px solid #ccc; border-radius: 6px; padding: 1rem; margin-bottom: 1rem; }
+  .wf-card h2 { font-size: 1.1rem; color: #444; margin-bottom: 0.85rem; }
+
+  .wf-tabs { display: flex; border-bottom: 2px solid #ccc; margin-bottom: 1rem; }
+  .wf-tab { padding: 0.5rem 0.85rem; font-size: 0.85rem; color: #777; border-bottom: 3px solid transparent; margin-bottom: -2px; }
+  .wf-tab.active { color: #222; border-bottom-color: #555; font-weight: 600; }
+
+  .wf-section { margin-bottom: 1rem; }
+  .wf-section-title { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; color: #777; margin-bottom: 0.4rem; font-weight: 600; }
+  .wf-help { font-size: 0.78rem; color: #999; margin-top: 0.3rem; }
+
+  .wf-label { display: block; font-size: 0.82rem; color: #555; margin-bottom: 0.25rem; font-weight: 500; }
+  .wf-input { width: 100%; padding: 0.45rem 0.55rem; border: 2px solid #bbb; border-radius: 4px; background: #fff; font-size: 0.85rem; color: #555; }
+  .wf-input.short { width: 6rem; }
+  .wf-readonly { background: #f3f3f3; }
+  .wf-textarea { width: 100%; padding: 0.55rem; border: 2px solid #bbb; border-radius: 4px; background: #f3f3f3; font-size: 0.82rem; color: #555; min-height: 7rem; resize: vertical; }
+  .wf-select { display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.45rem 0.6rem; border: 2px solid #bbb; border-radius: 4px; background: #fff; font-size: 0.85rem; color: #555; min-width: 12rem; justify-content: space-between; }
+  .wf-select::after { content: "▾"; color: #888; }
+  .wf-select.full { width: 100%; }
+
+  .wf-button { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.55rem 0.95rem; background: #ddd; border: 2px solid #aaa; border-radius: 4px; color: #444; font-size: 0.88rem; }
+  .wf-button.primary { background: #c4c4c4; border-color: #777; color: #222; font-weight: 600; }
+
+  .wf-row-of-fields { display: flex; gap: 0.5rem; align-items: flex-end; margin-bottom: 0.4rem; }
+  .wf-row-of-fields .wf-col { flex: 1; }
+  .wf-row-of-fields .wf-col.narrow { flex: 0 0 8rem; }
+  .wf-row-of-fields .wf-col.label { flex: 0 0 7rem; }
+
+  .wf-switch { display: inline-flex; align-items: center; gap: 0.45rem; }
+  .wf-switch .knob { width: 2.2rem; height: 1.1rem; background: #888; border-radius: 999px; position: relative; }
+  .wf-switch .knob::after { content: ""; width: 0.85rem; height: 0.85rem; background: #fff; border-radius: 50%; position: absolute; top: 0.12rem; left: 1.2rem; }
+
+  .wf-summary { background: #f3f3f3; border: 1px solid #ccc; border-radius: 4px; padding: 0.65rem 0.8rem; font-size: 0.82rem; color: #555; }
+  .wf-summary dl { display: grid; grid-template-columns: max-content 1fr; gap: 0.3rem 0.85rem; }
+  .wf-summary dt { color: #888; font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.03em; }
+  .wf-summary dd { color: #444; }
+  .wf-tag { display: inline-block; padding: 0.1rem 0.4rem; background: #e0e0e0; border: 1px solid #bbb; border-radius: 3px; font-size: 0.72rem; color: #555; margin-right: 0.3rem; }
+
+  .wf-sql-preview { position: relative; }
+  .wf-copy-btn { position: absolute; top: 0.4rem; right: 0.4rem; width: 1.7rem; height: 1.7rem; border: 1px solid #bbb; border-radius: 3px; background: #fff; color: #888; display: inline-flex; align-items: center; justify-content: center; font-size: 0.75rem; }
+
+  .wf-actions { display: flex; gap: 0.6rem; margin-top: 0.5rem; }
+  .wf-actions .wf-button { flex: 1; justify-content: center; }
+
+  .wf-empty-results { background: #f5f5f5; border: 2px dashed #ccc; border-radius: 6px; padding: 2rem; color: #999; font-size: 0.85rem; text-align: center; }
+  .wf-annotation { font-size: 0.78rem; color: #999; font-style: italic; margin: 0.4rem 0 0.4rem 0; }
+</style>
+</head>
+<body>
+<div class="wf-container">
+  <header class="wf-header">
+    <div class="wf-logo">Pathling Admin</div>
+    <nav class="wf-nav">
+      <a href="#">Dashboard</a>
+      <a href="#">Resources</a>
+      <a href="#">Import</a>
+      <a href="#">Export</a>
+      <a href="#">Bulk submit</a>
+      <a href="#" class="active">SQL on FHIR</a>
+    </nav>
+  </header>
+
+  <main class="wf-main">
+    <h1 class="wf-page-title">SQL on FHIR</h1>
+
+    <div class="wf-segmented">
+      <div>View definition</div>
+      <div class="active">SQL query</div>
+    </div>
+
+    <div class="wf-row">
+      <div class="wf-col">
+        <div class="wf-card">
+          <h2>SQL query</h2>
+
+          <div class="wf-tabs">
+            <div class="wf-tab active">Select Library</div>
+            <div class="wf-tab">Provide Library</div>
+          </div>
+
+          <!-- Library picker -->
+          <div class="wf-section">
+            <label class="wf-label">SQLQuery Library</label>
+            <div class="wf-select full">patients-with-conditions <span style="color:#999">(Library/lib-42)</span></div>
+            <div class="wf-help">Lists Library resources whose type.coding.code = sql-query.</div>
+          </div>
+
+          <!-- Read-only SQL preview -->
+          <div class="wf-section">
+            <label class="wf-label">SQL</label>
+            <div class="wf-sql-preview">
+              <button class="wf-copy-btn" aria-label="Copy SQL">⧉</button>
+              <textarea class="wf-textarea mono" readonly rows="8">SELECT p.given_name, p.family_name, c.condition_name, c.onset_date
+FROM patients p
+JOIN conditions c
+  ON concat('Patient/', p.patient_id) = c.patient_ref
+WHERE p.patient_id = :patient_id
+ORDER BY c.onset_date</textarea>
+            </div>
+            <div class="wf-help">Decoded from Library.content[0].data (Base64). Read-only in the stored tab.</div>
+          </div>
+
+          <!-- Summary of related artefacts and declared parameters -->
+          <div class="wf-section">
+            <div class="wf-section-title">Tables</div>
+            <div class="wf-summary">
+              <dl>
+                <dt>patients</dt>
+                <dd class="mono">→ ViewDefinition/patients <span class="wf-tag">Patient</span></dd>
+                <dt>conditions</dt>
+                <dd class="mono">→ ViewDefinition/conditions <span class="wf-tag">Condition</span></dd>
+              </dl>
+            </div>
+          </div>
+
+          <div class="wf-section">
+            <div class="wf-section-title">Declared parameters</div>
+            <div class="wf-summary">
+              <dl>
+                <dt>patient_id</dt>
+                <dd><span class="wf-tag">string</span> (no default)</dd>
+              </dl>
+            </div>
+          </div>
+
+          <!-- Runtime values -->
+          <div class="wf-section">
+            <div class="wf-section-title">Runtime parameter values</div>
+            <div class="wf-row-of-fields">
+              <div class="wf-col label">
+                <label class="wf-label mono">patient_id</label>
+              </div>
+              <div class="wf-col">
+                <input class="wf-input" value="Patient/pat-1">
+              </div>
+            </div>
+          </div>
+
+          <!-- Output / limit / header -->
+          <div class="wf-section">
+            <div class="wf-row-of-fields">
+              <div class="wf-col">
+                <label class="wf-label">Output format</label>
+                <div class="wf-select">csv</div>
+              </div>
+              <div class="wf-col narrow">
+                <label class="wf-label">Limit</label>
+                <input class="wf-input short" value="100">
+              </div>
+              <div class="wf-col">
+                <label class="wf-label">Header row</label>
+                <div class="wf-switch"><span class="knob"></span><span style="font-size:0.82rem;color:#555">on</span></div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Actions -->
+          <div class="wf-actions">
+            <button class="wf-button primary">▶ Execute</button>
+          </div>
+          <p class="wf-annotation">"Save to server" is hidden in the Select Library tab - the Library already exists.</p>
+        </div>
+      </div>
+
+      <div class="wf-col">
+        <div class="wf-empty-results">
+          Execute a query to see results here.
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+</body>
+</html>

--- a/openspec/changes/add-sqlquery-run-ui/wireframes/sql-query-stored.html
+++ b/openspec/changes/add-sqlquery-run-ui/wireframes/sql-query-stored.html
@@ -107,8 +107,8 @@
 
           <!-- Library picker -->
           <div class="wf-section">
-            <label class="wf-label">SQLQuery Library</label>
-            <div class="wf-select full">patients-with-conditions <span style="color:#999">(Library/lib-42)</span></div>
+            <label class="wf-label">SQL Query</label>
+            <div class="wf-select full"><span>Library/lib-42 <span style="color:#999">(patients-with-conditions)</span></span></div>
             <div class="wf-help">Lists Library resources whose type.coding.code = sql-query.</div>
           </div>
 
@@ -129,7 +129,7 @@ ORDER BY c.onset_date</textarea>
 
           <!-- Summary of related artefacts and declared parameters -->
           <div class="wf-section">
-            <div class="wf-section-title">Tables</div>
+            <div class="wf-section-title">Dependencies</div>
             <div class="wf-summary">
               <dl>
                 <dt>patients</dt>

--- a/server/src/main/java/au/csiro/pathling/FhirServer.java
+++ b/server/src/main/java/au/csiro/pathling/FhirServer.java
@@ -174,6 +174,14 @@ public class FhirServer extends RestfulServer {
 
   @Nonnull private final transient ViewDefinitionExportProvider viewDefinitionExportProvider;
 
+  @Nonnull
+  private final transient au.csiro.pathling.operations.sqlquery.SqlQueryRunProvider
+      sqlQueryRunProvider;
+
+  @Nonnull
+  private final transient au.csiro.pathling.operations.sqlquery.SqlQueryInstanceRunProvider
+      sqlQueryInstanceRunProvider;
+
   /**
    * Constructs a new FhirServer.
    *
@@ -203,7 +211,10 @@ public class FhirServer extends RestfulServer {
    * @param viewDefinitionRunProvider the view definition run provider
    * @param viewDefinitionInstanceRunProvider the view definition instance run provider
    * @param viewDefinitionExportProvider the view definition export provider
+   * @param sqlQueryRunProvider the SQL query run provider
+   * @param sqlQueryInstanceRunProvider the SQL query instance run provider
    */
+  @SuppressWarnings("java:S107")
   public FhirServer(
       @Nonnull final FhirContext fhirContext,
       @Nonnull final ServerConfiguration configuration,
@@ -230,7 +241,11 @@ public class FhirServer extends RestfulServer {
       @Nonnull final BatchProvider batchProvider,
       @Nonnull final ViewDefinitionRunProvider viewDefinitionRunProvider,
       @Nonnull final ViewDefinitionInstanceRunProvider viewDefinitionInstanceRunProvider,
-      @Nonnull final ViewDefinitionExportProvider viewDefinitionExportProvider) {
+      @Nonnull final ViewDefinitionExportProvider viewDefinitionExportProvider,
+      @Nonnull final au.csiro.pathling.operations.sqlquery.SqlQueryRunProvider sqlQueryRunProvider,
+      @Nonnull
+          final au.csiro.pathling.operations.sqlquery.SqlQueryInstanceRunProvider
+              sqlQueryInstanceRunProvider) {
     // Pass the FhirContext to the RestfulServer superclass to ensure custom types like
     // ViewDefinitionResource are recognized when parsing request bodies.
     super(fhirContext);
@@ -259,6 +274,8 @@ public class FhirServer extends RestfulServer {
     this.viewDefinitionRunProvider = viewDefinitionRunProvider;
     this.viewDefinitionInstanceRunProvider = viewDefinitionInstanceRunProvider;
     this.viewDefinitionExportProvider = viewDefinitionExportProvider;
+    this.sqlQueryRunProvider = sqlQueryRunProvider;
+    this.sqlQueryInstanceRunProvider = sqlQueryInstanceRunProvider;
   }
 
   @Override
@@ -375,6 +392,12 @@ public class FhirServer extends RestfulServer {
       // Register view definition export provider.
       if (ops.isViewDefinitionExportEnabled()) {
         registerProvider(viewDefinitionExportProvider);
+      }
+
+      // Register SQL query run providers.
+      if (ops.isSqlQueryRunEnabled()) {
+        registerProvider(sqlQueryRunProvider);
+        registerProvider(sqlQueryInstanceRunProvider);
       }
 
       // CORS configuration.

--- a/server/src/main/java/au/csiro/pathling/config/OperationConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/OperationConfiguration.java
@@ -70,6 +70,9 @@ public class OperationConfiguration {
   /** Enables $viewdefinition-export operation. */
   private boolean viewDefinitionExportEnabled = true;
 
+  /** Enables $sqlquery-run operation. */
+  private boolean sqlQueryRunEnabled = true;
+
   /** Enables $bulk-submit operation. */
   private boolean bulkSubmitEnabled = true;
 

--- a/server/src/main/java/au/csiro/pathling/config/ServerConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/ServerConfiguration.java
@@ -111,6 +111,9 @@ public class ServerConfiguration {
   /** Configuration for enabling/disabling individual server operations. */
   @Valid @NotNull private OperationConfiguration operations = new OperationConfiguration();
 
+  /** Configuration for resource limits applied to the $sqlquery-run operation. */
+  @Valid @NotNull private SqlQueryConfiguration sqlQuery = new SqlQueryConfiguration();
+
   /** Configuration for the admin UI. */
   @Valid @NotNull private AdminUiConfiguration adminUi = new AdminUiConfiguration();
 

--- a/server/src/main/java/au/csiro/pathling/config/SqlQueryConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/SqlQueryConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.config;
+
+import jakarta.validation.constraints.Min;
+import lombok.Data;
+import lombok.ToString;
+
+/**
+ * Configuration for the {@code $sqlquery-run} operation. Controls the resource limits applied to
+ * each query in order to prevent a single request from consuming an unbounded share of server
+ * resources.
+ *
+ * @author John Grimes
+ */
+@Data
+@ToString(doNotUseGetters = true)
+public class SqlQueryConfiguration {
+
+  /**
+   * The maximum number of rows that a single {@code $sqlquery-run} response may stream. Always
+   * applied; clamps the caller-supplied {@code _limit} when that value is larger. Modelled as a
+   * {@code long} so that operators can express "effectively disabled" with a value above {@link
+   * Integer#MAX_VALUE}; the executor clamps to {@code Integer.MAX_VALUE} on the way into Spark's
+   * {@code limit(int)} API.
+   */
+  @Min(1)
+  private long maxRows = 1_000_000L;
+
+  /**
+   * The maximum wall-clock time in seconds that a single {@code $sqlquery-run} query may run before
+   * its Spark job group is cancelled. Set to cover the synchronous use case; long-running queries
+   * should use the asynchronous path.
+   */
+  @Min(1)
+  private long timeoutSeconds = 60L;
+}

--- a/server/src/main/java/au/csiro/pathling/fhir/ConformanceProvider.java
+++ b/server/src/main/java/au/csiro/pathling/fhir/ConformanceProvider.java
@@ -504,6 +504,9 @@ public class ConformanceProvider
     addOperationIfEnabled(operations, "viewdefinition-run", ops.isViewDefinitionRunEnabled());
     addOperationIfEnabled(operations, "viewdefinition-export", ops.isViewDefinitionExportEnabled());
 
+    // Add SQL query run operation.
+    addOperationIfEnabled(operations, "sqlquery-run", ops.isSqlQueryRunEnabled());
+
     // Add bulk submit operations if configured and enabled.
     if (configuration.getBulkSubmit() != null && ops.isBulkSubmitEnabled()) {
       addOperationIfEnabled(operations, "bulk-submit", true);

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/LibraryReferenceResolver.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/LibraryReferenceResolver.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.errors.ResourceNotFoundError;
+import au.csiro.pathling.io.source.DataSource;
+import au.csiro.pathling.read.ReadExecutor;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
+import org.apache.spark.sql.functions;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Reference;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves a {@link Reference} pointing at a stored {@code Library} resource. Supports both forms
+ * defined by FHIR References:
+ *
+ * <ul>
+ *   <li>Relative literal references such as {@code Library/abc} (or a bare id).
+ *   <li>Canonical references such as {@code https://example.org/Library/foo} or {@code
+ *       https://example.org/Library/foo|1.2}, matched against {@code Library.url}.
+ * </ul>
+ */
+@Component
+public class LibraryReferenceResolver {
+
+  private static final String LIBRARY = "Library";
+
+  @Nonnull private final ReadExecutor readExecutor;
+
+  @Nonnull private final DataSource dataSource;
+
+  @Nonnull private final FhirEncoders fhirEncoders;
+
+  /**
+   * Constructs a new LibraryReferenceResolver.
+   *
+   * @param readExecutor used for relative-reference reads
+   * @param dataSource the data source used for canonical-reference search
+   * @param fhirEncoders FHIR encoders used to decode the search result rows
+   */
+  @Autowired
+  public LibraryReferenceResolver(
+      @Nonnull final ReadExecutor readExecutor,
+      @Nonnull final DataSource dataSource,
+      @Nonnull final FhirEncoders fhirEncoders) {
+    this.readExecutor = readExecutor;
+    this.dataSource = dataSource;
+    this.fhirEncoders = fhirEncoders;
+  }
+
+  /**
+   * Resolves the reference to a stored Library resource.
+   *
+   * @param reference the reference to resolve; must carry a non-blank {@code reference} value
+   * @return the resolved Library resource
+   * @throws InvalidRequestException if the reference is malformed
+   * @throws ResourceNotFoundException if no Library matches the reference
+   */
+  @Nonnull
+  public IBaseResource resolve(@Nonnull final Reference reference) {
+    final String ref = reference.getReference();
+    if (ref == null || ref.isBlank()) {
+      throw new InvalidRequestException(
+          "queryReference must carry a non-blank Reference.reference value");
+    }
+
+    if (isCanonical(ref)) {
+      return resolveCanonical(ref);
+    }
+    return resolveRelative(ref);
+  }
+
+  private boolean isCanonical(@Nonnull final String ref) {
+    return ref.startsWith("http://")
+        || ref.startsWith("https://")
+        || ref.startsWith("urn:")
+        || ref.contains("|");
+  }
+
+  /**
+   * Resolves a relative literal reference. Accepts {@code Library/abc} or a bare id; anything that
+   * names a different resource type is rejected.
+   */
+  @Nonnull
+  private IBaseResource resolveRelative(@Nonnull final String ref) {
+    final String id;
+    if (ref.contains("/")) {
+      final int slash = ref.indexOf('/');
+      final String type = ref.substring(0, slash);
+      if (!LIBRARY.equals(type)) {
+        throw new InvalidRequestException(
+            "queryReference must point at a Library resource, but found '" + type + "'");
+      }
+      id = ref.substring(slash + 1);
+    } else {
+      id = ref;
+    }
+
+    if (id.isBlank()) {
+      throw new InvalidRequestException("queryReference is missing a Library id");
+    }
+
+    try {
+      return readExecutor.read(LIBRARY, id);
+    } catch (final ResourceNotFoundError e) {
+      throw new ResourceNotFoundException("Library with ID '" + id + "' not found");
+    } catch (final IllegalArgumentException e) {
+      if (e.getMessage() != null && e.getMessage().contains("No data found for resource type")) {
+        throw new ResourceNotFoundException("Library with ID '" + id + "' not found");
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Resolves a canonical reference of the form {@code [url]} or {@code [url]|[version]}. When
+   * multiple matches exist, prefers an exact {@code url|version} match, then the latest active
+   * version (by {@code Library.version} string ordering, since FHIR doesn't constrain its shape).
+   */
+  @Nonnull
+  private IBaseResource resolveCanonical(@Nonnull final String canonical) {
+    final int pipe = canonical.indexOf('|');
+    final String url = pipe >= 0 ? canonical.substring(0, pipe) : canonical;
+    final String version = pipe >= 0 ? canonical.substring(pipe + 1) : null;
+
+    if (url.isBlank()) {
+      throw new InvalidRequestException("queryReference canonical is missing the url segment");
+    }
+
+    final Dataset<Row> libraries = dataSource.read(LIBRARY);
+    Dataset<Row> filtered = libraries.filter(libraries.col("url").equalTo(url));
+    if (version != null && !version.isBlank()) {
+      filtered = filtered.filter(functions.col("version").equalTo(version));
+    }
+
+    final ExpressionEncoder<IBaseResource> encoder = fhirEncoders.of(LIBRARY);
+    final List<IBaseResource> candidates = filtered.as(encoder).collectAsList();
+    if (candidates.isEmpty()) {
+      throw new ResourceNotFoundException(
+          "Library with canonical reference '" + canonical + "' not found");
+    }
+    return pickBestCandidate(candidates, version);
+  }
+
+  /**
+   * Selects the most appropriate Library when multiple match the canonical url. With a version
+   * suffix all matches already share that version, so any candidate suffices. Without a version
+   * suffix, prefer active over draft/retired, then take the lexicographically greatest version
+   * string (a reasonable proxy for "latest" given FHIR's freeform versioning).
+   */
+  @Nonnull
+  private IBaseResource pickBestCandidate(
+      @Nonnull final List<IBaseResource> candidates, @Nullable final String version) {
+    if (candidates.size() == 1 || version != null) {
+      return candidates.get(0);
+    }
+    return candidates.stream()
+        .map(Library.class::cast)
+        .max(
+            Comparator.comparing((Library lib) -> lib.getStatus() == PublicationStatus.ACTIVE)
+                .thenComparing(lib -> Objects.toString(lib.getVersion(), "")))
+        .map(IBaseResource.class::cast)
+        .orElseThrow(
+            () ->
+                new ResourceNotFoundException(
+                    "Library with canonical reference could not be selected"));
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ParsedSqlQuery.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ParsedSqlQuery.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import jakarta.annotation.Nonnull;
+import java.util.List;
+import lombok.Value;
+
+/**
+ * Represents a parsed SQLQuery Library resource containing the SQL text, ViewDefinition
+ * dependencies, and declared parameters.
+ */
+@Value
+public class ParsedSqlQuery {
+
+  /** The decoded SQL query text. */
+  @Nonnull String sql;
+
+  /** The ViewDefinition dependencies referenced in the SQL query. */
+  @Nonnull List<ViewArtifactReference> viewReferences;
+
+  /** The declared parameters that can be bound at execution time. */
+  @Nonnull List<SqlParameterDeclaration> declaredParameters;
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlParameterDeclaration.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlParameterDeclaration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import jakarta.annotation.Nonnull;
+import lombok.Value;
+
+/**
+ * Represents a declared parameter within a SQLQuery Library resource. Each parameter has a name
+ * (used as a placeholder in the SQL via colon-prefix notation) and a FHIR type.
+ */
+@Value
+public class SqlParameterDeclaration {
+
+  /** The name of the parameter, referenced in SQL as {@code :name}. */
+  @Nonnull String name;
+
+  /** The FHIR type code of the parameter (e.g., "string", "integer", "date"). */
+  @Nonnull String type;
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
@@ -23,12 +23,12 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.List;
 import java.util.Map;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.IntegerType;
-import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Reference;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -49,6 +49,8 @@ public class SqlQueryExecutionHelper {
 
   @Nonnull private final QueryableDataSource deltaLake;
 
+  @Nonnull private final LibraryReferenceResolver libraryReferenceResolver;
+
   /**
    * Constructs a new SqlQueryExecutionHelper.
    *
@@ -57,41 +59,48 @@ public class SqlQueryExecutionHelper {
    * @param executor validates and runs the SQL against Spark
    * @param streamer streams the result dataset in the requested format
    * @param deltaLake the queryable data source backing FhirView execution
+   * @param libraryReferenceResolver resolves a queryReference to a stored Library
    */
+  @SuppressWarnings("java:S107")
   @Autowired
   public SqlQueryExecutionHelper(
       @Nonnull final SqlQueryRequestParser requestParser,
       @Nonnull final ViewResolver viewResolver,
       @Nonnull final SqlQueryExecutor executor,
       @Nonnull final SqlQueryResultStreamer streamer,
-      @Nonnull final QueryableDataSource deltaLake) {
+      @Nonnull final QueryableDataSource deltaLake,
+      @Nonnull final LibraryReferenceResolver libraryReferenceResolver) {
     this.requestParser = requestParser;
     this.viewResolver = viewResolver;
     this.executor = executor;
     this.streamer = streamer;
     this.deltaLake = deltaLake;
+    this.libraryReferenceResolver = libraryReferenceResolver;
   }
 
   /**
-   * Executes a SQL query from a Library resource and streams results to the HTTP response.
+   * Executes a {@code $sqlquery-run} request and streams results to the HTTP response. Exactly one
+   * of {@code queryResource} and {@code queryReference} must be provided.
    *
-   * @param libraryResource the Library resource containing the SQLQuery
+   * @param queryResource the inline SQLQuery Library resource, if supplied
+   * @param queryReference reference to a stored SQLQuery Library, if supplied
    * @param format the output format, overrides Accept header if provided
    * @param acceptHeader the HTTP Accept header value, used as fallback if format is not provided
    * @param includeHeader whether to include a header row in CSV output
    * @param limit the maximum number of rows to return
-   * @param parameterValues runtime parameter values to bind to the SQL query
+   * @param parameters runtime parameter bindings as a Parameters resource
    * @param requestId the HAPI per-request id used to namespace registered temp views
    * @param response the HTTP response for streaming output
    */
   @SuppressWarnings("java:S107")
   public void executeSqlQuery(
-      @Nonnull final IBaseResource libraryResource,
+      @Nullable final IBaseResource queryResource,
+      @Nullable final Reference queryReference,
       @Nullable final String format,
       @Nullable final String acceptHeader,
       @Nullable final BooleanType includeHeader,
       @Nullable final IntegerType limit,
-      @Nullable final List<ParametersParameterComponent> parameterValues,
+      @Nullable final Parameters parameters,
       @Nonnull final String requestId,
       @Nullable final HttpServletResponse response) {
 
@@ -99,9 +108,10 @@ public class SqlQueryExecutionHelper {
       throw new InvalidRequestException("HTTP response is required for this operation");
     }
 
+    final IBaseResource library = selectLibrary(queryResource, queryReference);
+
     final SqlQueryRequest request =
-        requestParser.parse(
-            libraryResource, format, acceptHeader, includeHeader, limit, parameterValues);
+        requestParser.parse(library, format, acceptHeader, includeHeader, limit, parameters);
 
     final Map<String, FhirView> resolvedViews =
         viewResolver.resolve(request.getParsedQuery().getViewReferences());
@@ -114,5 +124,30 @@ public class SqlQueryExecutionHelper {
         result ->
             streamer.stream(
                 result, request.getOutputFormat(), request.isIncludeHeader(), response));
+  }
+
+  /**
+   * Enforces the OperationDefinition's "exactly one of queryResource / queryReference" contract and
+   * returns the resolved Library resource. Returns 400 if neither or both are provided; bubbles up
+   * the resolver's 404 if a queryReference doesn't match a stored Library.
+   */
+  @Nonnull
+  private IBaseResource selectLibrary(
+      @Nullable final IBaseResource queryResource, @Nullable final Reference queryReference) {
+    final boolean hasResource = queryResource != null;
+    final boolean hasReference = queryReference != null && !queryReference.isEmpty();
+
+    if (hasResource && hasReference) {
+      throw new InvalidRequestException(
+          "Exactly one of 'queryResource' and 'queryReference' must be provided, not both");
+    }
+    if (!hasResource && !hasReference) {
+      throw new InvalidRequestException(
+          "One of 'queryResource' or 'queryReference' must be provided");
+    }
+    if (hasResource) {
+      return queryResource;
+    }
+    return libraryReferenceResolver.resolve(queryReference);
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
+import au.csiro.pathling.operations.view.ResultStreamingHelper;
+import au.csiro.pathling.read.ReadExecutor;
+import au.csiro.pathling.security.PathlingAuthority;
+import au.csiro.pathling.security.ResourceAccess.AccessType;
+import au.csiro.pathling.security.SecurityAspect;
+import au.csiro.pathling.views.FhirView;
+import au.csiro.pathling.views.ViewDefinitionGson;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r4.model.Type;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Orchestrates the execution of the {@code $sqlquery-run} operation. Parses the SQLQuery Library
+ * resource, resolves ViewDefinition dependencies, validates and executes the SQL query, and streams
+ * results in the requested format.
+ */
+@Slf4j
+@Component
+public class SqlQueryExecutionHelper {
+
+  @Nonnull private final SparkSession sparkSession;
+
+  @Nonnull private final QueryableDataSource deltaLake;
+
+  @Nonnull private final FhirContext fhirContext;
+
+  @Nonnull private final ServerConfiguration serverConfiguration;
+
+  @Nonnull private final SqlQueryLibraryParser libraryParser;
+
+  @Nonnull private final SqlValidator sqlValidator;
+
+  @Nonnull private final ViewRegistrationService viewRegistrationService;
+
+  @Nonnull private final ReadExecutor readExecutor;
+
+  @Nonnull private final Gson gson;
+
+  @Nonnull private final ResultStreamingHelper streamingHelper;
+
+  /**
+   * Constructs a new SqlQueryExecutionHelper.
+   *
+   * @param sparkSession the Spark session
+   * @param deltaLake the queryable data source
+   * @param fhirContext the FHIR context
+   * @param serverConfiguration the server configuration
+   * @param libraryParser the SQLQuery Library parser
+   * @param sqlValidator the SQL validator
+   * @param viewRegistrationService the view registration service
+   * @param readExecutor the read executor for reading stored resources
+   */
+  @SuppressWarnings("java:S107")
+  @Autowired
+  public SqlQueryExecutionHelper(
+      @Nonnull final SparkSession sparkSession,
+      @Nonnull final QueryableDataSource deltaLake,
+      @Nonnull final FhirContext fhirContext,
+      @Nonnull final ServerConfiguration serverConfiguration,
+      @Nonnull final SqlQueryLibraryParser libraryParser,
+      @Nonnull final SqlValidator sqlValidator,
+      @Nonnull final ViewRegistrationService viewRegistrationService,
+      @Nonnull final ReadExecutor readExecutor) {
+    this.sparkSession = sparkSession;
+    this.deltaLake = deltaLake;
+    this.fhirContext = fhirContext;
+    this.serverConfiguration = serverConfiguration;
+    this.libraryParser = libraryParser;
+    this.sqlValidator = sqlValidator;
+    this.viewRegistrationService = viewRegistrationService;
+    this.readExecutor = readExecutor;
+    this.gson = ViewDefinitionGson.create();
+    this.streamingHelper = new ResultStreamingHelper(gson);
+  }
+
+  /**
+   * Executes a SQL query from a Library resource and streams results to the HTTP response.
+   *
+   * @param libraryResource the Library resource containing the SQLQuery
+   * @param format the output format, overrides Accept header if provided
+   * @param acceptHeader the HTTP Accept header value, used as fallback if format is not provided
+   * @param includeHeader whether to include a header row in CSV output
+   * @param limit the maximum number of rows to return
+   * @param parameterValues runtime parameter values to bind to the SQL query
+   * @param response the HTTP response for streaming output
+   */
+  @SuppressWarnings("java:S107")
+  public void executeSqlQuery(
+      @Nonnull final IBaseResource libraryResource,
+      @Nullable final String format,
+      @Nullable final String acceptHeader,
+      @Nullable final BooleanType includeHeader,
+      @Nullable final IntegerType limit,
+      @Nullable final List<ParametersParameterComponent> parameterValues,
+      @Nullable final HttpServletResponse response) {
+
+    if (response == null) {
+      throw new InvalidRequestException("HTTP response is required for this operation");
+    }
+
+    // Parse the Library resource as a SQLQuery.
+    final Library library = castToLibrary(libraryResource);
+    final ParsedSqlQuery parsedQuery = libraryParser.parse(library);
+
+    // Resolve ViewDefinitions and check authorization.
+    final Map<String, FhirView> resolvedViews = resolveViewDefinitions(parsedQuery);
+
+    // Validate the SQL structure before execution.
+    sqlValidator.validate(parsedQuery.getSql());
+
+    // Determine output format.
+    final SqlQueryOutputFormat outputFormat =
+        (format != null && !format.isBlank())
+            ? SqlQueryOutputFormat.fromString(format)
+            : SqlQueryOutputFormat.fromAcceptHeader(acceptHeader);
+    final boolean shouldIncludeHeader = includeHeader == null || includeHeader.booleanValue();
+
+    // Register views and execute the query.
+    Map<String, String> registeredViews = Map.of();
+    try {
+      registeredViews = viewRegistrationService.registerViews(resolvedViews, deltaLake);
+
+      // Rewrite SQL to use prefixed temp view names.
+      final String rewrittenSql =
+          viewRegistrationService.rewriteSql(parsedQuery.getSql(), registeredViews);
+
+      // Build parameter map for Spark parameterized queries.
+      final Map<String, String> parameterMap = buildParameterMap(parameterValues);
+
+      // Execute the SQL query. Use parameterized queries only when parameters are provided.
+      Dataset<Row> result;
+      if (parameterMap.isEmpty()) {
+        result = sparkSession.sql(rewrittenSql);
+      } else {
+        @SuppressWarnings("unchecked")
+        final java.util.Map<String, Object> objectMap =
+            (java.util.Map<String, Object>) (java.util.Map<String, ?>) parameterMap;
+        result = sparkSession.sql(rewrittenSql, objectMap);
+      }
+
+      // Apply limit if specified.
+      if (limit != null && limit.getValue() != null) {
+        result = result.limit(limit.getValue());
+      }
+
+      // Stream results.
+      streamResults(result, outputFormat, shouldIncludeHeader, response);
+
+    } finally {
+      viewRegistrationService.dropViews(registeredViews.values());
+    }
+  }
+
+  /** Casts a FHIR resource to a Library, throwing if it is not a Library. */
+  @Nonnull
+  private Library castToLibrary(@Nonnull final IBaseResource resource) {
+    if (resource instanceof final Library library) {
+      return library;
+    }
+    throw new InvalidRequestException(
+        "Expected a Library resource but received: " + resource.fhirType());
+  }
+
+  /**
+   * Resolves ViewDefinition references from the parsed SQL query. Each relatedArtifact reference is
+   * resolved to a FhirView. Authorization is checked for each referenced resource type.
+   */
+  @Nonnull
+  private Map<String, FhirView> resolveViewDefinitions(@Nonnull final ParsedSqlQuery parsedQuery) {
+    final Map<String, FhirView> resolvedViews = new LinkedHashMap<>();
+
+    for (final ViewArtifactReference ref : parsedQuery.getViewReferences()) {
+      final String viewDefinitionId = extractViewDefinitionId(ref.getCanonicalUrl());
+      final IBaseResource viewResource;
+      try {
+        viewResource = readExecutor.read("ViewDefinition", viewDefinitionId);
+      } catch (final Exception e) {
+        throw new InvalidRequestException(
+            "Failed to resolve ViewDefinition for label '"
+                + ref.getLabel()
+                + "' with reference '"
+                + ref.getCanonicalUrl()
+                + "': "
+                + e.getMessage());
+      }
+
+      // Parse the ViewDefinition into a FhirView.
+      final FhirView view = parseViewDefinition(viewResource);
+
+      // Check resource-level authorization for the ViewDefinition's target resource type.
+      if (serverConfiguration.getAuth().isEnabled()) {
+        SecurityAspect.checkHasAuthority(
+            PathlingAuthority.resourceAccess(AccessType.READ, view.getResource()));
+      }
+
+      resolvedViews.put(ref.getLabel(), view);
+    }
+
+    return resolvedViews;
+  }
+
+  /**
+   * Extracts a ViewDefinition ID from a canonical URL or relative reference. Supports relative
+   * references like "ViewDefinition/my-id" and plain IDs.
+   */
+  @Nonnull
+  private String extractViewDefinitionId(@Nonnull final String canonicalUrl) {
+    // Handle relative references like "ViewDefinition/my-id".
+    if (canonicalUrl.contains("/")) {
+      final String[] parts = canonicalUrl.split("/");
+      return parts[parts.length - 1];
+    }
+    // Plain ID.
+    return canonicalUrl;
+  }
+
+  /** Parses a ViewDefinition resource into a FhirView using JSON round-tripping. */
+  @Nonnull
+  private FhirView parseViewDefinition(@Nonnull final IBaseResource viewResource) {
+    try {
+      final String viewJson = fhirContext.newJsonParser().encodeResourceToString(viewResource);
+      return gson.fromJson(viewJson, FhirView.class);
+    } catch (final JsonSyntaxException e) {
+      throw new InvalidRequestException("Invalid ViewDefinition: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Builds a parameter map from FHIR Parameters components. Parameter values are converted to
+   * string representations for Spark's parameterized query API.
+   */
+  @Nonnull
+  private Map<String, String> buildParameterMap(
+      @Nullable final List<ParametersParameterComponent> parameterValues) {
+    final Map<String, String> params = new HashMap<>();
+    if (parameterValues == null) {
+      return params;
+    }
+
+    for (final ParametersParameterComponent param : parameterValues) {
+      // Each parameter component has 'name' and 'value' parts.
+      String name = null;
+      String value = null;
+
+      for (final ParametersParameterComponent part : param.getPart()) {
+        if ("name".equals(part.getName()) && part.getValue() != null) {
+          name = part.getValue().primitiveValue();
+        } else if ("value".equals(part.getName()) && part.getValue() != null) {
+          final Type valueType = part.getValue();
+          value = valueType.primitiveValue();
+        }
+      }
+
+      if (name != null && value != null) {
+        params.put(name, value);
+      }
+    }
+
+    return params;
+  }
+
+  /** Streams query results to the HTTP response in the specified format. */
+  private void streamResults(
+      @Nonnull final Dataset<Row> result,
+      @Nonnull final SqlQueryOutputFormat outputFormat,
+      final boolean shouldIncludeHeader,
+      @Nonnull final HttpServletResponse response) {
+
+    response.setContentType(outputFormat.getContentType());
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    response.setStatus(HttpServletResponse.SC_OK);
+
+    try {
+      if (outputFormat == SqlQueryOutputFormat.PARQUET) {
+        streamParquet(result, response);
+      } else {
+        streamTabular(result, outputFormat, shouldIncludeHeader, response);
+      }
+    } catch (final IOException e) {
+      log.error("Error streaming SQL query results", e);
+      throw new InvalidRequestException("Error streaming results: " + e.getMessage());
+    }
+  }
+
+  /** Streams results in a tabular format (NDJSON, CSV, or JSON). */
+  private void streamTabular(
+      @Nonnull final Dataset<Row> result,
+      @Nonnull final SqlQueryOutputFormat outputFormat,
+      final boolean shouldIncludeHeader,
+      @Nonnull final HttpServletResponse response)
+      throws IOException {
+
+    final OutputStream outputStream = response.getOutputStream();
+    final StructType schema = result.schema();
+
+    // For CSV with header, write header immediately to minimise TTFB.
+    if (outputFormat == SqlQueryOutputFormat.CSV && shouldIncludeHeader) {
+      final List<String> columnNames = java.util.Arrays.stream(schema.fieldNames()).toList();
+      streamingHelper.writeCsvHeader(outputStream, columnNames);
+      outputStream.flush();
+    }
+
+    final Iterator<Row> iterator = result.toLocalIterator();
+    switch (outputFormat) {
+      case NDJSON -> streamingHelper.streamNdjson(outputStream, iterator, schema);
+      case JSON -> streamingHelper.writeJson(outputStream, iterator, schema);
+      default -> streamingHelper.streamCsv(outputStream, iterator, schema);
+    }
+    outputStream.flush();
+  }
+
+  /** Writes results as Parquet to a temporary file and streams it to the HTTP response. */
+  private void streamParquet(
+      @Nonnull final Dataset<Row> result, @Nonnull final HttpServletResponse response)
+      throws IOException {
+
+    final Path tempDir = Files.createTempDirectory("sqlquery-parquet-");
+    final String outputPath = tempDir.resolve("result").toString();
+
+    try {
+      result.coalesce(1).write().mode(SaveMode.Overwrite).parquet(outputPath);
+
+      // Find the generated Parquet file.
+      final Path parquetFile = findParquetFile(Path.of(outputPath));
+      if (parquetFile == null) {
+        throw new InvalidRequestException("Failed to generate Parquet output");
+      }
+
+      // Stream the Parquet file to the response.
+      response.setContentType(SqlQueryOutputFormat.PARQUET.getContentType());
+      try (final var inputStream = Files.newInputStream(parquetFile);
+          final var outputStream = response.getOutputStream()) {
+        inputStream.transferTo(outputStream);
+        outputStream.flush();
+      }
+    } finally {
+      // Clean up temp directory.
+      deleteRecursively(tempDir);
+    }
+  }
+
+  /** Finds the first Parquet file in the given directory. */
+  @Nullable
+  private Path findParquetFile(@Nonnull final Path directory) throws IOException {
+    if (!Files.isDirectory(directory)) {
+      return null;
+    }
+    try (final var stream = Files.list(directory)) {
+      return stream.filter(p -> p.toString().endsWith(".parquet")).findFirst().orElse(null);
+    }
+  }
+
+  /** Recursively deletes a directory and its contents. */
+  private void deleteRecursively(@Nonnull final Path path) {
+    try {
+      if (Files.isDirectory(path)) {
+        try (final var stream = Files.list(path)) {
+          stream.forEach(this::deleteRecursively);
+        }
+      }
+      Files.deleteIfExists(path);
+    } catch (final IOException e) {
+      log.warn("Failed to clean up temporary file: {}", path, e);
+    }
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
@@ -17,109 +17,59 @@
 
 package au.csiro.pathling.operations.sqlquery;
 
-import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
-import au.csiro.pathling.operations.view.ResultStreamingHelper;
-import au.csiro.pathling.read.ReadExecutor;
-import au.csiro.pathling.security.PathlingAuthority;
-import au.csiro.pathling.security.ResourceAccess.AccessType;
-import au.csiro.pathling.security.SecurityAspect;
 import au.csiro.pathling.views.FhirView;
-import au.csiro.pathling.views.ViewDefinitionGson;
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
-import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SaveMode;
-import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.types.StructType;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.IntegerType;
-import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
-import org.hl7.fhir.r4.model.Type;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * Orchestrates the execution of the {@code $sqlquery-run} operation. Parses the SQLQuery Library
- * resource, resolves ViewDefinition dependencies, validates and executes the SQL query, and streams
- * results in the requested format.
+ * Orchestrates the {@code $sqlquery-run} operation by chaining the parser, view resolver, executor
+ * and result streamer.
  */
-@Slf4j
 @Component
 public class SqlQueryExecutionHelper {
 
-  @Nonnull private final SparkSession sparkSession;
+  @Nonnull private final SqlQueryRequestParser requestParser;
+
+  @Nonnull private final ViewResolver viewResolver;
+
+  @Nonnull private final SqlQueryExecutor executor;
+
+  @Nonnull private final SqlQueryResultStreamer streamer;
 
   @Nonnull private final QueryableDataSource deltaLake;
-
-  @Nonnull private final FhirContext fhirContext;
-
-  @Nonnull private final ServerConfiguration serverConfiguration;
-
-  @Nonnull private final SqlQueryLibraryParser libraryParser;
-
-  @Nonnull private final SqlValidator sqlValidator;
-
-  @Nonnull private final ViewRegistrationService viewRegistrationService;
-
-  @Nonnull private final ReadExecutor readExecutor;
-
-  @Nonnull private final Gson gson;
-
-  @Nonnull private final ResultStreamingHelper streamingHelper;
 
   /**
    * Constructs a new SqlQueryExecutionHelper.
    *
-   * @param sparkSession the Spark session
-   * @param deltaLake the queryable data source
-   * @param fhirContext the FHIR context
-   * @param serverConfiguration the server configuration
-   * @param libraryParser the SQLQuery Library parser
-   * @param sqlValidator the SQL validator
-   * @param viewRegistrationService the view registration service
-   * @param readExecutor the read executor for reading stored resources
+   * @param requestParser parses raw HTTP inputs into a validated request
+   * @param viewResolver resolves view references to parsed FhirViews with auth checks
+   * @param executor validates and runs the SQL against Spark
+   * @param streamer streams the result dataset in the requested format
+   * @param deltaLake the queryable data source backing FhirView execution
    */
-  @SuppressWarnings("java:S107")
   @Autowired
   public SqlQueryExecutionHelper(
-      @Nonnull final SparkSession sparkSession,
-      @Nonnull final QueryableDataSource deltaLake,
-      @Nonnull final FhirContext fhirContext,
-      @Nonnull final ServerConfiguration serverConfiguration,
-      @Nonnull final SqlQueryLibraryParser libraryParser,
-      @Nonnull final SqlValidator sqlValidator,
-      @Nonnull final ViewRegistrationService viewRegistrationService,
-      @Nonnull final ReadExecutor readExecutor) {
-    this.sparkSession = sparkSession;
+      @Nonnull final SqlQueryRequestParser requestParser,
+      @Nonnull final ViewResolver viewResolver,
+      @Nonnull final SqlQueryExecutor executor,
+      @Nonnull final SqlQueryResultStreamer streamer,
+      @Nonnull final QueryableDataSource deltaLake) {
+    this.requestParser = requestParser;
+    this.viewResolver = viewResolver;
+    this.executor = executor;
+    this.streamer = streamer;
     this.deltaLake = deltaLake;
-    this.fhirContext = fhirContext;
-    this.serverConfiguration = serverConfiguration;
-    this.libraryParser = libraryParser;
-    this.sqlValidator = sqlValidator;
-    this.viewRegistrationService = viewRegistrationService;
-    this.readExecutor = readExecutor;
-    this.gson = ViewDefinitionGson.create();
-    this.streamingHelper = new ResultStreamingHelper(gson);
   }
 
   /**
@@ -149,285 +99,20 @@ public class SqlQueryExecutionHelper {
       throw new InvalidRequestException("HTTP response is required for this operation");
     }
 
-    // Parse the Library resource as a SQLQuery.
-    final Library library = castToLibrary(libraryResource);
+    final SqlQueryRequest request =
+        requestParser.parse(
+            libraryResource, format, acceptHeader, includeHeader, limit, parameterValues);
 
-    // Log the raw Library contents for debugging.
-    log.info(
-        "SQLQuery Library has {} relatedArtifact entries", library.getRelatedArtifact().size());
-    for (final org.hl7.fhir.r4.model.RelatedArtifact ra : library.getRelatedArtifact()) {
-      log.info(
-          "  relatedArtifact: type={}, label={}, resource={}",
-          ra.getType(),
-          ra.getLabel(),
-          ra.getResource());
-    }
+    final Map<String, FhirView> resolvedViews =
+        viewResolver.resolve(request.getParsedQuery().getViewReferences());
 
-    final ParsedSqlQuery parsedQuery = libraryParser.parse(library);
-    log.info(
-        "Parsed SQL query: {} view references, {} parameters",
-        parsedQuery.getViewReferences().size(),
-        parsedQuery.getDeclaredParameters().size());
-
-    // Resolve ViewDefinitions and check authorization.
-    final Map<String, FhirView> resolvedViews = resolveViewDefinitions(parsedQuery);
-
-    // Validate the SQL structure before execution.
-    sqlValidator.validate(parsedQuery.getSql());
-
-    // Determine output format.
-    final SqlQueryOutputFormat outputFormat =
-        (format != null && !format.isBlank())
-            ? SqlQueryOutputFormat.fromString(format)
-            : SqlQueryOutputFormat.fromAcceptHeader(acceptHeader);
-    final boolean shouldIncludeHeader = includeHeader == null || includeHeader.booleanValue();
-
-    // Register views (request-scoped names) and execute the query.
-    Map<String, String> registeredViews = Map.of();
-    try {
-      registeredViews = viewRegistrationService.registerViews(resolvedViews, deltaLake, requestId);
-
-      // Rewrite SQL so the user-supplied labels resolve to the request-scoped temp views.
-      final String rewrittenSql =
-          viewRegistrationService.rewriteSql(parsedQuery.getSql(), registeredViews);
-
-      // Build parameter map for Spark parameterized queries.
-      final Map<String, String> parameterMap = buildParameterMap(parameterValues);
-
-      // Execute the SQL query. Use parameterized queries only when parameters are provided.
-      Dataset<Row> result;
-      if (parameterMap.isEmpty()) {
-        result = sparkSession.sql(rewrittenSql);
-      } else {
-        @SuppressWarnings("unchecked")
-        final java.util.Map<String, Object> objectMap =
-            (java.util.Map<String, Object>) (java.util.Map<String, ?>) parameterMap;
-        result = sparkSession.sql(rewrittenSql, objectMap);
-      }
-
-      // Apply limit if specified.
-      if (limit != null && limit.getValue() != null) {
-        result = result.limit(limit.getValue());
-      }
-
-      // Stream results.
-      streamResults(result, outputFormat, shouldIncludeHeader, response);
-
-    } finally {
-      viewRegistrationService.dropViews(registeredViews.values());
-    }
-  }
-
-  /** Casts a FHIR resource to a Library, throwing if it is not a Library. */
-  @Nonnull
-  private Library castToLibrary(@Nonnull final IBaseResource resource) {
-    if (resource instanceof final Library library) {
-      return library;
-    }
-    throw new InvalidRequestException(
-        "Expected a Library resource but received: " + resource.fhirType());
-  }
-
-  /**
-   * Resolves ViewDefinition references from the parsed SQL query. Each relatedArtifact reference is
-   * resolved to a FhirView. Authorization is checked for each referenced resource type.
-   */
-  @Nonnull
-  private Map<String, FhirView> resolveViewDefinitions(@Nonnull final ParsedSqlQuery parsedQuery) {
-    final Map<String, FhirView> resolvedViews = new LinkedHashMap<>();
-
-    for (final ViewArtifactReference ref : parsedQuery.getViewReferences()) {
-      final String viewDefinitionId = extractViewDefinitionId(ref.getCanonicalUrl());
-      final IBaseResource viewResource;
-      try {
-        viewResource = readExecutor.read("ViewDefinition", viewDefinitionId);
-      } catch (final Exception e) {
-        throw new InvalidRequestException(
-            "Failed to resolve ViewDefinition for label '"
-                + ref.getLabel()
-                + "' with reference '"
-                + ref.getCanonicalUrl()
-                + "': "
-                + e.getMessage());
-      }
-
-      // Parse the ViewDefinition into a FhirView.
-      final FhirView view = parseViewDefinition(viewResource);
-
-      // Check resource-level authorization for the ViewDefinition's target resource type.
-      if (serverConfiguration.getAuth().isEnabled()) {
-        SecurityAspect.checkHasAuthority(
-            PathlingAuthority.resourceAccess(AccessType.READ, view.getResource()));
-      }
-
-      resolvedViews.put(ref.getLabel(), view);
-    }
-
-    return resolvedViews;
-  }
-
-  /**
-   * Extracts a ViewDefinition ID from a canonical URL or relative reference. Supports relative
-   * references like "ViewDefinition/my-id" and plain IDs.
-   */
-  @Nonnull
-  private String extractViewDefinitionId(@Nonnull final String canonicalUrl) {
-    // Handle relative references like "ViewDefinition/my-id".
-    if (canonicalUrl.contains("/")) {
-      final String[] parts = canonicalUrl.split("/");
-      return parts[parts.length - 1];
-    }
-    // Plain ID.
-    return canonicalUrl;
-  }
-
-  /** Parses a ViewDefinition resource into a FhirView using JSON round-tripping. */
-  @Nonnull
-  private FhirView parseViewDefinition(@Nonnull final IBaseResource viewResource) {
-    try {
-      final String viewJson = fhirContext.newJsonParser().encodeResourceToString(viewResource);
-      return gson.fromJson(viewJson, FhirView.class);
-    } catch (final JsonSyntaxException e) {
-      throw new InvalidRequestException("Invalid ViewDefinition: " + e.getMessage());
-    }
-  }
-
-  /**
-   * Builds a parameter map from FHIR Parameters components. Parameter values are converted to
-   * string representations for Spark's parameterized query API.
-   */
-  @Nonnull
-  private Map<String, String> buildParameterMap(
-      @Nullable final List<ParametersParameterComponent> parameterValues) {
-    final Map<String, String> params = new HashMap<>();
-    if (parameterValues == null) {
-      return params;
-    }
-
-    for (final ParametersParameterComponent param : parameterValues) {
-      // Each parameter component has 'name' and 'value' parts.
-      String name = null;
-      String value = null;
-
-      for (final ParametersParameterComponent part : param.getPart()) {
-        if ("name".equals(part.getName()) && part.getValue() != null) {
-          name = part.getValue().primitiveValue();
-        } else if ("value".equals(part.getName()) && part.getValue() != null) {
-          final Type valueType = part.getValue();
-          value = valueType.primitiveValue();
-        }
-      }
-
-      if (name != null && value != null) {
-        params.put(name, value);
-      }
-    }
-
-    return params;
-  }
-
-  /** Streams query results to the HTTP response in the specified format. */
-  private void streamResults(
-      @Nonnull final Dataset<Row> result,
-      @Nonnull final SqlQueryOutputFormat outputFormat,
-      final boolean shouldIncludeHeader,
-      @Nonnull final HttpServletResponse response) {
-
-    response.setContentType(outputFormat.getContentType());
-    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-    response.setStatus(HttpServletResponse.SC_OK);
-
-    try {
-      if (outputFormat == SqlQueryOutputFormat.PARQUET) {
-        streamParquet(result, response);
-      } else {
-        streamTabular(result, outputFormat, shouldIncludeHeader, response);
-      }
-    } catch (final IOException e) {
-      log.error("Error streaming SQL query results", e);
-      throw new InvalidRequestException("Error streaming results: " + e.getMessage());
-    }
-  }
-
-  /** Streams results in a tabular format (NDJSON, CSV, or JSON). */
-  private void streamTabular(
-      @Nonnull final Dataset<Row> result,
-      @Nonnull final SqlQueryOutputFormat outputFormat,
-      final boolean shouldIncludeHeader,
-      @Nonnull final HttpServletResponse response)
-      throws IOException {
-
-    final OutputStream outputStream = response.getOutputStream();
-    final StructType schema = result.schema();
-
-    // For CSV with header, write header immediately to minimise TTFB.
-    if (outputFormat == SqlQueryOutputFormat.CSV && shouldIncludeHeader) {
-      final List<String> columnNames = java.util.Arrays.stream(schema.fieldNames()).toList();
-      streamingHelper.writeCsvHeader(outputStream, columnNames);
-      outputStream.flush();
-    }
-
-    final Iterator<Row> iterator = result.toLocalIterator();
-    switch (outputFormat) {
-      case NDJSON -> streamingHelper.streamNdjson(outputStream, iterator, schema);
-      case JSON -> streamingHelper.writeJson(outputStream, iterator, schema);
-      default -> streamingHelper.streamCsv(outputStream, iterator, schema);
-    }
-    outputStream.flush();
-  }
-
-  /** Writes results as Parquet to a temporary file and streams it to the HTTP response. */
-  private void streamParquet(
-      @Nonnull final Dataset<Row> result, @Nonnull final HttpServletResponse response)
-      throws IOException {
-
-    final Path tempDir = Files.createTempDirectory("sqlquery-parquet-");
-    final String outputPath = tempDir.resolve("result").toString();
-
-    try {
-      result.coalesce(1).write().mode(SaveMode.Overwrite).parquet(outputPath);
-
-      // Find the generated Parquet file.
-      final Path parquetFile = findParquetFile(Path.of(outputPath));
-      if (parquetFile == null) {
-        throw new InvalidRequestException("Failed to generate Parquet output");
-      }
-
-      // Stream the Parquet file to the response.
-      response.setContentType(SqlQueryOutputFormat.PARQUET.getContentType());
-      try (final var inputStream = Files.newInputStream(parquetFile);
-          final var outputStream = response.getOutputStream()) {
-        inputStream.transferTo(outputStream);
-        outputStream.flush();
-      }
-    } finally {
-      // Clean up temp directory.
-      deleteRecursively(tempDir);
-    }
-  }
-
-  /** Finds the first Parquet file in the given directory. */
-  @Nullable
-  private Path findParquetFile(@Nonnull final Path directory) throws IOException {
-    if (!Files.isDirectory(directory)) {
-      return null;
-    }
-    try (final var stream = Files.list(directory)) {
-      return stream.filter(p -> p.toString().endsWith(".parquet")).findFirst().orElse(null);
-    }
-  }
-
-  /** Recursively deletes a directory and its contents. */
-  private void deleteRecursively(@Nonnull final Path path) {
-    try {
-      if (Files.isDirectory(path)) {
-        try (final var stream = Files.list(path)) {
-          stream.forEach(this::deleteRecursively);
-        }
-      }
-      Files.deleteIfExists(path);
-    } catch (final IOException e) {
-      log.warn("Failed to clean up temporary file: {}", path, e);
-    }
+    executor.execute(
+        request,
+        resolvedViews,
+        deltaLake,
+        requestId,
+        result ->
+            streamer.stream(
+                result, request.getOutputFormat(), request.isIncludeHeader(), response));
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
@@ -149,7 +149,23 @@ public class SqlQueryExecutionHelper {
 
     // Parse the Library resource as a SQLQuery.
     final Library library = castToLibrary(libraryResource);
+
+    // Log the raw Library contents for debugging.
+    log.info(
+        "SQLQuery Library has {} relatedArtifact entries", library.getRelatedArtifact().size());
+    for (final org.hl7.fhir.r4.model.RelatedArtifact ra : library.getRelatedArtifact()) {
+      log.info(
+          "  relatedArtifact: type={}, label={}, resource={}",
+          ra.getType(),
+          ra.getLabel(),
+          ra.getResource());
+    }
+
     final ParsedSqlQuery parsedQuery = libraryParser.parse(library);
+    log.info(
+        "Parsed SQL query: {} view references, {} parameters",
+        parsedQuery.getViewReferences().size(),
+        parsedQuery.getDeclaredParameters().size());
 
     // Resolve ViewDefinitions and check authorization.
     final Map<String, FhirView> resolvedViews = resolveViewDefinitions(parsedQuery);
@@ -165,26 +181,23 @@ public class SqlQueryExecutionHelper {
     final boolean shouldIncludeHeader = includeHeader == null || includeHeader.booleanValue();
 
     // Register views and execute the query.
-    Map<String, String> registeredViews = Map.of();
+    List<String> registeredViewNames = List.of();
     try {
-      registeredViews = viewRegistrationService.registerViews(resolvedViews, deltaLake);
-
-      // Rewrite SQL to use prefixed temp view names.
-      final String rewrittenSql =
-          viewRegistrationService.rewriteSql(parsedQuery.getSql(), registeredViews);
+      registeredViewNames = viewRegistrationService.registerViews(resolvedViews, deltaLake);
 
       // Build parameter map for Spark parameterized queries.
+      final String sql = parsedQuery.getSql();
       final Map<String, String> parameterMap = buildParameterMap(parameterValues);
 
       // Execute the SQL query. Use parameterized queries only when parameters are provided.
       Dataset<Row> result;
       if (parameterMap.isEmpty()) {
-        result = sparkSession.sql(rewrittenSql);
+        result = sparkSession.sql(sql);
       } else {
         @SuppressWarnings("unchecked")
         final java.util.Map<String, Object> objectMap =
             (java.util.Map<String, Object>) (java.util.Map<String, ?>) parameterMap;
-        result = sparkSession.sql(rewrittenSql, objectMap);
+        result = sparkSession.sql(sql, objectMap);
       }
 
       // Apply limit if specified.
@@ -196,7 +209,7 @@ public class SqlQueryExecutionHelper {
       streamResults(result, outputFormat, shouldIncludeHeader, response);
 
     } finally {
-      viewRegistrationService.dropViews(registeredViews.values());
+      viewRegistrationService.dropViews(registeredViewNames);
     }
   }
 

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutionHelper.java
@@ -131,6 +131,7 @@ public class SqlQueryExecutionHelper {
    * @param includeHeader whether to include a header row in CSV output
    * @param limit the maximum number of rows to return
    * @param parameterValues runtime parameter values to bind to the SQL query
+   * @param requestId the HAPI per-request id used to namespace registered temp views
    * @param response the HTTP response for streaming output
    */
   @SuppressWarnings("java:S107")
@@ -141,6 +142,7 @@ public class SqlQueryExecutionHelper {
       @Nullable final BooleanType includeHeader,
       @Nullable final IntegerType limit,
       @Nullable final List<ParametersParameterComponent> parameterValues,
+      @Nonnull final String requestId,
       @Nullable final HttpServletResponse response) {
 
     if (response == null) {
@@ -180,24 +182,27 @@ public class SqlQueryExecutionHelper {
             : SqlQueryOutputFormat.fromAcceptHeader(acceptHeader);
     final boolean shouldIncludeHeader = includeHeader == null || includeHeader.booleanValue();
 
-    // Register views and execute the query.
-    List<String> registeredViewNames = List.of();
+    // Register views (request-scoped names) and execute the query.
+    Map<String, String> registeredViews = Map.of();
     try {
-      registeredViewNames = viewRegistrationService.registerViews(resolvedViews, deltaLake);
+      registeredViews = viewRegistrationService.registerViews(resolvedViews, deltaLake, requestId);
+
+      // Rewrite SQL so the user-supplied labels resolve to the request-scoped temp views.
+      final String rewrittenSql =
+          viewRegistrationService.rewriteSql(parsedQuery.getSql(), registeredViews);
 
       // Build parameter map for Spark parameterized queries.
-      final String sql = parsedQuery.getSql();
       final Map<String, String> parameterMap = buildParameterMap(parameterValues);
 
       // Execute the SQL query. Use parameterized queries only when parameters are provided.
       Dataset<Row> result;
       if (parameterMap.isEmpty()) {
-        result = sparkSession.sql(sql);
+        result = sparkSession.sql(rewrittenSql);
       } else {
         @SuppressWarnings("unchecked")
         final java.util.Map<String, Object> objectMap =
             (java.util.Map<String, Object>) (java.util.Map<String, ?>) parameterMap;
-        result = sparkSession.sql(sql, objectMap);
+        result = sparkSession.sql(rewrittenSql, objectMap);
       }
 
       // Apply limit if specified.
@@ -209,7 +214,7 @@ public class SqlQueryExecutionHelper {
       streamResults(result, outputFormat, shouldIncludeHeader, response);
 
     } finally {
-      viewRegistrationService.dropViews(registeredViewNames);
+      viewRegistrationService.dropViews(registeredViews.values());
     }
   }
 

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutor.java
@@ -20,14 +20,11 @@ package au.csiro.pathling.operations.sqlquery;
 import au.csiro.pathling.io.source.DataSource;
 import au.csiro.pathling.views.FhirView;
 import jakarta.annotation.Nonnull;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
-import org.hl7.fhir.r4.model.Type;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -90,8 +87,9 @@ public class SqlQueryExecutor {
       final String rewrittenSql =
           viewRegistrationService.rewriteSql(request.getParsedQuery().getSql(), registeredViews);
 
-      final Map<String, String> parameterMap = buildParameterMap(request.getParameterValues());
-      Dataset<Row> result = runSql(rewrittenSql, parameterMap);
+      Dataset<Row> result = runSql(rewrittenSql, request.getParameterBindings());
+
+      sqlValidator.validateAnalyzed(result.queryExecution().analyzed());
 
       if (request.getLimit() != null) {
         result = result.limit(request.getLimit());
@@ -105,43 +103,10 @@ public class SqlQueryExecutor {
 
   @Nonnull
   private Dataset<Row> runSql(
-      @Nonnull final String sql, @Nonnull final Map<String, String> parameterMap) {
-    if (parameterMap.isEmpty()) {
+      @Nonnull final String sql, @Nonnull final Map<String, Object> parameterBindings) {
+    if (parameterBindings.isEmpty()) {
       return sparkSession.sql(sql);
     }
-    @SuppressWarnings("unchecked")
-    final Map<String, Object> objectMap = (Map<String, Object>) (Map<String, ?>) parameterMap;
-    return sparkSession.sql(sql, objectMap);
-  }
-
-  /**
-   * Builds the name → string-value map handed to Spark's parameterised query API. Parameter values
-   * are flattened to their primitive string representation; typed binding will replace this when
-   * comment #8 lands.
-   */
-  @Nonnull
-  private Map<String, String> buildParameterMap(
-      @Nonnull final java.util.List<ParametersParameterComponent> parameterValues) {
-    final Map<String, String> params = new HashMap<>();
-
-    for (final ParametersParameterComponent param : parameterValues) {
-      String name = null;
-      String value = null;
-
-      for (final ParametersParameterComponent part : param.getPart()) {
-        if ("name".equals(part.getName()) && part.getValue() != null) {
-          name = part.getValue().primitiveValue();
-        } else if ("value".equals(part.getName()) && part.getValue() != null) {
-          final Type valueType = part.getValue();
-          value = valueType.primitiveValue();
-        }
-      }
-
-      if (name != null && value != null) {
-        params.put(name, value);
-      }
-    }
-
-    return params;
+    return sparkSession.sql(sql, parameterBindings);
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutor.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.io.source.DataSource;
+import au.csiro.pathling.views.FhirView;
+import jakarta.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r4.model.Type;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Executes the SQL of a {@link SqlQueryRequest} against the configured Spark session, owning the
+ * lifecycle of the request-scoped temporary views the query references. The only piece of the
+ * pipeline that touches Spark.
+ */
+@Component
+public class SqlQueryExecutor {
+
+  @Nonnull private final SparkSession sparkSession;
+
+  @Nonnull private final ViewRegistrationService viewRegistrationService;
+
+  @Nonnull private final SqlValidator sqlValidator;
+
+  /**
+   * Constructs a new SqlQueryExecutor.
+   *
+   * @param sparkSession the Spark session
+   * @param viewRegistrationService manages temp-view registration / cleanup and SQL rewriting
+   * @param sqlValidator validates the SQL before execution
+   */
+  @Autowired
+  public SqlQueryExecutor(
+      @Nonnull final SparkSession sparkSession,
+      @Nonnull final ViewRegistrationService viewRegistrationService,
+      @Nonnull final SqlValidator sqlValidator) {
+    this.sparkSession = sparkSession;
+    this.viewRegistrationService = viewRegistrationService;
+    this.sqlValidator = sqlValidator;
+  }
+
+  /**
+   * Validates and executes the SQL, registering the resolved views under request-scoped temp view
+   * names for the duration of the call. The {@code consumer} is invoked with the result dataset
+   * before the temp views are dropped, so streaming and other terminal operations can complete
+   * before cleanup.
+   *
+   * @param request the parsed and validated request
+   * @param resolvedViews the views referenced by the SQL, keyed by table label
+   * @param dataSource the data source backing FhirView execution
+   * @param requestId the HAPI per-request id used to namespace temp view names
+   * @param consumer terminal consumer of the result dataset
+   */
+  public void execute(
+      @Nonnull final SqlQueryRequest request,
+      @Nonnull final Map<String, FhirView> resolvedViews,
+      @Nonnull final DataSource dataSource,
+      @Nonnull final String requestId,
+      @Nonnull final Consumer<Dataset<Row>> consumer) {
+
+    sqlValidator.validate(request.getParsedQuery().getSql());
+
+    Map<String, String> registeredViews = Map.of();
+    try {
+      registeredViews = viewRegistrationService.registerViews(resolvedViews, dataSource, requestId);
+
+      final String rewrittenSql =
+          viewRegistrationService.rewriteSql(request.getParsedQuery().getSql(), registeredViews);
+
+      final Map<String, String> parameterMap = buildParameterMap(request.getParameterValues());
+      Dataset<Row> result = runSql(rewrittenSql, parameterMap);
+
+      if (request.getLimit() != null) {
+        result = result.limit(request.getLimit());
+      }
+
+      consumer.accept(result);
+    } finally {
+      viewRegistrationService.dropViews(registeredViews.values());
+    }
+  }
+
+  @Nonnull
+  private Dataset<Row> runSql(
+      @Nonnull final String sql, @Nonnull final Map<String, String> parameterMap) {
+    if (parameterMap.isEmpty()) {
+      return sparkSession.sql(sql);
+    }
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> objectMap = (Map<String, Object>) (Map<String, ?>) parameterMap;
+    return sparkSession.sql(sql, objectMap);
+  }
+
+  /**
+   * Builds the name → string-value map handed to Spark's parameterised query API. Parameter values
+   * are flattened to their primitive string representation; typed binding will replace this when
+   * comment #8 lands.
+   */
+  @Nonnull
+  private Map<String, String> buildParameterMap(
+      @Nonnull final java.util.List<ParametersParameterComponent> parameterValues) {
+    final Map<String, String> params = new HashMap<>();
+
+    for (final ParametersParameterComponent param : parameterValues) {
+      String name = null;
+      String value = null;
+
+      for (final ParametersParameterComponent part : param.getPart()) {
+        if ("name".equals(part.getName()) && part.getValue() != null) {
+          name = part.getValue().primitiveValue();
+        } else if ("value".equals(part.getName()) && part.getValue() != null) {
+          final Type valueType = part.getValue();
+          value = valueType.primitiveValue();
+        }
+      }
+
+      if (name != null && value != null) {
+        params.put(name, value);
+      }
+    }
+
+    return params;
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutor.java
@@ -17,6 +17,8 @@
 
 package au.csiro.pathling.operations.sqlquery;
 
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.config.SqlQueryConfiguration;
 import au.csiro.pathling.io.source.DataSource;
 import au.csiro.pathling.views.FhirView;
 import jakarta.annotation.Nonnull;
@@ -24,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -35,6 +38,7 @@ import org.springframework.stereotype.Component;
  * lifecycle of the request-scoped temporary views the query references. The only piece of the
  * pipeline that touches Spark.
  */
+@Slf4j
 @Component
 public class SqlQueryExecutor {
 
@@ -44,21 +48,27 @@ public class SqlQueryExecutor {
 
   @Nonnull private final SqlValidator sqlValidator;
 
+  @Nonnull private final SqlQueryConfiguration sqlQueryConfig;
+
   /**
    * Constructs a new SqlQueryExecutor.
    *
    * @param sparkSession the Spark session
    * @param viewRegistrationService manages temp-view registration / cleanup and SQL rewriting
    * @param sqlValidator validates the SQL before execution
+   * @param serverConfiguration the server configuration, used to resolve the resource limits
+   *     applied to each query
    */
   @Autowired
   public SqlQueryExecutor(
       @Nonnull final SparkSession sparkSession,
       @Nonnull final ViewRegistrationService viewRegistrationService,
-      @Nonnull final SqlValidator sqlValidator) {
+      @Nonnull final SqlValidator sqlValidator,
+      @Nonnull final ServerConfiguration serverConfiguration) {
     this.sparkSession = sparkSession;
     this.viewRegistrationService = viewRegistrationService;
     this.sqlValidator = sqlValidator;
+    this.sqlQueryConfig = serverConfiguration.getSqlQuery();
   }
 
   /**
@@ -98,14 +108,34 @@ public class SqlQueryExecutor {
       sqlValidator.validateAnalyzed(
           result.queryExecution().analyzed(), Set.copyOf(registeredViews.values()));
 
-      if (request.getLimit() != null) {
-        result = result.limit(request.getLimit());
-      }
+      result = result.limit(effectiveLimit(request.getLimit(), requestId));
 
       consumer.accept(result);
     } finally {
       viewRegistrationService.dropViews(registeredViews.values());
     }
+  }
+
+  /**
+   * Resolves the row limit applied to the result dataset. The configured server cap is always
+   * applied; when the caller supplies a {@code _limit}, the lower of the two values wins. The
+   * server cap is clamped to {@link Integer#MAX_VALUE} so that it can be passed to Spark's {@code
+   * Dataset.limit(int)} API.
+   */
+  int effectiveLimit(final Integer callerLimit, @Nonnull final String requestId) {
+    final int cap = (int) Math.min(sqlQueryConfig.getMaxRows(), Integer.MAX_VALUE);
+    if (callerLimit == null) {
+      return cap;
+    }
+    if (callerLimit > cap) {
+      log.info(
+          "Caller-supplied _limit of {} clamped to server cap of {} for request {}.",
+          callerLimit,
+          cap,
+          requestId);
+      return cap;
+    }
+    return callerLimit;
   }
 
   @Nonnull

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutor.java
@@ -21,6 +21,7 @@ import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.config.SqlQueryConfiguration;
 import au.csiro.pathling.io.source.DataSource;
 import au.csiro.pathling.views.FhirView;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import jakarta.annotation.Nonnull;
 import java.util.Map;
 import java.util.Set;
@@ -50,6 +51,8 @@ public class SqlQueryExecutor {
 
   @Nonnull private final SqlQueryConfiguration sqlQueryConfig;
 
+  @Nonnull private final SqlQueryWatchdog watchdog;
+
   /**
    * Constructs a new SqlQueryExecutor.
    *
@@ -58,17 +61,21 @@ public class SqlQueryExecutor {
    * @param sqlValidator validates the SQL before execution
    * @param serverConfiguration the server configuration, used to resolve the resource limits
    *     applied to each query
+   * @param watchdog the watchdog used to schedule wall-clock timeouts and Spark job-group
+   *     cancellation for each query
    */
   @Autowired
   public SqlQueryExecutor(
       @Nonnull final SparkSession sparkSession,
       @Nonnull final ViewRegistrationService viewRegistrationService,
       @Nonnull final SqlValidator sqlValidator,
-      @Nonnull final ServerConfiguration serverConfiguration) {
+      @Nonnull final ServerConfiguration serverConfiguration,
+      @Nonnull final SqlQueryWatchdog watchdog) {
     this.sparkSession = sparkSession;
     this.viewRegistrationService = viewRegistrationService;
     this.sqlValidator = sqlValidator;
     this.sqlQueryConfig = serverConfiguration.getSqlQuery();
+    this.watchdog = watchdog;
   }
 
   /**
@@ -96,7 +103,13 @@ public class SqlQueryExecutor {
             .collect(Collectors.toUnmodifiableSet());
     sqlValidator.validate(request.getParsedQuery().getSql(), declaredLabels);
 
+    final String jobGroupId = "sqlquery-" + requestId;
+    sparkSession
+        .sparkContext()
+        .setJobGroup(jobGroupId, "$sqlquery-run " + requestId, /* interruptOnCancel= */ true);
+
     Map<String, String> registeredViews = Map.of();
+    final SqlQueryWatchdog.Watch watch = watchdog.start(jobGroupId);
     try {
       registeredViews = viewRegistrationService.registerViews(resolvedViews, dataSource, requestId);
 
@@ -111,7 +124,17 @@ public class SqlQueryExecutor {
       result = result.limit(effectiveLimit(request.getLimit(), requestId));
 
       consumer.accept(result);
+    } catch (final RuntimeException e) {
+      if (watch.timedOut()) {
+        throw new InvalidRequestException(
+            "Query exceeded the configured timeout of "
+                + sqlQueryConfig.getTimeoutSeconds()
+                + " seconds.");
+      }
+      throw e;
     } finally {
+      watch.complete();
+      sparkSession.sparkContext().clearJobGroup();
       viewRegistrationService.dropViews(registeredViews.values());
     }
   }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutor.java
@@ -21,7 +21,9 @@ import au.csiro.pathling.io.source.DataSource;
 import au.csiro.pathling.views.FhirView;
 import jakarta.annotation.Nonnull;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -78,7 +80,11 @@ public class SqlQueryExecutor {
       @Nonnull final String requestId,
       @Nonnull final Consumer<Dataset<Row>> consumer) {
 
-    sqlValidator.validate(request.getParsedQuery().getSql());
+    final Set<String> declaredLabels =
+        request.getParsedQuery().getViewReferences().stream()
+            .map(ViewArtifactReference::getLabel)
+            .collect(Collectors.toUnmodifiableSet());
+    sqlValidator.validate(request.getParsedQuery().getSql(), declaredLabels);
 
     Map<String, String> registeredViews = Map.of();
     try {
@@ -89,7 +95,8 @@ public class SqlQueryExecutor {
 
       Dataset<Row> result = runSql(rewrittenSql, request.getParameterBindings());
 
-      sqlValidator.validateAnalyzed(result.queryExecution().analyzed());
+      sqlValidator.validateAnalyzed(
+          result.queryExecution().analyzed(), Set.copyOf(registeredViews.values()));
 
       if (request.getLimit() != null) {
         result = result.limit(request.getLimit());

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryInstanceRunProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryInstanceRunProvider.java
@@ -108,7 +108,14 @@ public class SqlQueryInstanceRunProvider implements IResourceProvider {
     final String acceptHeader = requestDetails.getServletRequest().getHeader("Accept");
 
     executionHelper.executeSqlQuery(
-        queryResource, format, acceptHeader, includeHeader, limit, parameterValues, response);
+        queryResource,
+        format,
+        acceptHeader,
+        includeHeader,
+        limit,
+        parameterValues,
+        requestDetails.getRequestId(),
+        response);
   }
 
   /**
@@ -138,7 +145,14 @@ public class SqlQueryInstanceRunProvider implements IResourceProvider {
     final String acceptHeader = requestDetails.getServletRequest().getHeader("Accept");
 
     executionHelper.executeSqlQuery(
-        libraryResource, format, acceptHeader, includeHeader, limit, parameterValues, response);
+        libraryResource,
+        format,
+        acceptHeader,
+        includeHeader,
+        limit,
+        parameterValues,
+        requestDetails.getRequestId(),
+        response);
   }
 
   /** Reads a Library resource by ID. */

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryInstanceRunProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryInstanceRunProvider.java
@@ -17,25 +17,22 @@
 
 package au.csiro.pathling.operations.sqlquery;
 
-import au.csiro.pathling.errors.ResourceNotFoundError;
-import au.csiro.pathling.read.ReadExecutor;
 import au.csiro.pathling.security.OperationAccess;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
 import ca.uhn.fhir.rest.server.IResourceProvider;
-import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.List;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Library;
-import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Reference;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -61,20 +58,21 @@ public class SqlQueryInstanceRunProvider implements IResourceProvider {
 
   @Nonnull private final SqlQueryExecutionHelper executionHelper;
 
-  @Nonnull private final ReadExecutor readExecutor;
+  @Nonnull private final LibraryReferenceResolver libraryReferenceResolver;
 
   /**
    * Constructs a new SqlQueryInstanceRunProvider.
    *
    * @param executionHelper the helper for executing SQL queries
-   * @param readExecutor the read executor for reading stored Library resources
+   * @param libraryReferenceResolver resolves a Library reference to a stored resource, with the
+   *     same 404 semantics used by the type-level operation
    */
   @Autowired
   public SqlQueryInstanceRunProvider(
       @Nonnull final SqlQueryExecutionHelper executionHelper,
-      @Nonnull final ReadExecutor readExecutor) {
+      @Nonnull final LibraryReferenceResolver libraryReferenceResolver) {
     this.executionHelper = executionHelper;
-    this.readExecutor = readExecutor;
+    this.libraryReferenceResolver = libraryReferenceResolver;
   }
 
   @Override
@@ -83,25 +81,28 @@ public class SqlQueryInstanceRunProvider implements IResourceProvider {
   }
 
   /**
-   * Type-level {@code $sqlquery-run} operation that accepts a SQLQuery Library inline.
+   * Type-level {@code $sqlquery-run} operation that accepts a SQLQuery Library either inline
+   * ({@code queryResource}) or by reference ({@code queryReference}).
    *
-   * @param queryResource the SQLQuery Library resource
+   * @param queryResource the inline SQLQuery Library resource
+   * @param queryReference reference to a stored SQLQuery Library
    * @param format the output format (ndjson, csv, json, or parquet), overrides Accept header
    * @param includeHeader whether to include a header row in CSV output
    * @param limit the maximum number of rows to return
-   * @param parameterValues query parameter values to bind
+   * @param parameters runtime parameter bindings as a Parameters resource
    * @param requestDetails the servlet request details containing HTTP headers
    * @param response the HTTP response for streaming output
    */
   @Operation(name = "$sqlquery-run", idempotent = true, manualResponse = true)
   @OperationAccess("sqlquery-run")
+  @SuppressWarnings("java:S107")
   public void runTypeLevel(
-      @Nonnull @OperationParam(name = "queryResource") final IBaseResource queryResource,
+      @Nullable @OperationParam(name = "queryResource") final IBaseResource queryResource,
+      @Nullable @OperationParam(name = "queryReference") final Reference queryReference,
       @Nullable @OperationParam(name = "_format") final String format,
       @Nullable @OperationParam(name = "header") final BooleanType includeHeader,
       @Nullable @OperationParam(name = "_limit") final IntegerType limit,
-      @Nullable @OperationParam(name = "parameter")
-          final List<ParametersParameterComponent> parameterValues,
+      @Nullable @OperationParam(name = "parameters") final Parameters parameters,
       @Nonnull final ServletRequestDetails requestDetails,
       @Nullable final HttpServletResponse response) {
 
@@ -109,11 +110,12 @@ public class SqlQueryInstanceRunProvider implements IResourceProvider {
 
     executionHelper.executeSqlQuery(
         queryResource,
+        queryReference,
         format,
         acceptHeader,
         includeHeader,
         limit,
-        parameterValues,
+        parameters,
         requestDetails.getRequestId(),
         response);
   }
@@ -125,7 +127,7 @@ public class SqlQueryInstanceRunProvider implements IResourceProvider {
    * @param format the output format (ndjson, csv, json, or parquet), overrides Accept header
    * @param includeHeader whether to include a header row in CSV output
    * @param limit the maximum number of rows to return
-   * @param parameterValues query parameter values to bind
+   * @param parameters runtime parameter bindings as a Parameters resource
    * @param requestDetails the servlet request details containing HTTP headers
    * @param response the HTTP response for streaming output
    */
@@ -136,39 +138,23 @@ public class SqlQueryInstanceRunProvider implements IResourceProvider {
       @Nullable @OperationParam(name = "_format") final String format,
       @Nullable @OperationParam(name = "header") final BooleanType includeHeader,
       @Nullable @OperationParam(name = "_limit") final IntegerType limit,
-      @Nullable @OperationParam(name = "parameter")
-          final List<ParametersParameterComponent> parameterValues,
+      @Nullable @OperationParam(name = "parameters") final Parameters parameters,
       @Nonnull final ServletRequestDetails requestDetails,
       @Nullable final HttpServletResponse response) {
 
-    final IBaseResource libraryResource = readLibrary(libraryId);
+    final IBaseResource libraryResource =
+        libraryReferenceResolver.resolve(new Reference("Library/" + libraryId.getIdPart()));
     final String acceptHeader = requestDetails.getServletRequest().getHeader("Accept");
 
     executionHelper.executeSqlQuery(
         libraryResource,
+        null,
         format,
         acceptHeader,
         includeHeader,
         limit,
-        parameterValues,
+        parameters,
         requestDetails.getRequestId(),
         response);
-  }
-
-  /** Reads a Library resource by ID. */
-  @Nonnull
-  private IBaseResource readLibrary(@Nonnull final IdType libraryId) {
-    try {
-      return readExecutor.read("Library", libraryId.getIdPart());
-    } catch (final ResourceNotFoundError e) {
-      throw new ResourceNotFoundException(
-          "Library with ID '" + libraryId.getIdPart() + "' not found");
-    } catch (final IllegalArgumentException e) {
-      if (e.getMessage() != null && e.getMessage().contains("No data found for resource type")) {
-        throw new ResourceNotFoundException(
-            "Library with ID '" + libraryId.getIdPart() + "' not found");
-      }
-      throw e;
-    }
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryInstanceRunProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryInstanceRunProvider.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.errors.ResourceNotFoundError;
+import au.csiro.pathling.read.ReadExecutor;
+import au.csiro.pathling.security.OperationAccess;
+import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.server.IResourceProvider;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Provider for the type-level and instance-level {@code $sqlquery-run} operations for Library
+ * resources.
+ *
+ * <p>This provides operations at:
+ *
+ * <ul>
+ *   <li>{@code POST /fhir/Library/$sqlquery-run} — Type-level operation with queryResource
+ *       parameter
+ *   <li>{@code POST /fhir/Library/[id]/$sqlquery-run} — Instance-level operation using stored
+ *       Library
+ * </ul>
+ *
+ * @see <a
+ *     href="https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/OperationDefinition-SQLQueryRun.html">SQLQueryRun</a>
+ * @see SqlQueryRunProvider for system-level $sqlquery-run operation
+ */
+@Component
+public class SqlQueryInstanceRunProvider implements IResourceProvider {
+
+  @Nonnull private final SqlQueryExecutionHelper executionHelper;
+
+  @Nonnull private final ReadExecutor readExecutor;
+
+  /**
+   * Constructs a new SqlQueryInstanceRunProvider.
+   *
+   * @param executionHelper the helper for executing SQL queries
+   * @param readExecutor the read executor for reading stored Library resources
+   */
+  @Autowired
+  public SqlQueryInstanceRunProvider(
+      @Nonnull final SqlQueryExecutionHelper executionHelper,
+      @Nonnull final ReadExecutor readExecutor) {
+    this.executionHelper = executionHelper;
+    this.readExecutor = readExecutor;
+  }
+
+  @Override
+  public Class<Library> getResourceType() {
+    return Library.class;
+  }
+
+  /**
+   * Type-level {@code $sqlquery-run} operation that accepts a SQLQuery Library inline.
+   *
+   * @param queryResource the SQLQuery Library resource
+   * @param format the output format (ndjson, csv, json, or parquet), overrides Accept header
+   * @param includeHeader whether to include a header row in CSV output
+   * @param limit the maximum number of rows to return
+   * @param parameterValues query parameter values to bind
+   * @param requestDetails the servlet request details containing HTTP headers
+   * @param response the HTTP response for streaming output
+   */
+  @Operation(name = "$sqlquery-run", idempotent = true, manualResponse = true)
+  @OperationAccess("sqlquery-run")
+  public void runTypeLevel(
+      @Nonnull @OperationParam(name = "queryResource") final IBaseResource queryResource,
+      @Nullable @OperationParam(name = "_format") final String format,
+      @Nullable @OperationParam(name = "header") final BooleanType includeHeader,
+      @Nullable @OperationParam(name = "_limit") final IntegerType limit,
+      @Nullable @OperationParam(name = "parameter")
+          final List<ParametersParameterComponent> parameterValues,
+      @Nonnull final ServletRequestDetails requestDetails,
+      @Nullable final HttpServletResponse response) {
+
+    final String acceptHeader = requestDetails.getServletRequest().getHeader("Accept");
+
+    executionHelper.executeSqlQuery(
+        queryResource, format, acceptHeader, includeHeader, limit, parameterValues, response);
+  }
+
+  /**
+   * Instance-level {@code $sqlquery-run} operation that uses a stored Library by ID.
+   *
+   * @param libraryId the ID of the stored Library resource
+   * @param format the output format (ndjson, csv, json, or parquet), overrides Accept header
+   * @param includeHeader whether to include a header row in CSV output
+   * @param limit the maximum number of rows to return
+   * @param parameterValues query parameter values to bind
+   * @param requestDetails the servlet request details containing HTTP headers
+   * @param response the HTTP response for streaming output
+   */
+  @Operation(name = "$sqlquery-run", idempotent = true, manualResponse = true)
+  @OperationAccess("sqlquery-run")
+  public void runById(
+      @IdParam final IdType libraryId,
+      @Nullable @OperationParam(name = "_format") final String format,
+      @Nullable @OperationParam(name = "header") final BooleanType includeHeader,
+      @Nullable @OperationParam(name = "_limit") final IntegerType limit,
+      @Nullable @OperationParam(name = "parameter")
+          final List<ParametersParameterComponent> parameterValues,
+      @Nonnull final ServletRequestDetails requestDetails,
+      @Nullable final HttpServletResponse response) {
+
+    final IBaseResource libraryResource = readLibrary(libraryId);
+    final String acceptHeader = requestDetails.getServletRequest().getHeader("Accept");
+
+    executionHelper.executeSqlQuery(
+        libraryResource, format, acceptHeader, includeHeader, limit, parameterValues, response);
+  }
+
+  /** Reads a Library resource by ID. */
+  @Nonnull
+  private IBaseResource readLibrary(@Nonnull final IdType libraryId) {
+    try {
+      return readExecutor.read("Library", libraryId.getIdPart());
+    } catch (final ResourceNotFoundError e) {
+      throw new ResourceNotFoundException(
+          "Library with ID '" + libraryId.getIdPart() + "' not found");
+    } catch (final IllegalArgumentException e) {
+      if (e.getMessage() != null && e.getMessage().contains("No data found for resource type")) {
+        throw new ResourceNotFoundException(
+            "Library with ID '" + libraryId.getIdPart() + "' not found");
+      }
+      throw e;
+    }
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParser.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParser.java
@@ -58,10 +58,12 @@ public class SqlQueryLibraryParser {
 
   private static final String SQL_CONTENT_TYPE_PREFIX = "application/sql";
 
-  private static final String LIBRARY_TYPE_SYSTEM =
+  /** Code system identifying the SQLQuery Library profile. */
+  public static final String LIBRARY_TYPE_SYSTEM =
       "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes";
 
-  private static final String LIBRARY_TYPE_CODE = "sql-query";
+  /** {@link #LIBRARY_TYPE_SYSTEM} code identifying a SQLQuery Library. */
+  public static final String LIBRARY_TYPE_CODE = "sql-query";
 
   private static final Pattern LABEL_PATTERN = Pattern.compile("^[A-Za-z]\\w*$");
 

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParser.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParser.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import jakarta.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.hl7.fhir.r4.model.Attachment;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.ParameterDefinition;
+import org.hl7.fhir.r4.model.RelatedArtifact;
+import org.springframework.stereotype.Component;
+
+/**
+ * Parses a FHIR R4 Library resource conforming to the SQLQuery profile. Extracts the SQL text,
+ * ViewDefinition dependencies, and parameter declarations.
+ *
+ * <p>The SQLQuery profile requires:
+ *
+ * <ul>
+ *   <li>A {@code content} entry with content type starting with {@code application/sql} containing
+ *       Base64-encoded SQL text.
+ *   <li>Zero or more {@code relatedArtifact} entries, each with a {@code label} (table alias) and
+ *       {@code resource} (canonical URL of the ViewDefinition).
+ *   <li>Zero or more {@code parameter} entries declaring typed input parameters.
+ * </ul>
+ *
+ * @see <a
+ *     href="https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/StructureDefinition-SQLQuery.html">SQLQuery</a>
+ */
+@Component
+public class SqlQueryLibraryParser {
+
+  private static final String SQL_CONTENT_TYPE_PREFIX = "application/sql";
+
+  /**
+   * Parses a Library resource into a {@link ParsedSqlQuery}.
+   *
+   * @param library the Library resource to parse
+   * @return the parsed SQL query containing SQL text, view references, and parameter declarations
+   * @throws InvalidRequestException if the Library does not conform to the SQLQuery profile
+   */
+  @Nonnull
+  public ParsedSqlQuery parse(@Nonnull final Library library) {
+    final String sql = extractSql(library);
+    final List<ViewArtifactReference> viewReferences = extractViewReferences(library);
+    final List<SqlParameterDeclaration> parameters = extractParameters(library);
+    return new ParsedSqlQuery(sql, viewReferences, parameters);
+  }
+
+  /**
+   * Extracts the SQL text from the Library's content entries.
+   *
+   * @param library the Library resource
+   * @return the decoded SQL text
+   * @throws InvalidRequestException if no SQL content is found or the content is invalid
+   */
+  @Nonnull
+  private String extractSql(@Nonnull final Library library) {
+    for (final Attachment attachment : library.getContent()) {
+      final String contentType = attachment.getContentType();
+      if (contentType != null && contentType.startsWith(SQL_CONTENT_TYPE_PREFIX)) {
+        final byte[] data = attachment.getData();
+        if (data == null || data.length == 0) {
+          throw new InvalidRequestException(
+              "SQLQuery Library has an application/sql content entry with no data");
+        }
+        // The data is Base64-encoded in the FHIR resource. HAPI decodes it automatically when
+        // using getData(), so we can use it directly.
+        return new String(data, StandardCharsets.UTF_8);
+      }
+    }
+    throw new InvalidRequestException(
+        "SQLQuery Library must contain a content entry with content type application/sql");
+  }
+
+  /**
+   * Extracts ViewDefinition references from the Library's related artifacts.
+   *
+   * @param library the Library resource
+   * @return the list of view artifact references
+   */
+  @Nonnull
+  private List<ViewArtifactReference> extractViewReferences(@Nonnull final Library library) {
+    final List<ViewArtifactReference> references = new ArrayList<>();
+    for (final RelatedArtifact artifact : library.getRelatedArtifact()) {
+      final String label = artifact.getLabel();
+      final String resource = artifact.getResource();
+      if (label == null || label.isBlank()) {
+        throw new InvalidRequestException(
+            "Each relatedArtifact in the SQLQuery Library must have a label");
+      }
+      if (resource == null || resource.isBlank()) {
+        throw new InvalidRequestException(
+            "Each relatedArtifact in the SQLQuery Library must have a resource reference");
+      }
+      references.add(new ViewArtifactReference(label, resource));
+    }
+    return references;
+  }
+
+  /**
+   * Extracts parameter declarations from the Library's parameter entries.
+   *
+   * @param library the Library resource
+   * @return the list of parameter declarations
+   */
+  @Nonnull
+  private List<SqlParameterDeclaration> extractParameters(@Nonnull final Library library) {
+    final List<SqlParameterDeclaration> parameters = new ArrayList<>();
+    for (final ParameterDefinition param : library.getParameter()) {
+      final String name = param.getName();
+      final String type = param.getType();
+      if (name == null || name.isBlank()) {
+        throw new InvalidRequestException(
+            "Each parameter in the SQLQuery Library must have a name");
+      }
+      if (type == null || type.isBlank()) {
+        throw new InvalidRequestException(
+            "Each parameter in the SQLQuery Library must have a type");
+      }
+      parameters.add(new SqlParameterDeclaration(name, type));
+    }
+    return parameters;
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParser.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParser.java
@@ -22,24 +22,32 @@ import jakarta.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.hl7.fhir.r4.model.Attachment;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.ParameterDefinition;
+import org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse;
 import org.hl7.fhir.r4.model.RelatedArtifact;
+import org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType;
 import org.springframework.stereotype.Component;
 
 /**
  * Parses a FHIR R4 Library resource conforming to the SQLQuery profile. Extracts the SQL text,
- * ViewDefinition dependencies, and parameter declarations.
+ * ViewDefinition dependencies, and parameter declarations, and enforces the profile invariants.
  *
  * <p>The SQLQuery profile requires:
  *
  * <ul>
+ *   <li>{@code Library.type} carrying a coding of {@code sql-query} from the SQL on FHIR library
+ *       types code system.
  *   <li>A {@code content} entry with content type starting with {@code application/sql} containing
  *       Base64-encoded SQL text.
- *   <li>Zero or more {@code relatedArtifact} entries, each with a {@code label} (table alias) and
- *       {@code resource} (canonical URL of the ViewDefinition).
- *   <li>Zero or more {@code parameter} entries declaring typed input parameters.
+ *   <li>Each {@code relatedArtifact} of type {@code depends-on}, with a label matching {@code
+ *       ^[A-Za-z][A-Za-z0-9_]*$} and a {@code resource} canonical URL pointing at the referenced
+ *       ViewDefinition.
+ *   <li>Each {@code parameter} declared with {@code use = in} and a name and type.
  * </ul>
  *
  * @see <a
@@ -50,6 +58,13 @@ public class SqlQueryLibraryParser {
 
   private static final String SQL_CONTENT_TYPE_PREFIX = "application/sql";
 
+  private static final String LIBRARY_TYPE_SYSTEM =
+      "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes";
+
+  private static final String LIBRARY_TYPE_CODE = "sql-query";
+
+  private static final Pattern LABEL_PATTERN = Pattern.compile("^[A-Za-z][A-Za-z0-9_]*$");
+
   /**
    * Parses a Library resource into a {@link ParsedSqlQuery}.
    *
@@ -59,10 +74,39 @@ public class SqlQueryLibraryParser {
    */
   @Nonnull
   public ParsedSqlQuery parse(@Nonnull final Library library) {
+    validateLibraryType(library);
     final String sql = extractSql(library);
     final List<ViewArtifactReference> viewReferences = extractViewReferences(library);
     final List<SqlParameterDeclaration> parameters = extractParameters(library);
     return new ParsedSqlQuery(sql, viewReferences, parameters);
+  }
+
+  /**
+   * Verifies that the Library carries the SQLQuery profile's type coding. The check accepts any
+   * coding with the expected system and code, regardless of additional codings, so that authors can
+   * layer their own classifications without breaking conformance.
+   */
+  private void validateLibraryType(@Nonnull final Library library) {
+    final CodeableConcept type = library.getType();
+    if (type == null || type.isEmpty()) {
+      throw new InvalidRequestException(
+          "SQLQuery Library must declare Library.type with the SQLQuery coding ("
+              + LIBRARY_TYPE_SYSTEM
+              + "#"
+              + LIBRARY_TYPE_CODE
+              + ")");
+    }
+    for (final Coding coding : type.getCoding()) {
+      if (LIBRARY_TYPE_SYSTEM.equals(coding.getSystem())
+          && LIBRARY_TYPE_CODE.equals(coding.getCode())) {
+        return;
+      }
+    }
+    throw new InvalidRequestException(
+        "SQLQuery Library.type must include a coding with system "
+            + LIBRARY_TYPE_SYSTEM
+            + " and code "
+            + LIBRARY_TYPE_CODE);
   }
 
   /**
@@ -92,7 +136,8 @@ public class SqlQueryLibraryParser {
   }
 
   /**
-   * Extracts ViewDefinition references from the Library's related artifacts.
+   * Extracts ViewDefinition references from the Library's related artifacts, enforcing that each
+   * artifact is of type {@code depends-on} with a label matching the SQLQuery profile pattern.
    *
    * @param library the Library resource
    * @return the list of view artifact references
@@ -101,11 +146,24 @@ public class SqlQueryLibraryParser {
   private List<ViewArtifactReference> extractViewReferences(@Nonnull final Library library) {
     final List<ViewArtifactReference> references = new ArrayList<>();
     for (final RelatedArtifact artifact : library.getRelatedArtifact()) {
+      if (artifact.getType() != RelatedArtifactType.DEPENDSON) {
+        throw new InvalidRequestException(
+            "SQLQuery Library relatedArtifact must have type 'depends-on', but found '"
+                + (artifact.getType() == null ? "null" : artifact.getType().toCode())
+                + "'");
+      }
       final String label = artifact.getLabel();
       final String resource = artifact.getResource();
       if (label == null || label.isBlank()) {
         throw new InvalidRequestException(
             "Each relatedArtifact in the SQLQuery Library must have a label");
+      }
+      if (!LABEL_PATTERN.matcher(label).matches()) {
+        throw new InvalidRequestException(
+            "SQLQuery Library relatedArtifact label '"
+                + label
+                + "' does not match the required pattern "
+                + LABEL_PATTERN.pattern());
       }
       if (resource == null || resource.isBlank()) {
         throw new InvalidRequestException(
@@ -117,7 +175,8 @@ public class SqlQueryLibraryParser {
   }
 
   /**
-   * Extracts parameter declarations from the Library's parameter entries.
+   * Extracts parameter declarations from the Library's parameter entries, enforcing that each
+   * declaration is an input ({@code use = in}) and carries both a name and a type.
    *
    * @param library the Library resource
    * @return the list of parameter declarations
@@ -135,6 +194,14 @@ public class SqlQueryLibraryParser {
       if (type == null || type.isBlank()) {
         throw new InvalidRequestException(
             "Each parameter in the SQLQuery Library must have a type");
+      }
+      if (param.getUse() != ParameterUse.IN) {
+        throw new InvalidRequestException(
+            "SQLQuery Library parameter '"
+                + name
+                + "' must declare use = in, but found '"
+                + (param.getUse() == null ? "null" : param.getUse().toCode())
+                + "'");
       }
       parameters.add(new SqlParameterDeclaration(name, type));
     }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParser.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParser.java
@@ -63,7 +63,7 @@ public class SqlQueryLibraryParser {
 
   private static final String LIBRARY_TYPE_CODE = "sql-query";
 
-  private static final Pattern LABEL_PATTERN = Pattern.compile("^[A-Za-z][A-Za-z0-9_]*$");
+  private static final Pattern LABEL_PATTERN = Pattern.compile("^[A-Za-z]\\w*$");
 
   /**
    * Parses a Library resource into a {@link ParsedSqlQuery}.

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryOutputFormat.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryOutputFormat.java
@@ -41,7 +41,13 @@ public enum SqlQueryOutputFormat {
   JSON("json", "application/json"),
 
   /** Apache Parquet columnar format. */
-  PARQUET("parquet", "application/vnd.apache.parquet");
+  PARQUET("parquet", "application/vnd.apache.parquet"),
+
+  /**
+   * FHIR-native format — emits a {@code Parameters} resource (JSON) with one repeating {@code row}
+   * parameter per result row, each column rendered as a part with a typed {@code value[x]}.
+   */
+  FHIR("fhir", "application/fhir+json");
 
   @Nonnull private final String code;
 

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryOutputFormat.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryOutputFormat.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
+import lombok.Getter;
+
+/**
+ * Output format options for the {@code $sqlquery-run} operation. Supports NDJSON, CSV, JSON, and
+ * Parquet formats as specified in the SQL on FHIR v2 specification.
+ */
+@Getter
+public enum SqlQueryOutputFormat {
+
+  /** Newline-delimited JSON format. */
+  NDJSON("ndjson", "application/x-ndjson"),
+
+  /** Comma-separated values format. */
+  CSV("csv", "text/csv"),
+
+  /** JSON format — single document containing an array of objects. */
+  JSON("json", "application/json"),
+
+  /** Apache Parquet columnar format. */
+  PARQUET("parquet", "application/vnd.apache.parquet");
+
+  @Nonnull private final String code;
+
+  @Nonnull private final String contentType;
+
+  SqlQueryOutputFormat(@Nonnull final String code, @Nonnull final String contentType) {
+    this.code = code;
+    this.contentType = contentType;
+  }
+
+  /** The default format when no valid format is specified. */
+  private static final SqlQueryOutputFormat DEFAULT_FORMAT = NDJSON;
+
+  /**
+   * Parses a format string into a SqlQueryOutputFormat.
+   *
+   * @param format the format string to parse, or null for default
+   * @return the corresponding format, defaulting to NDJSON
+   */
+  @Nonnull
+  public static SqlQueryOutputFormat fromString(@Nullable final String format) {
+    if (isNullOrBlank(format)) {
+      return DEFAULT_FORMAT;
+    }
+    final String normalised = format.toLowerCase().trim();
+    return Arrays.stream(values())
+        .filter(f -> f.code.equals(normalised) || f.contentType.equals(normalised))
+        .findFirst()
+        .orElse(DEFAULT_FORMAT);
+  }
+
+  /**
+   * Parses an HTTP Accept header into a SqlQueryOutputFormat. Supports quality values (e.g.,
+   * "text/csv;q=0.9, application/x-ndjson;q=1.0") and returns the format with the highest quality
+   * value that matches a supported content type.
+   *
+   * @param acceptHeader the Accept header value, or null for default
+   * @return the corresponding format, defaulting to NDJSON
+   */
+  @Nonnull
+  public static SqlQueryOutputFormat fromAcceptHeader(@Nullable final String acceptHeader) {
+    if (isNullOrBlank(acceptHeader)) {
+      return DEFAULT_FORMAT;
+    }
+
+    return Arrays.stream(acceptHeader.split(","))
+        .map(SqlQueryOutputFormat::parseMediaType)
+        .sorted(Comparator.comparingDouble(MediaType::quality).reversed())
+        .map(mt -> matchContentType(mt.type()))
+        .flatMap(Optional::stream)
+        .findFirst()
+        .orElse(DEFAULT_FORMAT);
+  }
+
+  /** Checks if a string is null or blank. */
+  private static boolean isNullOrBlank(@Nullable final String value) {
+    return value == null || value.isBlank();
+  }
+
+  /** Matches a content type string against supported formats. */
+  @Nonnull
+  private static Optional<SqlQueryOutputFormat> matchContentType(
+      @Nonnull final String contentType) {
+    if ("*/*".equals(contentType)) {
+      return Optional.of(DEFAULT_FORMAT);
+    }
+    return Arrays.stream(values()).filter(f -> f.contentType.equals(contentType)).findFirst();
+  }
+
+  /** Parses a single media type entry from an Accept header (e.g., "text/csv;q=0.9"). */
+  @Nonnull
+  private static MediaType parseMediaType(@Nonnull final String mediaTypeString) {
+    final String[] parts = mediaTypeString.split(";");
+    final String type = parts[0].trim().toLowerCase();
+    final double quality = extractQualityValue(parts);
+    return new MediaType(type, quality);
+  }
+
+  /** Extracts the quality value from media type parameters, defaulting to 1.0. */
+  private static double extractQualityValue(@Nonnull final String[] parts) {
+    for (int i = 1; i < parts.length; i++) {
+      final String param = parts[i].trim();
+      if (param.startsWith("q=")) {
+        try {
+          return Double.parseDouble(param.substring(2).trim());
+        } catch (final NumberFormatException e) {
+          return 1.0;
+        }
+      }
+    }
+    return 1.0;
+  }
+
+  /** Represents a parsed media type with its quality value. */
+  private record MediaType(@Nonnull String type, double quality) {}
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryOutputFormat.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryOutputFormat.java
@@ -25,8 +25,9 @@ import java.util.Optional;
 import lombok.Getter;
 
 /**
- * Output format options for the {@code $sqlquery-run} operation. Supports NDJSON, CSV, JSON, and
- * Parquet formats as specified in the SQL on FHIR v2 specification.
+ * Output format options for the {@code $sqlquery-run} operation. Supports NDJSON, CSV, JSON,
+ * Parquet, and FHIR ({@code Parameters} resource) formats as specified in the SQL on FHIR v2
+ * specification.
  */
 @Getter
 public enum SqlQueryOutputFormat {

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequest.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequest.java
@@ -19,9 +19,8 @@ package au.csiro.pathling.operations.sqlquery;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import java.util.List;
+import java.util.Map;
 import lombok.Value;
-import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
 
 /**
  * The validated, normalised inputs to a single {@code $sqlquery-run} invocation. Produced by {@link
@@ -43,6 +42,10 @@ public class SqlQueryRequest {
   /** Optional row cap; {@code null} means no cap. */
   @Nullable Integer limit;
 
-  /** Raw runtime parameter bindings as supplied on the wire. */
-  @Nonnull List<ParametersParameterComponent> parameterValues;
+  /**
+   * Runtime parameter bindings, typed against the declarations in {@code Library.parameter}. Keys
+   * are the parameter names; values are typed Java objects ready to hand to Spark's parameterised
+   * SQL API.
+   */
+  @Nonnull Map<String, Object> parameterBindings;
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequest.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import lombok.Value;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+
+/**
+ * The validated, normalised inputs to a single {@code $sqlquery-run} invocation. Produced by {@link
+ * SqlQueryRequestParser} from the raw HTTP-level parameters and consumed by the downstream resolver
+ * / executor / streamer pipeline.
+ */
+@Value
+public class SqlQueryRequest {
+
+  /** The decoded SQLQuery Library: SQL text, view references, declared parameters. */
+  @Nonnull ParsedSqlQuery parsedQuery;
+
+  /** The selected output format, after applying {@code _format} / {@code Accept} fallback. */
+  @Nonnull SqlQueryOutputFormat outputFormat;
+
+  /** Whether to include a header row when emitting CSV. */
+  boolean includeHeader;
+
+  /** Optional row cap; {@code null} means no cap. */
+  @Nullable Integer limit;
+
+  /** Raw runtime parameter bindings as supplied on the wire. */
+  @Nonnull List<ParametersParameterComponent> parameterValues;
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
@@ -20,13 +20,25 @@ package au.csiro.pathling.operations.sqlquery;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import java.util.List;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Base64BinaryType;
+import org.hl7.fhir.r4.model.BaseDateTimeType;
 import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.DateType;
+import org.hl7.fhir.r4.model.DecimalType;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r4.model.PrimitiveType;
+import org.hl7.fhir.r4.model.TimeType;
+import org.hl7.fhir.r4.model.Type;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -38,6 +50,14 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class SqlQueryRequestParser {
+
+  /** FHIR primitive types whose runtime value is treated as a Java {@code String}. */
+  private static final Set<String> STRING_LIKE_TYPES =
+      Set.of("string", "code", "id", "uri", "url", "canonical", "oid", "uuid");
+
+  /** FHIR primitive types whose runtime value is treated as a Java {@code Integer}. */
+  private static final Set<String> INTEGER_LIKE_TYPES =
+      Set.of("integer", "unsignedInt", "positiveInt");
 
   @Nonnull private final SqlQueryLibraryParser libraryParser;
 
@@ -59,7 +79,7 @@ public class SqlQueryRequestParser {
    * @param acceptHeader the HTTP {@code Accept} header value, used as a fallback for {@code format}
    * @param includeHeader whether to include a CSV header row; {@code null} defaults to {@code true}
    * @param limit optional row cap
-   * @param parameterValues raw runtime parameter bindings
+   * @param parameters runtime parameter bindings as a {@code Parameters} resource
    * @return the validated request
    * @throws InvalidRequestException if the inputs are not a valid SQLQuery invocation
    */
@@ -71,23 +91,24 @@ public class SqlQueryRequestParser {
       @Nullable final String acceptHeader,
       @Nullable final BooleanType includeHeader,
       @Nullable final IntegerType limit,
-      @Nullable final List<ParametersParameterComponent> parameterValues) {
+      @Nullable final Parameters parameters) {
 
     final Library library = castToLibrary(queryResource);
 
-    log.info(
-        "SQLQuery Library has {} relatedArtifact entries", library.getRelatedArtifact().size());
-    for (final org.hl7.fhir.r4.model.RelatedArtifact ra : library.getRelatedArtifact()) {
-      log.info(
-          "  relatedArtifact: type={}, label={}, resource={}",
-          ra.getType(),
-          ra.getLabel(),
-          ra.getResource());
+    if (log.isDebugEnabled()) {
+      for (final org.hl7.fhir.r4.model.RelatedArtifact ra : library.getRelatedArtifact()) {
+        log.debug(
+            "  relatedArtifact: type={}, label={}, resource={}",
+            ra.getType(),
+            ra.getLabel(),
+            ra.getResource());
+      }
     }
 
     final ParsedSqlQuery parsedQuery = libraryParser.parse(library);
-    log.info(
-        "Parsed SQL query: {} view references, {} parameters",
+    log.debug(
+        "Parsed SQLQuery Library: {} relatedArtifact entries, {} view references, {} parameters",
+        library.getRelatedArtifact().size(),
         parsedQuery.getViewReferences().size(),
         parsedQuery.getDeclaredParameters().size());
 
@@ -95,11 +116,11 @@ public class SqlQueryRequestParser {
     final boolean shouldIncludeHeader = includeHeader == null || includeHeader.booleanValue();
     final Integer limitValue =
         (limit != null && limit.getValue() != null) ? limit.getValue() : null;
-    final List<ParametersParameterComponent> safeParameterValues =
-        parameterValues != null ? parameterValues : List.of();
+    final Map<String, Object> parameterBindings =
+        bindParameters(parameters, parsedQuery.getDeclaredParameters());
 
     return new SqlQueryRequest(
-        parsedQuery, outputFormat, shouldIncludeHeader, limitValue, safeParameterValues);
+        parsedQuery, outputFormat, shouldIncludeHeader, limitValue, parameterBindings);
   }
 
   @Nonnull
@@ -118,5 +139,95 @@ public class SqlQueryRequestParser {
       return SqlQueryOutputFormat.fromString(format);
     }
     return SqlQueryOutputFormat.fromAcceptHeader(acceptHeader);
+  }
+
+  /**
+   * Validates the runtime parameter bindings against the declarations in {@code Library.parameter}
+   * and converts each {@code value[x]} to a typed Java object.
+   *
+   * @param parameters the runtime bindings, may be {@code null}
+   * @param declaredParameters the declarations from the SQLQuery Library
+   * @return an ordered map of name → typed Java value
+   * @throws InvalidRequestException if a binding is malformed, names a parameter that was not
+   *     declared, or supplies a value of the wrong FHIR type
+   */
+  @Nonnull
+  private Map<String, Object> bindParameters(
+      @Nullable final Parameters parameters,
+      @Nonnull final java.util.List<SqlParameterDeclaration> declaredParameters) {
+
+    if (parameters == null || parameters.getParameter().isEmpty()) {
+      return Map.of();
+    }
+
+    final Map<String, String> declaredByName = new LinkedHashMap<>();
+    for (final SqlParameterDeclaration declaration : declaredParameters) {
+      declaredByName.put(declaration.getName(), declaration.getType());
+    }
+
+    final Map<String, Object> bindings = new LinkedHashMap<>();
+    for (final ParametersParameterComponent binding : parameters.getParameter()) {
+      final String name = binding.getName();
+      if (name == null || name.isBlank()) {
+        throw new InvalidRequestException(
+            "Each runtime parameter binding must have a non-empty name");
+      }
+      final String declaredType = declaredByName.get(name);
+      if (declaredType == null) {
+        throw new InvalidRequestException(
+            "Runtime parameter '"
+                + name
+                + "' is not declared in the SQLQuery Library's parameter list");
+      }
+      final Type value = binding.getValue();
+      if (value == null) {
+        throw new InvalidRequestException("Runtime parameter '" + name + "' has no value[x]");
+      }
+      bindings.put(name, convertTypedValue(name, declaredType, value));
+    }
+    return bindings;
+  }
+
+  /**
+   * Converts a runtime {@code value[x]} to the Java type matching the declared FHIR type, after
+   * checking the wire FHIR type matches the declaration.
+   */
+  @Nonnull
+  private Object convertTypedValue(
+      @Nonnull final String name, @Nonnull final String declaredType, @Nonnull final Type value) {
+
+    final String wireType = value.fhirType();
+    if (!declaredType.equals(wireType)) {
+      throw new InvalidRequestException(
+          "Runtime parameter '"
+              + name
+              + "' was declared as '"
+              + declaredType
+              + "' but supplied as '"
+              + wireType
+              + "'");
+    }
+
+    if (INTEGER_LIKE_TYPES.contains(declaredType)) {
+      return ((IntegerType) value).getValue();
+    }
+    if (STRING_LIKE_TYPES.contains(declaredType)) {
+      return ((PrimitiveType<?>) value).getValueAsString();
+    }
+    return switch (declaredType) {
+      case "boolean" -> ((BooleanType) value).getValue();
+      case "decimal" -> ((DecimalType) value).getValue();
+      case "date" -> LocalDate.parse(((DateType) value).getValueAsString());
+      case "dateTime", "instant" -> ((BaseDateTimeType) value).getValue().toInstant();
+      case "time" -> LocalTime.parse(((TimeType) value).getValueAsString());
+      case "base64Binary" -> ((Base64BinaryType) value).getValue();
+      default ->
+          throw new InvalidRequestException(
+              "Runtime parameter '"
+                  + name
+                  + "' declares unsupported FHIR type '"
+                  + declaredType
+                  + "'");
+    };
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Validates and normalises the raw HTTP inputs of a {@code $sqlquery-run} invocation into a {@link
+ * SqlQueryRequest}. Has no Spark dependency; performs only structural FHIR-level validation and
+ * parsing.
+ */
+@Slf4j
+@Component
+public class SqlQueryRequestParser {
+
+  @Nonnull private final SqlQueryLibraryParser libraryParser;
+
+  /**
+   * Constructs a new SqlQueryRequestParser.
+   *
+   * @param libraryParser parser for the SQLQuery Library profile
+   */
+  @Autowired
+  public SqlQueryRequestParser(@Nonnull final SqlQueryLibraryParser libraryParser) {
+    this.libraryParser = libraryParser;
+  }
+
+  /**
+   * Parses the raw inputs into a validated {@link SqlQueryRequest}.
+   *
+   * @param queryResource the inline Library resource carrying the SQLQuery
+   * @param format the explicit {@code _format} parameter, if any
+   * @param acceptHeader the HTTP {@code Accept} header value, used as a fallback for {@code format}
+   * @param includeHeader whether to include a CSV header row; {@code null} defaults to {@code true}
+   * @param limit optional row cap
+   * @param parameterValues raw runtime parameter bindings
+   * @return the validated request
+   * @throws InvalidRequestException if the inputs are not a valid SQLQuery invocation
+   */
+  @Nonnull
+  @SuppressWarnings("java:S107")
+  public SqlQueryRequest parse(
+      @Nonnull final IBaseResource queryResource,
+      @Nullable final String format,
+      @Nullable final String acceptHeader,
+      @Nullable final BooleanType includeHeader,
+      @Nullable final IntegerType limit,
+      @Nullable final List<ParametersParameterComponent> parameterValues) {
+
+    final Library library = castToLibrary(queryResource);
+
+    log.info(
+        "SQLQuery Library has {} relatedArtifact entries", library.getRelatedArtifact().size());
+    for (final org.hl7.fhir.r4.model.RelatedArtifact ra : library.getRelatedArtifact()) {
+      log.info(
+          "  relatedArtifact: type={}, label={}, resource={}",
+          ra.getType(),
+          ra.getLabel(),
+          ra.getResource());
+    }
+
+    final ParsedSqlQuery parsedQuery = libraryParser.parse(library);
+    log.info(
+        "Parsed SQL query: {} view references, {} parameters",
+        parsedQuery.getViewReferences().size(),
+        parsedQuery.getDeclaredParameters().size());
+
+    final SqlQueryOutputFormat outputFormat = selectOutputFormat(format, acceptHeader);
+    final boolean shouldIncludeHeader = includeHeader == null || includeHeader.booleanValue();
+    final Integer limitValue =
+        (limit != null && limit.getValue() != null) ? limit.getValue() : null;
+    final List<ParametersParameterComponent> safeParameterValues =
+        parameterValues != null ? parameterValues : List.of();
+
+    return new SqlQueryRequest(
+        parsedQuery, outputFormat, shouldIncludeHeader, limitValue, safeParameterValues);
+  }
+
+  @Nonnull
+  private Library castToLibrary(@Nonnull final IBaseResource resource) {
+    if (resource instanceof final Library library) {
+      return library;
+    }
+    throw new InvalidRequestException(
+        "Expected a Library resource but received: " + resource.fhirType());
+  }
+
+  @Nonnull
+  private SqlQueryOutputFormat selectOutputFormat(
+      @Nullable final String format, @Nullable final String acceptHeader) {
+    if (format != null && !format.isBlank()) {
+      return SqlQueryOutputFormat.fromString(format);
+    }
+    return SqlQueryOutputFormat.fromAcceptHeader(acceptHeader);
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
@@ -183,6 +183,10 @@ public class SqlQueryRequestParser {
       if (value == null) {
         throw new InvalidRequestException("Runtime parameter '" + name + "' has no value[x]");
       }
+      if (bindings.containsKey(name)) {
+        throw new InvalidRequestException(
+            "Runtime parameter '" + name + "' is supplied more than once");
+      }
       bindings.put(name, convertTypedValue(name, declaredType, value));
     }
     return bindings;

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
@@ -187,6 +187,10 @@ public class SqlQueryRequestParser {
         throw new InvalidRequestException(
             "Runtime parameter '" + name + "' is supplied more than once");
       }
+      if (bindings.containsKey(name)) {
+        throw new InvalidRequestException(
+            "Runtime parameter '" + name + "' is supplied more than once");
+      }
       bindings.put(name, convertTypedValue(name, declaredType, value));
     }
     return bindings;

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
@@ -187,10 +187,6 @@ public class SqlQueryRequestParser {
         throw new InvalidRequestException(
             "Runtime parameter '" + name + "' is supplied more than once");
       }
-      if (bindings.containsKey(name)) {
-        throw new InvalidRequestException(
-            "Runtime parameter '" + name + "' is supplied more than once");
-      }
       bindings.put(name, convertTypedValue(name, declaredType, value));
     }
     return bindings;

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamer.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamer.java
@@ -67,7 +67,9 @@ public class SqlQueryResultStreamer {
       @Nonnull final HttpServletResponse response) {
 
     response.setContentType(outputFormat.getContentType());
-    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    if (outputFormat != SqlQueryOutputFormat.PARQUET) {
+      response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    }
     response.setStatus(HttpServletResponse.SC_OK);
 
     try {

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamer.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamer.java
@@ -71,15 +71,22 @@ public class SqlQueryResultStreamer {
     response.setStatus(HttpServletResponse.SC_OK);
 
     try {
-      if (outputFormat == SqlQueryOutputFormat.PARQUET) {
-        streamParquet(result, response);
-      } else {
-        streamTabular(result, outputFormat, includeHeader, response);
+      switch (outputFormat) {
+        case PARQUET -> streamParquet(result, response);
+        case FHIR -> streamFhir(result, response);
+        default -> streamTabular(result, outputFormat, includeHeader, response);
       }
     } catch (final IOException e) {
       log.error("Error streaming SQL query results", e);
       throw new InvalidRequestException("Error streaming results: " + e.getMessage());
     }
+  }
+
+  private void streamFhir(
+      @Nonnull final Dataset<Row> result, @Nonnull final HttpServletResponse response)
+      throws IOException {
+    final OutputStream outputStream = response.getOutputStream();
+    streamingHelper.streamFhirJson(outputStream, result.toLocalIterator(), result.schema());
   }
 
   private void streamTabular(

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamer.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamer.java
@@ -26,8 +26,13 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -44,6 +49,22 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class SqlQueryResultStreamer {
+
+  /**
+   * Mode {@code 0700} on POSIX file systems so that other local users cannot read, list, or write
+   * the temporary directory holding Parquet output. Empty on non-POSIX file systems, where the
+   * platform's default ACLs apply instead.
+   */
+  private static final FileAttribute<?>[] OWNER_ONLY_DIR_ATTRS =
+      FileSystems.getDefault().supportedFileAttributeViews().contains("posix")
+          ? new FileAttribute<?>[] {
+            PosixFilePermissions.asFileAttribute(
+                EnumSet.of(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE))
+          }
+          : new FileAttribute<?>[0];
 
   @Nonnull private final ResultStreamingHelper streamingHelper;
 
@@ -120,7 +141,7 @@ public class SqlQueryResultStreamer {
       @Nonnull final Dataset<Row> result, @Nonnull final HttpServletResponse response)
       throws IOException {
 
-    final Path tempDir = Files.createTempDirectory("sqlquery-parquet-");
+    final Path tempDir = Files.createTempDirectory("sqlquery-parquet-", OWNER_ONLY_DIR_ATTRS);
     final String outputPath = tempDir.resolve("result").toString();
 
     try {

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamer.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamer.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.operations.view.ResultStreamingHelper;
+import au.csiro.pathling.views.ViewDefinitionGson;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.types.StructType;
+import org.springframework.stereotype.Component;
+
+/**
+ * Streams a SQL query result to the HTTP response in the requested format. Owns the format dispatch
+ * and the Parquet temporary-file lifecycle.
+ */
+@Slf4j
+@Component
+public class SqlQueryResultStreamer {
+
+  @Nonnull private final ResultStreamingHelper streamingHelper;
+
+  /** Constructs a new SqlQueryResultStreamer. */
+  public SqlQueryResultStreamer() {
+    this.streamingHelper = new ResultStreamingHelper(ViewDefinitionGson.create());
+  }
+
+  /**
+   * Streams the result dataset to the response in the requested format.
+   *
+   * @param result the result dataset
+   * @param outputFormat the requested output format
+   * @param includeHeader whether to include a header row when emitting CSV
+   * @param response the HTTP response to write to
+   */
+  public void stream(
+      @Nonnull final Dataset<Row> result,
+      @Nonnull final SqlQueryOutputFormat outputFormat,
+      final boolean includeHeader,
+      @Nonnull final HttpServletResponse response) {
+
+    response.setContentType(outputFormat.getContentType());
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    response.setStatus(HttpServletResponse.SC_OK);
+
+    try {
+      if (outputFormat == SqlQueryOutputFormat.PARQUET) {
+        streamParquet(result, response);
+      } else {
+        streamTabular(result, outputFormat, includeHeader, response);
+      }
+    } catch (final IOException e) {
+      log.error("Error streaming SQL query results", e);
+      throw new InvalidRequestException("Error streaming results: " + e.getMessage());
+    }
+  }
+
+  private void streamTabular(
+      @Nonnull final Dataset<Row> result,
+      @Nonnull final SqlQueryOutputFormat outputFormat,
+      final boolean includeHeader,
+      @Nonnull final HttpServletResponse response)
+      throws IOException {
+
+    final OutputStream outputStream = response.getOutputStream();
+    final StructType schema = result.schema();
+
+    if (outputFormat == SqlQueryOutputFormat.CSV && includeHeader) {
+      final List<String> columnNames = java.util.Arrays.stream(schema.fieldNames()).toList();
+      streamingHelper.writeCsvHeader(outputStream, columnNames);
+      outputStream.flush();
+    }
+
+    final Iterator<Row> iterator = result.toLocalIterator();
+    switch (outputFormat) {
+      case NDJSON -> streamingHelper.streamNdjson(outputStream, iterator, schema);
+      case JSON -> streamingHelper.writeJson(outputStream, iterator, schema);
+      default -> streamingHelper.streamCsv(outputStream, iterator, schema);
+    }
+    outputStream.flush();
+  }
+
+  private void streamParquet(
+      @Nonnull final Dataset<Row> result, @Nonnull final HttpServletResponse response)
+      throws IOException {
+
+    final Path tempDir = Files.createTempDirectory("sqlquery-parquet-");
+    final String outputPath = tempDir.resolve("result").toString();
+
+    try {
+      result.coalesce(1).write().mode(SaveMode.Overwrite).parquet(outputPath);
+
+      final Path parquetFile = findParquetFile(Path.of(outputPath));
+      if (parquetFile == null) {
+        throw new InvalidRequestException("Failed to generate Parquet output");
+      }
+
+      response.setContentType(SqlQueryOutputFormat.PARQUET.getContentType());
+      try (final var inputStream = Files.newInputStream(parquetFile);
+          final var outputStream = response.getOutputStream()) {
+        inputStream.transferTo(outputStream);
+        outputStream.flush();
+      }
+    } finally {
+      deleteRecursively(tempDir);
+    }
+  }
+
+  @Nullable
+  private Path findParquetFile(@Nonnull final Path directory) throws IOException {
+    if (!Files.isDirectory(directory)) {
+      return null;
+    }
+    try (final var stream = Files.list(directory)) {
+      return stream.filter(p -> p.toString().endsWith(".parquet")).findFirst().orElse(null);
+    }
+  }
+
+  private void deleteRecursively(@Nonnull final Path path) {
+    try {
+      if (Files.isDirectory(path)) {
+        try (final var stream = Files.list(path)) {
+          stream.forEach(this::deleteRecursively);
+        }
+      }
+      Files.deleteIfExists(path);
+    } catch (final IOException e) {
+      log.warn("Failed to clean up temporary file: {}", path, e);
+    }
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunProvider.java
@@ -85,6 +85,13 @@ public class SqlQueryRunProvider {
     final String acceptHeader = requestDetails.getServletRequest().getHeader("Accept");
 
     executionHelper.executeSqlQuery(
-        queryResource, format, acceptHeader, includeHeader, limit, parameterValues, response);
+        queryResource,
+        format,
+        acceptHeader,
+        includeHeader,
+        limit,
+        parameterValues,
+        requestDetails.getRequestId(),
+        response);
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunProvider.java
@@ -24,11 +24,11 @@ import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.List;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.IntegerType;
-import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Reference;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -59,26 +59,29 @@ public class SqlQueryRunProvider {
   }
 
   /**
-   * Executes a SQL query provided inline as a Library resource and returns the results in the
-   * requested format. This is the system-level operation at {@code /fhir/$sqlquery-run}.
+   * Executes a SQL query provided either inline ({@code queryResource}) or by reference ({@code
+   * queryReference}) and returns the results in the requested format. This is the system-level
+   * operation at {@code /fhir/$sqlquery-run}.
    *
-   * @param queryResource the SQLQuery Library resource
+   * @param queryResource the inline SQLQuery Library resource
+   * @param queryReference reference to a stored SQLQuery Library
    * @param format the output format (ndjson, csv, json, or parquet), overrides Accept header
    * @param includeHeader whether to include a header row in CSV output
    * @param limit the maximum number of rows to return
-   * @param parameterValues query parameter values to bind
+   * @param parameters runtime parameter bindings as a Parameters resource
    * @param requestDetails the servlet request details containing HTTP headers
    * @param response the HTTP response for streaming output
    */
   @Operation(name = "$sqlquery-run", idempotent = true, manualResponse = true)
   @OperationAccess("sqlquery-run")
+  @SuppressWarnings("java:S107")
   public void run(
-      @Nonnull @OperationParam(name = "queryResource") final IBaseResource queryResource,
+      @Nullable @OperationParam(name = "queryResource") final IBaseResource queryResource,
+      @Nullable @OperationParam(name = "queryReference") final Reference queryReference,
       @Nullable @OperationParam(name = "_format") final String format,
       @Nullable @OperationParam(name = "header") final BooleanType includeHeader,
       @Nullable @OperationParam(name = "_limit") final IntegerType limit,
-      @Nullable @OperationParam(name = "parameter")
-          final List<ParametersParameterComponent> parameterValues,
+      @Nullable @OperationParam(name = "parameters") final Parameters parameters,
       @Nonnull final ServletRequestDetails requestDetails,
       @Nullable final HttpServletResponse response) {
 
@@ -86,11 +89,12 @@ public class SqlQueryRunProvider {
 
     executionHelper.executeSqlQuery(
         queryResource,
+        queryReference,
         format,
         acceptHeader,
         includeHeader,
         limit,
-        parameterValues,
+        parameters,
         requestDetails.getRequestId(),
         response);
   }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.security.OperationAccess;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Provider for the system-level {@code $sqlquery-run} operation from the SQL on FHIR v2
+ * specification. Executes a SQL query against materialised ViewDefinition tables.
+ *
+ * <p>This provides a system-level operation at {@code /fhir/$sqlquery-run} that accepts a SQLQuery
+ * Library resource inline or by reference.
+ *
+ * @see <a
+ *     href="https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/OperationDefinition-SQLQueryRun.html">SQLQueryRun</a>
+ * @see SqlQueryInstanceRunProvider for type-level and instance-level operations
+ */
+@Component
+public class SqlQueryRunProvider {
+
+  @Nonnull private final SqlQueryExecutionHelper executionHelper;
+
+  /**
+   * Constructs a new SqlQueryRunProvider.
+   *
+   * @param executionHelper the helper for executing SQL queries
+   */
+  @Autowired
+  public SqlQueryRunProvider(@Nonnull final SqlQueryExecutionHelper executionHelper) {
+    this.executionHelper = executionHelper;
+  }
+
+  /**
+   * Executes a SQL query provided inline as a Library resource and returns the results in the
+   * requested format. This is the system-level operation at {@code /fhir/$sqlquery-run}.
+   *
+   * @param queryResource the SQLQuery Library resource
+   * @param format the output format (ndjson, csv, json, or parquet), overrides Accept header
+   * @param includeHeader whether to include a header row in CSV output
+   * @param limit the maximum number of rows to return
+   * @param parameterValues query parameter values to bind
+   * @param requestDetails the servlet request details containing HTTP headers
+   * @param response the HTTP response for streaming output
+   */
+  @Operation(name = "$sqlquery-run", idempotent = true, manualResponse = true)
+  @OperationAccess("sqlquery-run")
+  public void run(
+      @Nonnull @OperationParam(name = "queryResource") final IBaseResource queryResource,
+      @Nullable @OperationParam(name = "_format") final String format,
+      @Nullable @OperationParam(name = "header") final BooleanType includeHeader,
+      @Nullable @OperationParam(name = "_limit") final IntegerType limit,
+      @Nullable @OperationParam(name = "parameter")
+          final List<ParametersParameterComponent> parameterValues,
+      @Nonnull final ServletRequestDetails requestDetails,
+      @Nullable final HttpServletResponse response) {
+
+    final String acceptHeader = requestDetails.getServletRequest().getHeader("Accept");
+
+    executionHelper.executeSqlQuery(
+        queryResource, format, acceptHeader, includeHeader, limit, parameterValues, response);
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryWatchdog.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryWatchdog.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.config.SqlQueryConfiguration;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.PreDestroy;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.SparkSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Schedules a wall-clock timeout against each {@code $sqlquery-run} query and cancels the
+ * associated Spark job group when the timeout fires. Used to defend the synchronous {@code
+ * $sqlquery-run} surface against queries that consume an unbounded share of compute resources - for
+ * example, generators chained with array-builder functions that produce few output rows but
+ * traverse very large intermediate sets, which the row cap cannot short-circuit.
+ *
+ * <p>Mirrors the cancellation pattern used by {@code AsyncAspect}: {@code setJobGroup(...,
+ * interruptOnCancel=true)} pairs with {@code cancelJobGroup}, which propagates cancellation to
+ * in-flight Spark task threads as a thrown exception.
+ *
+ * @author John Grimes
+ */
+@Slf4j
+@Component
+public class SqlQueryWatchdog {
+
+  @Nonnull private final SparkSession sparkSession;
+
+  @Nonnull private final SqlQueryConfiguration config;
+
+  @Nonnull private final ScheduledExecutorService scheduler;
+
+  /**
+   * Constructs a new SqlQueryWatchdog.
+   *
+   * @param sparkSession the Spark session whose job groups will be cancelled on timeout
+   * @param serverConfiguration the server configuration, used to resolve the timeout value
+   */
+  @Autowired
+  public SqlQueryWatchdog(
+      @Nonnull final SparkSession sparkSession,
+      @Nonnull final ServerConfiguration serverConfiguration) {
+    this.sparkSession = sparkSession;
+    this.config = serverConfiguration.getSqlQuery();
+    this.scheduler =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              final Thread t = new Thread(r, "sqlquery-watchdog");
+              t.setDaemon(true);
+              return t;
+            });
+  }
+
+  /**
+   * Starts a watchdog for the given Spark job group. The returned {@link Watch} must be completed
+   * by the caller in a {@code finally} block.
+   *
+   * @param jobGroupId the Spark job group id to cancel if the timeout fires
+   * @return a handle that exposes whether the timeout fired and lets the caller cancel the
+   *     scheduled cancellation when the query completes normally
+   */
+  @Nonnull
+  public Watch start(@Nonnull final String jobGroupId) {
+    final long timeoutSeconds = config.getTimeoutSeconds();
+    final AtomicBoolean timedOut = new AtomicBoolean(false);
+    final ScheduledFuture<?> task =
+        scheduler.schedule(
+            () -> {
+              timedOut.set(true);
+              log.warn(
+                  "$sqlquery-run timeout fired for jobGroupId={} after {} seconds; cancelling.",
+                  jobGroupId,
+                  timeoutSeconds);
+              try {
+                sparkSession.sparkContext().cancelJobGroup(jobGroupId);
+              } catch (final RuntimeException e) {
+                log.warn("Failed to cancel job group {}: {}", jobGroupId, e.getMessage());
+              }
+            },
+            timeoutSeconds,
+            TimeUnit.SECONDS);
+    return new Watch(task, timedOut);
+  }
+
+  /** Shuts down the scheduler when the bean is destroyed. */
+  @PreDestroy
+  public void shutdown() {
+    scheduler.shutdownNow();
+  }
+
+  /** Handle returned by {@link #start(String)}. */
+  public static final class Watch {
+
+    @Nonnull private final ScheduledFuture<?> task;
+
+    @Nonnull private final AtomicBoolean timedOut;
+
+    Watch(@Nonnull final ScheduledFuture<?> task, @Nonnull final AtomicBoolean timedOut) {
+      this.task = task;
+      this.timedOut = timedOut;
+    }
+
+    /**
+     * Cancels the scheduled cancellation. Idempotent. Safe to call after the timeout has already
+     * fired.
+     */
+    public void complete() {
+      task.cancel(false);
+    }
+
+    /** Returns true if the timeout fired before {@link #complete()} was called. */
+    public boolean timedOut() {
+      return timedOut.get();
+    }
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
@@ -39,16 +39,26 @@ import scala.jdk.javaapi.CollectionConverters;
  * prevents SQL injection attacks and ensures that users cannot execute DDL, DML, or other dangerous
  * operations through the {@code $sqlquery-run} endpoint.
  *
- * <p>Validation is performed on the unresolved logical plan produced by Spark's SQL parser. The
- * validator walks the entire plan tree and checks every plan node and expression against a
- * whitelist. Any node not in the whitelist causes the query to be rejected.
+ * <p>Allow-lists and reject-lists are matched on fully-qualified class names so that classes from
+ * unrelated packages (for example a third-party plugin's {@code Project}) cannot slip through.
+ *
+ * <p>Two validation entry-points are exposed:
+ *
+ * <ul>
+ *   <li>{@link #validate(String)} parses the SQL and walks the unresolved logical plan. Cheap and
+ *       suitable for early rejection before any temp views are registered.
+ *   <li>{@link #validateAnalyzed(LogicalPlan)} walks an analyzed plan. Required to catch constructs
+ *       like {@code HiveSimpleUDF} / {@code HiveGenericUDF}, which are inserted by the analyser and
+ *       so are absent from the unresolved tree.
+ * </ul>
  *
  * <p>Three validation layers are applied:
  *
  * <ol>
- *   <li><strong>Plan node whitelist</strong> — only read-only plan nodes are permitted.
- *   <li><strong>Expression whitelist</strong> — only safe expression types are permitted.
- *   <li><strong>UDF allowlist</strong> — {@code ScalaUDF} is permitted only for Pathling's
+ *   <li><strong>Plan node allow-list</strong> — only read-only plan nodes are permitted. All {@link
+ *       Command} subclasses are rejected outright.
+ *   <li><strong>Expression allow-list</strong> — only safe expression types are permitted.
+ *   <li><strong>UDF allow-list</strong> — {@link ScalaUDF} is permitted only for Pathling's
  *       registered UDFs.
  * </ol>
  *
@@ -61,75 +71,62 @@ public class SqlValidator {
 
   @Nonnull private final SparkSession sparkSession;
 
-  // Allowed plan node class names (simple names). Any plan node not in this set is rejected.
-  // All Command subclasses (DDL/DML) are additionally rejected via instanceof check.
+  // Fully-qualified plan node class names that are permitted. All Command subclasses are
+  // additionally rejected via instanceof check.
   private static final Set<String> ALLOWED_PLAN_NODES =
       Set.of(
-          // Basic operations.
-          "Project",
-          "Filter",
-          "Sort",
-          "GlobalLimit",
-          "LocalLimit",
-          "Tail",
-          "Offset",
-          "ReturnAnswer",
-          // Set operations.
-          "Union",
-          "Intersect",
-          "Except",
-          // Joins.
-          "Join",
-          "LateralJoin",
-          "AsOfJoin",
-          // Aggregation and grouping.
-          "Aggregate",
-          "Expand",
-          "Window",
-          "WithWindowDefinition",
-          // Table and relation access.
-          "UnresolvedRelation",
-          "SubqueryAlias",
-          "LocalRelation",
-          "OneRowRelation",
-          "EmptyRelation",
-          "Range",
-          "View",
-          "UnresolvedInlineTable",
-          "UnresolvedTableValuedFunction",
-          // Common table expressions.
-          "WithCTE",
-          "CTERelationDef",
-          "CTERelationRef",
-          "UnresolvedWith",
-          // Deduplication.
-          "Distinct",
-          "Deduplicate",
-          // Pivot and unpivot.
-          "Pivot",
-          "Unpivot",
-          // Generate (LATERAL VIEW / EXPLODE).
-          "Generate",
-          // Hints.
-          "ResolvedHint",
-          "UnresolvedHint",
-          // Sampling.
-          "Sample",
-          // Repartitioning (read-only).
-          "Repartition",
-          "RebalancePartitions",
-          // Transposition.
-          "Transpose",
-          // Subquery wrapper.
-          "Subquery",
-          // Unresolved plan-specific nodes.
-          "UnresolvedSubqueryColumnAliases");
+          // org.apache.spark.sql.catalyst.plans.logical
+          "org.apache.spark.sql.catalyst.plans.logical.Project",
+          "org.apache.spark.sql.catalyst.plans.logical.Filter",
+          "org.apache.spark.sql.catalyst.plans.logical.Sort",
+          "org.apache.spark.sql.catalyst.plans.logical.GlobalLimit",
+          "org.apache.spark.sql.catalyst.plans.logical.LocalLimit",
+          "org.apache.spark.sql.catalyst.plans.logical.Tail",
+          "org.apache.spark.sql.catalyst.plans.logical.Offset",
+          "org.apache.spark.sql.catalyst.plans.logical.ReturnAnswer",
+          "org.apache.spark.sql.catalyst.plans.logical.Union",
+          "org.apache.spark.sql.catalyst.plans.logical.Intersect",
+          "org.apache.spark.sql.catalyst.plans.logical.Except",
+          "org.apache.spark.sql.catalyst.plans.logical.Join",
+          "org.apache.spark.sql.catalyst.plans.logical.LateralJoin",
+          "org.apache.spark.sql.catalyst.plans.logical.AsOfJoin",
+          "org.apache.spark.sql.catalyst.plans.logical.Aggregate",
+          "org.apache.spark.sql.catalyst.plans.logical.Expand",
+          "org.apache.spark.sql.catalyst.plans.logical.Window",
+          "org.apache.spark.sql.catalyst.plans.logical.WithWindowDefinition",
+          "org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias",
+          "org.apache.spark.sql.catalyst.plans.logical.LocalRelation",
+          "org.apache.spark.sql.catalyst.plans.logical.OneRowRelation",
+          "org.apache.spark.sql.catalyst.plans.logical.EmptyRelation",
+          "org.apache.spark.sql.catalyst.plans.logical.Range",
+          "org.apache.spark.sql.catalyst.plans.logical.View",
+          "org.apache.spark.sql.catalyst.plans.logical.WithCTE",
+          "org.apache.spark.sql.catalyst.plans.logical.CTERelationDef",
+          "org.apache.spark.sql.catalyst.plans.logical.CTERelationRef",
+          "org.apache.spark.sql.catalyst.plans.logical.UnresolvedWith",
+          "org.apache.spark.sql.catalyst.plans.logical.Distinct",
+          "org.apache.spark.sql.catalyst.plans.logical.Deduplicate",
+          "org.apache.spark.sql.catalyst.plans.logical.Pivot",
+          "org.apache.spark.sql.catalyst.plans.logical.Unpivot",
+          "org.apache.spark.sql.catalyst.plans.logical.Generate",
+          "org.apache.spark.sql.catalyst.plans.logical.ResolvedHint",
+          "org.apache.spark.sql.catalyst.plans.logical.UnresolvedHint",
+          "org.apache.spark.sql.catalyst.plans.logical.Sample",
+          "org.apache.spark.sql.catalyst.plans.logical.Repartition",
+          "org.apache.spark.sql.catalyst.plans.logical.RebalancePartitions",
+          "org.apache.spark.sql.catalyst.plans.logical.Subquery",
+          // org.apache.spark.sql.catalyst.analysis
+          "org.apache.spark.sql.catalyst.analysis.UnresolvedRelation",
+          "org.apache.spark.sql.catalyst.analysis.UnresolvedInlineTable",
+          "org.apache.spark.sql.catalyst.analysis.UnresolvedTableValuedFunction",
+          "org.apache.spark.sql.catalyst.analysis.UnresolvedSubqueryColumnAliases");
 
-  // Function names that are explicitly rejected because they enable arbitrary code execution.
+  // Function names rejected outright because they enable arbitrary code execution.
   private static final Set<String> REJECTED_FUNCTION_NAMES =
       Set.of("reflect", "java_method", "try_reflect");
 
-  // Pathling-registered UDF names that are allowed in ScalaUDF expressions.
+  // Pathling-registered UDF names that are allowed in ScalaUDF expressions. Source of truth lives
+  // here; SqlValidatorIntegrityTest fails if this drifts from the actual Spark function registry.
   private static final Set<String> ALLOWED_UDF_NAMES =
       Set.of(
           // Terminology UDFs (registered by TerminologyUdfRegistrar).
@@ -157,155 +154,149 @@ public class SqlValidator {
           "low_boundary_for_time",
           "high_boundary_for_time");
 
-  // Allowed expression class names for the unresolved plan. Expressions not in this set (and not
-  // covered by special handling for UnresolvedFunction and ScalaUDF) are rejected.
+  // Fully-qualified expression class names that are permitted (besides UnresolvedFunction and
+  // ScalaUDF, which receive special handling).
   @SuppressWarnings("java:S1192")
   private static final Set<String> ALLOWED_EXPRESSION_NAMES =
       Set.of(
           // Literals and references.
-          "Literal",
-          "UnresolvedAttribute",
-          "UnresolvedStar",
-          "UnresolvedNamedLambdaVariable",
-          "NamedLambdaVariable",
-          "LambdaVariable",
-          "Alias",
-          "UnresolvedAlias",
-          "OuterReference",
-          "UnresolvedOrdinal",
-          "VariableReference",
-          "AttributeReference",
-          "BoundReference",
+          "org.apache.spark.sql.catalyst.expressions.Literal",
+          "org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute",
+          "org.apache.spark.sql.catalyst.analysis.UnresolvedStar",
+          "org.apache.spark.sql.catalyst.expressions.UnresolvedNamedLambdaVariable",
+          "org.apache.spark.sql.catalyst.expressions.NamedLambdaVariable",
+          "org.apache.spark.sql.catalyst.expressions.objects.LambdaVariable",
+          "org.apache.spark.sql.catalyst.expressions.Alias",
+          "org.apache.spark.sql.catalyst.analysis.UnresolvedAlias",
+          "org.apache.spark.sql.catalyst.expressions.OuterReference",
+          "org.apache.spark.sql.catalyst.analysis.UnresolvedOrdinal",
+          "org.apache.spark.sql.catalyst.expressions.VariableReference",
+          "org.apache.spark.sql.catalyst.expressions.AttributeReference",
+          "org.apache.spark.sql.catalyst.expressions.BoundReference",
           // Arithmetic.
-          "Add",
-          "Subtract",
-          "Multiply",
-          "Divide",
-          "IntegralDivide",
-          "Remainder",
-          "Pmod",
-          "UnaryMinus",
-          "UnaryPositive",
-          "Abs",
+          "org.apache.spark.sql.catalyst.expressions.Add",
+          "org.apache.spark.sql.catalyst.expressions.Subtract",
+          "org.apache.spark.sql.catalyst.expressions.Multiply",
+          "org.apache.spark.sql.catalyst.expressions.Divide",
+          "org.apache.spark.sql.catalyst.expressions.IntegralDivide",
+          "org.apache.spark.sql.catalyst.expressions.Remainder",
+          "org.apache.spark.sql.catalyst.expressions.Pmod",
+          "org.apache.spark.sql.catalyst.expressions.UnaryMinus",
+          "org.apache.spark.sql.catalyst.expressions.UnaryPositive",
+          "org.apache.spark.sql.catalyst.expressions.Abs",
           // Comparison.
-          "EqualTo",
-          "EqualNullSafe",
-          "LessThan",
-          "LessThanOrEqual",
-          "GreaterThan",
-          "GreaterThanOrEqual",
+          "org.apache.spark.sql.catalyst.expressions.EqualTo",
+          "org.apache.spark.sql.catalyst.expressions.EqualNullSafe",
+          "org.apache.spark.sql.catalyst.expressions.LessThan",
+          "org.apache.spark.sql.catalyst.expressions.LessThanOrEqual",
+          "org.apache.spark.sql.catalyst.expressions.GreaterThan",
+          "org.apache.spark.sql.catalyst.expressions.GreaterThanOrEqual",
           // Predicates.
-          "In",
-          "InSet",
-          "InSubquery",
-          "Between",
-          "Like",
-          "ILike",
-          "RLike",
-          "LikeAll",
-          "LikeAny",
-          "NotLikeAll",
-          "NotLikeAny",
-          "Contains",
-          "StartsWith",
-          "EndsWith",
-          "StringInstr",
-          "StringLocate",
-          "FindInSet",
+          "org.apache.spark.sql.catalyst.expressions.In",
+          "org.apache.spark.sql.catalyst.expressions.InSet",
+          "org.apache.spark.sql.catalyst.expressions.InSubquery",
+          "org.apache.spark.sql.catalyst.expressions.Between",
+          "org.apache.spark.sql.catalyst.expressions.Like",
+          "org.apache.spark.sql.catalyst.expressions.ILike",
+          "org.apache.spark.sql.catalyst.expressions.RLike",
+          "org.apache.spark.sql.catalyst.expressions.LikeAll",
+          "org.apache.spark.sql.catalyst.expressions.LikeAny",
+          "org.apache.spark.sql.catalyst.expressions.NotLikeAll",
+          "org.apache.spark.sql.catalyst.expressions.NotLikeAny",
+          "org.apache.spark.sql.catalyst.expressions.Contains",
+          "org.apache.spark.sql.catalyst.expressions.StartsWith",
+          "org.apache.spark.sql.catalyst.expressions.EndsWith",
+          "org.apache.spark.sql.catalyst.expressions.StringInstr",
+          "org.apache.spark.sql.catalyst.expressions.StringLocate",
+          "org.apache.spark.sql.catalyst.expressions.FindInSet",
           // Logical operators.
-          "And",
-          "Or",
-          "Not",
+          "org.apache.spark.sql.catalyst.expressions.And",
+          "org.apache.spark.sql.catalyst.expressions.Or",
+          "org.apache.spark.sql.catalyst.expressions.Not",
           // Null handling.
-          "IsNull",
-          "IsNotNull",
-          "Coalesce",
-          "NullIf",
-          "Nvl",
-          "Nvl2",
-          "IfNull",
-          "NaNvl",
-          "IsNaN",
+          "org.apache.spark.sql.catalyst.expressions.IsNull",
+          "org.apache.spark.sql.catalyst.expressions.IsNotNull",
+          "org.apache.spark.sql.catalyst.expressions.Coalesce",
+          "org.apache.spark.sql.catalyst.expressions.NullIf",
+          "org.apache.spark.sql.catalyst.expressions.Nvl",
+          "org.apache.spark.sql.catalyst.expressions.Nvl2",
+          "org.apache.spark.sql.catalyst.expressions.NaNvl",
+          "org.apache.spark.sql.catalyst.expressions.IsNaN",
           // Conditional.
-          "If",
-          "CaseWhen",
-          "Greatest",
-          "Least",
+          "org.apache.spark.sql.catalyst.expressions.If",
+          "org.apache.spark.sql.catalyst.expressions.CaseWhen",
+          "org.apache.spark.sql.catalyst.expressions.Greatest",
+          "org.apache.spark.sql.catalyst.expressions.Least",
           // Type casting.
-          "Cast",
-          "AnsiCast",
-          "ToBinary",
-          "TryToBinary",
-          "ToNumber",
-          "TryToNumber",
-          "ToCharacter",
+          "org.apache.spark.sql.catalyst.expressions.Cast",
+          "org.apache.spark.sql.catalyst.expressions.ToBinary",
+          "org.apache.spark.sql.catalyst.expressions.TryToBinary",
+          "org.apache.spark.sql.catalyst.expressions.ToNumber",
+          "org.apache.spark.sql.catalyst.expressions.TryToNumber",
+          "org.apache.spark.sql.catalyst.expressions.ToCharacter",
           // Sorting.
-          "SortOrder",
+          "org.apache.spark.sql.catalyst.expressions.SortOrder",
           // Subquery expressions.
-          "ScalarSubquery",
-          "Exists",
-          "ListQuery",
-          "LateralSubquery",
+          "org.apache.spark.sql.catalyst.expressions.ScalarSubquery",
+          "org.apache.spark.sql.catalyst.expressions.Exists",
+          "org.apache.spark.sql.catalyst.expressions.ListQuery",
+          "org.apache.spark.sql.catalyst.expressions.LateralSubquery",
           // Generator expressions.
-          "Explode",
-          "PosExplode",
-          "Inline",
-          "Stack",
+          "org.apache.spark.sql.catalyst.expressions.Explode",
+          "org.apache.spark.sql.catalyst.expressions.PosExplode",
+          "org.apache.spark.sql.catalyst.expressions.Inline",
+          "org.apache.spark.sql.catalyst.expressions.Stack",
           // Window expressions.
-          "WindowExpression",
-          "WindowSpecDefinition",
-          "SpecifiedWindowFrame",
-          "UnspecifiedFrame",
+          "org.apache.spark.sql.catalyst.expressions.WindowExpression",
+          "org.apache.spark.sql.catalyst.expressions.WindowSpecDefinition",
+          "org.apache.spark.sql.catalyst.expressions.SpecifiedWindowFrame",
+          "org.apache.spark.sql.catalyst.expressions.UnspecifiedFrame",
           // Struct, array, and map expressions.
-          "CreateNamedStruct",
-          "CreateArray",
-          "CreateMap",
-          "GetStructField",
-          "GetArrayStructFields",
-          "GetArrayItem",
-          "GetMapValue",
+          "org.apache.spark.sql.catalyst.expressions.CreateNamedStruct",
+          "org.apache.spark.sql.catalyst.expressions.CreateArray",
+          "org.apache.spark.sql.catalyst.expressions.CreateMap",
+          "org.apache.spark.sql.catalyst.expressions.GetStructField",
+          "org.apache.spark.sql.catalyst.expressions.GetArrayStructFields",
+          "org.apache.spark.sql.catalyst.expressions.GetArrayItem",
+          "org.apache.spark.sql.catalyst.expressions.GetMapValue",
           // Higher-order functions.
-          "LambdaFunction",
+          "org.apache.spark.sql.catalyst.expressions.LambdaFunction",
           // Grouping.
-          "Grouping",
-          "GroupingID",
+          "org.apache.spark.sql.catalyst.expressions.Grouping",
+          "org.apache.spark.sql.catalyst.expressions.GroupingID",
           // Unresolved expression types.
-          "UnresolvedExtractValue",
-          "UnresolvedRegex",
-          "NamedArgumentExpression",
+          "org.apache.spark.sql.catalyst.analysis.UnresolvedExtractValue",
+          "org.apache.spark.sql.catalyst.analysis.UnresolvedRegex",
+          "org.apache.spark.sql.catalyst.expressions.NamedArgumentExpression",
           // Non-deterministic (safe).
-          "Rand",
-          "Randn",
-          "Uuid",
-          "Shuffle",
-          "RandStr",
-          "Uniform",
+          "org.apache.spark.sql.catalyst.expressions.Rand",
+          "org.apache.spark.sql.catalyst.expressions.Randn",
+          "org.apache.spark.sql.catalyst.expressions.Uuid",
+          "org.apache.spark.sql.catalyst.expressions.Shuffle",
           // Error handling.
-          "RaiseError",
-          "TryEval",
-          "AssertTrue",
+          "org.apache.spark.sql.catalyst.expressions.RaiseError",
+          "org.apache.spark.sql.catalyst.expressions.TryEval",
+          "org.apache.spark.sql.catalyst.expressions.AssertTrue",
           // Utility.
-          "Empty2Null",
-          "TypeOf",
+          "org.apache.spark.sql.catalyst.expressions.Empty2Null",
+          "org.apache.spark.sql.catalyst.expressions.TypeOf",
           // Bitwise operations.
-          "BitwiseAnd",
-          "BitwiseOr",
-          "BitwiseXor",
-          "BitwiseNot");
+          "org.apache.spark.sql.catalyst.expressions.BitwiseAnd",
+          "org.apache.spark.sql.catalyst.expressions.BitwiseOr",
+          "org.apache.spark.sql.catalyst.expressions.BitwiseXor",
+          "org.apache.spark.sql.catalyst.expressions.BitwiseNot");
 
-  // Expression types that are explicitly rejected because they enable unsafe operations.
+  // Fully-qualified expression class names that are explicitly rejected.
   private static final Set<String> REJECTED_EXPRESSION_NAMES =
       Set.of(
-          "CallMethodViaReflection",
-          "TryReflect",
-          "PythonUDF",
-          "HiveSimpleUDF",
-          "HiveGenericUDF",
-          "HiveUDAF",
-          "PrintToStderr",
-          "StaticInvoke",
-          "Invoke",
-          "NewInstance");
+          "org.apache.spark.sql.catalyst.expressions.CallMethodViaReflection",
+          "org.apache.spark.sql.catalyst.expressions.PythonUDF",
+          "org.apache.spark.sql.hive.HiveSimpleUDF",
+          "org.apache.spark.sql.hive.HiveGenericUDF",
+          "org.apache.spark.sql.catalyst.expressions.PrintToStderr",
+          "org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke",
+          "org.apache.spark.sql.catalyst.expressions.objects.Invoke",
+          "org.apache.spark.sql.catalyst.expressions.objects.NewInstance");
 
   /**
    * Constructs a new SqlValidator.
@@ -318,7 +309,8 @@ public class SqlValidator {
   }
 
   /**
-   * Validates that the given SQL query is read-only and contains only allowed operations.
+   * Validates that the given SQL parses to an unresolved logical plan that contains only allowed
+   * operations. Suitable for early rejection before any temp views are registered.
    *
    * @param sql the SQL query to validate
    * @throws InvalidRequestException if the query contains disallowed operations
@@ -334,10 +326,19 @@ public class SqlValidator {
   }
 
   /**
-   * Recursively validates a logical plan node and all its children and expressions.
+   * Validates an analyzed logical plan against the same allow-lists as {@link #validate(String)}.
+   * Required to catch constructs like {@code HiveSimpleUDF} / {@code HiveGenericUDF} that are
+   * inserted by the analyser and so are absent from the unresolved tree.
    *
-   * @param plan the logical plan node to validate
+   * @param plan an analyzed logical plan, typically obtained via {@code
+   *     dataset.queryExecution().analyzed()}
+   * @throws InvalidRequestException if the plan contains disallowed operations
    */
+  public void validateAnalyzed(@Nonnull final LogicalPlan plan) {
+    walkPlan(plan);
+  }
+
+  /** Recursively validates a logical plan node and all its children and expressions. */
   private void walkPlan(@Nonnull final LogicalPlan plan) {
     validatePlanNode(plan);
     final List<Expression> expressions = CollectionConverters.asJava(plan.expressions());
@@ -353,12 +354,9 @@ public class SqlValidator {
   /**
    * Recursively validates an expression and all its child expressions. If the expression is a
    * subquery expression, its inner plan is also validated.
-   *
-   * @param expr the expression to validate
    */
   private void walkExpression(@Nonnull final Expression expr) {
     validateExpression(expr);
-    // Subquery expressions contain an inner logical plan that must also be validated.
     if (expr instanceof final SubqueryExpression subquery) {
       walkPlan(subquery.plan());
     }
@@ -369,67 +367,46 @@ public class SqlValidator {
   }
 
   /**
-   * Validates that a plan node is in the allowed set.
-   *
-   * @param plan the plan node to validate
-   * @throws InvalidRequestException if the plan node is not allowed
+   * Validates that a plan node is in the allowed FQN set. All {@link Command} subclasses (DDL, DML,
+   * SHOW, DESCRIBE, etc.) are rejected outright, regardless of package.
    */
   private void validatePlanNode(@Nonnull final LogicalPlan plan) {
-    // All Command subclasses are rejected (DDL, DML, SHOW, DESCRIBE, etc.).
     if (plan instanceof Command) {
       throw new InvalidRequestException(
           "SQL contains a disallowed operation: " + plan.getClass().getSimpleName());
     }
-    final String className = plan.getClass().getSimpleName();
-    // Scala objects have a trailing '$' in their class name which must be stripped for matching.
-    final String normalised =
-        className.endsWith("$") ? className.substring(0, className.length() - 1) : className;
-    if (!ALLOWED_PLAN_NODES.contains(normalised)) {
-      throw new InvalidRequestException("SQL contains a disallowed plan node: " + className);
+    if (!ALLOWED_PLAN_NODES.contains(canonicalClassName(plan))) {
+      throw new InvalidRequestException(
+          "SQL contains a disallowed plan node: " + plan.getClass().getSimpleName());
     }
   }
 
-  /**
-   * Validates that an expression is in the allowed set.
-   *
-   * @param expr the expression to validate
-   * @throws InvalidRequestException if the expression is not allowed
-   */
+  /** Validates that an expression is in the allowed FQN set or recognised as a Pathling UDF. */
   private void validateExpression(@Nonnull final Expression expr) {
-    final String className = expr.getClass().getSimpleName();
+    final String fqn = canonicalClassName(expr);
 
-    // Check explicitly rejected types first.
-    if (REJECTED_EXPRESSION_NAMES.contains(className)) {
-      throw new InvalidRequestException("SQL contains a disallowed expression: " + className);
+    if (REJECTED_EXPRESSION_NAMES.contains(fqn)) {
+      throw new InvalidRequestException(
+          "SQL contains a disallowed expression: " + expr.getClass().getSimpleName());
     }
 
-    // Special handling for UnresolvedFunction: validate the function name.
     if (expr instanceof final UnresolvedFunction unresolvedFunc) {
       validateFunctionName(unresolvedFunc);
       return;
     }
 
-    // Special handling for ScalaUDF: validate against UDF allowlist.
     if (expr instanceof final ScalaUDF scalaUdf) {
       validateUdf(scalaUdf);
       return;
     }
 
-    // Check against the allowed expression names. Scala objects have a trailing '$' in their
-    // class name which must be stripped for matching.
-    final String normalised =
-        className.endsWith("$") ? className.substring(0, className.length() - 1) : className;
-    if (!ALLOWED_EXPRESSION_NAMES.contains(normalised)) {
-      throw new InvalidRequestException("SQL contains a disallowed expression: " + className);
+    if (!ALLOWED_EXPRESSION_NAMES.contains(fqn)) {
+      throw new InvalidRequestException(
+          "SQL contains a disallowed expression: " + expr.getClass().getSimpleName());
     }
   }
 
-  /**
-   * Validates that an unresolved function is not a known-dangerous function.
-   *
-   * @param func the unresolved function to validate
-   * @throws InvalidRequestException if the function is dangerous
-   */
+  /** Validates that an unresolved function is not a known-dangerous function. */
   private void validateFunctionName(@Nonnull final UnresolvedFunction func) {
     final List<String> nameParts = CollectionConverters.asJava(func.nameParts());
     if (!nameParts.isEmpty()) {
@@ -441,12 +418,7 @@ public class SqlValidator {
     }
   }
 
-  /**
-   * Validates that a ScalaUDF is in the Pathling UDF allowlist.
-   *
-   * @param udf the ScalaUDF to validate
-   * @throws InvalidRequestException if the UDF is not in the allowlist
-   */
+  /** Validates that a ScalaUDF is in the Pathling UDF allow-list. */
   private void validateUdf(@Nonnull final ScalaUDF udf) {
     final Option<String> nameOpt = udf.udfName();
     if (nameOpt.isDefined()) {
@@ -457,5 +429,39 @@ public class SqlValidator {
     } else {
       throw new InvalidRequestException("SQL contains an unnamed UDF, which is not allowed");
     }
+  }
+
+  /**
+   * Returns the FQN of the object's class with any trailing {@code $} stripped, so that Scala case
+   * objects (whose runtime class name ends in {@code $}) match the form held in the allow-lists.
+   */
+  @Nonnull
+  private static String canonicalClassName(@Nonnull final Object node) {
+    final String name = node.getClass().getName();
+    return name.endsWith("$") ? name.substring(0, name.length() - 1) : name;
+  }
+
+  /** Allow-list entries, exposed for build-time integrity tests. */
+  @Nonnull
+  static Set<String> allowedPlanNodes() {
+    return ALLOWED_PLAN_NODES;
+  }
+
+  /** Allow-list entries, exposed for build-time integrity tests. */
+  @Nonnull
+  static Set<String> allowedExpressionNames() {
+    return ALLOWED_EXPRESSION_NAMES;
+  }
+
+  /** Reject-list entries, exposed for build-time integrity tests. */
+  @Nonnull
+  static Set<String> rejectedExpressionNames() {
+    return REJECTED_EXPRESSION_NAMES;
+  }
+
+  /** Allow-list entries, exposed for build-time integrity tests. */
+  @Nonnull
+  static Set<String> allowedUdfNames() {
+    return ALLOWED_UDF_NAMES;
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
@@ -1,0 +1,461 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import jakarta.annotation.Nonnull;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.UnresolvedFunction;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.ScalaUDF;
+import org.apache.spark.sql.catalyst.expressions.SubqueryExpression;
+import org.apache.spark.sql.catalyst.plans.logical.Command;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import scala.Option;
+import scala.jdk.javaapi.CollectionConverters;
+
+/**
+ * Validates that SQL queries are strictly read-only and contain only allowed operations. This
+ * prevents SQL injection attacks and ensures that users cannot execute DDL, DML, or other dangerous
+ * operations through the {@code $sqlquery-run} endpoint.
+ *
+ * <p>Validation is performed on the unresolved logical plan produced by Spark's SQL parser. The
+ * validator walks the entire plan tree and checks every plan node and expression against a
+ * whitelist. Any node not in the whitelist causes the query to be rejected.
+ *
+ * <p>Three validation layers are applied:
+ *
+ * <ol>
+ *   <li><strong>Plan node whitelist</strong> — only read-only plan nodes are permitted.
+ *   <li><strong>Expression whitelist</strong> — only safe expression types are permitted.
+ *   <li><strong>UDF allowlist</strong> — {@code ScalaUDF} is permitted only for Pathling's
+ *       registered UDFs.
+ * </ol>
+ *
+ * @see <a
+ *     href="https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/OperationDefinition-SQLQueryRun.html">SQLQueryRun</a>
+ */
+@Slf4j
+@Component
+public class SqlValidator {
+
+  @Nonnull private final SparkSession sparkSession;
+
+  // Allowed plan node class names (simple names). Any plan node not in this set is rejected.
+  // All Command subclasses (DDL/DML) are additionally rejected via instanceof check.
+  private static final Set<String> ALLOWED_PLAN_NODES =
+      Set.of(
+          // Basic operations.
+          "Project",
+          "Filter",
+          "Sort",
+          "GlobalLimit",
+          "LocalLimit",
+          "Tail",
+          "Offset",
+          "ReturnAnswer",
+          // Set operations.
+          "Union",
+          "Intersect",
+          "Except",
+          // Joins.
+          "Join",
+          "LateralJoin",
+          "AsOfJoin",
+          // Aggregation and grouping.
+          "Aggregate",
+          "Expand",
+          "Window",
+          "WithWindowDefinition",
+          // Table and relation access.
+          "UnresolvedRelation",
+          "SubqueryAlias",
+          "LocalRelation",
+          "OneRowRelation",
+          "EmptyRelation",
+          "Range",
+          "View",
+          "UnresolvedInlineTable",
+          "UnresolvedTableValuedFunction",
+          // Common table expressions.
+          "WithCTE",
+          "CTERelationDef",
+          "CTERelationRef",
+          "UnresolvedWith",
+          // Deduplication.
+          "Distinct",
+          "Deduplicate",
+          // Pivot and unpivot.
+          "Pivot",
+          "Unpivot",
+          // Generate (LATERAL VIEW / EXPLODE).
+          "Generate",
+          // Hints.
+          "ResolvedHint",
+          "UnresolvedHint",
+          // Sampling.
+          "Sample",
+          // Repartitioning (read-only).
+          "Repartition",
+          "RebalancePartitions",
+          // Transposition.
+          "Transpose",
+          // Subquery wrapper.
+          "Subquery",
+          // Unresolved plan-specific nodes.
+          "UnresolvedSubqueryColumnAliases");
+
+  // Function names that are explicitly rejected because they enable arbitrary code execution.
+  private static final Set<String> REJECTED_FUNCTION_NAMES =
+      Set.of("reflect", "java_method", "try_reflect");
+
+  // Pathling-registered UDF names that are allowed in ScalaUDF expressions.
+  private static final Set<String> ALLOWED_UDF_NAMES =
+      Set.of(
+          // Terminology UDFs (registered by TerminologyUdfRegistrar).
+          "display",
+          "member_of",
+          "subsumes",
+          "designation",
+          "translate_coding",
+          "property_string",
+          "property_code",
+          "property_integer",
+          "property_boolean",
+          "property_decimal",
+          "property_dateTime",
+          "property_Coding",
+          // FHIRPath UDFs (registered by PathlingUdfRegistrar).
+          "to_null",
+          "string_to_quantity",
+          "quantity_to_literal",
+          "decimal_to_literal",
+          "coding_to_literal",
+          "convert_quantity_to_unit",
+          "low_boundary_for_date",
+          "high_boundary_for_date",
+          "low_boundary_for_time",
+          "high_boundary_for_time");
+
+  // Allowed expression class names for the unresolved plan. Expressions not in this set (and not
+  // covered by special handling for UnresolvedFunction and ScalaUDF) are rejected.
+  @SuppressWarnings("java:S1192")
+  private static final Set<String> ALLOWED_EXPRESSION_NAMES =
+      Set.of(
+          // Literals and references.
+          "Literal",
+          "UnresolvedAttribute",
+          "UnresolvedStar",
+          "UnresolvedNamedLambdaVariable",
+          "NamedLambdaVariable",
+          "LambdaVariable",
+          "Alias",
+          "UnresolvedAlias",
+          "OuterReference",
+          "UnresolvedOrdinal",
+          "VariableReference",
+          "AttributeReference",
+          "BoundReference",
+          // Arithmetic.
+          "Add",
+          "Subtract",
+          "Multiply",
+          "Divide",
+          "IntegralDivide",
+          "Remainder",
+          "Pmod",
+          "UnaryMinus",
+          "UnaryPositive",
+          "Abs",
+          // Comparison.
+          "EqualTo",
+          "EqualNullSafe",
+          "LessThan",
+          "LessThanOrEqual",
+          "GreaterThan",
+          "GreaterThanOrEqual",
+          // Predicates.
+          "In",
+          "InSet",
+          "InSubquery",
+          "Between",
+          "Like",
+          "ILike",
+          "RLike",
+          "LikeAll",
+          "LikeAny",
+          "NotLikeAll",
+          "NotLikeAny",
+          "Contains",
+          "StartsWith",
+          "EndsWith",
+          "StringInstr",
+          "StringLocate",
+          "FindInSet",
+          // Logical operators.
+          "And",
+          "Or",
+          "Not",
+          // Null handling.
+          "IsNull",
+          "IsNotNull",
+          "Coalesce",
+          "NullIf",
+          "Nvl",
+          "Nvl2",
+          "IfNull",
+          "NaNvl",
+          "IsNaN",
+          // Conditional.
+          "If",
+          "CaseWhen",
+          "Greatest",
+          "Least",
+          // Type casting.
+          "Cast",
+          "AnsiCast",
+          "ToBinary",
+          "TryToBinary",
+          "ToNumber",
+          "TryToNumber",
+          "ToCharacter",
+          // Sorting.
+          "SortOrder",
+          // Subquery expressions.
+          "ScalarSubquery",
+          "Exists",
+          "ListQuery",
+          "LateralSubquery",
+          // Generator expressions.
+          "Explode",
+          "PosExplode",
+          "Inline",
+          "Stack",
+          // Window expressions.
+          "WindowExpression",
+          "WindowSpecDefinition",
+          "SpecifiedWindowFrame",
+          "UnspecifiedFrame",
+          // Struct, array, and map expressions.
+          "CreateNamedStruct",
+          "CreateArray",
+          "CreateMap",
+          "GetStructField",
+          "GetArrayStructFields",
+          "GetArrayItem",
+          "GetMapValue",
+          // Higher-order functions.
+          "LambdaFunction",
+          // Grouping.
+          "Grouping",
+          "GroupingID",
+          // Unresolved expression types.
+          "UnresolvedExtractValue",
+          "UnresolvedRegex",
+          "NamedArgumentExpression",
+          // Non-deterministic (safe).
+          "Rand",
+          "Randn",
+          "Uuid",
+          "Shuffle",
+          "RandStr",
+          "Uniform",
+          // Error handling.
+          "RaiseError",
+          "TryEval",
+          "AssertTrue",
+          // Utility.
+          "Empty2Null",
+          "TypeOf",
+          // Bitwise operations.
+          "BitwiseAnd",
+          "BitwiseOr",
+          "BitwiseXor",
+          "BitwiseNot");
+
+  // Expression types that are explicitly rejected because they enable unsafe operations.
+  private static final Set<String> REJECTED_EXPRESSION_NAMES =
+      Set.of(
+          "CallMethodViaReflection",
+          "TryReflect",
+          "PythonUDF",
+          "HiveSimpleUDF",
+          "HiveGenericUDF",
+          "HiveUDAF",
+          "PrintToStderr",
+          "StaticInvoke",
+          "Invoke",
+          "NewInstance");
+
+  /**
+   * Constructs a new SqlValidator.
+   *
+   * @param sparkSession the Spark session used for SQL parsing
+   */
+  @Autowired
+  public SqlValidator(@Nonnull final SparkSession sparkSession) {
+    this.sparkSession = sparkSession;
+  }
+
+  /**
+   * Validates that the given SQL query is read-only and contains only allowed operations.
+   *
+   * @param sql the SQL query to validate
+   * @throws InvalidRequestException if the query contains disallowed operations
+   */
+  public void validate(@Nonnull final String sql) {
+    final LogicalPlan plan;
+    try {
+      plan = sparkSession.sessionState().sqlParser().parsePlan(sql);
+    } catch (final Exception e) {
+      throw new InvalidRequestException("Invalid SQL syntax: " + e.getMessage());
+    }
+    walkPlan(plan);
+  }
+
+  /**
+   * Recursively validates a logical plan node and all its children and expressions.
+   *
+   * @param plan the logical plan node to validate
+   */
+  private void walkPlan(@Nonnull final LogicalPlan plan) {
+    validatePlanNode(plan);
+    final List<Expression> expressions = CollectionConverters.asJava(plan.expressions());
+    for (final Expression expr : expressions) {
+      walkExpression(expr);
+    }
+    final List<LogicalPlan> children = CollectionConverters.asJava(plan.children());
+    for (final LogicalPlan child : children) {
+      walkPlan(child);
+    }
+  }
+
+  /**
+   * Recursively validates an expression and all its child expressions. If the expression is a
+   * subquery expression, its inner plan is also validated.
+   *
+   * @param expr the expression to validate
+   */
+  private void walkExpression(@Nonnull final Expression expr) {
+    validateExpression(expr);
+    // Subquery expressions contain an inner logical plan that must also be validated.
+    if (expr instanceof final SubqueryExpression subquery) {
+      walkPlan(subquery.plan());
+    }
+    final List<Expression> children = CollectionConverters.asJava(expr.children());
+    for (final Expression child : children) {
+      walkExpression(child);
+    }
+  }
+
+  /**
+   * Validates that a plan node is in the allowed set.
+   *
+   * @param plan the plan node to validate
+   * @throws InvalidRequestException if the plan node is not allowed
+   */
+  private void validatePlanNode(@Nonnull final LogicalPlan plan) {
+    // All Command subclasses are rejected (DDL, DML, SHOW, DESCRIBE, etc.).
+    if (plan instanceof Command) {
+      throw new InvalidRequestException(
+          "SQL contains a disallowed operation: " + plan.getClass().getSimpleName());
+    }
+    final String className = plan.getClass().getSimpleName();
+    // Scala objects have a trailing '$' in their class name which must be stripped for matching.
+    final String normalised =
+        className.endsWith("$") ? className.substring(0, className.length() - 1) : className;
+    if (!ALLOWED_PLAN_NODES.contains(normalised)) {
+      throw new InvalidRequestException("SQL contains a disallowed plan node: " + className);
+    }
+  }
+
+  /**
+   * Validates that an expression is in the allowed set.
+   *
+   * @param expr the expression to validate
+   * @throws InvalidRequestException if the expression is not allowed
+   */
+  private void validateExpression(@Nonnull final Expression expr) {
+    final String className = expr.getClass().getSimpleName();
+
+    // Check explicitly rejected types first.
+    if (REJECTED_EXPRESSION_NAMES.contains(className)) {
+      throw new InvalidRequestException("SQL contains a disallowed expression: " + className);
+    }
+
+    // Special handling for UnresolvedFunction: validate the function name.
+    if (expr instanceof final UnresolvedFunction unresolvedFunc) {
+      validateFunctionName(unresolvedFunc);
+      return;
+    }
+
+    // Special handling for ScalaUDF: validate against UDF allowlist.
+    if (expr instanceof final ScalaUDF scalaUdf) {
+      validateUdf(scalaUdf);
+      return;
+    }
+
+    // Check against the allowed expression names. Scala objects have a trailing '$' in their
+    // class name which must be stripped for matching.
+    final String normalised =
+        className.endsWith("$") ? className.substring(0, className.length() - 1) : className;
+    if (!ALLOWED_EXPRESSION_NAMES.contains(normalised)) {
+      throw new InvalidRequestException("SQL contains a disallowed expression: " + className);
+    }
+  }
+
+  /**
+   * Validates that an unresolved function is not a known-dangerous function.
+   *
+   * @param func the unresolved function to validate
+   * @throws InvalidRequestException if the function is dangerous
+   */
+  private void validateFunctionName(@Nonnull final UnresolvedFunction func) {
+    final List<String> nameParts = CollectionConverters.asJava(func.nameParts());
+    if (!nameParts.isEmpty()) {
+      final String simpleName = nameParts.getLast().toLowerCase();
+      if (REJECTED_FUNCTION_NAMES.contains(simpleName)) {
+        throw new InvalidRequestException(
+            "SQL contains a disallowed function: " + String.join(".", nameParts));
+      }
+    }
+  }
+
+  /**
+   * Validates that a ScalaUDF is in the Pathling UDF allowlist.
+   *
+   * @param udf the ScalaUDF to validate
+   * @throws InvalidRequestException if the UDF is not in the allowlist
+   */
+  private void validateUdf(@Nonnull final ScalaUDF udf) {
+    final Option<String> nameOpt = udf.udfName();
+    if (nameOpt.isDefined()) {
+      final String name = nameOpt.get();
+      if (!ALLOWED_UDF_NAMES.contains(name)) {
+        throw new InvalidRequestException("SQL contains a disallowed UDF: " + name);
+      }
+    } else {
+      throw new InvalidRequestException("SQL contains an unnamed UDF, which is not allowed");
+    }
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
@@ -69,6 +69,14 @@ import scala.jdk.javaapi.CollectionConverters;
 @Component
 public class SqlValidator {
 
+  /**
+   * FQN prefix for Pathling-defined Catalyst plan nodes and expressions. Classes from this package
+   * are trusted because Pathling owns them and uses them internally (e.g. for FhirView execution).
+   * Without this carve-out, every expression class injected by the FhirView executor would have to
+   * be hand-listed and kept in sync with the encoders module.
+   */
+  private static final String PATHLING_PACKAGE_PREFIX = "au.csiro.pathling.";
+
   @Nonnull private final SparkSession sparkSession;
 
   // Fully-qualified plan node class names that are permitted. All Command subclasses are
@@ -322,32 +330,38 @@ public class SqlValidator {
     } catch (final Exception e) {
       throw new InvalidRequestException("Invalid SQL syntax: " + e.getMessage());
     }
-    walkPlan(plan);
+    walkPlan(plan, /* strict= */ true);
   }
 
   /**
-   * Validates an analyzed logical plan against the same allow-lists as {@link #validate(String)}.
-   * Required to catch constructs like {@code HiveSimpleUDF} / {@code HiveGenericUDF} that are
-   * inserted by the analyser and so are absent from the unresolved tree.
+   * Validates an analyzed logical plan against the reject-list. Required to catch constructs like
+   * {@code HiveSimpleUDF} / {@code HiveGenericUDF} that are inserted by the analyser and so are
+   * absent from the unresolved tree.
+   *
+   * <p>Unlike {@link #validate(String)}, this walk does <em>not</em> enforce the allow-list,
+   * because the analyser legitimately introduces many Spark expression types ({@code Flatten},
+   * {@code GetStructField} variants, etc.) that user-written SQL would not name directly. The
+   * unresolved-plan walk is the appropriate place to enforce the allow-list; the analyzed-plan
+   * walk's job is to catch constructs that <em>only</em> appear post-analysis.
    *
    * @param plan an analyzed logical plan, typically obtained via {@code
    *     dataset.queryExecution().analyzed()}
-   * @throws InvalidRequestException if the plan contains disallowed operations
+   * @throws InvalidRequestException if the plan contains rejected operations
    */
   public void validateAnalyzed(@Nonnull final LogicalPlan plan) {
-    walkPlan(plan);
+    walkPlan(plan, /* strict= */ false);
   }
 
   /** Recursively validates a logical plan node and all its children and expressions. */
-  private void walkPlan(@Nonnull final LogicalPlan plan) {
-    validatePlanNode(plan);
+  private void walkPlan(@Nonnull final LogicalPlan plan, final boolean strict) {
+    validatePlanNode(plan, strict);
     final List<Expression> expressions = CollectionConverters.asJava(plan.expressions());
     for (final Expression expr : expressions) {
-      walkExpression(expr);
+      walkExpression(expr, strict);
     }
     final List<LogicalPlan> children = CollectionConverters.asJava(plan.children());
     for (final LogicalPlan child : children) {
-      walkPlan(child);
+      walkPlan(child, strict);
     }
   }
 
@@ -355,34 +369,46 @@ public class SqlValidator {
    * Recursively validates an expression and all its child expressions. If the expression is a
    * subquery expression, its inner plan is also validated.
    */
-  private void walkExpression(@Nonnull final Expression expr) {
-    validateExpression(expr);
+  private void walkExpression(@Nonnull final Expression expr, final boolean strict) {
+    validateExpression(expr, strict);
     if (expr instanceof final SubqueryExpression subquery) {
-      walkPlan(subquery.plan());
+      walkPlan(subquery.plan(), strict);
     }
     final List<Expression> children = CollectionConverters.asJava(expr.children());
     for (final Expression child : children) {
-      walkExpression(child);
+      walkExpression(child, strict);
     }
   }
 
   /**
-   * Validates that a plan node is in the allowed FQN set. All {@link Command} subclasses (DDL, DML,
-   * SHOW, DESCRIBE, etc.) are rejected outright, regardless of package.
+   * Validates that a plan node is permitted. All {@link Command} subclasses (DDL, DML, SHOW,
+   * DESCRIBE, etc.) are rejected outright, regardless of package, in both modes. In strict mode,
+   * the allow-list is additionally enforced.
    */
-  private void validatePlanNode(@Nonnull final LogicalPlan plan) {
+  private void validatePlanNode(@Nonnull final LogicalPlan plan, final boolean strict) {
     if (plan instanceof Command) {
       throw new InvalidRequestException(
           "SQL contains a disallowed operation: " + plan.getClass().getSimpleName());
     }
-    if (!ALLOWED_PLAN_NODES.contains(canonicalClassName(plan))) {
+    if (!strict) {
+      return;
+    }
+    final String fqn = canonicalClassName(plan);
+    if (fqn.startsWith(PATHLING_PACKAGE_PREFIX)) {
+      return;
+    }
+    if (!ALLOWED_PLAN_NODES.contains(fqn)) {
       throw new InvalidRequestException(
           "SQL contains a disallowed plan node: " + plan.getClass().getSimpleName());
     }
   }
 
-  /** Validates that an expression is in the allowed FQN set or recognised as a Pathling UDF. */
-  private void validateExpression(@Nonnull final Expression expr) {
+  /**
+   * Validates an expression. In both modes, explicitly rejected expression types and disallowed
+   * function names are caught, and ScalaUDF is gated by the Pathling UDF allow-list. In strict
+   * mode, the expression allow-list is additionally enforced.
+   */
+  private void validateExpression(@Nonnull final Expression expr, final boolean strict) {
     final String fqn = canonicalClassName(expr);
 
     if (REJECTED_EXPRESSION_NAMES.contains(fqn)) {
@@ -397,6 +423,14 @@ public class SqlValidator {
 
     if (expr instanceof final ScalaUDF scalaUdf) {
       validateUdf(scalaUdf);
+      return;
+    }
+
+    if (!strict) {
+      return;
+    }
+
+    if (fqn.startsWith(PATHLING_PACKAGE_PREFIX)) {
       return;
     }
 

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
@@ -19,20 +19,28 @@ package au.csiro.pathling.operations.sqlquery;
 
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import jakarta.annotation.Nonnull;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.FunctionIdentifier;
 import org.apache.spark.sql.catalyst.analysis.UnresolvedFunction;
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation;
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo;
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression;
 import org.apache.spark.sql.catalyst.plans.logical.Command;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
+import org.apache.spark.sql.catalyst.plans.logical.UnresolvedWith;
+import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import scala.Option;
+import scala.Tuple2;
 import scala.jdk.javaapi.CollectionConverters;
 
 /**
@@ -46,18 +54,25 @@ import scala.jdk.javaapi.CollectionConverters;
  * <p>Two validation entry-points are exposed:
  *
  * <ul>
- *   <li>{@link #validate(String)} parses the SQL and walks the unresolved logical plan. Cheap and
- *       suitable for early rejection before any temp views are registered.
- *   <li>{@link #validateAnalyzed(LogicalPlan)} walks an analyzed plan. Required to catch constructs
- *       like {@code HiveSimpleUDF} / {@code HiveGenericUDF}, which are inserted by the analyser and
- *       so are absent from the unresolved tree.
+ *   <li>{@link #validate(String, Set)} parses the SQL and walks the unresolved logical plan,
+ *       enforcing that every relation reference resolves to a declared label or a CTE defined
+ *       within the same query. Cheap and suitable for early rejection before any temp views are
+ *       registered.
+ *   <li>{@link #validateAnalyzed(LogicalPlan, Set)} walks an analyzed plan. Required to catch
+ *       constructs like {@code HiveSimpleUDF} / {@code HiveGenericUDF}, which are inserted by the
+ *       analyser and so are absent from the unresolved tree, and to reject any leaf physical
+ *       relation whose source is not one of the registered request-scoped temp views.
  * </ul>
  *
- * <p>Three validation layers are applied:
+ * <p>Four validation layers are applied:
  *
  * <ol>
  *   <li><strong>Plan node allow-list</strong> — only read-only plan nodes are permitted. All {@link
  *       Command} subclasses are rejected outright.
+ *   <li><strong>Relation allow-list</strong> — every {@link UnresolvedRelation} must be a
+ *       single-part identifier present in the declared label set or among the CTEs defined within
+ *       the query. This rejects datasource short-name file reads such as {@code
+ *       parquet.`/etc/passwd`}, which would otherwise be resolved by Spark to a direct file read.
  *   <li><strong>Expression allow-list</strong> — only safe expression types are permitted.
  *   <li><strong>Built-in functions only</strong> — every {@link UnresolvedFunction} in user SQL
  *       must resolve to a built-in Spark function. Pathling-registered UDFs (terminology, FHIRPath
@@ -298,81 +313,174 @@ public class SqlValidator {
   }
 
   /**
+   * Pattern that legitimate relation identifiers must match. Mirrors the {@code
+   * SqlQueryLibraryParser} label pattern so that anything Spark's parser produces as an
+   * UnresolvedRelation but which could not have been a declared label is rejected outright.
+   */
+  private static final Pattern LABEL_PATTERN = Pattern.compile("^[A-Za-z]\\w*$");
+
+  /**
    * Validates that the given SQL parses to an unresolved logical plan that contains only allowed
-   * operations. Suitable for early rejection before any temp views are registered.
+   * operations and that every relation reference resolves to either a declared label or a CTE
+   * defined within the same query. Suitable for early rejection before any temp views are
+   * registered.
    *
    * @param sql the SQL query to validate
-   * @throws InvalidRequestException if the query contains disallowed operations
+   * @param allowedLabels the set of relation labels declared in the request (i.e. the labels of the
+   *     {@code Library.relatedArtifact} entries) that may appear as relation references
+   * @throws InvalidRequestException if the query contains disallowed operations or references an
+   *     undeclared table
    */
-  public void validate(@Nonnull final String sql) {
+  public void validate(@Nonnull final String sql, @Nonnull final Set<String> allowedLabels) {
     final LogicalPlan plan;
     try {
       plan = sparkSession.sessionState().sqlParser().parsePlan(sql);
     } catch (final Exception e) {
       throw new InvalidRequestException("Invalid SQL syntax: " + e.getMessage());
     }
-    walkPlan(plan, /* strict= */ true);
+    final Set<String> effectiveLabels = new HashSet<>(allowedLabels);
+    collectCteNames(plan, effectiveLabels);
+    walkPlanStrict(plan, effectiveLabels);
   }
 
   /**
-   * Validates an analyzed logical plan against the reject-list. Required to catch constructs like
-   * {@code HiveSimpleUDF} / {@code HiveGenericUDF} that are inserted by the analyser and so are
-   * absent from the unresolved tree.
+   * Validates an analyzed logical plan against the reject-list and additionally rejects any leaf
+   * relation whose source is not one of the request-scoped temp views the executor registered.
+   * Required to catch constructs like {@code HiveSimpleUDF} / {@code HiveGenericUDF} that are
+   * inserted by the analyser and so are absent from the unresolved tree, and to catch any future
+   * parser change that would let a datasource short-name reference (e.g. {@code parquet.`/path`})
+   * slip past the parse-time check.
    *
-   * <p>Unlike {@link #validate(String)}, this walk does <em>not</em> enforce the allow-list,
-   * because the analyser legitimately introduces many Spark expression types ({@code Flatten},
-   * {@code GetStructField} variants, etc.) that user-written SQL would not name directly. The
-   * unresolved-plan walk is the appropriate place to enforce the allow-list; the analyzed-plan
-   * walk's job is to catch constructs that <em>only</em> appear post-analysis.
+   * <p>Unlike {@link #validate(String, Set)}, this walk does <em>not</em> enforce the expression
+   * allow-list, because the analyser legitimately introduces many Spark expression types ({@code
+   * Flatten}, {@code GetStructField} variants, etc.) that user-written SQL would not name directly.
    *
    * @param plan an analyzed logical plan, typically obtained via {@code
    *     dataset.queryExecution().analyzed()}
-   * @throws InvalidRequestException if the plan contains rejected operations
+   * @param registeredViewNames the names of the request-scoped temporary views that were registered
+   *     for this query - any leaf physical relation must be reachable only as a descendant of a
+   *     {@link SubqueryAlias} whose name appears in this set
+   * @throws InvalidRequestException if the plan contains rejected operations or references a
+   *     relation that is not one of the registered temp views
    */
-  public void validateAnalyzed(@Nonnull final LogicalPlan plan) {
-    walkPlan(plan, /* strict= */ false);
+  public void validateAnalyzed(
+      @Nonnull final LogicalPlan plan, @Nonnull final Set<String> registeredViewNames) {
+    walkPlanAnalyzed(plan, registeredViewNames, /* inTrustedAlias= */ false);
   }
 
-  /** Recursively validates a logical plan node and all its children and expressions. */
-  private void walkPlan(@Nonnull final LogicalPlan plan, final boolean strict) {
-    validatePlanNode(plan, strict);
-    final List<Expression> expressions = CollectionConverters.asJava(plan.expressions());
-    for (final Expression expr : expressions) {
-      walkExpression(expr, strict);
+  /**
+   * Pre-walks the parsed plan to collect names of common-table-expressions defined anywhere in the
+   * tree, so that {@code WITH ... SELECT} queries can refer to their CTEs without each CTE name
+   * being a declared label.
+   */
+  private static void collectCteNames(
+      @Nonnull final LogicalPlan plan, @Nonnull final Set<String> out) {
+    if (plan instanceof final UnresolvedWith with) {
+      final List<Tuple2<String, SubqueryAlias>> ctes =
+          CollectionConverters.asJava(with.cteRelations());
+      for (final Tuple2<String, SubqueryAlias> cte : ctes) {
+        out.add(cte._1());
+        collectCteNames(cte._2(), out);
+      }
     }
     final List<LogicalPlan> children = CollectionConverters.asJava(plan.children());
     for (final LogicalPlan child : children) {
-      walkPlan(child, strict);
+      collectCteNames(child, out);
+    }
+    final List<Expression> expressions = CollectionConverters.asJava(plan.expressions());
+    for (final Expression expr : expressions) {
+      collectCteNamesInExpression(expr, out);
     }
   }
 
-  /**
-   * Recursively validates an expression and all its child expressions. If the expression is a
-   * subquery expression, its inner plan is also validated.
-   */
-  private void walkExpression(@Nonnull final Expression expr, final boolean strict) {
-    validateExpression(expr, strict);
+  /** Recurses through expression subqueries to pick up CTEs defined inside them. */
+  private static void collectCteNamesInExpression(
+      @Nonnull final Expression expr, @Nonnull final Set<String> out) {
     if (expr instanceof final SubqueryExpression subquery) {
-      walkPlan(subquery.plan(), strict);
+      collectCteNames(subquery.plan(), out);
     }
     final List<Expression> children = CollectionConverters.asJava(expr.children());
     for (final Expression child : children) {
-      walkExpression(child, strict);
+      collectCteNamesInExpression(child, out);
+    }
+  }
+
+  /** Recursively validates a parsed plan in strict mode. */
+  private void walkPlanStrict(
+      @Nonnull final LogicalPlan plan, @Nonnull final Set<String> allowedLabels) {
+    validatePlanNodeStrict(plan, allowedLabels);
+    final List<Expression> expressions = CollectionConverters.asJava(plan.expressions());
+    for (final Expression expr : expressions) {
+      walkExpressionStrict(expr, allowedLabels);
+    }
+    final List<LogicalPlan> children = CollectionConverters.asJava(plan.children());
+    for (final LogicalPlan child : children) {
+      walkPlanStrict(child, allowedLabels);
+    }
+  }
+
+  /** Recursively validates an analyzed plan, tracking whether we are inside a trusted alias. */
+  private void walkPlanAnalyzed(
+      @Nonnull final LogicalPlan plan,
+      @Nonnull final Set<String> registeredViewNames,
+      final boolean inTrustedAlias) {
+    validatePlanNodeAnalyzed(plan, registeredViewNames, inTrustedAlias);
+    final List<Expression> expressions = CollectionConverters.asJava(plan.expressions());
+    for (final Expression expr : expressions) {
+      walkExpressionAnalyzed(expr, registeredViewNames);
+    }
+    final boolean childTrust = inTrustedAlias || isTrustedAlias(plan, registeredViewNames);
+    final List<LogicalPlan> children = CollectionConverters.asJava(plan.children());
+    for (final LogicalPlan child : children) {
+      walkPlanAnalyzed(child, registeredViewNames, childTrust);
+    }
+  }
+
+  /** Returns true when the given node is a SubqueryAlias whose name is a registered temp view. */
+  private static boolean isTrustedAlias(
+      @Nonnull final LogicalPlan plan, @Nonnull final Set<String> registeredViewNames) {
+    if (!(plan instanceof final SubqueryAlias alias)) {
+      return false;
+    }
+    return registeredViewNames.contains(alias.identifier().name());
+  }
+
+  /** Recursively validates an expression tree (strict mode). */
+  private void walkExpressionStrict(
+      @Nonnull final Expression expr, @Nonnull final Set<String> allowedLabels) {
+    validateExpression(expr, /* strict= */ true);
+    if (expr instanceof final SubqueryExpression subquery) {
+      walkPlanStrict(subquery.plan(), allowedLabels);
+    }
+    final List<Expression> children = CollectionConverters.asJava(expr.children());
+    for (final Expression child : children) {
+      walkExpressionStrict(child, allowedLabels);
+    }
+  }
+
+  /** Recursively validates an expression tree (analyzed mode). */
+  private void walkExpressionAnalyzed(
+      @Nonnull final Expression expr, @Nonnull final Set<String> registeredViewNames) {
+    validateExpression(expr, /* strict= */ false);
+    if (expr instanceof final SubqueryExpression subquery) {
+      walkPlanAnalyzed(subquery.plan(), registeredViewNames, /* inTrustedAlias= */ false);
+    }
+    final List<Expression> children = CollectionConverters.asJava(expr.children());
+    for (final Expression child : children) {
+      walkExpressionAnalyzed(child, registeredViewNames);
     }
   }
 
   /**
-   * Validates that a plan node is permitted. All {@link Command} subclasses (DDL, DML, SHOW,
-   * DESCRIBE, etc.) are rejected outright, regardless of package, in both modes. In strict mode,
-   * the allow-list is additionally enforced.
+   * Validates that a parsed plan node is permitted. All {@link Command} subclasses (DDL, DML, SHOW,
+   * DESCRIBE, etc.) are rejected outright. The plan-node allow-list is enforced and relation
+   * references are checked against the supplied label set.
    */
-  private void validatePlanNode(@Nonnull final LogicalPlan plan, final boolean strict) {
+  private void validatePlanNodeStrict(
+      @Nonnull final LogicalPlan plan, @Nonnull final Set<String> allowedLabels) {
     if (plan instanceof Command) {
       throw new InvalidRequestException(
           "SQL contains a disallowed operation: " + plan.getClass().getSimpleName());
-    }
-    if (!strict) {
-      return;
     }
     final String fqn = canonicalClassName(plan);
     if (fqn.startsWith(PATHLING_PACKAGE_PREFIX)) {
@@ -382,6 +490,56 @@ public class SqlValidator {
       throw new InvalidRequestException(
           "SQL contains a disallowed plan node: " + plan.getClass().getSimpleName());
     }
+    if (plan instanceof final UnresolvedRelation relation) {
+      validateRelationReference(relation, allowedLabels);
+    }
+  }
+
+  /**
+   * Validates that an analyzed plan node is permitted. All {@link Command} subclasses are rejected
+   * outright. Any {@link UnresolvedRelation} surviving analysis is rejected. Leaf physical
+   * relations ({@link LogicalRelation}, {@link HiveTableRelation}) are rejected unless they are
+   * descendants of a trusted {@link SubqueryAlias}.
+   */
+  private void validatePlanNodeAnalyzed(
+      @Nonnull final LogicalPlan plan,
+      @Nonnull final Set<String> registeredViewNames,
+      final boolean inTrustedAlias) {
+    if (plan instanceof Command) {
+      throw new InvalidRequestException(
+          "SQL contains a disallowed operation: " + plan.getClass().getSimpleName());
+    }
+    if (plan instanceof final UnresolvedRelation relation) {
+      throw new InvalidRequestException(
+          "SQL references an undeclared table: " + joinIdentifier(relation));
+    }
+    if (!inTrustedAlias && (plan instanceof LogicalRelation || plan instanceof HiveTableRelation)) {
+      throw new InvalidRequestException(
+          "SQL references an unauthorised data source: " + plan.getClass().getSimpleName());
+    }
+  }
+
+  /**
+   * Enforces that an unresolved relation is a single-part identifier matching {@link
+   * #LABEL_PATTERN} and present in the allowed-label set. Rejects two-part datasource short-name
+   * references such as {@code parquet.`/etc/passwd`}.
+   */
+  private static void validateRelationReference(
+      @Nonnull final UnresolvedRelation relation, @Nonnull final Set<String> allowedLabels) {
+    final List<String> parts = CollectionConverters.asJava(relation.multipartIdentifier());
+    if (parts.size() != 1) {
+      throw new InvalidRequestException(
+          "SQL references an undeclared table: " + String.join(".", parts));
+    }
+    final String name = parts.get(0);
+    if (!LABEL_PATTERN.matcher(name).matches() || !allowedLabels.contains(name)) {
+      throw new InvalidRequestException("SQL references an undeclared table: " + name);
+    }
+  }
+
+  @Nonnull
+  private static String joinIdentifier(@Nonnull final UnresolvedRelation relation) {
+    return String.join(".", CollectionConverters.asJava(relation.multipartIdentifier()));
   }
 
   /**

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
@@ -23,9 +23,10 @@ import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.FunctionIdentifier;
 import org.apache.spark.sql.catalyst.analysis.UnresolvedFunction;
 import org.apache.spark.sql.catalyst.expressions.Expression;
-import org.apache.spark.sql.catalyst.expressions.ScalaUDF;
+import org.apache.spark.sql.catalyst.expressions.ExpressionInfo;
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression;
 import org.apache.spark.sql.catalyst.plans.logical.Command;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -58,8 +59,12 @@ import scala.jdk.javaapi.CollectionConverters;
  *   <li><strong>Plan node allow-list</strong> — only read-only plan nodes are permitted. All {@link
  *       Command} subclasses are rejected outright.
  *   <li><strong>Expression allow-list</strong> — only safe expression types are permitted.
- *   <li><strong>UDF allow-list</strong> — {@link ScalaUDF} is permitted only for Pathling's
- *       registered UDFs.
+ *   <li><strong>Built-in functions only</strong> — every {@link UnresolvedFunction} in user SQL
+ *       must resolve to a built-in Spark function. Pathling-registered UDFs (terminology, FHIRPath
+ *       helpers, etc.) are intended for use within ViewDefinitions; the {@code $sqlquery-run}
+ *       surface stays portable and implementation-agnostic. UDFs introduced by referenced views are
+ *       unaffected because they appear in the analyzed plan, not in the unresolved tree this rule
+ *       walks.
  * </ol>
  *
  * @see <a
@@ -133,37 +138,13 @@ public class SqlValidator {
   private static final Set<String> REJECTED_FUNCTION_NAMES =
       Set.of("reflect", "java_method", "try_reflect");
 
-  // Pathling-registered UDF names that are allowed in ScalaUDF expressions. Source of truth lives
-  // here; SqlValidatorIntegrityTest fails if this drifts from the actual Spark function registry.
-  private static final Set<String> ALLOWED_UDF_NAMES =
-      Set.of(
-          // Terminology UDFs (registered by TerminologyUdfRegistrar).
-          "display",
-          "member_of",
-          "subsumes",
-          "designation",
-          "translate_coding",
-          "property_string",
-          "property_code",
-          "property_integer",
-          "property_boolean",
-          "property_decimal",
-          "property_dateTime",
-          "property_Coding",
-          // FHIRPath UDFs (registered by PathlingUdfRegistrar).
-          "to_null",
-          "string_to_quantity",
-          "quantity_to_literal",
-          "decimal_to_literal",
-          "coding_to_literal",
-          "convert_quantity_to_unit",
-          "low_boundary_for_date",
-          "high_boundary_for_date",
-          "low_boundary_for_time",
-          "high_boundary_for_time");
+  // Source marker used by Spark's ExpressionInfo for built-in functions. Anything else (scala_udf,
+  // hive, python_udf, sql_udf, java_udf, ...) is implementation-specific and rejected from user
+  // SQL.
+  private static final String BUILTIN_FUNCTION_SOURCE = "built-in";
 
-  // Fully-qualified expression class names that are permitted (besides UnresolvedFunction and
-  // ScalaUDF, which receive special handling).
+  // Fully-qualified expression class names that are permitted (besides UnresolvedFunction, which
+  // receives special handling).
   @SuppressWarnings("java:S1192")
   private static final Set<String> ALLOWED_EXPRESSION_NAMES =
       Set.of(
@@ -405,8 +386,8 @@ public class SqlValidator {
 
   /**
    * Validates an expression. In both modes, explicitly rejected expression types and disallowed
-   * function names are caught, and ScalaUDF is gated by the Pathling UDF allow-list. In strict
-   * mode, the expression allow-list is additionally enforced.
+   * function names are caught. In strict mode, the expression allow-list is additionally enforced
+   * and {@link UnresolvedFunction}s are required to resolve to a built-in Spark function.
    */
   private void validateExpression(@Nonnull final Expression expr, final boolean strict) {
     final String fqn = canonicalClassName(expr);
@@ -418,11 +399,6 @@ public class SqlValidator {
 
     if (expr instanceof final UnresolvedFunction unresolvedFunc) {
       validateFunctionName(unresolvedFunc);
-      return;
-    }
-
-    if (expr instanceof final ScalaUDF scalaUdf) {
-      validateUdf(scalaUdf);
       return;
     }
 
@@ -440,29 +416,67 @@ public class SqlValidator {
     }
   }
 
-  /** Validates that an unresolved function is not a known-dangerous function. */
+  /**
+   * Validates an unresolved function reference from user SQL. Rejects known-dangerous names
+   * (reflection-style functions) and any function whose Spark registry entry is not flagged as
+   * built-in - that is, any UDF (Pathling-registered terminology and FHIRPath helpers, Hive UDFs,
+   * Python/SQL/Java UDFs). Pathling UDFs belong in ViewDefinitions; user SQL should remain portable
+   * and implementation-agnostic. Unknown function names are left alone here so that Spark's
+   * analyser produces its standard "function not found" error, which is more helpful than a
+   * synthetic rejection.
+   */
   private void validateFunctionName(@Nonnull final UnresolvedFunction func) {
     final List<String> nameParts = CollectionConverters.asJava(func.nameParts());
-    if (!nameParts.isEmpty()) {
-      final String simpleName = nameParts.getLast().toLowerCase();
-      if (REJECTED_FUNCTION_NAMES.contains(simpleName)) {
-        throw new InvalidRequestException(
-            "SQL contains a disallowed function: " + String.join(".", nameParts));
-      }
+    if (nameParts.isEmpty()) {
+      return;
+    }
+    final String simpleName = nameParts.getLast().toLowerCase();
+    if (REJECTED_FUNCTION_NAMES.contains(simpleName)) {
+      throw new InvalidRequestException(
+          "SQL contains a disallowed function: " + String.join(".", nameParts));
+    }
+    if (isNonBuiltInFunction(nameParts)) {
+      throw new InvalidRequestException(
+          "SQL contains a non-built-in function: "
+              + String.join(".", nameParts)
+              + ". Implementation-specific functions belong in ViewDefinitions, not in user SQL.");
     }
   }
 
-  /** Validates that a ScalaUDF is in the Pathling UDF allow-list. */
-  private void validateUdf(@Nonnull final ScalaUDF udf) {
-    final Option<String> nameOpt = udf.udfName();
-    if (nameOpt.isDefined()) {
-      final String name = nameOpt.get();
-      if (!ALLOWED_UDF_NAMES.contains(name)) {
-        throw new InvalidRequestException("SQL contains a disallowed UDF: " + name);
-      }
-    } else {
-      throw new InvalidRequestException("SQL contains an unnamed UDF, which is not allowed");
+  /**
+   * Returns {@code true} if the name resolves in the Spark function registry to a non-built-in
+   * function (any UDF kind: scala, hive, python, sql, java). Returns {@code false} when the name
+   * does not resolve at all, so that Spark's standard "function not found" error is preserved.
+   */
+  private boolean isNonBuiltInFunction(@Nonnull final List<String> nameParts) {
+    final FunctionIdentifier id = toFunctionIdentifier(nameParts);
+    if (id == null) {
+      return false;
     }
+    final Option<ExpressionInfo> info;
+    try {
+      info = sparkSession.sessionState().functionRegistry().lookupFunction(id);
+    } catch (final Exception e) {
+      return false;
+    }
+    return info.isDefined() && !BUILTIN_FUNCTION_SOURCE.equals(info.get().getSource());
+  }
+
+  /**
+   * Builds a Spark {@link FunctionIdentifier} from a 1- or 2-part name (function or
+   * database.function). Three-or-more-part names (catalog-qualified) are not modelled by {@code
+   * FunctionIdentifier}, so we return {@code null} and let Spark's analyser handle them.
+   */
+  @jakarta.annotation.Nullable
+  private static FunctionIdentifier toFunctionIdentifier(@Nonnull final List<String> nameParts) {
+    final int n = nameParts.size();
+    if (n == 1) {
+      return new FunctionIdentifier(nameParts.get(0));
+    }
+    if (n == 2) {
+      return new FunctionIdentifier(nameParts.get(1), Option.apply(nameParts.get(0)));
+    }
+    return null;
   }
 
   /**
@@ -491,11 +505,5 @@ public class SqlValidator {
   @Nonnull
   static Set<String> rejectedExpressionNames() {
     return REJECTED_EXPRESSION_NAMES;
-  }
-
-  /** Allow-list entries, exposed for build-time integrity tests. */
-  @Nonnull
-  static Set<String> allowedUdfNames() {
-    return ALLOWED_UDF_NAMES;
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
@@ -146,7 +146,6 @@ public class SqlValidator {
           // org.apache.spark.sql.catalyst.analysis
           "org.apache.spark.sql.catalyst.analysis.UnresolvedRelation",
           "org.apache.spark.sql.catalyst.analysis.UnresolvedInlineTable",
-          "org.apache.spark.sql.catalyst.analysis.UnresolvedTableValuedFunction",
           "org.apache.spark.sql.catalyst.analysis.UnresolvedSubqueryColumnAliases");
 
   // Function names rejected outright because they enable arbitrary code execution.

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewArtifactReference.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewArtifactReference.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import jakarta.annotation.Nonnull;
+import lombok.Value;
+
+/**
+ * Represents a reference to a ViewDefinition dependency within a SQLQuery Library resource. Each
+ * reference has a label (the table alias used in the SQL) and a canonical URL pointing to the
+ * ViewDefinition.
+ */
+@Value
+public class ViewArtifactReference {
+
+  /** The table alias used in the SQL query to reference this ViewDefinition. */
+  @Nonnull String label;
+
+  /** The canonical URL or relative reference to the ViewDefinition resource. */
+  @Nonnull String canonicalUrl;
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
@@ -28,7 +28,6 @@ import jakarta.annotation.Nonnull;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.Dataset;
@@ -150,9 +149,12 @@ public class ViewRegistrationService {
   }
 
   /**
-   * Rewrites SQL table references to use the prefixed temporary view names. Each label in the SQL
-   * is replaced with the corresponding temporary view name, matched on word boundaries so that
-   * labels appearing as substrings of other identifiers are not affected.
+   * Rewrites SQL table references to use the prefixed temporary view names. Each unquoted
+   * identifier token whose text equals a label is replaced with the corresponding temporary view
+   * name; backtick-quoted identifiers matching a label are also rewritten. Single-quoted and
+   * double-quoted string literals, line comments ({@code -- ...}), and block comments ({@code /*
+   * ... *}{@code /}) are left untouched, so a literal value happening to equal a label (e.g. {@code
+   * WHERE x = 'patients'}) is preserved.
    *
    * @param sql the original SQL query
    * @param labelToViewName the mapping from labels to temporary view names
@@ -162,23 +164,162 @@ public class ViewRegistrationService {
   public String rewriteSql(
       @Nonnull final String sql, @Nonnull final Map<String, String> labelToViewName) {
 
-    String rewritten = sql;
-    // Replace longest labels first to avoid partial replacements where one label is a prefix of
-    // another.
-    final var sortedEntries =
-        labelToViewName.entrySet().stream()
-            .sorted((a, b) -> Integer.compare(b.getKey().length(), a.getKey().length()))
-            .toList();
-
-    for (final Map.Entry<String, String> entry : sortedEntries) {
-      final String label = entry.getKey();
-      final String viewName = entry.getValue();
-      final Pattern pattern = Pattern.compile("\\b" + Pattern.quote(label) + "\\b");
-      final Matcher matcher = pattern.matcher(rewritten);
-      rewritten = matcher.replaceAll(Matcher.quoteReplacement(viewName));
+    if (labelToViewName.isEmpty()) {
+      return sql;
     }
 
-    return rewritten;
+    final int n = sql.length();
+    final StringBuilder out = new StringBuilder(n);
+    int i = 0;
+    while (i < n) {
+      final char c = sql.charAt(i);
+
+      if (c == '\'' || c == '"') {
+        i = copyStringLiteral(sql, i, c, out);
+        continue;
+      }
+      if (c == '`') {
+        i = copyOrRewriteBacktickIdentifier(sql, i, labelToViewName, out);
+        continue;
+      }
+      if (c == '-' && i + 1 < n && sql.charAt(i + 1) == '-') {
+        i = copyLineComment(sql, i, out);
+        continue;
+      }
+      if (c == '/' && i + 1 < n && sql.charAt(i + 1) == '*') {
+        i = copyBlockComment(sql, i, out);
+        continue;
+      }
+      if (Character.isLetter(c) || c == '_') {
+        i = copyOrRewriteIdentifier(sql, i, labelToViewName, out);
+        continue;
+      }
+
+      out.append(c);
+      i++;
+    }
+    return out.toString();
+  }
+
+  /**
+   * Copies a {@code '...'} or {@code "..."} string literal verbatim, honouring both doubled-quote
+   * and backslash escapes (Spark accepts either). Returns the position after the closing quote.
+   */
+  private static int copyStringLiteral(
+      @Nonnull final String sql,
+      final int start,
+      final char quote,
+      @Nonnull final StringBuilder out) {
+    final int n = sql.length();
+    out.append(quote);
+    int i = start + 1;
+    while (i < n) {
+      final char d = sql.charAt(i);
+      if (d == '\\' && i + 1 < n) {
+        out.append(d).append(sql.charAt(i + 1));
+        i += 2;
+        continue;
+      }
+      if (d == quote) {
+        if (i + 1 < n && sql.charAt(i + 1) == quote) {
+          out.append(d).append(d);
+          i += 2;
+          continue;
+        }
+        out.append(d);
+        return i + 1;
+      }
+      out.append(d);
+      i++;
+    }
+    return i;
+  }
+
+  /**
+   * A backtick-quoted identifier is a delimited identifier in Spark SQL. If its text matches a
+   * label, rewrite it to the (unquoted) temp view name; otherwise copy it verbatim.
+   */
+  private static int copyOrRewriteBacktickIdentifier(
+      @Nonnull final String sql,
+      final int start,
+      @Nonnull final Map<String, String> labelToViewName,
+      @Nonnull final StringBuilder out) {
+    final int n = sql.length();
+    int j = start + 1;
+    while (j < n && sql.charAt(j) != '`') {
+      j++;
+    }
+    if (j >= n) {
+      // Unterminated backtick — copy the rest verbatim and stop.
+      out.append(sql, start, n);
+      return n;
+    }
+    final String inner = sql.substring(start + 1, j);
+    final String replacement = labelToViewName.get(inner);
+    if (replacement != null) {
+      out.append(replacement);
+    } else {
+      out.append(sql, start, j + 1);
+    }
+    return j + 1;
+  }
+
+  /** Copies a {@code -- ...} line comment up to (and including) the terminating newline. */
+  private static int copyLineComment(
+      @Nonnull final String sql, final int start, @Nonnull final StringBuilder out) {
+    final int n = sql.length();
+    int i = start;
+    while (i < n && sql.charAt(i) != '\n') {
+      out.append(sql.charAt(i));
+      i++;
+    }
+    return i;
+  }
+
+  /** Copies a {@code /* ... *}{@code /} block comment verbatim. */
+  private static int copyBlockComment(
+      @Nonnull final String sql, final int start, @Nonnull final StringBuilder out) {
+    final int n = sql.length();
+    out.append("/*");
+    int i = start + 2;
+    while (i + 1 < n) {
+      if (sql.charAt(i) == '*' && sql.charAt(i + 1) == '/') {
+        out.append("*/");
+        return i + 2;
+      }
+      out.append(sql.charAt(i));
+      i++;
+    }
+    while (i < n) {
+      out.append(sql.charAt(i));
+      i++;
+    }
+    return i;
+  }
+
+  /**
+   * Reads an unquoted identifier starting at {@code start} and replaces it with the matching temp
+   * view name if the token equals a known label.
+   */
+  private static int copyOrRewriteIdentifier(
+      @Nonnull final String sql,
+      final int start,
+      @Nonnull final Map<String, String> labelToViewName,
+      @Nonnull final StringBuilder out) {
+    final int n = sql.length();
+    int j = start;
+    while (j < n) {
+      final char ch = sql.charAt(j);
+      if (Character.isLetterOrDigit(ch) || ch == '_') {
+        j++;
+      } else {
+        break;
+      }
+    }
+    final String token = sql.substring(start, j);
+    final String replacement = labelToViewName.get(token);
+    out.append(replacement != null ? replacement : token);
+    return j;
   }
 
   /**

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.config.QueryConfiguration;
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.io.source.DataSource;
+import au.csiro.pathling.views.FhirView;
+import au.csiro.pathling.views.FhirViewExecutor;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import jakarta.annotation.Nonnull;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Manages the lifecycle of Spark temporary views for SQL query execution. Each execution registers
+ * ViewDefinition results as temporary views with UUID-prefixed names for thread safety, and drops
+ * them after execution completes.
+ */
+@Slf4j
+@Component
+public class ViewRegistrationService {
+
+  private static final String VIEW_NAME_PREFIX = "sqlquery_";
+
+  @Nonnull private final SparkSession sparkSession;
+
+  @Nonnull private final FhirContext fhirContext;
+
+  @Nonnull private final QueryConfiguration queryConfiguration;
+
+  /**
+   * Constructs a new ViewRegistrationService.
+   *
+   * @param sparkSession the Spark session
+   * @param fhirContext the FHIR context
+   * @param serverConfiguration the server configuration
+   */
+  @Autowired
+  public ViewRegistrationService(
+      @Nonnull final SparkSession sparkSession,
+      @Nonnull final FhirContext fhirContext,
+      @Nonnull final ServerConfiguration serverConfiguration) {
+    this.sparkSession = sparkSession;
+    this.fhirContext = fhirContext;
+    this.queryConfiguration = serverConfiguration.getQuery();
+  }
+
+  /**
+   * Registers resolved ViewDefinitions as Spark temporary views. Each view is given a UUID-prefixed
+   * name to avoid conflicts between concurrent executions.
+   *
+   * @param resolvedViews a map from label (table alias) to the parsed FhirView
+   * @param dataSource the data source to use for view execution
+   * @return a map from original label to the actual temporary view name
+   */
+  @Nonnull
+  public Map<String, String> registerViews(
+      @Nonnull final Map<String, FhirView> resolvedViews, @Nonnull final DataSource dataSource) {
+
+    final String executionId = UUID.randomUUID().toString().replace("-", "");
+    final Map<String, String> labelToViewName = new LinkedHashMap<>();
+
+    for (final Map.Entry<String, FhirView> entry : resolvedViews.entrySet()) {
+      final String label = entry.getKey();
+      final FhirView view = entry.getValue();
+      final String tempViewName = VIEW_NAME_PREFIX + executionId + "_" + label;
+
+      final FhirViewExecutor executor =
+          new FhirViewExecutor(fhirContext, dataSource, queryConfiguration);
+      final Dataset<Row> result;
+      try {
+        result = executor.buildQuery(view);
+      } catch (final Exception e) {
+        // Drop any views that were already registered before failing.
+        dropViews(labelToViewName.values());
+        throw new InvalidRequestException(
+            "Failed to execute ViewDefinition for label '" + label + "': " + e.getMessage());
+      }
+
+      result.createOrReplaceTempView(tempViewName);
+      labelToViewName.put(label, tempViewName);
+      log.debug("Registered temporary view '{}' for label '{}'", tempViewName, label);
+    }
+
+    return labelToViewName;
+  }
+
+  /**
+   * Drops the specified temporary views from the Spark session.
+   *
+   * @param tempViewNames the names of the temporary views to drop
+   */
+  public void dropViews(@Nonnull final Collection<String> tempViewNames) {
+    for (final String viewName : tempViewNames) {
+      try {
+        sparkSession.catalog().dropTempView(viewName);
+        log.debug("Dropped temporary view '{}'", viewName);
+      } catch (final Exception e) {
+        log.warn("Failed to drop temporary view '{}': {}", viewName, e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Rewrites SQL table references to use the prefixed temporary view names. Each label in the SQL
+   * is replaced with the corresponding temporary view name.
+   *
+   * @param sql the original SQL query
+   * @param labelToViewName the mapping from labels to temporary view names
+   * @return the rewritten SQL query
+   */
+  @Nonnull
+  public String rewriteSql(
+      @Nonnull final String sql, @Nonnull final Map<String, String> labelToViewName) {
+
+    String rewritten = sql;
+    // Replace labels in order of longest first to avoid partial replacements.
+    final var sortedEntries =
+        labelToViewName.entrySet().stream()
+            .sorted((a, b) -> Integer.compare(b.getKey().length(), a.getKey().length()))
+            .toList();
+
+    for (final Map.Entry<String, String> entry : sortedEntries) {
+      final String label = entry.getKey();
+      final String viewName = entry.getValue();
+      // Replace word-boundary-delimited occurrences of the label. This handles the label as a
+      // table reference in FROM, JOIN, and subquery contexts.
+      final Pattern pattern = Pattern.compile("\\b" + Pattern.quote(label) + "\\b");
+      final Matcher matcher = pattern.matcher(rewritten);
+      rewritten = matcher.replaceAll(viewName);
+    }
+
+    return rewritten;
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
@@ -47,7 +47,7 @@ public class ViewRegistrationService {
 
   private static final String VIEW_NAME_PREFIX = "sqlquery_";
 
-  private static final Pattern UNSAFE_REQUEST_ID_CHARS = Pattern.compile("[^A-Za-z0-9_]");
+  private static final Pattern UNSAFE_REQUEST_ID_CHARS = Pattern.compile("\\W");
 
   @Nonnull private final SparkSession sparkSession;
 
@@ -172,33 +172,36 @@ public class ViewRegistrationService {
     final StringBuilder out = new StringBuilder(n);
     int i = 0;
     while (i < n) {
-      final char c = sql.charAt(i);
-
-      if (c == '\'' || c == '"') {
-        i = copyStringLiteral(sql, i, c, out);
-        continue;
-      }
-      if (c == '`') {
-        i = copyOrRewriteBacktickIdentifier(sql, i, labelToViewName, out);
-        continue;
-      }
-      if (c == '-' && i + 1 < n && sql.charAt(i + 1) == '-') {
-        i = copyLineComment(sql, i, out);
-        continue;
-      }
-      if (c == '/' && i + 1 < n && sql.charAt(i + 1) == '*') {
-        i = copyBlockComment(sql, i, out);
-        continue;
-      }
-      if (Character.isLetter(c) || c == '_') {
-        i = copyOrRewriteIdentifier(sql, i, labelToViewName, out);
-        continue;
-      }
-
-      out.append(c);
-      i++;
+      i = consumeNextToken(sql, n, i, labelToViewName, out);
     }
     return out.toString();
+  }
+
+  /** Consumes one token starting at {@code i} and returns the index after it. */
+  private static int consumeNextToken(
+      @Nonnull final String sql,
+      final int n,
+      final int i,
+      @Nonnull final Map<String, String> labelToViewName,
+      @Nonnull final StringBuilder out) {
+    final char c = sql.charAt(i);
+    if (c == '\'' || c == '"') {
+      return copyStringLiteral(sql, i, c, out);
+    }
+    if (c == '`') {
+      return copyOrRewriteBacktickIdentifier(sql, i, labelToViewName, out);
+    }
+    if (c == '-' && i + 1 < n && sql.charAt(i + 1) == '-') {
+      return copyLineComment(sql, i, out);
+    }
+    if (c == '/' && i + 1 < n && sql.charAt(i + 1) == '*') {
+      return copyBlockComment(sql, i, out);
+    }
+    if (Character.isLetter(c) || c == '_') {
+      return copyOrRewriteIdentifier(sql, i, labelToViewName, out);
+    }
+    out.append(c);
+    return i + 1;
   }
 
   /**
@@ -218,19 +221,17 @@ public class ViewRegistrationService {
       if (d == '\\' && i + 1 < n) {
         out.append(d).append(sql.charAt(i + 1));
         i += 2;
-        continue;
-      }
-      if (d == quote) {
-        if (i + 1 < n && sql.charAt(i + 1) == quote) {
-          out.append(d).append(d);
-          i += 2;
-          continue;
-        }
+      } else if (d == quote && i + 1 < n && sql.charAt(i + 1) == quote) {
+        // Doubled quote inside the literal — Spark treats this as an escaped quote.
+        out.append(d).append(d);
+        i += 2;
+      } else if (d == quote) {
         out.append(d);
         return i + 1;
+      } else {
+        out.append(d);
+        i++;
       }
-      out.append(d);
-      i++;
     }
     return i;
   }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
@@ -25,10 +25,11 @@ import au.csiro.pathling.views.FhirViewExecutor;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import jakarta.annotation.Nonnull;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -37,13 +38,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * Manages the lifecycle of Spark temporary views for SQL query execution. Views are registered
- * using the label names from the SQLQuery Library's relatedArtifact entries, so the SQL can
- * reference them directly. All registered views are dropped after execution completes.
+ * Manages the lifecycle of Spark temporary views for SQL query execution. Each execution scopes its
+ * views to the HAPI per-request id so that concurrent {@code $sqlquery-run} requests using the same
+ * label cannot clobber one another in Spark's session-global temporary view catalog.
  */
 @Slf4j
 @Component
 public class ViewRegistrationService {
+
+  private static final String VIEW_NAME_PREFIX = "sqlquery_";
+
+  private static final Pattern UNSAFE_REQUEST_ID_CHARS = Pattern.compile("[^A-Za-z0-9_]");
 
   @Nonnull private final SparkSession sparkSession;
 
@@ -69,18 +74,21 @@ public class ViewRegistrationService {
   }
 
   /**
-   * Registers resolved ViewDefinitions as Spark temporary views. Each view is registered using its
-   * label name directly, so the SQL query can reference it without rewriting.
+   * Registers resolved ViewDefinitions as Spark temporary views, scoped by the request id so that
+   * concurrent executions cannot clobber one another in the session-global catalog.
    *
    * @param resolvedViews a map from label (table alias) to the parsed FhirView
    * @param dataSource the data source to use for view execution
-   * @return the list of registered view names (for cleanup)
+   * @param requestId the per-request id used to namespace registered view names
+   * @return a map from original label to the actual temporary view name
    */
   @Nonnull
-  public List<String> registerViews(
-      @Nonnull final Map<String, FhirView> resolvedViews, @Nonnull final DataSource dataSource) {
+  public Map<String, String> registerViews(
+      @Nonnull final Map<String, FhirView> resolvedViews,
+      @Nonnull final DataSource dataSource,
+      @Nonnull final String requestId) {
 
-    final List<String> registeredViewNames = new ArrayList<>();
+    final Map<String, String> labelToViewName = new LinkedHashMap<>();
 
     for (final Map.Entry<String, FhirView> entry : resolvedViews.entrySet()) {
       final String label = entry.getKey();
@@ -93,26 +101,45 @@ public class ViewRegistrationService {
         result = executor.buildQuery(view);
       } catch (final Exception e) {
         // Drop any views that were already registered before failing.
-        dropViews(registeredViewNames);
+        dropViews(labelToViewName.values());
         throw new InvalidRequestException(
             "Failed to execute ViewDefinition for label '" + label + "': " + e.getMessage());
       }
 
-      result.createOrReplaceTempView(label);
-      registeredViewNames.add(label);
-      log.info("Registered temporary view '{}' for resource type '{}'", label, view.getResource());
+      final String tempViewName = registerDataset(label, result, requestId);
+      labelToViewName.put(label, tempViewName);
+      log.info(
+          "Registered temporary view '{}' for label '{}' (resource type '{}')",
+          tempViewName,
+          label,
+          view.getResource());
     }
 
-    return registeredViewNames;
+    return labelToViewName;
+  }
+
+  /**
+   * Registers an already-built dataset under a request-scoped temp view name and returns that name.
+   * Visible for tests that need to exercise the temp-view namespacing without going through
+   * FhirViewExecutor.
+   */
+  @Nonnull
+  String registerDataset(
+      @Nonnull final String label,
+      @Nonnull final Dataset<Row> dataset,
+      @Nonnull final String requestId) {
+    final String tempViewName = resolveTempViewName(requestId, label);
+    dataset.createOrReplaceTempView(tempViewName);
+    return tempViewName;
   }
 
   /**
    * Drops the specified temporary views from the Spark session.
    *
-   * @param viewNames the names of the temporary views to drop
+   * @param tempViewNames the names of the temporary views to drop
    */
-  public void dropViews(@Nonnull final Collection<String> viewNames) {
-    for (final String viewName : viewNames) {
+  public void dropViews(@Nonnull final Collection<String> tempViewNames) {
+    for (final String viewName : tempViewNames) {
       try {
         sparkSession.catalog().dropTempView(viewName);
         log.debug("Dropped temporary view '{}'", viewName);
@@ -120,5 +147,54 @@ public class ViewRegistrationService {
         log.warn("Failed to drop temporary view '{}': {}", viewName, e.getMessage());
       }
     }
+  }
+
+  /**
+   * Rewrites SQL table references to use the prefixed temporary view names. Each label in the SQL
+   * is replaced with the corresponding temporary view name, matched on word boundaries so that
+   * labels appearing as substrings of other identifiers are not affected.
+   *
+   * @param sql the original SQL query
+   * @param labelToViewName the mapping from labels to temporary view names
+   * @return the rewritten SQL query
+   */
+  @Nonnull
+  public String rewriteSql(
+      @Nonnull final String sql, @Nonnull final Map<String, String> labelToViewName) {
+
+    String rewritten = sql;
+    // Replace longest labels first to avoid partial replacements where one label is a prefix of
+    // another.
+    final var sortedEntries =
+        labelToViewName.entrySet().stream()
+            .sorted((a, b) -> Integer.compare(b.getKey().length(), a.getKey().length()))
+            .toList();
+
+    for (final Map.Entry<String, String> entry : sortedEntries) {
+      final String label = entry.getKey();
+      final String viewName = entry.getValue();
+      final Pattern pattern = Pattern.compile("\\b" + Pattern.quote(label) + "\\b");
+      final Matcher matcher = pattern.matcher(rewritten);
+      rewritten = matcher.replaceAll(Matcher.quoteReplacement(viewName));
+    }
+
+    return rewritten;
+  }
+
+  /**
+   * Constructs the request-scoped temp view name for a given label.
+   *
+   * <p>The request id is sanitised to keep the resulting identifier valid for use as a Spark temp
+   * view name (HAPI default is 16 alphanumerics, but {@code X-Request-ID} can carry arbitrary
+   * characters).
+   */
+  @Nonnull
+  static String resolveTempViewName(@Nonnull final String requestId, @Nonnull final String label) {
+    return VIEW_NAME_PREFIX + sanitiseRequestId(requestId) + "_" + label;
+  }
+
+  @Nonnull
+  private static String sanitiseRequestId(@Nonnull final String requestId) {
+    return UNSAFE_REQUEST_ID_CHARS.matcher(requestId).replaceAll("");
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
@@ -25,12 +25,10 @@ import au.csiro.pathling.views.FhirViewExecutor;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import jakarta.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -39,15 +37,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * Manages the lifecycle of Spark temporary views for SQL query execution. Each execution registers
- * ViewDefinition results as temporary views with UUID-prefixed names for thread safety, and drops
- * them after execution completes.
+ * Manages the lifecycle of Spark temporary views for SQL query execution. Views are registered
+ * using the label names from the SQLQuery Library's relatedArtifact entries, so the SQL can
+ * reference them directly. All registered views are dropped after execution completes.
  */
 @Slf4j
 @Component
 public class ViewRegistrationService {
-
-  private static final String VIEW_NAME_PREFIX = "sqlquery_";
 
   @Nonnull private final SparkSession sparkSession;
 
@@ -73,24 +69,22 @@ public class ViewRegistrationService {
   }
 
   /**
-   * Registers resolved ViewDefinitions as Spark temporary views. Each view is given a UUID-prefixed
-   * name to avoid conflicts between concurrent executions.
+   * Registers resolved ViewDefinitions as Spark temporary views. Each view is registered using its
+   * label name directly, so the SQL query can reference it without rewriting.
    *
    * @param resolvedViews a map from label (table alias) to the parsed FhirView
    * @param dataSource the data source to use for view execution
-   * @return a map from original label to the actual temporary view name
+   * @return the list of registered view names (for cleanup)
    */
   @Nonnull
-  public Map<String, String> registerViews(
+  public List<String> registerViews(
       @Nonnull final Map<String, FhirView> resolvedViews, @Nonnull final DataSource dataSource) {
 
-    final String executionId = UUID.randomUUID().toString().replace("-", "");
-    final Map<String, String> labelToViewName = new LinkedHashMap<>();
+    final List<String> registeredViewNames = new ArrayList<>();
 
     for (final Map.Entry<String, FhirView> entry : resolvedViews.entrySet()) {
       final String label = entry.getKey();
       final FhirView view = entry.getValue();
-      final String tempViewName = VIEW_NAME_PREFIX + executionId + "_" + label;
 
       final FhirViewExecutor executor =
           new FhirViewExecutor(fhirContext, dataSource, queryConfiguration);
@@ -99,26 +93,26 @@ public class ViewRegistrationService {
         result = executor.buildQuery(view);
       } catch (final Exception e) {
         // Drop any views that were already registered before failing.
-        dropViews(labelToViewName.values());
+        dropViews(registeredViewNames);
         throw new InvalidRequestException(
             "Failed to execute ViewDefinition for label '" + label + "': " + e.getMessage());
       }
 
-      result.createOrReplaceTempView(tempViewName);
-      labelToViewName.put(label, tempViewName);
-      log.debug("Registered temporary view '{}' for label '{}'", tempViewName, label);
+      result.createOrReplaceTempView(label);
+      registeredViewNames.add(label);
+      log.info("Registered temporary view '{}' for resource type '{}'", label, view.getResource());
     }
 
-    return labelToViewName;
+    return registeredViewNames;
   }
 
   /**
    * Drops the specified temporary views from the Spark session.
    *
-   * @param tempViewNames the names of the temporary views to drop
+   * @param viewNames the names of the temporary views to drop
    */
-  public void dropViews(@Nonnull final Collection<String> tempViewNames) {
-    for (final String viewName : tempViewNames) {
+  public void dropViews(@Nonnull final Collection<String> viewNames) {
+    for (final String viewName : viewNames) {
       try {
         sparkSession.catalog().dropTempView(viewName);
         log.debug("Dropped temporary view '{}'", viewName);
@@ -126,37 +120,5 @@ public class ViewRegistrationService {
         log.warn("Failed to drop temporary view '{}': {}", viewName, e.getMessage());
       }
     }
-  }
-
-  /**
-   * Rewrites SQL table references to use the prefixed temporary view names. Each label in the SQL
-   * is replaced with the corresponding temporary view name.
-   *
-   * @param sql the original SQL query
-   * @param labelToViewName the mapping from labels to temporary view names
-   * @return the rewritten SQL query
-   */
-  @Nonnull
-  public String rewriteSql(
-      @Nonnull final String sql, @Nonnull final Map<String, String> labelToViewName) {
-
-    String rewritten = sql;
-    // Replace labels in order of longest first to avoid partial replacements.
-    final var sortedEntries =
-        labelToViewName.entrySet().stream()
-            .sorted((a, b) -> Integer.compare(b.getKey().length(), a.getKey().length()))
-            .toList();
-
-    for (final Map.Entry<String, String> entry : sortedEntries) {
-      final String label = entry.getKey();
-      final String viewName = entry.getValue();
-      // Replace word-boundary-delimited occurrences of the label. This handles the label as a
-      // table reference in FROM, JOIN, and subquery contexts.
-      final Pattern pattern = Pattern.compile("\\b" + Pattern.quote(label) + "\\b");
-      final Matcher matcher = pattern.matcher(rewritten);
-      rewritten = matcher.replaceAll(viewName);
-    }
-
-    return rewritten;
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
@@ -193,8 +193,18 @@ public class ViewRegistrationService {
     return VIEW_NAME_PREFIX + sanitiseRequestId(requestId) + "_" + label;
   }
 
+  /**
+   * Strips characters that aren't valid in a Spark identifier. Falls back to a hash of the original
+   * input when the result would otherwise be empty (e.g. a request id consisting only of dashes,
+   * which would collide with another all-special-chars id and reintroduce the temp-view clobbering
+   * this namespacing exists to prevent).
+   */
   @Nonnull
   private static String sanitiseRequestId(@Nonnull final String requestId) {
-    return UNSAFE_REQUEST_ID_CHARS.matcher(requestId).replaceAll("");
+    final String sanitised = UNSAFE_REQUEST_ID_CHARS.matcher(requestId).replaceAll("");
+    if (!sanitised.isEmpty()) {
+      return sanitised;
+    }
+    return "r" + Integer.toUnsignedString(requestId.hashCode(), 16);
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewResolver.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewResolver.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.read.ReadExecutor;
+import au.csiro.pathling.security.PathlingAuthority;
+import au.csiro.pathling.security.ResourceAccess.AccessType;
+import au.csiro.pathling.security.SecurityAspect;
+import au.csiro.pathling.views.FhirView;
+import au.csiro.pathling.views.ViewDefinitionGson;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import jakarta.annotation.Nonnull;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves the {@link ViewArtifactReference}s declared by a SQLQuery Library into parsed {@link
+ * FhirView}s, performing the per-resource-type authorisation check along the way. Has no Spark
+ * dependency; the FhirView is the parsed view configuration, not yet a {@code Dataset}.
+ */
+@Component
+public class ViewResolver {
+
+  @Nonnull private final ReadExecutor readExecutor;
+
+  @Nonnull private final ServerConfiguration serverConfiguration;
+
+  @Nonnull private final FhirContext fhirContext;
+
+  @Nonnull private final Gson gson;
+
+  /**
+   * Constructs a new ViewResolver.
+   *
+   * @param readExecutor read executor for stored ViewDefinition resources
+   * @param serverConfiguration server configuration (used for the auth toggle)
+   * @param fhirContext FHIR context used to serialise the resolved ViewDefinition for parsing
+   */
+  @Autowired
+  public ViewResolver(
+      @Nonnull final ReadExecutor readExecutor,
+      @Nonnull final ServerConfiguration serverConfiguration,
+      @Nonnull final FhirContext fhirContext) {
+    this.readExecutor = readExecutor;
+    this.serverConfiguration = serverConfiguration;
+    this.fhirContext = fhirContext;
+    this.gson = ViewDefinitionGson.create();
+  }
+
+  /**
+   * Resolves each view reference to a parsed {@link FhirView}, preserving label order.
+   *
+   * @param references the references declared by the SQLQuery Library, keyed by table label
+   * @return a map from label to resolved FhirView
+   * @throws InvalidRequestException if a reference cannot be resolved or parsed
+   */
+  @Nonnull
+  public Map<String, FhirView> resolve(@Nonnull final List<ViewArtifactReference> references) {
+    final Map<String, FhirView> resolved = new LinkedHashMap<>();
+
+    for (final ViewArtifactReference ref : references) {
+      final String viewDefinitionId = extractViewDefinitionId(ref.getCanonicalUrl());
+      final IBaseResource viewResource;
+      try {
+        viewResource = readExecutor.read("ViewDefinition", viewDefinitionId);
+      } catch (final Exception e) {
+        throw new InvalidRequestException(
+            "Failed to resolve ViewDefinition for label '"
+                + ref.getLabel()
+                + "' with reference '"
+                + ref.getCanonicalUrl()
+                + "': "
+                + e.getMessage());
+      }
+
+      final FhirView view = parseViewDefinition(viewResource);
+
+      if (serverConfiguration.getAuth().isEnabled()) {
+        SecurityAspect.checkHasAuthority(
+            PathlingAuthority.resourceAccess(AccessType.READ, view.getResource()));
+      }
+
+      resolved.put(ref.getLabel(), view);
+    }
+
+    return resolved;
+  }
+
+  /**
+   * Extracts a ViewDefinition id from a canonical URL or relative reference. Supports relative
+   * references like {@code ViewDefinition/my-id} and bare ids.
+   */
+  @Nonnull
+  private String extractViewDefinitionId(@Nonnull final String canonicalUrl) {
+    if (canonicalUrl.contains("/")) {
+      final String[] parts = canonicalUrl.split("/");
+      return parts[parts.length - 1];
+    }
+    return canonicalUrl;
+  }
+
+  /** Parses a ViewDefinition resource into a FhirView via JSON round-tripping. */
+  @Nonnull
+  private FhirView parseViewDefinition(@Nonnull final IBaseResource viewResource) {
+    try {
+      final String viewJson = fhirContext.newJsonParser().encodeResourceToString(viewResource);
+      return gson.fromJson(viewJson, FhirView.class);
+    } catch (final JsonSyntaxException e) {
+      throw new InvalidRequestException("Invalid ViewDefinition: " + e.getMessage());
+    }
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/view/ResultStreamingHelper.java
+++ b/server/src/main/java/au/csiro/pathling/operations/view/ResultStreamingHelper.java
@@ -17,14 +17,21 @@
 
 package au.csiro.pathling.operations.view;
 
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import com.google.gson.Gson;
+import com.google.gson.stream.JsonWriter;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -33,8 +40,23 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.BinaryType;
+import org.apache.spark.sql.types.BooleanType;
+import org.apache.spark.sql.types.ByteType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DateType;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.DoubleType;
+import org.apache.spark.sql.types.FloatType;
+import org.apache.spark.sql.types.IntegerType;
+import org.apache.spark.sql.types.LongType;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.ShortType;
+import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.TimestampNTZType;
+import org.apache.spark.sql.types.TimestampType;
 import scala.jdk.javaapi.CollectionConverters;
 
 /**
@@ -191,6 +213,162 @@ public class ResultStreamingHelper {
       return list;
     }
     return value;
+  }
+
+  /**
+   * Streams results as a FHIR {@code Parameters} resource in JSON, with one repeating {@code row}
+   * parameter per result row. Each column is rendered as a part with a typed {@code value[x]}
+   * matched to the Spark column type. NULL values are represented by omitting the part.
+   *
+   * <p>The output is written row-by-row so memory stays bounded regardless of result size.
+   *
+   * @param outputStream the output stream to write to
+   * @param iterator the row iterator
+   * @param schema the result schema
+   * @throws IOException if writing fails
+   * @throws UnprocessableEntityException if any column has a Spark type that cannot be mapped to a
+   *     FHIR primitive
+   */
+  public void streamFhirJson(
+      @Nonnull final OutputStream outputStream,
+      @Nonnull final Iterator<Row> iterator,
+      @Nonnull final StructType schema)
+      throws IOException {
+
+    rejectUnsupportedColumnTypes(schema);
+
+    final OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
+    try (final JsonWriter json = new JsonWriter(writer)) {
+      json.beginObject();
+      json.name("resourceType").value("Parameters");
+      json.name("parameter").beginArray();
+      while (iterator.hasNext()) {
+        final Row row = iterator.next();
+        writeFhirRow(json, row, schema);
+      }
+      json.endArray();
+      json.endObject();
+    }
+    outputStream.flush();
+  }
+
+  /** Walks the result schema once and rejects any column whose type cannot be FHIR-encoded. */
+  private void rejectUnsupportedColumnTypes(@Nonnull final StructType schema) {
+    for (final StructField field : schema.fields()) {
+      final DataType dt = field.dataType();
+      if (dt instanceof ArrayType || dt instanceof MapType || dt instanceof StructType) {
+        throw new UnprocessableEntityException(
+            "Column '"
+                + field.name()
+                + "' of type "
+                + dt.simpleString()
+                + " cannot be expressed as a FHIR primitive; use a different _format");
+      }
+    }
+  }
+
+  private void writeFhirRow(
+      @Nonnull final JsonWriter json, @Nonnull final Row row, @Nonnull final StructType schema)
+      throws IOException {
+    json.beginObject();
+    json.name("name").value("row");
+    json.name("part").beginArray();
+    final StructField[] fields = schema.fields();
+    for (int i = 0; i < fields.length; i++) {
+      final Object value = row.get(i);
+      if (value == null) {
+        // Per spec, SQL NULL is represented by omitting the part.
+        continue;
+      }
+      writeFhirPart(json, fields[i], value);
+    }
+    json.endArray();
+    json.endObject();
+  }
+
+  private void writeFhirPart(
+      @Nonnull final JsonWriter json, @Nonnull final StructField field, @Nonnull final Object value)
+      throws IOException {
+    json.beginObject();
+    json.name("name").value(field.name());
+
+    final DataType dt = field.dataType();
+    if (dt instanceof BooleanType) {
+      json.name("valueBoolean").value((Boolean) value);
+    } else if (dt instanceof IntegerType || dt instanceof ShortType || dt instanceof ByteType) {
+      json.name("valueInteger").value(((Number) value).intValue());
+    } else if (dt instanceof LongType
+        || dt instanceof DecimalType
+        || dt instanceof DoubleType
+        || dt instanceof FloatType) {
+      json.name("valueDecimal").value(toBigDecimal((Number) value));
+    } else if (dt instanceof StringType) {
+      json.name("valueString").value(value.toString());
+    } else if (dt instanceof DateType) {
+      json.name("valueDate").value(formatDate(value));
+    } else if (dt instanceof TimestampType) {
+      json.name("valueInstant").value(formatInstant(value));
+    } else if (dt instanceof TimestampNTZType) {
+      json.name("valueDateTime").value(formatLocalDateTime(value));
+    } else if (dt instanceof BinaryType) {
+      json.name("valueBase64Binary").value(Base64.getEncoder().encodeToString((byte[]) value));
+    } else {
+      throw new UnprocessableEntityException(
+          "Column '"
+              + field.name()
+              + "' of type "
+              + dt.simpleString()
+              + " cannot be expressed as a FHIR primitive");
+    }
+
+    json.endObject();
+  }
+
+  @Nonnull
+  private BigDecimal toBigDecimal(@Nonnull final Number value) {
+    if (value instanceof final BigDecimal bd) {
+      return bd;
+    }
+    if (value instanceof final java.math.BigInteger bi) {
+      return new BigDecimal(bi);
+    }
+    if (value instanceof final Double d) {
+      return BigDecimal.valueOf(d);
+    }
+    if (value instanceof final Float f) {
+      return BigDecimal.valueOf(f.doubleValue());
+    }
+    return BigDecimal.valueOf(value.longValue());
+  }
+
+  @Nonnull
+  private String formatDate(@Nonnull final Object value) {
+    if (value instanceof final LocalDate ld) {
+      return ld.toString();
+    }
+    if (value instanceof final java.sql.Date sqlDate) {
+      return sqlDate.toLocalDate().toString();
+    }
+    return value.toString();
+  }
+
+  @Nonnull
+  private String formatInstant(@Nonnull final Object value) {
+    if (value instanceof final Instant instant) {
+      return instant.toString();
+    }
+    if (value instanceof final java.sql.Timestamp ts) {
+      return ts.toInstant().toString();
+    }
+    return value.toString();
+  }
+
+  @Nonnull
+  private String formatLocalDateTime(@Nonnull final Object value) {
+    if (value instanceof final LocalDateTime ldt) {
+      return ldt.toString();
+    }
+    return value.toString();
   }
 
   /** Converts a Spark Row to a list of values for CSV output. */

--- a/server/src/main/java/au/csiro/pathling/operations/view/ResultStreamingHelper.java
+++ b/server/src/main/java/au/csiro/pathling/operations/view/ResultStreamingHelper.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.view;
+
+import com.google.gson.Gson;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import scala.jdk.javaapi.CollectionConverters;
+
+/**
+ * Shared utility methods for streaming query results in different formats (NDJSON, CSV, JSON). Used
+ * by both {@link ViewExecutionHelper} and the {@code $sqlquery-run} operation.
+ */
+public class ResultStreamingHelper {
+
+  @Nonnull private final Gson gson;
+
+  /**
+   * Constructs a new ResultStreamingHelper.
+   *
+   * @param gson the Gson instance for JSON serialisation
+   */
+  public ResultStreamingHelper(@Nonnull final Gson gson) {
+    this.gson = gson;
+  }
+
+  /**
+   * Writes the CSV header row.
+   *
+   * @param outputStream the output stream to write to
+   * @param columnNames the column names for the header
+   * @throws IOException if writing fails
+   */
+  public void writeCsvHeader(
+      @Nonnull final OutputStream outputStream, @Nonnull final List<String> columnNames)
+      throws IOException {
+    final OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
+    final CSVPrinter printer =
+        new CSVPrinter(
+            writer,
+            CSVFormat.DEFAULT
+                .builder()
+                .setHeader(columnNames.toArray(String[]::new))
+                .setSkipHeaderRecord(false)
+                .build());
+    printer.flush();
+  }
+
+  /**
+   * Streams results as NDJSON.
+   *
+   * @param outputStream the output stream to write to
+   * @param iterator the row iterator
+   * @param schema the result schema
+   * @throws IOException if writing fails
+   */
+  public void streamNdjson(
+      @Nonnull final OutputStream outputStream,
+      @Nonnull final Iterator<Row> iterator,
+      @Nonnull final StructType schema)
+      throws IOException {
+    while (iterator.hasNext()) {
+      final Row row = iterator.next();
+      final String json = rowToJson(row, schema);
+      outputStream.write(json.getBytes(StandardCharsets.UTF_8));
+      outputStream.write('\n');
+      outputStream.flush();
+    }
+  }
+
+  /**
+   * Streams results as CSV. The header is written separately for TTFB optimisation.
+   *
+   * @param outputStream the output stream to write to
+   * @param iterator the row iterator
+   * @param schema the result schema
+   * @throws IOException if writing fails
+   */
+  public void streamCsv(
+      @Nonnull final OutputStream outputStream,
+      @Nonnull final Iterator<Row> iterator,
+      @Nonnull final StructType schema)
+      throws IOException {
+    final OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
+    final CSVPrinter printer = new CSVPrinter(writer, CSVFormat.DEFAULT);
+
+    while (iterator.hasNext()) {
+      final Row row = iterator.next();
+      printer.printRecord(rowToList(row, schema));
+      printer.flush();
+    }
+  }
+
+  /**
+   * Writes results as a single JSON document containing an array. Unlike NDJSON, this cannot be
+   * streamed row-by-row as it requires proper JSON array formatting.
+   *
+   * @param outputStream the output stream to write to
+   * @param iterator the row iterator
+   * @param schema the result schema
+   * @throws IOException if writing fails
+   */
+  public void writeJson(
+      @Nonnull final OutputStream outputStream,
+      @Nonnull final Iterator<Row> iterator,
+      @Nonnull final StructType schema)
+      throws IOException {
+    final List<Map<String, Object>> rows = new ArrayList<>();
+    while (iterator.hasNext()) {
+      final Row row = iterator.next();
+      rows.add(rowToMap(row, schema));
+    }
+    final String json = gson.toJson(rows);
+    outputStream.write(json.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /** Converts a Spark Row to a Map for JSON serialisation. */
+  @Nonnull
+  public Map<String, Object> rowToMap(@Nonnull final Row row, @Nonnull final StructType schema) {
+    final Map<String, Object> map = new LinkedHashMap<>();
+    final StructField[] fields = schema.fields();
+    for (int i = 0; i < fields.length; i++) {
+      final String name = fields[i].name();
+      final Object value = row.get(i);
+      if (value != null) {
+        map.put(name, convertValue(value, fields[i].dataType()));
+      }
+    }
+    return map;
+  }
+
+  /** Converts a Spark Row to a JSON string. */
+  @Nonnull
+  public String rowToJson(@Nonnull final Row row, @Nonnull final StructType schema) {
+    return gson.toJson(rowToMap(row, schema));
+  }
+
+  /** Converts a value for JSON serialisation. */
+  @Nullable
+  public Object convertValue(
+      @Nullable final Object value, @Nonnull final org.apache.spark.sql.types.DataType dataType) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof final Row nestedRow && dataType instanceof final StructType structType) {
+      final Map<String, Object> nested = new LinkedHashMap<>();
+      final StructField[] fields = structType.fields();
+      for (int i = 0; i < fields.length; i++) {
+        final Object nestedValue = nestedRow.get(i);
+        if (nestedValue != null) {
+          nested.put(fields[i].name(), convertValue(nestedValue, fields[i].dataType()));
+        }
+      }
+      return nested;
+    }
+    if (value instanceof final scala.collection.Seq<?> seq) {
+      final List<?> list = CollectionConverters.asJava(seq);
+      if (dataType instanceof final ArrayType arrayType) {
+        return list.stream().map(item -> convertValue(item, arrayType.elementType())).toList();
+      }
+      return list;
+    }
+    return value;
+  }
+
+  /** Converts a Spark Row to a list of values for CSV output. */
+  @Nonnull
+  public List<Object> rowToList(@Nonnull final Row row, @Nonnull final StructType schema) {
+    final List<Object> values = new ArrayList<>();
+    final StructField[] fields = schema.fields();
+    for (int i = 0; i < fields.length; i++) {
+      final Object value = row.get(i);
+      values.add(convertValueForCsv(value, fields[i].dataType()));
+    }
+    return values;
+  }
+
+  /** Converts a value for CSV output. */
+  @Nullable
+  public Object convertValueForCsv(
+      @Nullable final Object value, @Nonnull final org.apache.spark.sql.types.DataType dataType) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Row || value instanceof scala.collection.Seq<?>) {
+      return gson.toJson(convertValue(value, dataType));
+    }
+    return value;
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/view/ResultStreamingHelper.java
+++ b/server/src/main/java/au/csiro/pathling/operations/view/ResultStreamingHelper.java
@@ -237,18 +237,20 @@ public class ResultStreamingHelper {
 
     rejectUnsupportedColumnTypes(schema);
 
+    // Don't try-with-resources the JsonWriter: closing it cascades through the wrapped writer
+    // and closes the servlet response output stream, which the container still needs.
     final OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
-    try (final JsonWriter json = new JsonWriter(writer)) {
-      json.beginObject();
-      json.name("resourceType").value("Parameters");
-      json.name("parameter").beginArray();
-      while (iterator.hasNext()) {
-        final Row row = iterator.next();
-        writeFhirRow(json, row, schema);
-      }
-      json.endArray();
-      json.endObject();
+    final JsonWriter json = new JsonWriter(writer);
+    json.beginObject();
+    json.name("resourceType").value("Parameters");
+    json.name("parameter").beginArray();
+    while (iterator.hasNext()) {
+      final Row row = iterator.next();
+      writeFhirRow(json, row, schema);
     }
+    json.endArray();
+    json.endObject();
+    json.flush();
     outputStream.flush();
   }
 

--- a/server/src/main/java/au/csiro/pathling/operations/view/ViewExecutionHelper.java
+++ b/server/src/main/java/au/csiro/pathling/operations/view/ViewExecutionHelper.java
@@ -42,23 +42,16 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.ConstraintViolationException;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.types.ArrayType;
-import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.BooleanType;
@@ -67,7 +60,6 @@ import org.hl7.fhir.r4.model.InstantType;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import scala.jdk.javaapi.CollectionConverters;
 
 /**
  * Helper class for executing ViewDefinition queries. Contains shared logic used by both {@link
@@ -94,6 +86,8 @@ public class ViewExecutionHelper {
   @Nonnull private final ServerConfiguration serverConfiguration;
 
   @Nonnull private final Gson gson;
+
+  @Nonnull private final ResultStreamingHelper streamingHelper;
 
   /**
    * Constructs a new ViewExecutionHelper.
@@ -123,6 +117,7 @@ public class ViewExecutionHelper {
     this.groupMemberService = groupMemberService;
     this.serverConfiguration = serverConfiguration;
     this.gson = ViewDefinitionGson.create();
+    this.streamingHelper = new ResultStreamingHelper(gson);
   }
 
   /**
@@ -188,7 +183,7 @@ public class ViewExecutionHelper {
 
       // For CSV with header, write header immediately to minimise TTFB.
       if (outputFormat == ViewOutputFormat.CSV && shouldIncludeHeader) {
-        writeCsvHeader(outputStream, columnNames);
+        streamingHelper.writeCsvHeader(outputStream, columnNames);
         outputStream.flush();
       }
 
@@ -234,9 +229,9 @@ public class ViewExecutionHelper {
     final Iterator<Row> iterator = result.toLocalIterator();
 
     switch (outputFormat) {
-      case NDJSON -> streamNdjson(outputStream, iterator, schema);
-      case JSON -> writeJson(outputStream, iterator, schema);
-      default -> streamCsv(outputStream, iterator, schema);
+      case NDJSON -> streamingHelper.streamNdjson(outputStream, iterator, schema);
+      case JSON -> streamingHelper.writeJson(outputStream, iterator, schema);
+      default -> streamingHelper.streamCsv(outputStream, iterator, schema);
     }
   }
 
@@ -343,147 +338,13 @@ public class ViewExecutionHelper {
         });
   }
 
-  /** Writes the CSV header row. */
-  private void writeCsvHeader(
-      @Nonnull final OutputStream outputStream, @Nonnull final List<String> columnNames)
-      throws IOException {
-    final OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
-    final CSVPrinter printer =
-        new CSVPrinter(
-            writer,
-            CSVFormat.DEFAULT
-                .builder()
-                .setHeader(columnNames.toArray(String[]::new))
-                .setSkipHeaderRecord(false)
-                .build());
-    printer.flush();
-    // Don't close the printer as we need to keep the stream open.
-  }
-
-  /** Streams results as NDJSON. */
-  private void streamNdjson(
-      @Nonnull final OutputStream outputStream,
-      @Nonnull final Iterator<Row> iterator,
-      @Nonnull final StructType schema)
-      throws IOException {
-    while (iterator.hasNext()) {
-      final Row row = iterator.next();
-      final String json = rowToJson(row, schema);
-      outputStream.write(json.getBytes(StandardCharsets.UTF_8));
-      outputStream.write('\n');
-      outputStream.flush();
-    }
-  }
-
-  /** Streams results as CSV. The header is written separately for TTFB optimisation. */
-  private void streamCsv(
-      @Nonnull final OutputStream outputStream,
-      @Nonnull final Iterator<Row> iterator,
-      @Nonnull final StructType schema)
-      throws IOException {
-    final OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
-    // Header was already written for TTFB optimisation, so always use DEFAULT (no header).
-    final CSVPrinter printer = new CSVPrinter(writer, CSVFormat.DEFAULT);
-
-    while (iterator.hasNext()) {
-      final Row row = iterator.next();
-      printer.printRecord(rowToList(row, schema));
-      printer.flush();
-    }
-  }
-
   /**
-   * Writes results as a single JSON document containing an array. Unlike NDJSON, this cannot be
-   * streamed row-by-row as it requires proper JSON array formatting.
+   * Returns the result streaming helper for use by other components.
+   *
+   * @return the result streaming helper
    */
-  private void writeJson(
-      @Nonnull final OutputStream outputStream,
-      @Nonnull final Iterator<Row> iterator,
-      @Nonnull final StructType schema)
-      throws IOException {
-    final List<Map<String, Object>> rows = new ArrayList<>();
-    while (iterator.hasNext()) {
-      final Row row = iterator.next();
-      rows.add(rowToMap(row, schema));
-    }
-    final String json = gson.toJson(rows);
-    outputStream.write(json.getBytes(StandardCharsets.UTF_8));
-  }
-
-  /** Converts a Spark Row to a Map for JSON serialisation. */
   @Nonnull
-  private Map<String, Object> rowToMap(@Nonnull final Row row, @Nonnull final StructType schema) {
-    final Map<String, Object> map = new LinkedHashMap<>();
-    final StructField[] fields = schema.fields();
-    for (int i = 0; i < fields.length; i++) {
-      final String name = fields[i].name();
-      final Object value = row.get(i);
-      if (value != null) {
-        map.put(name, convertValue(value, fields[i].dataType()));
-      }
-    }
-    return map;
-  }
-
-  /** Converts a Spark Row to a JSON string. */
-  @Nonnull
-  private String rowToJson(@Nonnull final Row row, @Nonnull final StructType schema) {
-    return gson.toJson(rowToMap(row, schema));
-  }
-
-  /** Converts a value for JSON serialisation. */
-  @Nullable
-  private Object convertValue(
-      @Nullable final Object value, @Nonnull final org.apache.spark.sql.types.DataType dataType) {
-    if (value == null) {
-      return null;
-    }
-    // Handle nested struct.
-    if (value instanceof final Row nestedRow && dataType instanceof final StructType structType) {
-      final Map<String, Object> nested = new LinkedHashMap<>();
-      final StructField[] fields = structType.fields();
-      for (int i = 0; i < fields.length; i++) {
-        final Object nestedValue = nestedRow.get(i);
-        if (nestedValue != null) {
-          nested.put(fields[i].name(), convertValue(nestedValue, fields[i].dataType()));
-        }
-      }
-      return nested;
-    }
-    // Handle array.
-    if (value instanceof final scala.collection.Seq<?> seq) {
-      final List<?> list = CollectionConverters.asJava(seq);
-      if (dataType instanceof final ArrayType arrayType) {
-        return list.stream().map(item -> convertValue(item, arrayType.elementType())).toList();
-      }
-      return list;
-    }
-    return value;
-  }
-
-  /** Converts a Spark Row to a list of values for CSV output. */
-  @Nonnull
-  private List<Object> rowToList(@Nonnull final Row row, @Nonnull final StructType schema) {
-    final List<Object> values = new ArrayList<>();
-    final StructField[] fields = schema.fields();
-    for (int i = 0; i < fields.length; i++) {
-      final Object value = row.get(i);
-      values.add(convertValueForCsv(value, fields[i].dataType()));
-    }
-    return values;
-  }
-
-  /** Converts a value for CSV output. */
-  @Nullable
-  private Object convertValueForCsv(
-      @Nullable final Object value, @Nonnull final org.apache.spark.sql.types.DataType dataType) {
-    if (value == null) {
-      return null;
-    }
-    if (value instanceof Row || value instanceof scala.collection.Seq<?>) {
-      // For complex types in CSV, serialise as JSON.
-      return gson.toJson(convertValue(value, dataType));
-    }
-    return value;
+  public ResultStreamingHelper getStreamingHelper() {
+    return streamingHelper;
   }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -82,6 +82,17 @@ pathling:
     viewDefinitionExportEnabled: true
     bulkSubmitEnabled: true
 
+  # Resource limits applied to the $sqlquery-run operation. Both limits are always applied,
+  # regardless of any caller-supplied parameters.
+  sqlQuery:
+    # The maximum number of rows that a single response may stream. Clamps the caller-supplied
+    # _limit when that value is larger.
+    maxRows: 1000000
+
+    # The maximum wall-clock time in seconds that a single query may run before its Spark job
+    # group is cancelled. Long-running queries should use the asynchronous path.
+    timeoutSeconds: 60
+
   auth:
     # Enables authorization.
     enabled: false

--- a/server/src/main/resources/examples/sqlquery-run-examples.md
+++ b/server/src/main/resources/examples/sqlquery-run-examples.md
@@ -230,7 +230,7 @@ curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
       \"resource\": {
         \"resourceType\": \"Library\",
         \"status\": \"active\",
-        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"type\": {\"coding\": [{\"system\": \"https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes\", \"code\": \"sql-query\"}]},
         \"content\": [{
           \"contentType\": \"application/sql\",
           \"data\": \"${SQL_B64}\"
@@ -280,7 +280,7 @@ curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
       \"resource\": {
         \"resourceType\": \"Library\",
         \"status\": \"active\",
-        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"type\": {\"coding\": [{\"system\": \"https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes\", \"code\": \"sql-query\"}]},
         \"content\": [{
           \"contentType\": \"application/sql\",
           \"data\": \"${SQL_B64}\"
@@ -328,7 +328,7 @@ curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
       \"resource\": {
         \"resourceType\": \"Library\",
         \"status\": \"active\",
-        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"type\": {\"coding\": [{\"system\": \"https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes\", \"code\": \"sql-query\"}]},
         \"content\": [{
           \"contentType\": \"application/sql\",
           \"data\": \"${SQL_B64}\"
@@ -386,7 +386,7 @@ curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
       \"resource\": {
         \"resourceType\": \"Library\",
         \"status\": \"active\",
-        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"type\": {\"coding\": [{\"system\": \"https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes\", \"code\": \"sql-query\"}]},
         \"content\": [{
           \"contentType\": \"application/sql\",
           \"data\": \"${SQL_B64}\"
@@ -416,7 +416,7 @@ curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run" \
       \"resource\": {
         \"resourceType\": \"Library\",
         \"status\": \"active\",
-        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"type\": {\"coding\": [{\"system\": \"https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes\", \"code\": \"sql-query\"}]},
         \"content\": [{
           \"contentType\": \"application/sql\",
           \"data\": \"${SQL_B64}\"
@@ -444,7 +444,7 @@ curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=json" \
       \"resource\": {
         \"resourceType\": \"Library\",
         \"status\": \"active\",
-        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"type\": {\"coding\": [{\"system\": \"https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes\", \"code\": \"sql-query\"}]},
         \"content\": [{
           \"contentType\": \"application/sql\",
           \"data\": \"${SQL_B64}\"
@@ -472,7 +472,7 @@ curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run" \
       \"resource\": {
         \"resourceType\": \"Library\",
         \"status\": \"active\",
-        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"type\": {\"coding\": [{\"system\": \"https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes\", \"code\": \"sql-query\"}]},
         \"content\": [{
           \"contentType\": \"application/sql\",
           \"data\": \"${SQL_B64}\"

--- a/server/src/main/resources/examples/sqlquery-run-examples.md
+++ b/server/src/main/resources/examples/sqlquery-run-examples.md
@@ -1,0 +1,486 @@
+# $sqlquery-run Operation Examples
+
+These examples demonstrate the `$sqlquery-run` operation alongside the
+existing `$viewdefinition-run` operation. They use a small synthetic dataset
+of Patients and Conditions.
+
+## Prerequisites
+
+Start the server with a writable warehouse directory:
+
+```bash
+WAREHOUSE_DIR=$(mktemp -d)/warehouse
+mkdir -p "$WAREHOUSE_DIR"
+
+PATHLING_STORAGE_WAREHOUSEURL="file://${WAREHOUSE_DIR}" \
+PATHLING_STORAGE_DATABASENAME="default" \
+mvn spring-boot:run
+```
+
+## 1. Load Test Data
+
+### Patients
+
+```bash
+for p in \
+  '{"resourceType":"Patient","id":"pat-1","gender":"male","birthDate":"1990-05-15","name":[{"use":"official","family":"Smith","given":["John"]}]}' \
+  '{"resourceType":"Patient","id":"pat-2","gender":"female","birthDate":"1985-11-22","name":[{"use":"official","family":"Johnson","given":["Jane"]}]}' \
+  '{"resourceType":"Patient","id":"pat-3","gender":"male","birthDate":"2000-03-08","name":[{"use":"official","family":"Williams","given":["Bob"]}]}' \
+  '{"resourceType":"Patient","id":"pat-4","gender":"female","birthDate":"1978-07-30","name":[{"use":"official","family":"Brown","given":["Alice"]}]}' \
+  '{"resourceType":"Patient","id":"pat-5","gender":"male","birthDate":"1995-12-01","name":[{"use":"official","family":"Davis","given":["Charlie"]}]}'
+do
+  id=$(echo "$p" | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+  curl -s -o /dev/null -w "Patient/$id: %{http_code}\n" \
+    -X PUT "http://localhost:8080/fhir/Patient/$id" \
+    -H "Content-Type: application/fhir+json" -d "$p"
+done
+```
+
+### Conditions
+
+```bash
+for c in \
+  '{"resourceType":"Condition","id":"cnd-1","subject":{"reference":"Patient/pat-1"},"code":{"coding":[{"system":"http://snomed.info/sct","code":"73211009","display":"Diabetes mellitus"}]},"onsetDateTime":"2015-03-12"}' \
+  '{"resourceType":"Condition","id":"cnd-2","subject":{"reference":"Patient/pat-1"},"code":{"coding":[{"system":"http://snomed.info/sct","code":"38341003","display":"Hypertension"}]},"onsetDateTime":"2018-06-01"}' \
+  '{"resourceType":"Condition","id":"cnd-3","subject":{"reference":"Patient/pat-2"},"code":{"coding":[{"system":"http://snomed.info/sct","code":"195967001","display":"Asthma"}]},"onsetDateTime":"2010-09-20"}' \
+  '{"resourceType":"Condition","id":"cnd-4","subject":{"reference":"Patient/pat-3"},"code":{"coding":[{"system":"http://snomed.info/sct","code":"73211009","display":"Diabetes mellitus"}]},"onsetDateTime":"2020-01-15"}' \
+  '{"resourceType":"Condition","id":"cnd-5","subject":{"reference":"Patient/pat-4"},"code":{"coding":[{"system":"http://snomed.info/sct","code":"38341003","display":"Hypertension"}]},"onsetDateTime":"2012-11-30"}' \
+  '{"resourceType":"Condition","id":"cnd-6","subject":{"reference":"Patient/pat-5"},"code":{"coding":[{"system":"http://snomed.info/sct","code":"195967001","display":"Asthma"}]},"onsetDateTime":"2019-04-10"}'
+do
+  id=$(echo "$c" | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+  curl -s -o /dev/null -w "Condition/$id: %{http_code}\n" \
+    -X PUT "http://localhost:8080/fhir/Condition/$id" \
+    -H "Content-Type: application/fhir+json" -d "$c"
+done
+```
+
+### ViewDefinitions
+
+Create a Patient ViewDefinition:
+
+```bash
+curl -s -X POST "http://localhost:8080/fhir/ViewDefinition" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "ViewDefinition",
+    "name": "patients",
+    "resource": "Patient",
+    "select": [
+      {
+        "column": [
+          {"path": "id", "name": "patient_id"},
+          {"path": "gender", "name": "gender"},
+          {"path": "birthDate", "name": "birth_date"}
+        ]
+      },
+      {
+        "forEach": "name.where(use = '\''official'\'')",
+        "column": [
+          {"path": "family", "name": "family_name"},
+          {"path": "given.first()", "name": "given_name"}
+        ]
+      }
+    ]
+  }'
+```
+
+Create a Condition ViewDefinition:
+
+```bash
+curl -s -X POST "http://localhost:8080/fhir/ViewDefinition" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "ViewDefinition",
+    "name": "conditions",
+    "resource": "Condition",
+    "select": [
+      {
+        "column": [
+          {"path": "id", "name": "condition_id"},
+          {"path": "subject.reference", "name": "patient_ref"},
+          {"path": "code.coding.first().code", "name": "snomed_code"},
+          {"path": "code.coding.first().display", "name": "condition_name"},
+          {"path": "onsetDateTime", "name": "onset_date"}
+        ]
+      }
+    ]
+  }'
+```
+
+Note the IDs returned in the responses. Replace `<PATIENT_VD_ID>` and
+`<CONDITION_VD_ID>` in the examples below with these values. You can also
+look them up:
+
+```bash
+curl -s "http://localhost:8080/fhir/ViewDefinition?_count=10" \
+  -H "Accept: application/fhir+json" | python3 -m json.tool
+```
+
+## 2. $viewdefinition-run Examples
+
+### Instance-level $run on a stored ViewDefinition
+
+```bash
+curl -s "http://localhost:8080/fhir/ViewDefinition/<PATIENT_VD_ID>/\$run" \
+  -H "Accept: application/x-ndjson"
+```
+
+Expected output (NDJSON):
+
+```
+{"patient_id":"pat-1","gender":"male","birth_date":"1990-05-15","family_name":"Smith","given_name":"John"}
+{"patient_id":"pat-2","gender":"female","birth_date":"1985-11-22","family_name":"Johnson","given_name":"Jane"}
+{"patient_id":"pat-3","gender":"male","birth_date":"2000-03-08","family_name":"Williams","given_name":"Bob"}
+{"patient_id":"pat-4","gender":"female","birth_date":"1978-07-30","family_name":"Brown","given_name":"Alice"}
+{"patient_id":"pat-5","gender":"male","birth_date":"1995-12-01","family_name":"Davis","given_name":"Charlie"}
+```
+
+### Stored Condition ViewDefinition as CSV
+
+```bash
+curl -s "http://localhost:8080/fhir/ViewDefinition/<CONDITION_VD_ID>/\$run?_format=csv"
+```
+
+Expected output:
+
+```
+condition_id,patient_ref,snomed_code,condition_name,onset_date
+cnd-1,Patient/pat-1,73211009,Diabetes mellitus,2015-03-12
+cnd-2,Patient/pat-1,38341003,Hypertension,2018-06-01
+cnd-3,Patient/pat-2,195967001,Asthma,2010-09-20
+cnd-4,Patient/pat-3,73211009,Diabetes mellitus,2020-01-15
+cnd-5,Patient/pat-4,38341003,Hypertension,2012-11-30
+cnd-6,Patient/pat-5,195967001,Asthma,2019-04-10
+```
+
+### Inline ViewDefinition with inline resources (no stored data needed)
+
+```bash
+curl -s -X POST "http://localhost:8080/fhir/\$viewdefinition-run" \
+  -H "Content-Type: application/fhir+json" \
+  -H "Accept: application/x-ndjson" \
+  -d '{
+    "resourceType": "Parameters",
+    "parameter": [
+      {
+        "name": "viewResource",
+        "resource": {
+          "resourceType": "ViewDefinition",
+          "name": "patient_demographics",
+          "resource": "Patient",
+          "select": [
+            {
+              "column": [
+                {"path": "id", "name": "patient_id"},
+                {"path": "gender", "name": "gender"},
+                {"path": "birthDate", "name": "birth_date"}
+              ]
+            },
+            {
+              "forEach": "name.where(use = '\''official'\'')",
+              "column": [
+                {"path": "family", "name": "family_name"},
+                {"path": "given.first()", "name": "given_name"}
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "name": "resource",
+        "valueString": "{\"resourceType\":\"Patient\",\"id\":\"p1\",\"gender\":\"male\",\"birthDate\":\"1990-05-15\",\"name\":[{\"use\":\"official\",\"family\":\"Smith\",\"given\":[\"John\"]}]}"
+      },
+      {
+        "name": "resource",
+        "valueString": "{\"resourceType\":\"Patient\",\"id\":\"p2\",\"gender\":\"female\",\"birthDate\":\"1985-11-22\",\"name\":[{\"use\":\"official\",\"family\":\"Johnson\",\"given\":[\"Jane\"]}]}"
+      }
+    ]
+  }'
+```
+
+## 3. $sqlquery-run Examples
+
+The `$sqlquery-run` operation takes a Library resource conforming to the
+SQLQuery profile. The Library contains Base64-encoded SQL in its `content`,
+and references stored ViewDefinitions via `relatedArtifact`. The `label` on
+each artifact becomes the table name used in the SQL.
+
+### JOIN patients with conditions
+
+SQL:
+
+```sql
+SELECT p.given_name, p.family_name, p.gender, p.birth_date,
+       c.condition_name, c.onset_date
+FROM patients p
+JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref
+ORDER BY p.family_name, c.onset_date
+```
+
+```bash
+SQL="SELECT p.given_name, p.family_name, p.gender, p.birth_date, c.condition_name, c.onset_date FROM patients p JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref ORDER BY p.family_name, c.onset_date"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": [
+          {\"type\": \"depends-on\", \"label\": \"patients\", \"resource\": \"ViewDefinition/<PATIENT_VD_ID>\"},
+          {\"type\": \"depends-on\", \"label\": \"conditions\", \"resource\": \"ViewDefinition/<CONDITION_VD_ID>\"}
+        ]
+      }
+    }]
+  }"
+```
+
+Expected output:
+
+```
+given_name,family_name,gender,birth_date,condition_name,onset_date
+Alice,Brown,female,1978-07-30,Hypertension,2012-11-30
+Charlie,Davis,male,1995-12-01,Asthma,2019-04-10
+Jane,Johnson,female,1985-11-22,Asthma,2010-09-20
+John,Smith,male,1990-05-15,Diabetes mellitus,2015-03-12
+John,Smith,male,1990-05-15,Hypertension,2018-06-01
+Bob,Williams,male,2000-03-08,Diabetes mellitus,2020-01-15
+```
+
+### Aggregate: patients per condition
+
+SQL:
+
+```sql
+SELECT c.condition_name, count(*) AS patient_count
+FROM conditions c
+GROUP BY c.condition_name
+ORDER BY patient_count DESC
+```
+
+```bash
+SQL="SELECT c.condition_name, count(*) AS patient_count FROM conditions c GROUP BY c.condition_name ORDER BY patient_count DESC"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": [
+          {\"type\": \"depends-on\", \"label\": \"conditions\", \"resource\": \"ViewDefinition/<CONDITION_VD_ID>\"}
+        ]
+      }
+    }]
+  }"
+```
+
+Expected output:
+
+```
+condition_name,patient_count
+Diabetes mellitus,2
+Hypertension,2
+Asthma,2
+```
+
+### Aggregate: condition count per patient
+
+SQL:
+
+```sql
+SELECT p.given_name, p.family_name,
+       count(*) AS condition_count
+FROM patients p
+JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref
+GROUP BY p.given_name, p.family_name
+ORDER BY condition_count DESC
+```
+
+```bash
+SQL="SELECT p.given_name, p.family_name, count(*) AS condition_count FROM patients p JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref GROUP BY p.given_name, p.family_name ORDER BY condition_count DESC"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": [
+          {\"type\": \"depends-on\", \"label\": \"patients\", \"resource\": \"ViewDefinition/<PATIENT_VD_ID>\"},
+          {\"type\": \"depends-on\", \"label\": \"conditions\", \"resource\": \"ViewDefinition/<CONDITION_VD_ID>\"}
+        ]
+      }
+    }]
+  }"
+```
+
+Expected output:
+
+```
+given_name,family_name,condition_count
+John,Smith,2
+Jane,Johnson,1
+Alice,Brown,1
+Charlie,Davis,1
+Bob,Williams,1
+```
+
+### Aggregate: patients by age group and condition type
+
+SQL:
+
+```sql
+SELECT
+  CASE
+    WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 30 THEN '0-29'
+    WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 50 THEN '30-49'
+    WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 70 THEN '50-69'
+    ELSE '70+'
+  END AS age_group,
+  c.condition_name,
+  count(DISTINCT p.patient_id) AS patient_count
+FROM patients p
+JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref
+GROUP BY age_group, c.condition_name
+ORDER BY age_group, c.condition_name
+```
+
+```bash
+SQL="SELECT CASE WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 30 THEN '0-29' WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 50 THEN '30-49' WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 70 THEN '50-69' ELSE '70+' END AS age_group, c.condition_name, count(DISTINCT p.patient_id) AS patient_count FROM patients p JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref GROUP BY age_group, c.condition_name ORDER BY age_group, c.condition_name"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": [
+          {\"type\": \"depends-on\", \"label\": \"patients\", \"resource\": \"ViewDefinition/<PATIENT_VD_ID>\"},
+          {\"type\": \"depends-on\", \"label\": \"conditions\", \"resource\": \"ViewDefinition/<CONDITION_VD_ID>\"}
+        ]
+      }
+    }]
+  }"
+```
+
+### Simple query against a single view (NDJSON output)
+
+```bash
+SQL="SELECT patient_id, given_name, family_name FROM patients LIMIT 3"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run" \
+  -H "Content-Type: application/fhir+json" \
+  -H "Accept: application/x-ndjson" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": [
+          {\"type\": \"depends-on\", \"label\": \"patients\", \"resource\": \"ViewDefinition/<PATIENT_VD_ID>\"}
+        ]
+      }
+    }]
+  }"
+```
+
+### JSON output format
+
+```bash
+SQL="SELECT condition_name, onset_date FROM conditions ORDER BY onset_date"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=json" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": [
+          {\"type\": \"depends-on\", \"label\": \"conditions\", \"resource\": \"ViewDefinition/<CONDITION_VD_ID>\"}
+        ]
+      }
+    }]
+  }"
+```
+
+### SQL validation: DDL/DML rejected
+
+```bash
+SQL="DROP TABLE conditions"
+SQL_B64=$(echo -n "$SQL" | base64)
+
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run" \
+  -H "Content-Type: application/fhir+json" \
+  -d "{
+    \"resourceType\": \"Parameters\",
+    \"parameter\": [{
+      \"name\": \"queryResource\",
+      \"resource\": {
+        \"resourceType\": \"Library\",
+        \"status\": \"active\",
+        \"type\": {\"coding\": [{\"code\": \"logic-library\"}]},
+        \"content\": [{
+          \"contentType\": \"application/sql\",
+          \"data\": \"${SQL_B64}\"
+        }],
+        \"relatedArtifact\": []
+      }
+    }]
+  }"
+```
+
+Expected: 400 error with `"SQL contains a disallowed operation"`.

--- a/server/src/main/resources/examples/sqlquery-run-examples.md
+++ b/server/src/main/resources/examples/sqlquery-run-examples.md
@@ -205,6 +205,46 @@ SQLQuery profile. The Library contains Base64-encoded SQL in its `content`,
 and references stored ViewDefinitions via `relatedArtifact`. The `label` on
 each artifact becomes the table name used in the SQL.
 
+### Resolving the Library by reference
+
+Instead of passing the Library inline as `queryResource`, you can supply a
+`queryReference` pointing at a stored Library. Either form (relative literal
+or canonical) is accepted; exactly one of `queryResource` and `queryReference`
+must be present.
+
+Relative literal reference (`Library/<id>`):
+
+```bash
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "Parameters",
+    "parameter": [{
+      "name": "queryReference",
+      "valueReference": {"reference": "Library/<LIBRARY_ID>"}
+    }]
+  }'
+```
+
+Canonical reference (`[url]` or `[url]|[version]`, matched against
+`Library.url` and `Library.version`):
+
+```bash
+curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "Parameters",
+    "parameter": [{
+      "name": "queryReference",
+      "valueReference": {"reference": "https://example.org/Library/patients-with-conditions|1.0"}
+    }]
+  }'
+```
+
+If no Library matches, the server responds with 404. If neither (or both) of
+`queryResource` and `queryReference` are supplied, the server responds with
+400.
+
 ### JOIN patients with conditions
 
 SQL:

--- a/server/src/main/resources/examples/sqlquery-run-examples.md
+++ b/server/src/main/resources/examples/sqlquery-run-examples.md
@@ -259,7 +259,7 @@ ORDER BY p.family_name, c.onset_date
 
 ```bash
 SQL="SELECT p.given_name, p.family_name, p.gender, p.birth_date, c.condition_name, c.onset_date FROM patients p JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref ORDER BY p.family_name, c.onset_date"
-SQL_B64=$(echo -n "$SQL" | base64)
+SQL_B64=$(echo -n "$SQL" | base64 | tr -d '\n')
 
 curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
   -H "Content-Type: application/fhir+json" \
@@ -309,7 +309,7 @@ ORDER BY patient_count DESC
 
 ```bash
 SQL="SELECT c.condition_name, count(*) AS patient_count FROM conditions c GROUP BY c.condition_name ORDER BY patient_count DESC"
-SQL_B64=$(echo -n "$SQL" | base64)
+SQL_B64=$(echo -n "$SQL" | base64 | tr -d '\n')
 
 curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
   -H "Content-Type: application/fhir+json" \
@@ -357,7 +357,7 @@ ORDER BY condition_count DESC
 
 ```bash
 SQL="SELECT p.given_name, p.family_name, count(*) AS condition_count FROM patients p JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref GROUP BY p.given_name, p.family_name ORDER BY condition_count DESC"
-SQL_B64=$(echo -n "$SQL" | base64)
+SQL_B64=$(echo -n "$SQL" | base64 | tr -d '\n')
 
 curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
   -H "Content-Type: application/fhir+json" \
@@ -415,7 +415,7 @@ ORDER BY age_group, c.condition_name
 
 ```bash
 SQL="SELECT CASE WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 30 THEN '0-29' WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 50 THEN '30-49' WHEN floor(datediff(current_date(), p.birth_date) / 365.25) < 70 THEN '50-69' ELSE '70+' END AS age_group, c.condition_name, count(DISTINCT p.patient_id) AS patient_count FROM patients p JOIN conditions c ON concat('Patient/', p.patient_id) = c.patient_ref GROUP BY age_group, c.condition_name ORDER BY age_group, c.condition_name"
-SQL_B64=$(echo -n "$SQL" | base64)
+SQL_B64=$(echo -n "$SQL" | base64 | tr -d '\n')
 
 curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
   -H "Content-Type: application/fhir+json" \
@@ -444,7 +444,7 @@ curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=csv" \
 
 ```bash
 SQL="SELECT patient_id, given_name, family_name FROM patients LIMIT 3"
-SQL_B64=$(echo -n "$SQL" | base64)
+SQL_B64=$(echo -n "$SQL" | base64 | tr -d '\n')
 
 curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run" \
   -H "Content-Type: application/fhir+json" \
@@ -473,7 +473,7 @@ curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run" \
 
 ```bash
 SQL="SELECT condition_name, onset_date FROM conditions ORDER BY onset_date"
-SQL_B64=$(echo -n "$SQL" | base64)
+SQL_B64=$(echo -n "$SQL" | base64 | tr -d '\n')
 
 curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=json" \
   -H "Content-Type: application/fhir+json" \
@@ -501,7 +501,7 @@ curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run?_format=json" \
 
 ```bash
 SQL="DROP TABLE conditions"
-SQL_B64=$(echo -n "$SQL" | base64)
+SQL_B64=$(echo -n "$SQL" | base64 | tr -d '\n')
 
 curl -s -X POST "http://localhost:8080/fhir/\$sqlquery-run" \
   -H "Content-Type: application/fhir+json" \

--- a/server/src/main/resources/examples/start-demo.sh
+++ b/server/src/main/resources/examples/start-demo.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+#
+# Starts the Pathling server with a temporary warehouse and loads test data
+# for demonstrating the $viewdefinition-run and $sqlquery-run operations.
+#
+# Usage (from any directory within the repository):
+#   ./server/src/main/resources/examples/start-demo.sh
+#
+# The script will print the ViewDefinition IDs needed for the $sqlquery-run
+# examples in sqlquery-run-examples.md.
+
+set -euo pipefail
+
+BASE_URL="http://localhost:8080/fhir"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Resolve the server module directory (four levels up from examples/).
+SERVER_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+cd "$SERVER_DIR"
+echo "Working directory: $(pwd)"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+wait_for_server() {
+  echo "Waiting for server..."
+  for i in $(seq 1 40); do
+    if curl -sf -o /dev/null "$BASE_URL/metadata" 2>/dev/null; then
+      echo "Server is ready."
+      return 0
+    fi
+    sleep 2
+  done
+  echo "ERROR: Server did not start within 80 seconds." >&2
+  exit 1
+}
+
+post_resource() {
+  local type="$1" body="$2"
+  curl -s -X POST "$BASE_URL/$type" \
+    -H "Content-Type: application/fhir+json" \
+    -d "$body"
+}
+
+# ── generate NDJSON test data ────────────────────────────────────────────────
+
+DATA_DIR="$(mktemp -d)"
+echo "Generating test data in $DATA_DIR ..."
+
+python3 << PYEOF
+import json, random
+
+DATA_DIR = "$DATA_DIR"
+PATIENT_COUNT = 1000
+random.seed(42)
+
+FAMILIES = [
+    "Smith", "Johnson", "Williams", "Brown", "Davis", "Miller", "Wilson",
+    "Moore", "Taylor", "Anderson", "Thomas", "Jackson", "White", "Harris",
+    "Martin", "Thompson", "Garcia", "Martinez", "Robinson", "Clark",
+    "Rodriguez", "Lewis", "Lee", "Walker", "Hall", "Allen", "Young",
+    "King", "Wright", "Scott", "Green", "Baker", "Adams", "Nelson",
+    "Hill", "Ramirez", "Campbell", "Mitchell", "Roberts", "Carter",
+]
+GIVENS_MALE = [
+    "James", "John", "Robert", "Michael", "David", "William", "Richard",
+    "Joseph", "Thomas", "Charles", "Daniel", "Matthew", "Anthony", "Mark",
+    "Steven", "Paul", "Andrew", "Joshua", "Kenneth", "Kevin",
+]
+GIVENS_FEMALE = [
+    "Mary", "Patricia", "Jennifer", "Linda", "Barbara", "Elizabeth",
+    "Susan", "Jessica", "Sarah", "Karen", "Lisa", "Nancy", "Betty",
+    "Margaret", "Sandra", "Ashley", "Emily", "Donna", "Michelle", "Carol",
+]
+CONDITIONS = [
+    {"code": "73211009", "display": "Diabetes mellitus"},
+    {"code": "38341003", "display": "Hypertension"},
+    {"code": "195967001", "display": "Asthma"},
+]
+# Every 5 patients: pat0 gets 2 conditions, the rest get 1 each.
+CONDITION_PATTERN = [
+    [CONDITIONS[0], CONDITIONS[1]],
+    [CONDITIONS[2]],
+    [CONDITIONS[0]],
+    [CONDITIONS[1]],
+    [CONDITIONS[2]],
+]
+
+def random_date(lo, hi):
+    return f"{random.randint(lo,hi):04d}-{random.randint(1,12):02d}-{random.randint(1,28):02d}"
+
+cond_idx = 0
+with open(f"{DATA_DIR}/Patient.ndjson", "w") as pf, \
+     open(f"{DATA_DIR}/Condition.ndjson", "w") as cf:
+    for i in range(PATIENT_COUNT):
+        pid = f"pat-{i+1:04d}"
+        gender = "male" if i % 2 == 0 else "female"
+        givens = GIVENS_MALE if gender == "male" else GIVENS_FEMALE
+        pf.write(json.dumps({
+            "resourceType": "Patient", "id": pid, "gender": gender,
+            "birthDate": random_date(1950, 2005),
+            "name": [{"use": "official",
+                       "family": FAMILIES[i % len(FAMILIES)],
+                       "given": [givens[i % len(givens)]]}],
+        }) + "\n")
+        for cond in CONDITION_PATTERN[i % len(CONDITION_PATTERN)]:
+            cond_idx += 1
+            cid = f"cnd-{cond_idx:04d}"
+            cf.write(json.dumps({
+                "resourceType": "Condition", "id": cid,
+                "subject": {"reference": f"Patient/{pid}"},
+                "code": {"coding": [{"system": "http://snomed.info/sct",
+                                      "code": cond["code"],
+                                      "display": cond["display"]}]},
+                "onsetDateTime": random_date(2005, 2025),
+            }) + "\n")
+
+print(f"  Generated {PATIENT_COUNT} patients, {cond_idx} conditions")
+PYEOF
+
+echo "  Patient.ndjson:   $(wc -l < "$DATA_DIR/Patient.ndjson") lines"
+echo "  Condition.ndjson: $(wc -l < "$DATA_DIR/Condition.ndjson") lines"
+
+# ── start server ─────────────────────────────────────────────────────────────
+
+WAREHOUSE_DIR="$(mktemp -d)/warehouse"
+mkdir -p "$WAREHOUSE_DIR"
+echo ""
+echo "Warehouse: $WAREHOUSE_DIR"
+
+export PATHLING_STORAGE_WAREHOUSEURL="file://$WAREHOUSE_DIR"
+export PATHLING_STORAGE_DATABASENAME="default"
+export PATHLING_IMPORT_ALLOWABLESOURCES="file://$DATA_DIR"
+
+echo "Starting Pathling server..."
+mvn -q spring-boot:run \
+  -Dspring-boot.run.jvmArguments="--add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -XX:ReservedCodeCacheSize=256m" \
+  &
+SERVER_PID=$!
+trap 'echo "Stopping server (PID $SERVER_PID)..."; kill $SERVER_PID 2>/dev/null; wait $SERVER_PID 2>/dev/null; rm -rf "$DATA_DIR"' EXIT
+
+wait_for_server
+
+# ── bulk import via $import ──────────────────────────────────────────────────
+
+echo ""
+echo "=== Importing test data via \$import ==="
+
+IMPORT_RESPONSE=$(curl -s -D- -X POST "$BASE_URL/\$import" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/fhir+json" \
+  -H "Prefer: respond-async" \
+  -d "{
+    \"inputFormat\": \"application/fhir+ndjson\",
+    \"inputSource\": \"file://$DATA_DIR\",
+    \"input\": [
+      {\"type\": \"Patient\", \"url\": \"file://$DATA_DIR/Patient.ndjson\"},
+      {\"type\": \"Condition\", \"url\": \"file://$DATA_DIR/Condition.ndjson\"}
+    ]
+  }")
+
+JOB_URL=$(echo "$IMPORT_RESPONSE" | grep -i "^Content-Location:" | tr -d '\r' | awk '{print $2}')
+if [ -z "$JOB_URL" ]; then
+  echo "ERROR: Import request failed." >&2
+  echo "$IMPORT_RESPONSE"
+  exit 1
+fi
+echo "  Import job: $JOB_URL"
+
+# Poll the job until it completes.
+echo "  Waiting for import to complete..."
+for i in $(seq 1 60); do
+  sleep 2
+  JOB_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$JOB_URL" -H "Accept: application/fhir+json")
+  if [ "$JOB_STATUS" = "200" ]; then
+    echo "  Import complete."
+    break
+  elif [ "$JOB_STATUS" = "202" ]; then
+    # Still processing.
+    :
+  else
+    echo "  Import failed (HTTP $JOB_STATUS):"
+    curl -s "$JOB_URL" -H "Accept: application/fhir+json"
+    exit 1
+  fi
+done
+
+# ── create view definitions ──────────────────────────────────────────────────
+
+echo ""
+echo "=== Creating ViewDefinitions ==="
+
+PATIENT_VD=$(post_resource ViewDefinition '{
+  "resourceType": "ViewDefinition",
+  "name": "patients",
+  "resource": "Patient",
+  "select": [
+    {
+      "column": [
+        {"path": "id", "name": "patient_id"},
+        {"path": "gender", "name": "gender"},
+        {"path": "birthDate", "name": "birth_date"}
+      ]
+    },
+    {
+      "forEach": "name.where(use = '\''official'\'')",
+      "column": [
+        {"path": "family", "name": "family_name"},
+        {"path": "given.first()", "name": "given_name"}
+      ]
+    }
+  ]
+}')
+PATIENT_VD_ID=$(echo "$PATIENT_VD" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id','UNKNOWN'))")
+echo "  patients ViewDefinition: $PATIENT_VD_ID"
+
+CONDITION_VD=$(post_resource ViewDefinition '{
+  "resourceType": "ViewDefinition",
+  "name": "conditions",
+  "resource": "Condition",
+  "select": [
+    {
+      "column": [
+        {"path": "id", "name": "condition_id"},
+        {"path": "subject.reference", "name": "patient_ref"},
+        {"path": "code.coding.first().code", "name": "snomed_code"},
+        {"path": "code.coding.first().display", "name": "condition_name"},
+        {"path": "onsetDateTime", "name": "onset_date"}
+      ]
+    }
+  ]
+}')
+CONDITION_VD_ID=$(echo "$CONDITION_VD" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id','UNKNOWN'))")
+echo "  conditions ViewDefinition: $CONDITION_VD_ID"
+
+# ── summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "============================================================"
+echo "  Demo server ready at $BASE_URL"
+echo ""
+echo "  Patients ViewDefinition ID:   $PATIENT_VD_ID"
+echo "  Conditions ViewDefinition ID: $CONDITION_VD_ID"
+echo ""
+echo "  Replace <PATIENT_VD_ID> and <CONDITION_VD_ID> in the"
+echo "  examples in sqlquery-run-examples.md with the IDs above."
+echo ""
+echo "  Press Ctrl+C to stop the server."
+echo "============================================================"
+echo ""
+
+# Keep the script alive until the user kills it.
+wait $SERVER_PID

--- a/server/src/main/resources/examples/start-demo.sh
+++ b/server/src/main/resources/examples/start-demo.sh
@@ -136,7 +136,7 @@ mvn -q spring-boot:run \
   -Dspring-boot.run.jvmArguments="--add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -XX:ReservedCodeCacheSize=256m" \
   &
 SERVER_PID=$!
-trap 'echo "Stopping server (PID $SERVER_PID)..."; kill $SERVER_PID 2>/dev/null; wait $SERVER_PID 2>/dev/null; rm -rf "$DATA_DIR"' EXIT
+trap 'echo "Stopping server (PID $SERVER_PID)..."; kill $SERVER_PID 2>/dev/null; wait $SERVER_PID 2>/dev/null; rm -rf "$DATA_DIR" "$(dirname "$WAREHOUSE_DIR")"' EXIT
 
 wait_for_server
 

--- a/server/src/main/resources/fhir/sqlquery-run.OperationDefinition.json
+++ b/server/src/main/resources/fhir/sqlquery-run.OperationDefinition.json
@@ -35,7 +35,7 @@
       "use": "in",
       "min": 0,
       "max": "1",
-      "documentation": "The output format for the query results. Supported values are 'ndjson' (default), 'csv', 'json', and 'parquet'.",
+      "documentation": "The output format for the query results. Supported values are 'ndjson' (default), 'csv', 'json', 'parquet', and 'fhir'. The 'fhir' format returns a Parameters resource (application/fhir+json) with one repeating 'row' parameter per result row, each column rendered as a part with a typed value[x].",
       "type": "code"
     },
     {
@@ -55,29 +55,12 @@
       "type": "integer"
     },
     {
-      "name": "parameter",
+      "name": "parameters",
       "use": "in",
       "min": 0,
-      "max": "*",
-      "documentation": "Query parameter values to bind to the SQL query. Each parameter has a name and a value.",
-      "part": [
-        {
-          "name": "name",
-          "use": "in",
-          "min": 1,
-          "max": "1",
-          "documentation": "The name of the parameter, matching the colon-prefixed placeholder in the SQL.",
-          "type": "string"
-        },
-        {
-          "name": "value",
-          "use": "in",
-          "min": 1,
-          "max": "1",
-          "documentation": "The value to bind to the parameter.",
-          "type": "string"
-        }
-      ]
+      "max": "1",
+      "documentation": "Runtime parameter bindings as a Parameters resource. Each entry's name must match a Library.parameter declaration, and its value[x] must match the declared FHIR type.",
+      "type": "Parameters"
     }
   ]
 }

--- a/server/src/main/resources/fhir/sqlquery-run.OperationDefinition.json
+++ b/server/src/main/resources/fhir/sqlquery-run.OperationDefinition.json
@@ -1,0 +1,83 @@
+{
+  "resourceType": "OperationDefinition",
+  "name": "sqlquery-run",
+  "title": "Pathling SQLQuery Run Operation",
+  "status": "active",
+  "kind": "operation",
+  "experimental": false,
+  "publisher": "Australian e-Health Research Centre, CSIRO",
+  "description": "This operation executes a SQL query against materialised ViewDefinition tables within the Pathling server. The query is provided as a Library resource conforming to the SQLQuery profile from the SQL on FHIR v2 specification.",
+  "affectsState": false,
+  "code": "sqlquery-run",
+  "system": true,
+  "type": true,
+  "instance": true,
+  "resource": ["Library"],
+  "parameter": [
+    {
+      "name": "queryResource",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "documentation": "An inline Library resource conforming to the SQLQuery profile. Contains the SQL query, ViewDefinition dependencies, and parameter declarations.",
+      "type": "Resource"
+    },
+    {
+      "name": "queryReference",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "documentation": "A reference to a stored Library resource conforming to the SQLQuery profile.",
+      "type": "Reference"
+    },
+    {
+      "name": "_format",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "documentation": "The output format for the query results. Supported values are 'ndjson' (default), 'csv', 'json', and 'parquet'.",
+      "type": "code"
+    },
+    {
+      "name": "header",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "documentation": "For CSV output, whether to include a header row. Defaults to true.",
+      "type": "boolean"
+    },
+    {
+      "name": "_limit",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "documentation": "Maximum number of rows to return in the result.",
+      "type": "integer"
+    },
+    {
+      "name": "parameter",
+      "use": "in",
+      "min": 0,
+      "max": "*",
+      "documentation": "Query parameter values to bind to the SQL query. Each parameter has a name and a value.",
+      "part": [
+        {
+          "name": "name",
+          "use": "in",
+          "min": 1,
+          "max": "1",
+          "documentation": "The name of the parameter, matching the colon-prefixed placeholder in the SQL.",
+          "type": "string"
+        },
+        {
+          "name": "value",
+          "use": "in",
+          "min": 1,
+          "max": "1",
+          "documentation": "The value to bind to the parameter.",
+          "type": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/LibraryReferenceResolverTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/LibraryReferenceResolverTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.errors.ResourceNotFoundError;
+import au.csiro.pathling.io.source.DataSource;
+import au.csiro.pathling.read.ReadExecutor;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import java.util.List;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Reference;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+/**
+ * Tests for {@link LibraryReferenceResolver} covering both the relative-literal and canonical
+ * reference resolution paths.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+class LibraryReferenceResolverTest {
+
+  // ---------------------------------------------------------------------------
+  // Relative literal references — mocked ReadExecutor only.
+  // ---------------------------------------------------------------------------
+
+  @Nested
+  class RelativeReferences {
+
+    private ReadExecutor readExecutor;
+    private LibraryReferenceResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+      readExecutor = mock(ReadExecutor.class);
+      resolver =
+          new LibraryReferenceResolver(
+              readExecutor, mock(DataSource.class), mock(FhirEncoders.class));
+    }
+
+    @Test
+    void resolvesLibrarySlashId() {
+      final Library stored = newLibrary("abc", null, null, PublicationStatus.ACTIVE);
+      when(readExecutor.read(eq("Library"), eq("abc"))).thenReturn(stored);
+
+      final IBaseResource resolved = resolver.resolve(new Reference("Library/abc"));
+
+      assertThat(resolved).isSameAs(stored);
+    }
+
+    @Test
+    void resolvesBareId() {
+      final Library stored = newLibrary("abc", null, null, PublicationStatus.ACTIVE);
+      when(readExecutor.read(eq("Library"), eq("abc"))).thenReturn(stored);
+
+      final IBaseResource resolved = resolver.resolve(new Reference("abc"));
+
+      assertThat(resolved).isSameAs(stored);
+    }
+
+    @Test
+    void rejectsReferenceToOtherResourceType() {
+      assertThatThrownBy(() -> resolver.resolve(new Reference("Patient/abc")))
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessageContaining("Library");
+      verifyNoInteractions(readExecutor);
+    }
+
+    @Test
+    void rejectsBlankReference() {
+      assertThatThrownBy(() -> resolver.resolve(new Reference("")))
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessageContaining("non-blank");
+      verifyNoInteractions(readExecutor);
+    }
+
+    @Test
+    void rejectsLibrarySlashWithEmptyId() {
+      assertThatThrownBy(() -> resolver.resolve(new Reference("Library/")))
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessageContaining("missing");
+      verifyNoInteractions(readExecutor);
+    }
+
+    @Test
+    void translatesResourceNotFoundErrorToResourceNotFoundException() {
+      when(readExecutor.read(eq("Library"), eq("missing")))
+          .thenThrow(new ResourceNotFoundError("not there"));
+
+      assertThatThrownBy(() -> resolver.resolve(new Reference("Library/missing")))
+          .isInstanceOf(ResourceNotFoundException.class)
+          .hasMessageContaining("missing");
+    }
+
+    @Test
+    void translatesNoDataIllegalArgumentToResourceNotFoundException() {
+      when(readExecutor.read(eq("Library"), eq("anyone")))
+          .thenThrow(new IllegalArgumentException("No data found for resource type Library"));
+
+      assertThatThrownBy(() -> resolver.resolve(new Reference("Library/anyone")))
+          .isInstanceOf(ResourceNotFoundException.class)
+          .hasMessageContaining("anyone");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Canonical references — uses a real Spark session + FhirEncoders.
+  // ---------------------------------------------------------------------------
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class CanonicalReferences {
+
+    private SparkSession spark;
+    private FhirEncoders fhirEncoders;
+    private DataSource dataSource;
+    private LibraryReferenceResolver resolver;
+
+    @BeforeAll
+    void setUpAll() {
+      spark =
+          SparkSession.builder()
+              .master("local[1]")
+              .appName("LibraryReferenceResolverTest")
+              .config("spark.driver.bindAddress", "localhost")
+              .config("spark.driver.host", "localhost")
+              .config("spark.ui.enabled", false)
+              .config("spark.sql.shuffle.partitions", 1)
+              .getOrCreate();
+      fhirEncoders = FhirEncoders.forR4().getOrCreate();
+    }
+
+    @AfterAll
+    void tearDownAll() {
+      if (spark != null) {
+        spark.stop();
+      }
+    }
+
+    @BeforeEach
+    void setUp() {
+      dataSource = mock(DataSource.class);
+      resolver = new LibraryReferenceResolver(mock(ReadExecutor.class), dataSource, fhirEncoders);
+    }
+
+    @Test
+    void resolvesByCanonicalUrl() {
+      final Library stored =
+          newLibrary("a", "https://example.org/Library/foo", "1.0", PublicationStatus.ACTIVE);
+      when(dataSource.read("Library")).thenReturn(libraryDataset(stored));
+
+      final IBaseResource resolved =
+          resolver.resolve(new Reference("https://example.org/Library/foo"));
+
+      assertThat(resolved).isInstanceOf(Library.class);
+      assertThat(((Library) resolved).getId()).isEqualTo("Library/a");
+      verify(dataSource).read("Library");
+    }
+
+    @Test
+    void resolvesByCanonicalUrlWithVersion() {
+      final Library v1 =
+          newLibrary("a", "https://example.org/Library/foo", "1.0", PublicationStatus.ACTIVE);
+      final Library v2 =
+          newLibrary("b", "https://example.org/Library/foo", "2.0", PublicationStatus.ACTIVE);
+      when(dataSource.read("Library")).thenReturn(libraryDataset(v1, v2));
+
+      final IBaseResource resolved =
+          resolver.resolve(new Reference("https://example.org/Library/foo|2.0"));
+
+      assertThat(((Library) resolved).getId()).isEqualTo("Library/b");
+    }
+
+    @Test
+    void prefersActiveOverDraftWhenNoVersionSupplied() {
+      final Library draft =
+          newLibrary("a", "https://example.org/Library/foo", "1.0", PublicationStatus.DRAFT);
+      final Library active =
+          newLibrary("b", "https://example.org/Library/foo", "1.0", PublicationStatus.ACTIVE);
+      when(dataSource.read("Library")).thenReturn(libraryDataset(draft, active));
+
+      final IBaseResource resolved =
+          resolver.resolve(new Reference("https://example.org/Library/foo"));
+
+      assertThat(((Library) resolved).getId()).isEqualTo("Library/b");
+    }
+
+    @Test
+    void picksLatestActiveVersionWhenNoneSupplied() {
+      final Library v1 =
+          newLibrary("a", "https://example.org/Library/foo", "1.0", PublicationStatus.ACTIVE);
+      final Library v2 =
+          newLibrary("b", "https://example.org/Library/foo", "2.0", PublicationStatus.ACTIVE);
+      when(dataSource.read("Library")).thenReturn(libraryDataset(v1, v2));
+
+      final IBaseResource resolved =
+          resolver.resolve(new Reference("https://example.org/Library/foo"));
+
+      assertThat(((Library) resolved).getId()).isEqualTo("Library/b");
+    }
+
+    @Test
+    void returns404WhenCanonicalDoesNotMatch() {
+      when(dataSource.read("Library")).thenReturn(libraryDataset());
+
+      assertThatThrownBy(
+              () -> resolver.resolve(new Reference("https://example.org/Library/missing")))
+          .isInstanceOf(ResourceNotFoundException.class)
+          .hasMessageContaining("missing");
+    }
+
+    @Test
+    void returns404WhenVersionDoesNotMatch() {
+      final Library v1 =
+          newLibrary("a", "https://example.org/Library/foo", "1.0", PublicationStatus.ACTIVE);
+      when(dataSource.read("Library")).thenReturn(libraryDataset(v1));
+
+      assertThatThrownBy(
+              () -> resolver.resolve(new Reference("https://example.org/Library/foo|99.0")))
+          .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void treatsUrnReferenceAsCanonical() {
+      final Library stored = newLibrary("a", "urn:uuid:abc-123", "1.0", PublicationStatus.ACTIVE);
+      when(dataSource.read("Library")).thenReturn(libraryDataset(stored));
+
+      final IBaseResource resolved = resolver.resolve(new Reference("urn:uuid:abc-123"));
+
+      assertThat(((Library) resolved).getId()).isEqualTo("Library/a");
+    }
+
+    private Dataset<Row> libraryDataset(final Library... libraries) {
+      return spark.createDataset(List.of(libraries), fhirEncoders.of("Library")).toDF();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers shared across nested classes.
+  // ---------------------------------------------------------------------------
+
+  private static Library newLibrary(
+      final String id, final String url, final String version, final PublicationStatus status) {
+    final Library library = new Library();
+    library.setId("Library/" + id);
+    if (url != null) {
+      library.setUrl(url);
+    }
+    if (version != null) {
+      library.setVersion(version);
+    }
+    library.setStatus(status);
+    return library;
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/LibraryReferenceResolverTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/LibraryReferenceResolverTest.java
@@ -45,6 +45,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Tests for {@link LibraryReferenceResolver} covering both the relative-literal and canonical
@@ -91,30 +93,13 @@ class LibraryReferenceResolverTest {
       assertThat(resolved).isSameAs(stored);
     }
 
-    @Test
-    void rejectsReferenceToOtherResourceType() {
-      final Reference reference = new Reference("Patient/abc");
+    @ParameterizedTest(name = "rejects ''{0}'' with message containing ''{1}''")
+    @CsvSource({"Patient/abc, Library", "'', non-blank", "Library/, missing"})
+    void rejectsInvalidRelativeReference(final String input, final String expectedMessage) {
+      final Reference reference = new Reference(input);
       assertThatThrownBy(() -> resolver.resolve(reference))
           .isInstanceOf(InvalidRequestException.class)
-          .hasMessageContaining("Library");
-      verifyNoInteractions(readExecutor);
-    }
-
-    @Test
-    void rejectsBlankReference() {
-      final Reference reference = new Reference("");
-      assertThatThrownBy(() -> resolver.resolve(reference))
-          .isInstanceOf(InvalidRequestException.class)
-          .hasMessageContaining("non-blank");
-      verifyNoInteractions(readExecutor);
-    }
-
-    @Test
-    void rejectsLibrarySlashWithEmptyId() {
-      final Reference reference = new Reference("Library/");
-      assertThatThrownBy(() -> resolver.resolve(reference))
-          .isInstanceOf(InvalidRequestException.class)
-          .hasMessageContaining("missing");
+          .hasMessageContaining(expectedMessage);
       verifyNoInteractions(readExecutor);
     }
 

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/LibraryReferenceResolverTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/LibraryReferenceResolverTest.java
@@ -19,7 +19,6 @@ package au.csiro.pathling.operations.sqlquery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -75,7 +74,7 @@ class LibraryReferenceResolverTest {
     @Test
     void resolvesLibrarySlashId() {
       final Library stored = newLibrary("abc", null, null, PublicationStatus.ACTIVE);
-      when(readExecutor.read(eq("Library"), eq("abc"))).thenReturn(stored);
+      when(readExecutor.read("Library", "abc")).thenReturn(stored);
 
       final IBaseResource resolved = resolver.resolve(new Reference("Library/abc"));
 
@@ -85,7 +84,7 @@ class LibraryReferenceResolverTest {
     @Test
     void resolvesBareId() {
       final Library stored = newLibrary("abc", null, null, PublicationStatus.ACTIVE);
-      when(readExecutor.read(eq("Library"), eq("abc"))).thenReturn(stored);
+      when(readExecutor.read("Library", "abc")).thenReturn(stored);
 
       final IBaseResource resolved = resolver.resolve(new Reference("abc"));
 
@@ -94,7 +93,8 @@ class LibraryReferenceResolverTest {
 
     @Test
     void rejectsReferenceToOtherResourceType() {
-      assertThatThrownBy(() -> resolver.resolve(new Reference("Patient/abc")))
+      final Reference reference = new Reference("Patient/abc");
+      assertThatThrownBy(() -> resolver.resolve(reference))
           .isInstanceOf(InvalidRequestException.class)
           .hasMessageContaining("Library");
       verifyNoInteractions(readExecutor);
@@ -102,7 +102,8 @@ class LibraryReferenceResolverTest {
 
     @Test
     void rejectsBlankReference() {
-      assertThatThrownBy(() -> resolver.resolve(new Reference("")))
+      final Reference reference = new Reference("");
+      assertThatThrownBy(() -> resolver.resolve(reference))
           .isInstanceOf(InvalidRequestException.class)
           .hasMessageContaining("non-blank");
       verifyNoInteractions(readExecutor);
@@ -110,7 +111,8 @@ class LibraryReferenceResolverTest {
 
     @Test
     void rejectsLibrarySlashWithEmptyId() {
-      assertThatThrownBy(() -> resolver.resolve(new Reference("Library/")))
+      final Reference reference = new Reference("Library/");
+      assertThatThrownBy(() -> resolver.resolve(reference))
           .isInstanceOf(InvalidRequestException.class)
           .hasMessageContaining("missing");
       verifyNoInteractions(readExecutor);
@@ -118,20 +120,22 @@ class LibraryReferenceResolverTest {
 
     @Test
     void translatesResourceNotFoundErrorToResourceNotFoundException() {
-      when(readExecutor.read(eq("Library"), eq("missing")))
+      when(readExecutor.read("Library", "missing"))
           .thenThrow(new ResourceNotFoundError("not there"));
+      final Reference reference = new Reference("Library/missing");
 
-      assertThatThrownBy(() -> resolver.resolve(new Reference("Library/missing")))
+      assertThatThrownBy(() -> resolver.resolve(reference))
           .isInstanceOf(ResourceNotFoundException.class)
           .hasMessageContaining("missing");
     }
 
     @Test
     void translatesNoDataIllegalArgumentToResourceNotFoundException() {
-      when(readExecutor.read(eq("Library"), eq("anyone")))
+      when(readExecutor.read("Library", "anyone"))
           .thenThrow(new IllegalArgumentException("No data found for resource type Library"));
+      final Reference reference = new Reference("Library/anyone");
 
-      assertThatThrownBy(() -> resolver.resolve(new Reference("Library/anyone")))
+      assertThatThrownBy(() -> resolver.resolve(reference))
           .isInstanceOf(ResourceNotFoundException.class)
           .hasMessageContaining("anyone");
     }
@@ -236,9 +240,9 @@ class LibraryReferenceResolverTest {
     @Test
     void returns404WhenCanonicalDoesNotMatch() {
       when(dataSource.read("Library")).thenReturn(libraryDataset());
+      final Reference reference = new Reference("https://example.org/Library/missing");
 
-      assertThatThrownBy(
-              () -> resolver.resolve(new Reference("https://example.org/Library/missing")))
+      assertThatThrownBy(() -> resolver.resolve(reference))
           .isInstanceOf(ResourceNotFoundException.class)
           .hasMessageContaining("missing");
     }
@@ -248,9 +252,9 @@ class LibraryReferenceResolverTest {
       final Library v1 =
           newLibrary("a", "https://example.org/Library/foo", "1.0", PublicationStatus.ACTIVE);
       when(dataSource.read("Library")).thenReturn(libraryDataset(v1));
+      final Reference reference = new Reference("https://example.org/Library/foo|99.0");
 
-      assertThatThrownBy(
-              () -> resolver.resolve(new Reference("https://example.org/Library/foo|99.0")))
+      assertThatThrownBy(() -> resolver.resolve(reference))
           .isInstanceOf(ResourceNotFoundException.class);
     }
 

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutorTest.java
@@ -71,6 +71,7 @@ class SqlQueryExecutorTest {
         mock(SparkSession.class),
         mock(ViewRegistrationService.class),
         mock(SqlValidator.class),
-        serverConfiguration);
+        serverConfiguration,
+        mock(SqlQueryWatchdog.class));
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutorTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.config.SqlQueryConfiguration;
+import jakarta.annotation.Nonnull;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the row-cap clamp logic in {@link SqlQueryExecutor#effectiveLimit(Integer,
+ * String)}. These verify that the server-configured cap is always honoured and that a
+ * caller-supplied {@code _limit} can only narrow, never widen, the result set.
+ */
+class SqlQueryExecutorTest {
+
+  private static final String REQUEST_ID = "test-request";
+
+  @Test
+  void appliesServerCapWhenCallerHasNoLimit() {
+    final SqlQueryExecutor executor = newExecutor(2);
+    assertThat(executor.effectiveLimit(null, REQUEST_ID)).isEqualTo(2);
+  }
+
+  @Test
+  void appliesCallerLimitWhenLowerThanCap() {
+    final SqlQueryExecutor executor = newExecutor(1000);
+    assertThat(executor.effectiveLimit(5, REQUEST_ID)).isEqualTo(5);
+  }
+
+  @Test
+  void appliesServerCapWhenCallerLimitExceedsIt() {
+    final SqlQueryExecutor executor = newExecutor(10);
+    assertThat(executor.effectiveLimit(1_000_000, REQUEST_ID)).isEqualTo(10);
+  }
+
+  @Test
+  void clampsConfiguredCapToIntegerMaxValue() {
+    // A "disable the cap" value larger than Integer.MAX_VALUE must clamp down so it can be passed
+    // to Spark's Dataset.limit(int) API.
+    final SqlQueryExecutor executor = newExecutor(Long.MAX_VALUE);
+    assertThat(executor.effectiveLimit(null, REQUEST_ID)).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Nonnull
+  private static SqlQueryExecutor newExecutor(final long maxRows) {
+    final SqlQueryConfiguration sqlQueryConfig = new SqlQueryConfiguration();
+    sqlQueryConfig.setMaxRows(maxRows);
+    final ServerConfiguration serverConfiguration = new ServerConfiguration();
+    serverConfiguration.setSqlQuery(sqlQueryConfig);
+    return new SqlQueryExecutor(
+        mock(SparkSession.class),
+        mock(ViewRegistrationService.class),
+        mock(SqlValidator.class),
+        serverConfiguration);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParserTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParserTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import java.nio.charset.StandardCharsets;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.RelatedArtifact;
+import org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link SqlQueryLibraryParser}. */
+class SqlQueryLibraryParserTest {
+
+  private SqlQueryLibraryParser parser;
+
+  @BeforeEach
+  void setUp() {
+    parser = new SqlQueryLibraryParser();
+  }
+
+  @Test
+  void extractsSqlFromLibrary() {
+    final Library library = createMinimalLibrary("SELECT * FROM patients");
+    final ParsedSqlQuery result = parser.parse(library);
+    assertThat(result.getSql()).isEqualTo("SELECT * FROM patients");
+  }
+
+  @Test
+  void extractsViewReferences() {
+    final Library library = createMinimalLibrary("SELECT * FROM patients");
+    library.addRelatedArtifact(
+        new RelatedArtifact()
+            .setType(RelatedArtifactType.DEPENDSON)
+            .setLabel("patients")
+            .setResource("ViewDefinition/patient-view"));
+    library.addRelatedArtifact(
+        new RelatedArtifact()
+            .setType(RelatedArtifactType.DEPENDSON)
+            .setLabel("observations")
+            .setResource("ViewDefinition/obs-view"));
+
+    final ParsedSqlQuery result = parser.parse(library);
+
+    assertThat(result.getViewReferences()).hasSize(2);
+    assertThat(result.getViewReferences().get(0).getLabel()).isEqualTo("patients");
+    assertThat(result.getViewReferences().get(0).getCanonicalUrl())
+        .isEqualTo("ViewDefinition/patient-view");
+    assertThat(result.getViewReferences().get(1).getLabel()).isEqualTo("observations");
+    assertThat(result.getViewReferences().get(1).getCanonicalUrl())
+        .isEqualTo("ViewDefinition/obs-view");
+  }
+
+  @Test
+  void extractsParameters() {
+    final Library library = createMinimalLibrary("SELECT * FROM t WHERE age > :min_age");
+    library
+        .addParameter()
+        .setName("min_age")
+        .setType("integer")
+        .setUse(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.IN);
+
+    final ParsedSqlQuery result = parser.parse(library);
+
+    assertThat(result.getDeclaredParameters()).hasSize(1);
+    assertThat(result.getDeclaredParameters().get(0).getName()).isEqualTo("min_age");
+    assertThat(result.getDeclaredParameters().get(0).getType()).isEqualTo("integer");
+  }
+
+  @Test
+  void handlesEmptyViewReferencesAndParameters() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    final ParsedSqlQuery result = parser.parse(library);
+
+    assertThat(result.getSql()).isEqualTo("SELECT 1");
+    assertThat(result.getViewReferences()).isEmpty();
+    assertThat(result.getDeclaredParameters()).isEmpty();
+  }
+
+  @Test
+  void rejectsLibraryWithNoSqlContent() {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("application/sql");
+  }
+
+  @Test
+  void rejectsLibraryWithWrongContentType() {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library
+        .addContent()
+        .setContentType("text/plain")
+        .setData("SELECT 1".getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("application/sql");
+  }
+
+  @Test
+  void rejectsLibraryWithEmptySqlData() {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library.addContent().setContentType("application/sql").setData(new byte[0]);
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("no data");
+  }
+
+  @Test
+  void rejectsRelatedArtifactWithMissingLabel() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library.addRelatedArtifact(
+        new RelatedArtifact()
+            .setType(RelatedArtifactType.DEPENDSON)
+            .setResource("ViewDefinition/my-view"));
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("label");
+  }
+
+  @Test
+  void rejectsRelatedArtifactWithMissingResource() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library.addRelatedArtifact(
+        new RelatedArtifact().setType(RelatedArtifactType.DEPENDSON).setLabel("my_table"));
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("resource reference");
+  }
+
+  @Test
+  void rejectsParameterWithMissingName() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library
+        .addParameter()
+        .setType("string")
+        .setUse(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.IN);
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("name");
+  }
+
+  @Test
+  void rejectsParameterWithMissingType() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library
+        .addParameter()
+        .setName("param1")
+        .setUse(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.IN);
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("type");
+  }
+
+  @Test
+  void acceptsSqlContentTypeWithDialect() {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library
+        .addContent()
+        .setContentType("application/sql;dialect=spark")
+        .setData("SELECT 1".getBytes(StandardCharsets.UTF_8));
+
+    final ParsedSqlQuery result = parser.parse(library);
+    assertThat(result.getSql()).isEqualTo("SELECT 1");
+  }
+
+  /** Creates a minimal Library resource with the given SQL as Base64-encoded content. */
+  private Library createMinimalLibrary(final String sql) {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library
+        .addContent()
+        .setContentType("application/sql")
+        .setData(sql.getBytes(StandardCharsets.UTF_8));
+    return library;
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParserTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryLibraryParserTest.java
@@ -22,8 +22,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import java.nio.charset.StandardCharsets;
+import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
 import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse;
 import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +33,9 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link SqlQueryLibraryParser}. */
 class SqlQueryLibraryParserTest {
+
+  private static final String LIBRARY_TYPE_SYSTEM =
+      "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes";
 
   private SqlQueryLibraryParser parser;
 
@@ -74,11 +79,7 @@ class SqlQueryLibraryParserTest {
   @Test
   void extractsParameters() {
     final Library library = createMinimalLibrary("SELECT * FROM t WHERE age > :min_age");
-    library
-        .addParameter()
-        .setName("min_age")
-        .setType("integer")
-        .setUse(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.IN);
+    library.addParameter().setName("min_age").setType("integer").setUse(ParameterUse.IN);
 
     final ParsedSqlQuery result = parser.parse(library);
 
@@ -97,10 +98,15 @@ class SqlQueryLibraryParserTest {
     assertThat(result.getDeclaredParameters()).isEmpty();
   }
 
+  // ---------------------------------------------------------------------------
+  // SQL content rejections.
+  // ---------------------------------------------------------------------------
+
   @Test
   void rejectsLibraryWithNoSqlContent() {
     final Library library = new Library();
     library.setStatus(PublicationStatus.ACTIVE);
+    library.setType(sqlQueryTypeCoding());
 
     assertThatThrownBy(() -> parser.parse(library))
         .isInstanceOf(InvalidRequestException.class)
@@ -111,6 +117,7 @@ class SqlQueryLibraryParserTest {
   void rejectsLibraryWithWrongContentType() {
     final Library library = new Library();
     library.setStatus(PublicationStatus.ACTIVE);
+    library.setType(sqlQueryTypeCoding());
     library
         .addContent()
         .setContentType("text/plain")
@@ -125,12 +132,80 @@ class SqlQueryLibraryParserTest {
   void rejectsLibraryWithEmptySqlData() {
     final Library library = new Library();
     library.setStatus(PublicationStatus.ACTIVE);
+    library.setType(sqlQueryTypeCoding());
     library.addContent().setContentType("application/sql").setData(new byte[0]);
 
     assertThatThrownBy(() -> parser.parse(library))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("no data");
   }
+
+  // ---------------------------------------------------------------------------
+  // Library.type profile invariant.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void rejectsLibraryWithoutTypeCoding() {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library
+        .addContent()
+        .setContentType("application/sql")
+        .setData("SELECT 1".getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("Library.type")
+        .hasMessageContaining("sql-query");
+  }
+
+  @Test
+  void rejectsLibraryWithUnrelatedTypeCoding() {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library.setType(
+        new CodeableConcept()
+            .addCoding(
+                new org.hl7.fhir.r4.model.Coding()
+                    .setSystem("http://terminology.hl7.org/CodeSystem/library-type")
+                    .setCode("logic-library")));
+    library
+        .addContent()
+        .setContentType("application/sql")
+        .setData("SELECT 1".getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining(LIBRARY_TYPE_SYSTEM)
+        .hasMessageContaining("sql-query");
+  }
+
+  @Test
+  void acceptsLibraryWithAdditionalTypeCodings() {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library.setType(
+        new CodeableConcept()
+            .addCoding(
+                new org.hl7.fhir.r4.model.Coding()
+                    .setSystem("http://example.org/extra")
+                    .setCode("anything"))
+            .addCoding(
+                new org.hl7.fhir.r4.model.Coding()
+                    .setSystem(LIBRARY_TYPE_SYSTEM)
+                    .setCode("sql-query")));
+    library
+        .addContent()
+        .setContentType("application/sql")
+        .setData("SELECT 1".getBytes(StandardCharsets.UTF_8));
+
+    final ParsedSqlQuery result = parser.parse(library);
+    assertThat(result.getSql()).isEqualTo("SELECT 1");
+  }
+
+  // ---------------------------------------------------------------------------
+  // relatedArtifact profile invariants.
+  // ---------------------------------------------------------------------------
 
   @Test
   void rejectsRelatedArtifactWithMissingLabel() {
@@ -157,12 +232,81 @@ class SqlQueryLibraryParserTest {
   }
 
   @Test
+  void rejectsRelatedArtifactWithNonDependsOnType() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library.addRelatedArtifact(
+        new RelatedArtifact()
+            .setType(RelatedArtifactType.CITATION)
+            .setLabel("patients")
+            .setResource("ViewDefinition/patient-view"));
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("depends-on");
+  }
+
+  @Test
+  void rejectsRelatedArtifactWithMissingType() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library.addRelatedArtifact(
+        new RelatedArtifact().setLabel("patients").setResource("ViewDefinition/patient-view"));
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("depends-on");
+  }
+
+  @Test
+  void rejectsRelatedArtifactLabelStartingWithDigit() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library.addRelatedArtifact(
+        new RelatedArtifact()
+            .setType(RelatedArtifactType.DEPENDSON)
+            .setLabel("1patients")
+            .setResource("ViewDefinition/patient-view"));
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("1patients")
+        .hasMessageContaining("pattern");
+  }
+
+  @Test
+  void rejectsRelatedArtifactLabelWithIllegalCharacters() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library.addRelatedArtifact(
+        new RelatedArtifact()
+            .setType(RelatedArtifactType.DEPENDSON)
+            .setLabel("patients; DROP TABLE x")
+            .setResource("ViewDefinition/patient-view"));
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("pattern");
+  }
+
+  @Test
+  void acceptsRelatedArtifactLabelWithUnderscoresAndDigits() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library.addRelatedArtifact(
+        new RelatedArtifact()
+            .setType(RelatedArtifactType.DEPENDSON)
+            .setLabel("patients_2024")
+            .setResource("ViewDefinition/patient-view"));
+
+    final ParsedSqlQuery result = parser.parse(library);
+    assertThat(result.getViewReferences()).hasSize(1);
+    assertThat(result.getViewReferences().get(0).getLabel()).isEqualTo("patients_2024");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Parameter profile invariants.
+  // ---------------------------------------------------------------------------
+
+  @Test
   void rejectsParameterWithMissingName() {
     final Library library = createMinimalLibrary("SELECT 1");
-    library
-        .addParameter()
-        .setType("string")
-        .setUse(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.IN);
+    library.addParameter().setType("string").setUse(ParameterUse.IN);
 
     assertThatThrownBy(() -> parser.parse(library))
         .isInstanceOf(InvalidRequestException.class)
@@ -172,10 +316,7 @@ class SqlQueryLibraryParserTest {
   @Test
   void rejectsParameterWithMissingType() {
     final Library library = createMinimalLibrary("SELECT 1");
-    library
-        .addParameter()
-        .setName("param1")
-        .setUse(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.IN);
+    library.addParameter().setName("param1").setUse(ParameterUse.IN);
 
     assertThatThrownBy(() -> parser.parse(library))
         .isInstanceOf(InvalidRequestException.class)
@@ -183,9 +324,35 @@ class SqlQueryLibraryParserTest {
   }
 
   @Test
+  void rejectsParameterWithOutUse() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library.addParameter().setName("param1").setType("string").setUse(ParameterUse.OUT);
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("param1")
+        .hasMessageContaining("use = in");
+  }
+
+  @Test
+  void rejectsParameterWithMissingUse() {
+    final Library library = createMinimalLibrary("SELECT 1");
+    library.addParameter().setName("param1").setType("string");
+
+    assertThatThrownBy(() -> parser.parse(library))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("use = in");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Content type negotiation.
+  // ---------------------------------------------------------------------------
+
+  @Test
   void acceptsSqlContentTypeWithDialect() {
     final Library library = new Library();
     library.setStatus(PublicationStatus.ACTIVE);
+    library.setType(sqlQueryTypeCoding());
     library
         .addContent()
         .setContentType("application/sql;dialect=spark")
@@ -199,10 +366,18 @@ class SqlQueryLibraryParserTest {
   private Library createMinimalLibrary(final String sql) {
     final Library library = new Library();
     library.setStatus(PublicationStatus.ACTIVE);
+    library.setType(sqlQueryTypeCoding());
     library
         .addContent()
         .setContentType("application/sql")
         .setData(sql.getBytes(StandardCharsets.UTF_8));
     return library;
+  }
+
+  /** Returns the SQLQuery profile's required Library.type coding. */
+  private static CodeableConcept sqlQueryTypeCoding() {
+    return new CodeableConcept()
+        .addCoding(
+            new org.hl7.fhir.r4.model.Coding().setSystem(LIBRARY_TYPE_SYSTEM).setCode("sql-query"));
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryOutputFormatTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryOutputFormatTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for {@link SqlQueryOutputFormat} covering both the {@code _format} string and the {@code
+ * Accept} header parsing paths, including the q-value precedence used in content negotiation.
+ */
+class SqlQueryOutputFormatTest {
+
+  @ParameterizedTest(name = "fromString(\"{0}\") returns {1}")
+  @CsvSource({
+    "ndjson, NDJSON",
+    "csv, CSV",
+    "json, JSON",
+    "parquet, PARQUET",
+    "fhir, FHIR",
+    "application/x-ndjson, NDJSON",
+    "text/csv, CSV",
+    "application/json, JSON",
+    "application/vnd.apache.parquet, PARQUET",
+    "application/fhir+json, FHIR"
+  })
+  void fromStringMatchesCodeOrContentType(final String input, final SqlQueryOutputFormat expected) {
+    assertThat(SqlQueryOutputFormat.fromString(input)).isEqualTo(expected);
+  }
+
+  @ParameterizedTest(name = "fromString(\"{0}\") normalises and matches NDJSON")
+  @CsvSource({"NDJSON", "  ndjson  ", "Application/X-NDJSON"})
+  void fromStringIsCaseInsensitiveAndTrims(final String input) {
+    assertThat(SqlQueryOutputFormat.fromString(input)).isEqualTo(SqlQueryOutputFormat.NDJSON);
+  }
+
+  @Test
+  void fromStringDefaultsToNdjsonForNull() {
+    assertThat(SqlQueryOutputFormat.fromString(null)).isEqualTo(SqlQueryOutputFormat.NDJSON);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "   "})
+  void fromStringDefaultsToNdjsonForBlank(final String input) {
+    assertThat(SqlQueryOutputFormat.fromString(input)).isEqualTo(SqlQueryOutputFormat.NDJSON);
+  }
+
+  @Test
+  void fromStringDefaultsToNdjsonForUnknown() {
+    assertThat(SqlQueryOutputFormat.fromString("text/xml")).isEqualTo(SqlQueryOutputFormat.NDJSON);
+  }
+
+  @Test
+  void fromAcceptHeaderDefaultsToNdjsonForNull() {
+    assertThat(SqlQueryOutputFormat.fromAcceptHeader(null)).isEqualTo(SqlQueryOutputFormat.NDJSON);
+  }
+
+  @Test
+  void fromAcceptHeaderDefaultsToNdjsonForBlank() {
+    assertThat(SqlQueryOutputFormat.fromAcceptHeader("")).isEqualTo(SqlQueryOutputFormat.NDJSON);
+  }
+
+  @Test
+  void fromAcceptHeaderResolvesSingleSupportedType() {
+    assertThat(SqlQueryOutputFormat.fromAcceptHeader("text/csv"))
+        .isEqualTo(SqlQueryOutputFormat.CSV);
+  }
+
+  @Test
+  void fromAcceptHeaderPicksHigherQualityWinner() {
+    assertThat(
+            SqlQueryOutputFormat.fromAcceptHeader(
+                "text/csv;q=0.5, application/json;q=0.9, application/x-ndjson;q=1.0"))
+        .isEqualTo(SqlQueryOutputFormat.NDJSON);
+  }
+
+  @Test
+  void fromAcceptHeaderDefaultsQualityToOneWhenAbsent() {
+    assertThat(SqlQueryOutputFormat.fromAcceptHeader("text/csv, application/json;q=0.5"))
+        .isEqualTo(SqlQueryOutputFormat.CSV);
+  }
+
+  @Test
+  void fromAcceptHeaderTreatsWildcardAsDefault() {
+    assertThat(SqlQueryOutputFormat.fromAcceptHeader("*/*")).isEqualTo(SqlQueryOutputFormat.NDJSON);
+  }
+
+  @Test
+  void fromAcceptHeaderSkipsUnsupportedTypes() {
+    assertThat(SqlQueryOutputFormat.fromAcceptHeader("text/xml, text/csv"))
+        .isEqualTo(SqlQueryOutputFormat.CSV);
+  }
+
+  @Test
+  void fromAcceptHeaderDefaultsWhenAllUnsupported() {
+    assertThat(SqlQueryOutputFormat.fromAcceptHeader("text/xml, image/png"))
+        .isEqualTo(SqlQueryOutputFormat.NDJSON);
+  }
+
+  @Test
+  void fromAcceptHeaderTreatsMalformedQValueAsOne() {
+    assertThat(SqlQueryOutputFormat.fromAcceptHeader("text/csv;q=abc, application/json;q=0.5"))
+        .isEqualTo(SqlQueryOutputFormat.CSV);
+  }
+
+  @Test
+  void fromAcceptHeaderHandlesParametersOtherThanQ() {
+    assertThat(SqlQueryOutputFormat.fromAcceptHeader("text/csv;charset=utf-8"))
+        .isEqualTo(SqlQueryOutputFormat.CSV);
+  }
+
+  @Test
+  void getCodeAndContentTypeAreExposed() {
+    assertThat(SqlQueryOutputFormat.NDJSON.getCode()).isEqualTo("ndjson");
+    assertThat(SqlQueryOutputFormat.NDJSON.getContentType()).isEqualTo("application/x-ndjson");
+    assertThat(SqlQueryOutputFormat.PARQUET.getContentType())
+        .isEqualTo("application/vnd.apache.parquet");
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParserTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParserTest.java
@@ -260,6 +260,20 @@ class SqlQueryRequestParserTest {
         .hasMessageContaining("name");
   }
 
+  @Test
+  void rejectsRuntimeParameterSuppliedMoreThanOnce() {
+    final Library library = libraryWithSql("SELECT * FROM t WHERE age > :min_age");
+    library.addParameter().setName("min_age").setType("integer").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    params.addParameter().setName("min_age").setValue(new IntegerType(18));
+    params.addParameter().setName("min_age").setValue(new IntegerType(21));
+
+    assertThatThrownBy(() -> parser.parse(library, null, null, null, null, params))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("min_age")
+        .hasMessageContaining("more than once");
+  }
+
   /** Builds a minimal SQLQuery-typed Library carrying the given SQL. */
   private static Library libraryWithSql(final String sql) {
     final Library library = new Library();

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParserTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParserTest.java
@@ -118,7 +118,7 @@ class SqlQueryRequestParserTest {
 
     final SqlQueryRequest request = parser.parse(library, null, null, null, null, params);
 
-    assertThat(request.getParameterBindings().get("is_active")).isEqualTo(true);
+    assertThat(request.getParameterBindings()).containsEntry("is_active", true);
   }
 
   @Test
@@ -130,7 +130,7 @@ class SqlQueryRequestParserTest {
 
     final SqlQueryRequest request = parser.parse(library, null, null, null, null, params);
 
-    assertThat(request.getParameterBindings().get("name")).isEqualTo("alice");
+    assertThat(request.getParameterBindings()).containsEntry("name", "alice");
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParserTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParserTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Map;
+import org.hl7.fhir.r4.model.Base64BinaryType;
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.DateType;
+import org.hl7.fhir.r4.model.DecimalType;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.TimeType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SqlQueryRequestParser}, focused on the typed parameter binding path that
+ * cross-checks runtime {@code value[x]} against {@code Library.parameter} declarations.
+ */
+class SqlQueryRequestParserTest {
+
+  private static final String LIBRARY_TYPE_SYSTEM =
+      "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes";
+
+  private SqlQueryRequestParser parser;
+
+  @BeforeEach
+  void setUp() {
+    parser = new SqlQueryRequestParser(new SqlQueryLibraryParser());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Empty / null parameter inputs.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void returnsEmptyBindingsWhenParametersInputIsNull() {
+    final Library library = libraryWithSql("SELECT 1");
+    final SqlQueryRequest request = parser.parse(library, null, null, null, null, null);
+    assertThat(request.getParameterBindings()).isEmpty();
+  }
+
+  @Test
+  void returnsEmptyBindingsWhenParametersInputHasNoEntries() {
+    final Library library = libraryWithSql("SELECT 1");
+    final SqlQueryRequest request = parser.parse(library, null, null, null, null, new Parameters());
+    assertThat(request.getParameterBindings()).isEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Typed conversion - happy paths.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void bindsIntegerParameterAsJavaInteger() {
+    final Library library = libraryWithSql("SELECT * FROM t WHERE age > :min_age");
+    library.addParameter().setName("min_age").setType("integer").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    params.addParameter().setName("min_age").setValue(new IntegerType(42));
+
+    final SqlQueryRequest request = parser.parse(library, null, null, null, null, params);
+
+    assertThat(request.getParameterBindings()).containsExactly(Map.entry("min_age", 42));
+    assertThat(request.getParameterBindings().get("min_age")).isInstanceOf(Integer.class);
+  }
+
+  @Test
+  void bindsDecimalParameterAsBigDecimal() {
+    final Library library = libraryWithSql("SELECT * FROM t WHERE x > :threshold");
+    library.addParameter().setName("threshold").setType("decimal").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    params.addParameter().setName("threshold").setValue(new DecimalType("3.14"));
+
+    final SqlQueryRequest request = parser.parse(library, null, null, null, null, params);
+
+    assertThat(request.getParameterBindings().get("threshold"))
+        .isInstanceOf(BigDecimal.class)
+        .isEqualTo(new BigDecimal("3.14"));
+  }
+
+  @Test
+  void bindsBooleanParameterAsJavaBoolean() {
+    final Library library = libraryWithSql("SELECT * FROM t WHERE active = :is_active");
+    library.addParameter().setName("is_active").setType("boolean").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    params.addParameter().setName("is_active").setValue(new BooleanType(true));
+
+    final SqlQueryRequest request = parser.parse(library, null, null, null, null, params);
+
+    assertThat(request.getParameterBindings().get("is_active")).isEqualTo(true);
+  }
+
+  @Test
+  void bindsStringParameterAsJavaString() {
+    final Library library = libraryWithSql("SELECT * FROM t WHERE label = :name");
+    library.addParameter().setName("name").setType("string").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    params.addParameter().setName("name").setValue(new StringType("alice"));
+
+    final SqlQueryRequest request = parser.parse(library, null, null, null, null, params);
+
+    assertThat(request.getParameterBindings().get("name")).isEqualTo("alice");
+  }
+
+  @Test
+  void bindsDateParameterAsLocalDate() {
+    final Library library = libraryWithSql("SELECT * FROM t WHERE birth_date >= :since");
+    library.addParameter().setName("since").setType("date").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    params.addParameter().setName("since").setValue(new DateType("1990-05-15"));
+
+    final SqlQueryRequest request = parser.parse(library, null, null, null, null, params);
+
+    assertThat(request.getParameterBindings().get("since"))
+        .isInstanceOf(LocalDate.class)
+        .isEqualTo(LocalDate.of(1990, 5, 15));
+  }
+
+  @Test
+  void bindsDateTimeParameterAsInstant() {
+    final Library library = libraryWithSql("SELECT * FROM t WHERE created_at >= :since");
+    library.addParameter().setName("since").setType("dateTime").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    params.addParameter().setName("since").setValue(new DateTimeType("2026-01-15T10:30:00Z"));
+
+    final SqlQueryRequest request = parser.parse(library, null, null, null, null, params);
+
+    assertThat(request.getParameterBindings().get("since"))
+        .isInstanceOf(Instant.class)
+        .isEqualTo(Instant.parse("2026-01-15T10:30:00Z"));
+  }
+
+  @Test
+  void bindsTimeParameterAsLocalTime() {
+    final Library library = libraryWithSql("SELECT * FROM t WHERE clock = :at");
+    library.addParameter().setName("at").setType("time").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    params.addParameter().setName("at").setValue(new TimeType("14:30:00"));
+
+    final SqlQueryRequest request = parser.parse(library, null, null, null, null, params);
+
+    assertThat(request.getParameterBindings().get("at"))
+        .isInstanceOf(LocalTime.class)
+        .isEqualTo(LocalTime.of(14, 30, 0));
+  }
+
+  @Test
+  void bindsBase64BinaryParameterAsByteArray() {
+    final Library library = libraryWithSql("SELECT * FROM t WHERE blob = :payload");
+    library.addParameter().setName("payload").setType("base64Binary").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    final byte[] bytes = "hello".getBytes(StandardCharsets.UTF_8);
+    params.addParameter().setName("payload").setValue(new Base64BinaryType(bytes));
+
+    final SqlQueryRequest request = parser.parse(library, null, null, null, null, params);
+
+    assertThat(request.getParameterBindings().get("payload"))
+        .isInstanceOf(byte[].class)
+        .isEqualTo(bytes);
+  }
+
+  @Test
+  void preservesBindingOrder() {
+    final Library library = libraryWithSql("SELECT * FROM t WHERE a = :a AND b = :b AND c = :c");
+    library.addParameter().setName("a").setType("integer").setUse(ParameterUse.IN);
+    library.addParameter().setName("b").setType("integer").setUse(ParameterUse.IN);
+    library.addParameter().setName("c").setType("integer").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    params.addParameter().setName("c").setValue(new IntegerType(3));
+    params.addParameter().setName("a").setValue(new IntegerType(1));
+    params.addParameter().setName("b").setValue(new IntegerType(2));
+
+    final SqlQueryRequest request = parser.parse(library, null, null, null, null, params);
+
+    assertThat(request.getParameterBindings().keySet()).containsExactly("c", "a", "b");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Type-mismatch and undeclared-name rejections.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void rejectsTypeMismatchBetweenDeclarationAndRuntimeValue() {
+    final Library library = libraryWithSql("SELECT * FROM t WHERE age > :min_age");
+    library.addParameter().setName("min_age").setType("integer").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    params.addParameter().setName("min_age").setValue(new StringType("42"));
+
+    assertThatThrownBy(() -> parser.parse(library, null, null, null, null, params))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("min_age")
+        .hasMessageContaining("integer")
+        .hasMessageContaining("string");
+  }
+
+  @Test
+  void rejectsRuntimeParameterNotDeclaredInLibrary() {
+    final Library library = libraryWithSql("SELECT 1");
+    final Parameters params = new Parameters();
+    params.addParameter().setName("ghost").setValue(new IntegerType(1));
+
+    assertThatThrownBy(() -> parser.parse(library, null, null, null, null, params))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("ghost")
+        .hasMessageContaining("not declared");
+  }
+
+  @Test
+  void rejectsRuntimeParameterWithMissingValue() {
+    final Library library = libraryWithSql("SELECT 1");
+    library.addParameter().setName("min_age").setType("integer").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    params.addParameter().setName("min_age");
+
+    assertThatThrownBy(() -> parser.parse(library, null, null, null, null, params))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("min_age")
+        .hasMessageContaining("value");
+  }
+
+  @Test
+  void rejectsRuntimeParameterWithMissingName() {
+    final Library library = libraryWithSql("SELECT 1");
+    final Parameters params = new Parameters();
+    params.addParameter().setValue(new IntegerType(1));
+
+    assertThatThrownBy(() -> parser.parse(library, null, null, null, null, params))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("name");
+  }
+
+  /** Builds a minimal SQLQuery-typed Library carrying the given SQL. */
+  private static Library libraryWithSql(final String sql) {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library.setType(
+        new CodeableConcept()
+            .addCoding(new Coding().setSystem(LIBRARY_TYPE_SYSTEM).setCode("sql-query")));
+    library
+        .addContent()
+        .setContentType("application/sql")
+        .setData(sql.getBytes(StandardCharsets.UTF_8));
+    return library;
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamerTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamerTest.java
@@ -91,8 +91,7 @@ class SqlQueryResultStreamerTest {
 
     assertThat(response.getContentType()).startsWith("application/json");
     final String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
-    assertThat(body).startsWith("[").endsWith("]");
-    assertThat(body).contains("\"alice\"").contains("\"bob\"");
+    assertThat(body).startsWith("[").endsWith("]").contains("\"alice\"").contains("\"bob\"");
   }
 
   @Test
@@ -102,8 +101,7 @@ class SqlQueryResultStreamerTest {
 
     assertThat(response.getContentType()).startsWith("text/csv");
     final String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
-    assertThat(body).doesNotContain("id,name");
-    assertThat(body).contains("alice").contains("bob");
+    assertThat(body).doesNotContain("id,name").contains("alice").contains("bob");
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamerTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamerTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Tests for {@link SqlQueryResultStreamer} covering each output format. Uses a real local
+ * SparkSession to materialise a small Dataset and a Spring {@link MockHttpServletResponse} to
+ * capture written bytes and headers.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+class SqlQueryResultStreamerTest {
+
+  private SparkSession spark;
+  private SqlQueryResultStreamer streamer;
+
+  @BeforeAll
+  void setUpAll() {
+    spark =
+        SparkSession.builder()
+            .master("local[1]")
+            .appName("SqlQueryResultStreamerTest")
+            .config("spark.driver.bindAddress", "localhost")
+            .config("spark.driver.host", "localhost")
+            .config("spark.ui.enabled", false)
+            .config("spark.sql.shuffle.partitions", 1)
+            .getOrCreate();
+    streamer = new SqlQueryResultStreamer();
+  }
+
+  @AfterAll
+  void tearDownAll() {
+    if (spark != null) {
+      spark.stop();
+    }
+  }
+
+  @Test
+  void streamsNdjsonWithUtf8Encoding() {
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    streamer.stream(twoRowDataset(), SqlQueryOutputFormat.NDJSON, false, response);
+
+    assertThat(response.getContentType()).startsWith("application/x-ndjson");
+    assertThat(response.getCharacterEncoding()).isEqualToIgnoringCase("UTF-8");
+    assertThat(response.getStatus()).isEqualTo(200);
+    final String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+    assertThat(body)
+        .contains("\"id\":1")
+        .contains("\"id\":2")
+        .contains("\"name\":\"alice\"")
+        .contains("\"name\":\"bob\"");
+    // NDJSON: each row terminated by a newline.
+    assertThat(body.split("\n")).hasSize(2);
+  }
+
+  @Test
+  void streamsJsonAsArray() {
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    streamer.stream(twoRowDataset(), SqlQueryOutputFormat.JSON, false, response);
+
+    assertThat(response.getContentType()).startsWith("application/json");
+    final String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+    assertThat(body).startsWith("[").endsWith("]");
+    assertThat(body).contains("\"alice\"").contains("\"bob\"");
+  }
+
+  @Test
+  void streamsCsvWithoutHeaderByDefault() {
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    streamer.stream(twoRowDataset(), SqlQueryOutputFormat.CSV, false, response);
+
+    assertThat(response.getContentType()).startsWith("text/csv");
+    final String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+    assertThat(body).doesNotContain("id,name");
+    assertThat(body).contains("alice").contains("bob");
+  }
+
+  @Test
+  void streamsCsvWithHeaderWhenRequested() {
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    streamer.stream(twoRowDataset(), SqlQueryOutputFormat.CSV, true, response);
+
+    final String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+    assertThat(body).startsWith("id,name");
+  }
+
+  @Test
+  void streamsFhirParametersResource() {
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    streamer.stream(twoRowDataset(), SqlQueryOutputFormat.FHIR, false, response);
+
+    assertThat(response.getContentType()).startsWith("application/fhir+json");
+    final String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+    assertThat(body).contains("\"resourceType\":\"Parameters\"").contains("\"name\":\"row\"");
+  }
+
+  @Test
+  void streamsParquetWithoutSettingCharacterEncoding() {
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    streamer.stream(twoRowDataset(), SqlQueryOutputFormat.PARQUET, false, response);
+
+    assertThat(response.getContentType()).isEqualTo("application/vnd.apache.parquet");
+    // PARQUET is binary — no UTF-8 charset should be set.
+    assertThat(response.getCharacterEncoding()).isNotEqualToIgnoringCase("UTF-8");
+    // Parquet files start with the magic bytes "PAR1".
+    final byte[] bytes = response.getContentAsByteArray();
+    assertThat(bytes).isNotEmpty();
+    assertThat(new String(bytes, 0, 4, StandardCharsets.US_ASCII)).isEqualTo("PAR1");
+  }
+
+  private Dataset<Row> twoRowDataset() {
+    final StructType schema =
+        DataTypes.createStructType(
+            new org.apache.spark.sql.types.StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+              DataTypes.createStructField("name", DataTypes.StringType, true)
+            });
+    final List<Row> rows = List.of(RowFactory.create(1, "alice"), RowFactory.create(2, "bob"));
+    return spark.createDataFrame(rows, schema);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunProviderIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunProviderIT.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static au.csiro.pathling.operations.sqlquery.SqlQueryLibraryParser.LIBRARY_TYPE_CODE;
+import static au.csiro.pathling.operations.sqlquery.SqlQueryLibraryParser.LIBRARY_TYPE_SYSTEM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import com.google.gson.Gson;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.Attachment;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.Library;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Integration tests for {@link SqlQueryRunProvider} and {@link SqlQueryInstanceRunProvider} —
+ * exercises the full {@code $sqlquery-run} pipeline through HTTP, including the system-level,
+ * type-level, and instance-level entry points and the validation error paths.
+ *
+ * <p>Tests use SQL that does not depend on registered ViewDefinitions ({@code SELECT ... FROM
+ * (VALUES ...)}) so they are not affected by the Delta-Lake table-list caching that disables some
+ * of the {@link au.csiro.pathling.operations.view.ViewDefinitionRunProvider} integration tests.
+ */
+@Slf4j
+@Tag("IntegrationTest")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ResourceLock(value = "wiremock", mode = ResourceAccessMode.READ_WRITE)
+@ActiveProfiles({"integration-test"})
+class SqlQueryRunProviderIT {
+
+  private static final Gson GSON = new Gson();
+
+  private static final String SELF_CONTAINED_SQL =
+      "SELECT * FROM (VALUES (1, 'alice'), (2, 'bob')) AS t(id, name)";
+
+  @LocalServerPort int port;
+
+  @Autowired WebTestClient webTestClient;
+
+  @Autowired private FhirContext fhirContext;
+
+  private IParser jsonParser;
+
+  @DynamicPropertySource
+  static void configureProperties(final DynamicPropertyRegistry registry) {
+    final Path warehouseDir =
+        Path.of("src/test/resources/test-data/bulk/fhir/delta").toAbsolutePath();
+    registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir);
+  }
+
+  @BeforeEach
+  void setup() {
+    webTestClient =
+        webTestClient
+            .mutate()
+            .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024))
+            .build();
+    jsonParser = fhirContext.newJsonParser();
+  }
+
+  @Test
+  void systemLevelNdjsonHappyPath() {
+    final String parametersJson =
+        parametersJson(sqlQueryLibrary(SELF_CONTAINED_SQL), SqlQueryOutputFormat.NDJSON);
+
+    final String body = postOk("/fhir/$sqlquery-run", parametersJson, SqlQueryOutputFormat.NDJSON);
+
+    final String[] lines = body.trim().split("\n");
+    assertThat(lines).hasSize(2);
+    assertThat(body).contains("\"id\":1").contains("\"name\":\"alice\"");
+    assertThat(body).contains("\"id\":2").contains("\"name\":\"bob\"");
+  }
+
+  @Test
+  void systemLevelCsvWithHeader() {
+    final String parametersJson =
+        parametersJson(sqlQueryLibrary(SELF_CONTAINED_SQL), SqlQueryOutputFormat.CSV, true);
+
+    final String body = postOk("/fhir/$sqlquery-run", parametersJson, SqlQueryOutputFormat.CSV);
+
+    final String[] lines = body.trim().split("\n");
+    assertThat(lines.length).isGreaterThanOrEqualTo(3);
+    assertThat(lines[0]).contains("id").contains("name");
+    assertThat(lines[1]).contains("alice");
+    assertThat(lines[2]).contains("bob");
+  }
+
+  @Test
+  void systemLevelJsonOutput() {
+    final String parametersJson =
+        parametersJson(sqlQueryLibrary(SELF_CONTAINED_SQL), SqlQueryOutputFormat.JSON);
+
+    final String body = postOk("/fhir/$sqlquery-run", parametersJson, SqlQueryOutputFormat.JSON);
+
+    assertThat(body.trim()).startsWith("[").endsWith("]");
+    assertThat(body).contains("alice").contains("bob");
+  }
+
+  @Test
+  void typeLevelHappyPath() {
+    final String parametersJson =
+        parametersJson(sqlQueryLibrary(SELF_CONTAINED_SQL), SqlQueryOutputFormat.NDJSON);
+
+    final String body =
+        postOk("/fhir/Library/$sqlquery-run", parametersJson, SqlQueryOutputFormat.NDJSON);
+
+    assertThat(body).contains("alice").contains("bob");
+  }
+
+  @Test
+  void rejectsRequestWithNeitherQueryResourceNorQueryReference() {
+    final Map<String, Object> parameters = new LinkedHashMap<>();
+    parameters.put("resourceType", "Parameters");
+    parameters.put(
+        "parameter",
+        List.of(
+            Map.of(
+                "name", "_format", "valueString", SqlQueryOutputFormat.NDJSON.getContentType())));
+
+    postExpect4xx("/fhir/$sqlquery-run", GSON.toJson(parameters));
+  }
+
+  @Test
+  void rejectsLibraryWithoutSqlQueryTypeCoding() {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    final Attachment content = new Attachment();
+    content.setContentType("application/sql");
+    content.setData("SELECT 1".getBytes(StandardCharsets.UTF_8));
+    library.addContent(content);
+
+    postExpect4xx("/fhir/$sqlquery-run", parametersJson(library, SqlQueryOutputFormat.NDJSON));
+  }
+
+  @Test
+  void rejectsLibraryWithoutSqlContent() {
+    final Library library = sqlQueryLibrary("SELECT 1");
+    library.getContent().clear();
+
+    postExpect4xx("/fhir/$sqlquery-run", parametersJson(library, SqlQueryOutputFormat.NDJSON));
+  }
+
+  @Test
+  void instanceLevelRunWithNonExistentLibraryReturns404() {
+    webTestClient
+        .post()
+        .uri(
+            "http://localhost:"
+                + port
+                + "/fhir/Library/does-not-exist/$sqlquery-run?_format=ndjson")
+        .header("Content-Type", "application/fhir+json")
+        .header("Accept", SqlQueryOutputFormat.NDJSON.getContentType())
+        .bodyValue("{\"resourceType\":\"Parameters\"}")
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+  }
+
+  @Nonnull
+  private String postOk(
+      @Nonnull final String path,
+      @Nonnull final String body,
+      @Nonnull final SqlQueryOutputFormat format) {
+    final String contentType = format.getContentType();
+    final EntityExchangeResult<byte[]> result =
+        webTestClient
+            .post()
+            .uri("http://localhost:" + port + path)
+            .header("Content-Type", "application/fhir+json")
+            .header("Accept", contentType)
+            .bodyValue(body)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectHeader()
+            .contentTypeCompatibleWith(MediaType.parseMediaType(contentType))
+            .expectBody()
+            .returnResult();
+    return new String(
+        Objects.requireNonNull(result.getResponseBodyContent()), StandardCharsets.UTF_8);
+  }
+
+  private void postExpect4xx(@Nonnull final String path, @Nonnull final String body) {
+    webTestClient
+        .post()
+        .uri("http://localhost:" + port + path)
+        .header("Content-Type", "application/fhir+json")
+        .header("Accept", SqlQueryOutputFormat.NDJSON.getContentType())
+        .bodyValue(body)
+        .exchange()
+        .expectStatus()
+        .is4xxClientError();
+  }
+
+  @Nonnull
+  private Library sqlQueryLibrary(@Nonnull final String sql) {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library.setType(
+        new CodeableConcept()
+            .addCoding(new Coding().setSystem(LIBRARY_TYPE_SYSTEM).setCode(LIBRARY_TYPE_CODE)));
+    final Attachment content = new Attachment();
+    content.setContentType("application/sql");
+    content.setData(sql.getBytes(StandardCharsets.UTF_8));
+    library.addContent(content);
+    return library;
+  }
+
+  @Nonnull
+  private String parametersJson(
+      @Nonnull final Library library, @Nonnull final SqlQueryOutputFormat format) {
+    return parametersJson(library, format, null);
+  }
+
+  @Nonnull
+  private String parametersJson(
+      @Nonnull final Library library,
+      @Nonnull final SqlQueryOutputFormat format,
+      @Nullable final Boolean includeHeader) {
+    final String libraryJson = jsonParser.encodeResourceToString(library);
+    final Map<String, Object> parameters = new LinkedHashMap<>();
+    parameters.put("resourceType", "Parameters");
+    final List<Map<String, Object>> parameterList = new ArrayList<>();
+
+    final Map<String, Object> queryResourceParam = new LinkedHashMap<>();
+    queryResourceParam.put("name", "queryResource");
+    queryResourceParam.put("resource", GSON.fromJson(libraryJson, Map.class));
+    parameterList.add(queryResourceParam);
+
+    final Map<String, Object> formatParam = new LinkedHashMap<>();
+    formatParam.put("name", "_format");
+    formatParam.put("valueString", format.getCode());
+    parameterList.add(formatParam);
+
+    if (includeHeader != null) {
+      final Map<String, Object> headerParam = new LinkedHashMap<>();
+      headerParam.put("name", "header");
+      headerParam.put("valueBoolean", includeHeader);
+      parameterList.add(headerParam);
+    }
+
+    parameters.put("parameter", parameterList);
+    return GSON.toJson(parameters);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunSecurityIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunSecurityIT.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static au.csiro.pathling.operations.sqlquery.SqlQueryLibraryParser.LIBRARY_TYPE_CODE;
+import static au.csiro.pathling.operations.sqlquery.SqlQueryLibraryParser.LIBRARY_TYPE_SYSTEM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import com.google.gson.Gson;
+import jakarta.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.Attachment;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.Library;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Integration tests covering security guarantees of the {@code $sqlquery-run} pipeline. Confirms
+ * that requests using the datasource short-name syntax to read arbitrary local files are rejected
+ * with a 4xx response, and that a known-good baseline still succeeds.
+ */
+@Slf4j
+@Tag("IntegrationTest")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ResourceLock(value = "wiremock", mode = ResourceAccessMode.READ_WRITE)
+@ActiveProfiles({"integration-test"})
+class SqlQueryRunSecurityIT {
+
+  private static final Gson GSON = new Gson();
+
+  private static final String BASELINE_SQL =
+      "SELECT * FROM (VALUES (1, 'alice'), (2, 'bob')) AS t(id, name)";
+
+  @LocalServerPort int port;
+
+  @Autowired WebTestClient webTestClient;
+
+  @Autowired private FhirContext fhirContext;
+
+  private IParser jsonParser;
+
+  @DynamicPropertySource
+  static void configureProperties(final DynamicPropertyRegistry registry) {
+    final Path warehouseDir =
+        Path.of("src/test/resources/test-data/bulk/fhir/delta").toAbsolutePath();
+    registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir);
+  }
+
+  @BeforeEach
+  void setup() {
+    webTestClient =
+        webTestClient
+            .mutate()
+            .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024))
+            .build();
+    jsonParser = fhirContext.newJsonParser();
+  }
+
+  @Test
+  void rejectsCsvShortNameFileRead() {
+    final String body =
+        postExpect4xx(parametersJson(sqlQueryLibrary("SELECT * FROM csv.`/etc/passwd`")));
+    assertThat(body).contains("undeclared table");
+  }
+
+  @Test
+  void rejectsParquetWarehouseRead() {
+    final String body =
+        postExpect4xx(
+            parametersJson(
+                sqlQueryLibrary(
+                    "SELECT id, gender FROM"
+                        + " parquet.`/Users/gri306/Warehouse/default/Patient.parquet`")));
+    assertThat(body).contains("undeclared table");
+  }
+
+  @Test
+  void baselineHappyPathStillWorks() {
+    final String body = postOk(parametersJson(sqlQueryLibrary(BASELINE_SQL)));
+    assertThat(body).contains("alice").contains("bob");
+  }
+
+  @Nonnull
+  private String postOk(@Nonnull final String body) {
+    final EntityExchangeResult<byte[]> result =
+        webTestClient
+            .post()
+            .uri("http://localhost:" + port + "/fhir/$sqlquery-run")
+            .header("Content-Type", "application/fhir+json")
+            .header("Accept", SqlQueryOutputFormat.NDJSON.getContentType())
+            .bodyValue(body)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody()
+            .returnResult();
+    return new String(
+        Objects.requireNonNull(result.getResponseBodyContent()), StandardCharsets.UTF_8);
+  }
+
+  @Nonnull
+  private String postExpect4xx(@Nonnull final String body) {
+    final EntityExchangeResult<byte[]> result =
+        webTestClient
+            .post()
+            .uri("http://localhost:" + port + "/fhir/$sqlquery-run")
+            .header("Content-Type", "application/fhir+json")
+            .header("Accept", SqlQueryOutputFormat.NDJSON.getContentType())
+            .bodyValue(body)
+            .exchange()
+            .expectStatus()
+            .is4xxClientError()
+            .expectBody()
+            .returnResult();
+    final byte[] payload = result.getResponseBodyContent();
+    return payload == null ? "" : new String(payload, StandardCharsets.UTF_8);
+  }
+
+  @Nonnull
+  private Library sqlQueryLibrary(@Nonnull final String sql) {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library.setType(
+        new CodeableConcept()
+            .addCoding(new Coding().setSystem(LIBRARY_TYPE_SYSTEM).setCode(LIBRARY_TYPE_CODE)));
+    final Attachment content = new Attachment();
+    content.setContentType("application/sql");
+    content.setData(sql.getBytes(StandardCharsets.UTF_8));
+    library.addContent(content);
+    return library;
+  }
+
+  @Nonnull
+  private String parametersJson(@Nonnull final Library library) {
+    final String libraryJson = jsonParser.encodeResourceToString(library);
+    final Map<String, Object> parameters = new LinkedHashMap<>();
+    parameters.put("resourceType", "Parameters");
+    final List<Map<String, Object>> parameterList = new java.util.ArrayList<>();
+
+    final Map<String, Object> queryResourceParam = new LinkedHashMap<>();
+    queryResourceParam.put("name", "queryResource");
+    queryResourceParam.put("resource", GSON.fromJson(libraryJson, Map.class));
+    parameterList.add(queryResourceParam);
+
+    final Map<String, Object> formatParam = new LinkedHashMap<>();
+    formatParam.put("name", "_format");
+    formatParam.put("valueString", SqlQueryOutputFormat.NDJSON.getCode());
+    parameterList.add(formatParam);
+
+    parameters.put("parameter", parameterList);
+    return GSON.toJson(parameters);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunSecurityIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunSecurityIT.java
@@ -81,6 +81,9 @@ class SqlQueryRunSecurityIT {
     final Path warehouseDir =
         Path.of("src/test/resources/test-data/bulk/fhir/delta").toAbsolutePath();
     registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir);
+    // Use a deliberately small cap so the test can demonstrate clamping without depending on
+    // the production default.
+    registry.add("pathling.sqlQuery.maxRows", () -> "2");
   }
 
   @BeforeEach
@@ -115,6 +118,29 @@ class SqlQueryRunSecurityIT {
   void baselineHappyPathStillWorks() {
     final String body = postOk(parametersJson(sqlQueryLibrary(BASELINE_SQL)));
     assertThat(body).contains("alice").contains("bob");
+  }
+
+  @Test
+  void rejectsTvfDosAttack() {
+    // The literal exploit recorded in the threat model: a Cartesian product over two range TVFs.
+    // Must be rejected by the validator before any work is scheduled.
+    final String body =
+        postExpect4xx(
+            parametersJson(
+                sqlQueryLibrary(
+                    "SELECT count(*) FROM range(0, 1000000) a CROSS JOIN range(0, 1000000) b")));
+    assertThat(body).contains("disallowed plan node");
+  }
+
+  @Test
+  void enforcesServerRowCap() {
+    // The configured cap is 2; the source has 5 rows. Only 2 should make it through.
+    final String body =
+        postOk(
+            parametersJson(
+                sqlQueryLibrary("SELECT * FROM (VALUES (1), (2), (3), (4), (5)) AS t(id)")));
+    final long rowCount = body.lines().filter(line -> !line.isBlank()).count();
+    assertThat(rowCount).isEqualTo(2L);
   }
 
   @Nonnull

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunWithViewDefinitionsIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunWithViewDefinitionsIT.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static au.csiro.pathling.operations.sqlquery.SqlQueryLibraryParser.LIBRARY_TYPE_CODE;
+import static au.csiro.pathling.operations.sqlquery.SqlQueryLibraryParser.LIBRARY_TYPE_SYSTEM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import com.google.gson.Gson;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.Attachment;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.RelatedArtifact;
+import org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * End-to-end integration test for the {@code $sqlquery-run} operation against a referenced {@link
+ * au.csiro.pathling.encoders.ViewDefinitionResource}. Drives the full pipeline — Library parsing,
+ * ViewDefinition lookup, FhirView execution, request-scoped temp-view registration, SQL execution,
+ * and result streaming — using SQL that names the registered view.
+ *
+ * <p>Backed by {@link SqlQueryViewDefinitionTestConfiguration} which substitutes an in-memory
+ * {@link au.csiro.pathling.util.CustomObjectDataSource} for the production Delta Lake source so the
+ * pre-loaded ViewDefinition is visible at startup, sidestepping the table-list caching that
+ * disables the equivalent {@code ViewDefinitionRunProvider} instance-level tests.
+ */
+@Slf4j
+@Tag("IntegrationTest")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ResourceLock(value = "wiremock", mode = ResourceAccessMode.READ_WRITE)
+@ActiveProfiles({"integration-test"})
+@Import(SqlQueryViewDefinitionTestConfiguration.class)
+class SqlQueryRunWithViewDefinitionsIT {
+
+  private static final Gson GSON = new Gson();
+
+  private static final String VIEW_REFERENCE =
+      "ViewDefinition/" + SqlQueryViewDefinitionTestConfiguration.PATIENT_VIEW_ID;
+
+  @LocalServerPort int port;
+
+  @Autowired WebTestClient webTestClient;
+
+  @Autowired private FhirContext fhirContext;
+
+  private IParser jsonParser;
+
+  @DynamicPropertySource
+  static void configureProperties(final DynamicPropertyRegistry registry) {
+    final Path warehouseDir =
+        Path.of("src/test/resources/test-data/bulk/fhir/delta").toAbsolutePath();
+    registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir);
+  }
+
+  @BeforeEach
+  void setup() {
+    webTestClient =
+        webTestClient
+            .mutate()
+            .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024))
+            .build();
+    jsonParser = fhirContext.newJsonParser();
+  }
+
+  @Test
+  void runsSqlAgainstReferencedViewDefinition() {
+    final Library library =
+        sqlQueryLibrary(
+            "SELECT id, family_name FROM patients ORDER BY id", "patients", VIEW_REFERENCE);
+
+    final String body =
+        postOk(
+            "/fhir/$sqlquery-run",
+            parametersJson(library, SqlQueryOutputFormat.NDJSON),
+            SqlQueryOutputFormat.NDJSON);
+    log.debug("End-to-end NDJSON response:\n{}", body);
+
+    final String[] lines = body.trim().split("\n");
+    assertThat(lines).hasSize(3);
+    assertThat(body)
+        .contains("\"id\":\"p1\"")
+        .contains("\"family_name\":\"Smith\"")
+        .contains("\"id\":\"p2\"")
+        .contains("\"family_name\":\"Johnson\"")
+        .contains("\"id\":\"p3\"")
+        .contains("\"family_name\":\"Williams\"");
+  }
+
+  @Test
+  void appliesLimitParameter() {
+    final Library library =
+        sqlQueryLibrary(
+            "SELECT id, family_name FROM patients ORDER BY id", "patients", VIEW_REFERENCE);
+
+    final String body =
+        postOk(
+            "/fhir/$sqlquery-run",
+            parametersJson(library, SqlQueryOutputFormat.NDJSON, 2),
+            SqlQueryOutputFormat.NDJSON);
+
+    final String[] lines = body.trim().split("\n");
+    assertThat(lines).hasSize(2);
+  }
+
+  @Test
+  void returns400WhenReferencedViewDefinitionDoesNotExist() {
+    final Library library =
+        sqlQueryLibrary("SELECT id FROM patients", "patients", "ViewDefinition/does-not-exist");
+
+    webTestClient
+        .post()
+        .uri("http://localhost:" + port + "/fhir/$sqlquery-run")
+        .header("Content-Type", "application/fhir+json")
+        .header("Accept", SqlQueryOutputFormat.NDJSON.getContentType())
+        .bodyValue(parametersJson(library, SqlQueryOutputFormat.NDJSON))
+        .exchange()
+        .expectStatus()
+        .is4xxClientError();
+  }
+
+  @Nonnull
+  private String postOk(
+      @Nonnull final String path,
+      @Nonnull final String body,
+      @Nonnull final SqlQueryOutputFormat format) {
+    final String contentType = format.getContentType();
+    final EntityExchangeResult<byte[]> result =
+        webTestClient
+            .post()
+            .uri("http://localhost:" + port + path)
+            .header("Content-Type", "application/fhir+json")
+            .header("Accept", contentType)
+            .bodyValue(body)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectHeader()
+            .contentTypeCompatibleWith(MediaType.parseMediaType(contentType))
+            .expectBody()
+            .returnResult();
+    return new String(
+        Objects.requireNonNull(result.getResponseBodyContent()), StandardCharsets.UTF_8);
+  }
+
+  @Nonnull
+  private Library sqlQueryLibrary(
+      @Nonnull final String sql, @Nonnull final String label, @Nonnull final String viewReference) {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library.setType(
+        new CodeableConcept()
+            .addCoding(new Coding().setSystem(LIBRARY_TYPE_SYSTEM).setCode(LIBRARY_TYPE_CODE)));
+    final Attachment content = new Attachment();
+    content.setContentType("application/sql");
+    content.setData(sql.getBytes(StandardCharsets.UTF_8));
+    library.addContent(content);
+    library.addRelatedArtifact(
+        new RelatedArtifact()
+            .setType(RelatedArtifactType.DEPENDSON)
+            .setLabel(label)
+            .setResource(viewReference));
+    return library;
+  }
+
+  @Nonnull
+  private String parametersJson(
+      @Nonnull final Library library, @Nonnull final SqlQueryOutputFormat format) {
+    return parametersJson(library, format, null);
+  }
+
+  @Nonnull
+  private String parametersJson(
+      @Nonnull final Library library,
+      @Nonnull final SqlQueryOutputFormat format,
+      @Nullable final Integer limit) {
+    final String libraryJson = jsonParser.encodeResourceToString(library);
+    final Map<String, Object> parameters = new LinkedHashMap<>();
+    parameters.put("resourceType", "Parameters");
+    final List<Map<String, Object>> parameterList = new ArrayList<>();
+
+    final Map<String, Object> queryResourceParam = new LinkedHashMap<>();
+    queryResourceParam.put("name", "queryResource");
+    queryResourceParam.put("resource", GSON.fromJson(libraryJson, Map.class));
+    parameterList.add(queryResourceParam);
+
+    final Map<String, Object> formatParam = new LinkedHashMap<>();
+    formatParam.put("name", "_format");
+    formatParam.put("valueString", format.getCode());
+    parameterList.add(formatParam);
+
+    if (limit != null) {
+      final Map<String, Object> limitParam = new LinkedHashMap<>();
+      limitParam.put("name", "_limit");
+      limitParam.put("valueInteger", limit);
+      parameterList.add(limitParam);
+    }
+
+    parameters.put("parameter", parameterList);
+    return GSON.toJson(parameters);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunWithViewDefinitionsIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunWithViewDefinitionsIT.java
@@ -81,6 +81,9 @@ class SqlQueryRunWithViewDefinitionsIT {
   private static final String VIEW_REFERENCE =
       "ViewDefinition/" + SqlQueryViewDefinitionTestConfiguration.PATIENT_VIEW_ID;
 
+  private static final String OBSERVATION_VIEW_REFERENCE =
+      "ViewDefinition/" + SqlQueryViewDefinitionTestConfiguration.OBSERVATION_VIEW_ID;
+
   @LocalServerPort int port;
 
   @Autowired WebTestClient webTestClient;
@@ -144,6 +147,42 @@ class SqlQueryRunWithViewDefinitionsIT {
 
     final String[] lines = body.trim().split("\n");
     assertThat(lines).hasSize(2);
+  }
+
+  /**
+   * Exercises the case where the referenced ViewDefinition's FHIRPath compiles to a Pathling-
+   * registered UDF call (here {@code decimal_to_literal}, via {@code Quantity.value.toString()}).
+   * The view's analyzed plan therefore carries a {@code ScalaUDF}, which appears in the user SQL's
+   * analyzed plan after Spark substitutes the temp view in. The validator must permit this even
+   * though the same UDF, called directly from user SQL, would be rejected. Regression for the
+   * change that removed the UDF allow-list.
+   */
+  @Test
+  void runsSqlAgainstViewWithPathlingUdfInFhirPath() {
+    final Library library =
+        sqlQueryLibrary(
+            "SELECT id, subject, weight_kg FROM observations ORDER BY id",
+            "observations",
+            OBSERVATION_VIEW_REFERENCE);
+
+    final String body =
+        postOk(
+            "/fhir/$sqlquery-run",
+            parametersJson(library, SqlQueryOutputFormat.NDJSON),
+            SqlQueryOutputFormat.NDJSON);
+    log.debug("View-with-UDF NDJSON response:\n{}", body);
+
+    final String[] lines = body.trim().split("\n");
+    assertThat(lines).hasSize(3);
+    // decimal_to_literal strips trailing zeros: 70.50 -> "70.5", 82.250 -> "82.25", 65 -> "65".
+    assertThat(body)
+        .contains("\"id\":\"o1\"")
+        .contains("\"subject\":\"Patient/p1\"")
+        .contains("\"weight_kg\":\"70.5\"")
+        .contains("\"id\":\"o2\"")
+        .contains("\"weight_kg\":\"82.25\"")
+        .contains("\"id\":\"o3\"")
+        .contains("\"weight_kg\":\"65\"");
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryViewDefinitionTestConfiguration.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryViewDefinitionTestConfiguration.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.encoders.ViewDefinitionResource;
+import au.csiro.pathling.encoders.ViewDefinitionResource.ColumnComponent;
+import au.csiro.pathling.encoders.ViewDefinitionResource.SelectComponent;
+import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
+import au.csiro.pathling.util.CustomObjectDataSource;
+import jakarta.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.spark.sql.SparkSession;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.StringType;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * Test configuration that overrides the production {@code deltaLake} data source with an in-memory
+ * one pre-loaded with both Patient resources and a ViewDefinition that selects against them. Used
+ * by the {@code $sqlquery-run} end-to-end IT to drive a SQL query that resolves a ViewDefinition
+ * reference and executes against real FHIR data — the path the production warehouse caching defeats
+ * for resources created at runtime.
+ */
+@TestConfiguration
+public class SqlQueryViewDefinitionTestConfiguration {
+
+  /** The id of the pre-loaded ViewDefinition referenced by tests. */
+  public static final String PATIENT_VIEW_ID = "patient-view";
+
+  @Primary
+  @Bean
+  @Nonnull
+  public QueryableDataSource deltaLake(
+      @Nonnull final SparkSession sparkSession,
+      @Nonnull final PathlingContext pathlingContext,
+      @Nonnull final FhirEncoders fhirEncoders) {
+    final List<IBaseResource> resources = new ArrayList<>();
+    resources.add(patientView());
+    resources.add(patient("p1", "Smith"));
+    resources.add(patient("p2", "Johnson"));
+    resources.add(patient("p3", "Williams"));
+    return new CustomObjectDataSource(sparkSession, pathlingContext, fhirEncoders, resources);
+  }
+
+  @Nonnull
+  private static ViewDefinitionResource patientView() {
+    final ViewDefinitionResource view = new ViewDefinitionResource();
+    view.setId(PATIENT_VIEW_ID);
+    view.setName(new StringType("patient_view"));
+    view.setResource(new CodeType("Patient"));
+    view.setStatus(new CodeType("active"));
+    final SelectComponent select = new SelectComponent();
+    select.getColumn().add(column("id", "id"));
+    select.getColumn().add(column("family_name", "name.first().family"));
+    view.getSelect().add(select);
+    return view;
+  }
+
+  @Nonnull
+  private static ColumnComponent column(@Nonnull final String name, @Nonnull final String path) {
+    final ColumnComponent column = new ColumnComponent();
+    column.setName(new StringType(name));
+    column.setPath(new StringType(path));
+    return column;
+  }
+
+  @Nonnull
+  private static Patient patient(@Nonnull final String id, @Nonnull final String family) {
+    final Patient patient = new Patient();
+    patient.setId(id);
+    patient.addName().setFamily(family);
+    return patient;
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryViewDefinitionTestConfiguration.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryViewDefinitionTestConfiguration.java
@@ -25,12 +25,17 @@ import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.util.CustomObjectDataSource;
 import jakarta.annotation.Nonnull;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.spark.sql.SparkSession;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Observation.ObservationStatus;
 import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Quantity;
+import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.StringType;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -38,16 +43,34 @@ import org.springframework.context.annotation.Primary;
 
 /**
  * Test configuration that overrides the production {@code deltaLake} data source with an in-memory
- * one pre-loaded with both Patient resources and a ViewDefinition that selects against them. Used
- * by the {@code $sqlquery-run} end-to-end IT to drive a SQL query that resolves a ViewDefinition
- * reference and executes against real FHIR data — the path the production warehouse caching defeats
- * for resources created at runtime.
+ * one pre-loaded with FHIR resources and ViewDefinitions that select against them. Used by the
+ * {@code $sqlquery-run} end-to-end IT to drive a SQL query that resolves a ViewDefinition reference
+ * and executes against real FHIR data — the path the production warehouse caching defeats for
+ * resources created at runtime.
+ *
+ * <p>Two views are exposed:
+ *
+ * <ul>
+ *   <li>{@link #PATIENT_VIEW_ID} - a plain Patient view whose FHIRPath compiles to ordinary Spark
+ *       expressions only (used by the baseline IT cases).
+ *   <li>{@link #OBSERVATION_VIEW_ID} - an Observation view whose FHIRPath ({@code
+ *       value.ofType(Quantity).value.toString()}) compiles to a call to the Pathling-registered
+ *       {@code decimal_to_literal} UDF, exercising the case where the view-derived analyzed plan
+ *       carries a {@code ScalaUDF} that user SQL must be allowed to select through.
+ * </ul>
  */
 @TestConfiguration
 public class SqlQueryViewDefinitionTestConfiguration {
 
-  /** The id of the pre-loaded ViewDefinition referenced by tests. */
+  /** The id of the pre-loaded Patient ViewDefinition referenced by tests. */
   public static final String PATIENT_VIEW_ID = "patient-view";
+
+  /**
+   * The id of the pre-loaded Observation ViewDefinition referenced by tests. Its FHIRPath uses
+   * {@code .toString()} on a Decimal, which compiles to the Pathling-registered {@code
+   * decimal_to_literal} UDF.
+   */
+  public static final String OBSERVATION_VIEW_ID = "observation-view";
 
   @Primary
   @Bean
@@ -58,9 +81,13 @@ public class SqlQueryViewDefinitionTestConfiguration {
       @Nonnull final FhirEncoders fhirEncoders) {
     final List<IBaseResource> resources = new ArrayList<>();
     resources.add(patientView());
+    resources.add(observationView());
     resources.add(patient("p1", "Smith"));
     resources.add(patient("p2", "Johnson"));
     resources.add(patient("p3", "Williams"));
+    resources.add(observation("o1", "p1", new BigDecimal("70.50")));
+    resources.add(observation("o2", "p2", new BigDecimal("82.250")));
+    resources.add(observation("o3", "p3", new BigDecimal("65")));
     return new CustomObjectDataSource(sparkSession, pathlingContext, fhirEncoders, resources);
   }
 
@@ -74,6 +101,27 @@ public class SqlQueryViewDefinitionTestConfiguration {
     final SelectComponent select = new SelectComponent();
     select.getColumn().add(column("id", "id"));
     select.getColumn().add(column("family_name", "name.first().family"));
+    view.getSelect().add(select);
+    return view;
+  }
+
+  /**
+   * View whose {@code weight_kg} column compiles to a call to {@code decimal_to_literal}, so the
+   * resulting analyzed plan contains a Pathling {@code ScalaUDF}. Confirms that user SQL selecting
+   * from this view is not blocked by the validator's "no non-built-in functions" rule, since that
+   * rule only fires against {@code UnresolvedFunction}s in user-supplied SQL.
+   */
+  @Nonnull
+  private static ViewDefinitionResource observationView() {
+    final ViewDefinitionResource view = new ViewDefinitionResource();
+    view.setId(OBSERVATION_VIEW_ID);
+    view.setName(new StringType("observation_view"));
+    view.setResource(new CodeType("Observation"));
+    view.setStatus(new CodeType("active"));
+    final SelectComponent select = new SelectComponent();
+    select.getColumn().add(column("id", "id"));
+    select.getColumn().add(column("subject", "subject.reference"));
+    select.getColumn().add(column("weight_kg", "value.ofType(Quantity).value.toString()"));
     view.getSelect().add(select);
     return view;
   }
@@ -92,5 +140,21 @@ public class SqlQueryViewDefinitionTestConfiguration {
     patient.setId(id);
     patient.addName().setFamily(family);
     return patient;
+  }
+
+  @Nonnull
+  private static Observation observation(
+      @Nonnull final String id, @Nonnull final String patientId, @Nonnull final BigDecimal weight) {
+    final Observation observation = new Observation();
+    observation.setId(id);
+    observation.setStatus(ObservationStatus.FINAL);
+    observation.setSubject(new Reference("Patient/" + patientId));
+    final Quantity quantity = new Quantity();
+    quantity.setValue(weight);
+    quantity.setUnit("kg");
+    quantity.setSystem("http://unitsofmeasure.org");
+    quantity.setCode("kg");
+    observation.setValue(quantity);
+    return observation;
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryWatchdogTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryWatchdogTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.config.SqlQueryConfiguration;
+import jakarta.annotation.Nonnull;
+import java.time.Duration;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SqlQueryWatchdog}. The Spark session is mocked so the test does not need a
+ * running cluster - the watchdog's contract is to call {@code cancelJobGroup} once the timeout
+ * elapses and to suppress that call when the watch is completed first.
+ */
+class SqlQueryWatchdogTest {
+
+  private static final String JOB_GROUP_ID = "sqlquery-test-job";
+
+  private SqlQueryWatchdog watchdog;
+
+  @AfterEach
+  void tearDown() {
+    if (watchdog != null) {
+      watchdog.shutdown();
+    }
+  }
+
+  @Test
+  void cancelsJobGroupAfterTimeout() {
+    final SparkSession spark = mock(SparkSession.class);
+    final SparkContext context = mock(SparkContext.class);
+    when(spark.sparkContext()).thenReturn(context);
+    watchdog = newWatchdog(spark, /* timeoutSeconds= */ 1);
+
+    final SqlQueryWatchdog.Watch watch = watchdog.start(JOB_GROUP_ID);
+
+    // Allow time for the schedule to fire; verify the cancellation lands on the job group.
+    verify(context, timeout(5000)).cancelJobGroup(eq(JOB_GROUP_ID));
+    await().atMost(Duration.ofSeconds(5)).until(watch::timedOut);
+    assertThat(watch.timedOut()).isTrue();
+  }
+
+  @Test
+  void cancellationIsCancelledOnNormalCompletion() throws InterruptedException {
+    final SparkSession spark = mock(SparkSession.class);
+    final SparkContext context = mock(SparkContext.class);
+    when(spark.sparkContext()).thenReturn(context);
+    watchdog = newWatchdog(spark, /* timeoutSeconds= */ 60);
+
+    final SqlQueryWatchdog.Watch watch = watchdog.start(JOB_GROUP_ID);
+    watch.complete();
+
+    // Wait long enough that an unscheduled fire would have occurred if complete() did not cancel.
+    Thread.sleep(500);
+    verify(context, never()).cancelJobGroup(eq(JOB_GROUP_ID));
+    assertThat(watch.timedOut()).isFalse();
+  }
+
+  @Nonnull
+  private static SqlQueryWatchdog newWatchdog(
+      @Nonnull final SparkSession spark, final long timeoutSeconds) {
+    final SqlQueryConfiguration sqlQueryConfig = new SqlQueryConfiguration();
+    sqlQueryConfig.setTimeoutSeconds(timeoutSeconds);
+    final ServerConfiguration serverConfiguration = new ServerConfiguration();
+    serverConfiguration.setSqlQuery(sqlQueryConfig);
+    return new SqlQueryWatchdog(spark, serverConfiguration);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorIntegrityTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorIntegrityTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import au.csiro.pathling.test.SpringBootUnitTest;
+import java.util.stream.Stream;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Build-time integrity checks for {@link SqlValidator}. These tests fail fast if the validator's
+ * static allow-lists drift from reality:
+ *
+ * <ul>
+ *   <li>Every entry in the allow-list / reject-list must resolve to a class on the classpath
+ *       (catches typos and Spark renames).
+ *   <li>The UDF allow-list must match the set of UDFs the test SparkSession has registered (catches
+ *       hand-copy drift between {@link SqlValidator} and the registrars).
+ * </ul>
+ */
+@Import(SqlValidator.class)
+@SpringBootUnitTest
+class SqlValidatorIntegrityTest {
+
+  @Autowired private SparkSession sparkSession;
+
+  // ---------------------------------------------------------------------------
+  // FQN entries must resolve on the classpath.
+  // ---------------------------------------------------------------------------
+
+  @ParameterizedTest(name = "plan node: {0}")
+  @MethodSource("planNodeFqns")
+  @DisplayName("Every allowed plan node FQN resolves to a class on the classpath")
+  void allowedPlanNodeFqnResolves(final String fqn) {
+    assertThat(resolves(fqn)).as("FQN '%s' did not resolve on the classpath", fqn).isTrue();
+  }
+
+  @ParameterizedTest(name = "expression: {0}")
+  @MethodSource("expressionFqns")
+  @DisplayName("Every allowed expression FQN resolves to a class on the classpath")
+  void allowedExpressionFqnResolves(final String fqn) {
+    assertThat(resolves(fqn)).as("FQN '%s' did not resolve on the classpath", fqn).isTrue();
+  }
+
+  @ParameterizedTest(name = "rejected expression: {0}")
+  @MethodSource("rejectedExpressionFqns")
+  @DisplayName("Every rejected expression FQN resolves to a class on the classpath")
+  void rejectedExpressionFqnResolves(final String fqn) {
+    assertThat(resolves(fqn)).as("FQN '%s' did not resolve on the classpath", fqn).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // UDF allow-list must match what's actually registered.
+  // ---------------------------------------------------------------------------
+
+  @ParameterizedTest(name = "UDF: {0}")
+  @MethodSource("udfNames")
+  @DisplayName("Every allow-listed UDF name corresponds to a function registered in Spark")
+  void allowedUdfIsRegistered(final String name) {
+    assertThat(sparkSession.catalog().functionExists(name))
+        .as(
+            "Allow-list names UDF '%s' but no function with that name is registered in the test "
+                + "SparkSession. Either the UDF was retired (drop it from "
+                + "SqlValidator.ALLOWED_UDF_NAMES) or the registrar configuration drifted.",
+            name)
+        .isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers.
+  // ---------------------------------------------------------------------------
+
+  static Stream<String> planNodeFqns() {
+    return SqlValidator.allowedPlanNodes().stream();
+  }
+
+  static Stream<String> expressionFqns() {
+    return SqlValidator.allowedExpressionNames().stream();
+  }
+
+  static Stream<String> rejectedExpressionFqns() {
+    return SqlValidator.rejectedExpressionNames().stream();
+  }
+
+  static Stream<String> udfNames() {
+    return SqlValidator.allowedUdfNames().stream();
+  }
+
+  /**
+   * Tries to load the class by FQN; falls back to the {@code $}-suffixed form for Scala case
+   * objects.
+   */
+  private static boolean resolves(final String fqn) {
+    try {
+      Class.forName(fqn);
+      return true;
+    } catch (final ClassNotFoundException ignored) {
+      try {
+        Class.forName(fqn + "$");
+        return true;
+      } catch (final ClassNotFoundException ignored2) {
+        return false;
+      }
+    }
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorIntegrityTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorIntegrityTest.java
@@ -21,33 +21,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import au.csiro.pathling.test.SpringBootUnitTest;
 import java.util.stream.Stream;
-import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
 /**
- * Build-time integrity checks for {@link SqlValidator}. These tests fail fast if the validator's
- * static allow-lists drift from reality:
- *
- * <ul>
- *   <li>Every entry in the allow-list / reject-list must resolve to a class on the classpath
- *       (catches typos and Spark renames).
- *   <li>The UDF allow-list must match the set of UDFs the test SparkSession has registered (catches
- *       hand-copy drift between {@link SqlValidator} and the registrars).
- * </ul>
+ * Build-time integrity checks for {@link SqlValidator}. Every entry in the allow-list / reject-list
+ * must resolve to a class on the classpath (catches typos and Spark renames).
  */
 @Import(SqlValidator.class)
 @SpringBootUnitTest
 class SqlValidatorIntegrityTest {
-
-  @Autowired private SparkSession sparkSession;
-
-  // ---------------------------------------------------------------------------
-  // FQN entries must resolve on the classpath.
-  // ---------------------------------------------------------------------------
 
   @ParameterizedTest(name = "plan node: {0}")
   @MethodSource("planNodeFqns")
@@ -70,27 +55,6 @@ class SqlValidatorIntegrityTest {
     assertThat(resolves(fqn)).as("FQN '%s' did not resolve on the classpath", fqn).isTrue();
   }
 
-  // ---------------------------------------------------------------------------
-  // UDF allow-list must match what's actually registered.
-  // ---------------------------------------------------------------------------
-
-  @ParameterizedTest(name = "UDF: {0}")
-  @MethodSource("udfNames")
-  @DisplayName("Every allow-listed UDF name corresponds to a function registered in Spark")
-  void allowedUdfIsRegistered(final String name) {
-    assertThat(sparkSession.catalog().functionExists(name))
-        .as(
-            "Allow-list names UDF '%s' but no function with that name is registered in the test "
-                + "SparkSession. Either the UDF was retired (drop it from "
-                + "SqlValidator.ALLOWED_UDF_NAMES) or the registrar configuration drifted.",
-            name)
-        .isTrue();
-  }
-
-  // ---------------------------------------------------------------------------
-  // Helpers.
-  // ---------------------------------------------------------------------------
-
   static Stream<String> planNodeFqns() {
     return SqlValidator.allowedPlanNodes().stream();
   }
@@ -101,10 +65,6 @@ class SqlValidatorIntegrityTest {
 
   static Stream<String> rejectedExpressionFqns() {
     return SqlValidator.rejectedExpressionNames().stream();
-  }
-
-  static Stream<String> udfNames() {
-    return SqlValidator.allowedUdfNames().stream();
   }
 
   /**

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import au.csiro.pathling.test.SpringBootUnitTest;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+/** Unit tests for {@link SqlValidator}. */
+@Import(SqlValidator.class)
+@SpringBootUnitTest
+class SqlValidatorTest {
+
+  @Autowired private SqlValidator sqlValidator;
+
+  // -------------------------------------------------------------------------
+  // Valid SQL queries — should not throw.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void acceptsSimpleSelect() {
+    assertThatCode(() -> sqlValidator.validate("SELECT 1")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithAlias() {
+    assertThatCode(() -> sqlValidator.validate("SELECT 1 AS value")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectFromTable() {
+    assertThatCode(() -> sqlValidator.validate("SELECT * FROM my_view")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithWhere() {
+    assertThatCode(() -> sqlValidator.validate("SELECT a, b FROM t WHERE a > 10"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithJoin() {
+    assertThatCode(
+            () -> sqlValidator.validate("SELECT a.id, b.name FROM a JOIN b ON a.id = b.a_id"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithAggregation() {
+    assertThatCode(() -> sqlValidator.validate("SELECT count(*), sum(x) FROM t GROUP BY y"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithSubquery() {
+    assertThatCode(() -> sqlValidator.validate("SELECT * FROM (SELECT 1 AS x) sub"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithCte() {
+    assertThatCode(() -> sqlValidator.validate("WITH cte AS (SELECT 1 AS x) SELECT * FROM cte"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithOrderByAndLimit() {
+    assertThatCode(() -> sqlValidator.validate("SELECT * FROM t ORDER BY id LIMIT 10"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithCaseWhen() {
+    assertThatCode(
+            () ->
+                sqlValidator.validate(
+                    "SELECT CASE WHEN x > 0 THEN 'positive' ELSE 'negative' END FROM t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithStringFunctions() {
+    assertThatCode(
+            () -> sqlValidator.validate("SELECT upper(name), lower(name), length(name) FROM t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithMathFunctions() {
+    assertThatCode(() -> sqlValidator.validate("SELECT abs(-1), sqrt(4), round(3.14, 1)"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithDateFunctions() {
+    assertThatCode(() -> sqlValidator.validate("SELECT current_date(), current_timestamp()"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithUnion() {
+    assertThatCode(() -> sqlValidator.validate("SELECT 1 AS x UNION ALL SELECT 2 AS x"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithWindowFunction() {
+    assertThatCode(
+            () -> sqlValidator.validate("SELECT id, row_number() OVER (ORDER BY id) AS rn FROM t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithDistinct() {
+    assertThatCode(() -> sqlValidator.validate("SELECT DISTINCT name FROM t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithInClause() {
+    assertThatCode(() -> sqlValidator.validate("SELECT * FROM t WHERE id IN (1, 2, 3)"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithCast() {
+    assertThatCode(() -> sqlValidator.validate("SELECT CAST(x AS STRING) FROM t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsSelectWithCoalesce() {
+    assertThatCode(() -> sqlValidator.validate("SELECT coalesce(a, b, 'default') FROM t"))
+        .doesNotThrowAnyException();
+  }
+
+  // -------------------------------------------------------------------------
+  // Invalid SQL — should reject DDL and DML.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void rejectsDropTable() {
+    assertThatThrownBy(() -> sqlValidator.validate("DROP TABLE my_table"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed");
+  }
+
+  @Test
+  void rejectsCreateTable() {
+    assertThatThrownBy(() -> sqlValidator.validate("CREATE TABLE my_table (id INT)"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed");
+  }
+
+  @Test
+  void rejectsInsertInto() {
+    assertThatThrownBy(() -> sqlValidator.validate("INSERT INTO my_table VALUES (1, 'a')"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed");
+  }
+
+  @Test
+  void rejectsDeleteFrom() {
+    assertThatThrownBy(() -> sqlValidator.validate("DELETE FROM my_table WHERE id = 1"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed");
+  }
+
+  @Test
+  void rejectsUpdateStatement() {
+    assertThatThrownBy(() -> sqlValidator.validate("UPDATE my_table SET name = 'x' WHERE id = 1"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed");
+  }
+
+  @Test
+  void rejectsCreateView() {
+    assertThatThrownBy(() -> sqlValidator.validate("CREATE VIEW my_view AS SELECT 1"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed");
+  }
+
+  // -------------------------------------------------------------------------
+  // Invalid SQL — should reject dangerous functions.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void rejectsReflectFunction() {
+    assertThatThrownBy(
+            () -> sqlValidator.validate("SELECT reflect('java.lang.Runtime', 'getRuntime') FROM t"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed function");
+  }
+
+  @Test
+  void rejectsJavaMethodFunction() {
+    assertThatThrownBy(
+            () -> sqlValidator.validate("SELECT java_method('java.lang.Math', 'random') FROM t"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed function");
+  }
+
+  // -------------------------------------------------------------------------
+  // Invalid SQL syntax.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void rejectsInvalidSqlSyntax() {
+    assertThatThrownBy(() -> sqlValidator.validate("NOT VALID SQL AT ALL"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("Invalid SQL syntax");
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
@@ -230,4 +230,52 @@ class SqlValidatorTest {
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("Invalid SQL syntax");
   }
+
+  // -------------------------------------------------------------------------
+  // Regression corpus — known-bad queries the validator must reject.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Documents the queries that must always be rejected. New entries here lock current rejection
+   * behaviour into the test suite and double as a security-model checklist for future readers.
+   */
+  @org.junit.jupiter.params.ParameterizedTest(name = "rejects: {0}")
+  @org.junit.jupiter.params.provider.ValueSource(
+      strings = {
+        // Hive metastore commands.
+        "LOAD DATA INPATH '/tmp/x' INTO TABLE my_table",
+        "MSCK REPAIR TABLE my_table",
+        // Session configuration.
+        "SET spark.sql.shuffle.partitions = 200",
+        "SET",
+        "RESET",
+        // INSERT variants.
+        "INSERT OVERWRITE TABLE my_table SELECT 1",
+        "INSERT INTO my_table SELECT 1",
+        // Data manipulation.
+        "TRUNCATE TABLE my_table",
+        "ALTER TABLE my_table ADD COLUMNS (x INT)",
+        "MERGE INTO target USING source ON target.id = source.id WHEN MATCHED THEN UPDATE SET"
+            + " target.x = source.x",
+        // Catalog management.
+        "CREATE DATABASE my_db",
+        "DROP DATABASE my_db",
+        "USE my_db",
+        // Cache control.
+        "CACHE TABLE my_table",
+        "UNCACHE TABLE my_table",
+        "REFRESH TABLE my_table",
+        // Discovery / SHOW.
+        "SHOW TABLES",
+        "DESCRIBE my_table",
+        "EXPLAIN SELECT 1",
+        // Reflection-style functions.
+        "SELECT reflect('java.lang.Runtime', 'getRuntime')",
+        "SELECT java_method('java.lang.Math', 'random')"
+      })
+  void rejectsKnownDangerousQueries(final String sql) {
+    assertThatThrownBy(() -> sqlValidator.validate(sql))
+        .as("validator must reject: %s", sql)
+        .isInstanceOf(InvalidRequestException.class);
+  }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import au.csiro.pathling.test.SpringBootUnitTest;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import jakarta.annotation.Nonnull;
+import java.util.Set;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -44,59 +46,79 @@ class SqlValidatorTest {
     sparkSession.catalog().dropTempView(VIEW_NAME);
   }
 
+  /** Convenience wrapper threading a varargs label set into {@link SqlValidator#validate}. */
+  private void validate(@Nonnull final String sql, @Nonnull final String... labels) {
+    sqlValidator.validate(sql, Set.of(labels));
+  }
+
   // -------------------------------------------------------------------------
   // Valid SQL queries — should not throw.
   // -------------------------------------------------------------------------
 
   @Test
   void acceptsSimpleSelect() {
-    assertThatCode(() -> sqlValidator.validate("SELECT 1")).doesNotThrowAnyException();
+    assertThatCode(() -> validate("SELECT 1")).doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithAlias() {
-    assertThatCode(() -> sqlValidator.validate("SELECT 1 AS value")).doesNotThrowAnyException();
+    assertThatCode(() -> validate("SELECT 1 AS value")).doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectFromTable() {
-    assertThatCode(() -> sqlValidator.validate("SELECT * FROM my_view")).doesNotThrowAnyException();
+    assertThatCode(() -> validate("SELECT * FROM my_view", "my_view")).doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithWhere() {
-    assertThatCode(() -> sqlValidator.validate("SELECT a, b FROM t WHERE a > 10"))
+    assertThatCode(() -> validate("SELECT a, b FROM t WHERE a > 10", "t"))
         .doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithJoin() {
-    assertThatCode(
-            () -> sqlValidator.validate("SELECT a.id, b.name FROM a JOIN b ON a.id = b.a_id"))
+    assertThatCode(() -> validate("SELECT a.id, b.name FROM a JOIN b ON a.id = b.a_id", "a", "b"))
         .doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithAggregation() {
-    assertThatCode(() -> sqlValidator.validate("SELECT count(*), sum(x) FROM t GROUP BY y"))
+    assertThatCode(() -> validate("SELECT count(*), sum(x) FROM t GROUP BY y", "t"))
         .doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithSubquery() {
-    assertThatCode(() -> sqlValidator.validate("SELECT * FROM (SELECT 1 AS x) sub"))
-        .doesNotThrowAnyException();
+    assertThatCode(() -> validate("SELECT * FROM (SELECT 1 AS x) sub")).doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithCte() {
-    assertThatCode(() -> sqlValidator.validate("WITH cte AS (SELECT 1 AS x) SELECT * FROM cte"))
+    // The CTE name 'cte' is defined in the query itself, so no label is required.
+    assertThatCode(() -> validate("WITH cte AS (SELECT 1 AS x) SELECT * FROM cte"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsCteReferencingDeclaredLabel() {
+    // A CTE can wrap a declared label; the declared label is required, the CTE name is not.
+    assertThatCode(
+            () -> validate("WITH foo AS (SELECT * FROM patients) SELECT * FROM foo", "patients"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsNestedCtes() {
+    // Nested CTEs - both 'a' and 'b' are CTE-local names.
+    assertThatCode(
+            () -> validate("WITH a AS (SELECT 1 AS x), b AS (SELECT * FROM a) SELECT * FROM b"))
         .doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithOrderByAndLimit() {
-    assertThatCode(() -> sqlValidator.validate("SELECT * FROM t ORDER BY id LIMIT 10"))
+    assertThatCode(() -> validate("SELECT * FROM t ORDER BY id LIMIT 10", "t"))
         .doesNotThrowAnyException();
   }
 
@@ -104,64 +126,60 @@ class SqlValidatorTest {
   void acceptsSelectWithCaseWhen() {
     assertThatCode(
             () ->
-                sqlValidator.validate(
-                    "SELECT CASE WHEN x > 0 THEN 'positive' ELSE 'negative' END FROM t"))
+                validate("SELECT CASE WHEN x > 0 THEN 'positive' ELSE 'negative' END FROM t", "t"))
         .doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithStringFunctions() {
-    assertThatCode(
-            () -> sqlValidator.validate("SELECT upper(name), lower(name), length(name) FROM t"))
+    assertThatCode(() -> validate("SELECT upper(name), lower(name), length(name) FROM t", "t"))
         .doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithMathFunctions() {
-    assertThatCode(() -> sqlValidator.validate("SELECT abs(-1), sqrt(4), round(3.14, 1)"))
+    assertThatCode(() -> validate("SELECT abs(-1), sqrt(4), round(3.14, 1)"))
         .doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithDateFunctions() {
-    assertThatCode(() -> sqlValidator.validate("SELECT current_date(), current_timestamp()"))
+    assertThatCode(() -> validate("SELECT current_date(), current_timestamp()"))
         .doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithUnion() {
-    assertThatCode(() -> sqlValidator.validate("SELECT 1 AS x UNION ALL SELECT 2 AS x"))
+    assertThatCode(() -> validate("SELECT 1 AS x UNION ALL SELECT 2 AS x"))
         .doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithWindowFunction() {
-    assertThatCode(
-            () -> sqlValidator.validate("SELECT id, row_number() OVER (ORDER BY id) AS rn FROM t"))
+    assertThatCode(() -> validate("SELECT id, row_number() OVER (ORDER BY id) AS rn FROM t", "t"))
         .doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithDistinct() {
-    assertThatCode(() -> sqlValidator.validate("SELECT DISTINCT name FROM t"))
-        .doesNotThrowAnyException();
+    assertThatCode(() -> validate("SELECT DISTINCT name FROM t", "t")).doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithInClause() {
-    assertThatCode(() -> sqlValidator.validate("SELECT * FROM t WHERE id IN (1, 2, 3)"))
+    assertThatCode(() -> validate("SELECT * FROM t WHERE id IN (1, 2, 3)", "t"))
         .doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithCast() {
-    assertThatCode(() -> sqlValidator.validate("SELECT CAST(x AS STRING) FROM t"))
+    assertThatCode(() -> validate("SELECT CAST(x AS STRING) FROM t", "t"))
         .doesNotThrowAnyException();
   }
 
   @Test
   void acceptsSelectWithCoalesce() {
-    assertThatCode(() -> sqlValidator.validate("SELECT coalesce(a, b, 'default') FROM t"))
+    assertThatCode(() -> validate("SELECT coalesce(a, b, 'default') FROM t", "t"))
         .doesNotThrowAnyException();
   }
 
@@ -171,42 +189,42 @@ class SqlValidatorTest {
 
   @Test
   void rejectsDropTable() {
-    assertThatThrownBy(() -> sqlValidator.validate("DROP TABLE my_table"))
+    assertThatThrownBy(() -> validate("DROP TABLE my_table"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("disallowed");
   }
 
   @Test
   void rejectsCreateTable() {
-    assertThatThrownBy(() -> sqlValidator.validate("CREATE TABLE my_table (id INT)"))
+    assertThatThrownBy(() -> validate("CREATE TABLE my_table (id INT)"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("disallowed");
   }
 
   @Test
   void rejectsInsertInto() {
-    assertThatThrownBy(() -> sqlValidator.validate("INSERT INTO my_table VALUES (1, 'a')"))
+    assertThatThrownBy(() -> validate("INSERT INTO my_table VALUES (1, 'a')"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("disallowed");
   }
 
   @Test
   void rejectsDeleteFrom() {
-    assertThatThrownBy(() -> sqlValidator.validate("DELETE FROM my_table WHERE id = 1"))
+    assertThatThrownBy(() -> validate("DELETE FROM my_table WHERE id = 1"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("disallowed");
   }
 
   @Test
   void rejectsUpdateStatement() {
-    assertThatThrownBy(() -> sqlValidator.validate("UPDATE my_table SET name = 'x' WHERE id = 1"))
+    assertThatThrownBy(() -> validate("UPDATE my_table SET name = 'x' WHERE id = 1"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("disallowed");
   }
 
   @Test
   void rejectsCreateView() {
-    assertThatThrownBy(() -> sqlValidator.validate("CREATE VIEW my_view AS SELECT 1"))
+    assertThatThrownBy(() -> validate("CREATE VIEW my_view AS SELECT 1"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("disallowed");
   }
@@ -218,15 +236,14 @@ class SqlValidatorTest {
   @Test
   void rejectsReflectFunction() {
     assertThatThrownBy(
-            () -> sqlValidator.validate("SELECT reflect('java.lang.Runtime', 'getRuntime') FROM t"))
+            () -> validate("SELECT reflect('java.lang.Runtime', 'getRuntime') FROM t", "t"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("disallowed function");
   }
 
   @Test
   void rejectsJavaMethodFunction() {
-    assertThatThrownBy(
-            () -> sqlValidator.validate("SELECT java_method('java.lang.Math', 'random') FROM t"))
+    assertThatThrownBy(() -> validate("SELECT java_method('java.lang.Math', 'random') FROM t", "t"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("disallowed function");
   }
@@ -241,8 +258,7 @@ class SqlValidatorTest {
   void rejectsTerminologyUdfMemberOf() {
     assertThatThrownBy(
             () ->
-                sqlValidator.validate(
-                    "SELECT member_of(coding, 'http://snomed.info/sct?fhir_vs') FROM t"))
+                validate("SELECT member_of(coding, 'http://snomed.info/sct?fhir_vs') FROM t", "t"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("non-built-in function")
         .hasMessageContaining("member_of");
@@ -250,7 +266,7 @@ class SqlValidatorTest {
 
   @Test
   void rejectsTerminologyUdfDisplay() {
-    assertThatThrownBy(() -> sqlValidator.validate("SELECT display(coding) FROM t"))
+    assertThatThrownBy(() -> validate("SELECT display(coding) FROM t", "t"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("non-built-in function")
         .hasMessageContaining("display");
@@ -259,18 +275,85 @@ class SqlValidatorTest {
   @Test
   void rejectsTerminologyUdfTranslateCoding() {
     assertThatThrownBy(
-            () ->
-                sqlValidator.validate(
-                    "SELECT translate_coding(coding, 'http://example.org/cm') FROM t"))
+            () -> validate("SELECT translate_coding(coding, 'http://example.org/cm') FROM t", "t"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("non-built-in function");
   }
 
   @Test
   void rejectsFhirpathUdfStringToQuantity() {
-    assertThatThrownBy(() -> sqlValidator.validate("SELECT string_to_quantity('5 mg') FROM t"))
+    assertThatThrownBy(() -> validate("SELECT string_to_quantity('5 mg') FROM t", "t"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("non-built-in function");
+  }
+
+  // -------------------------------------------------------------------------
+  // Arbitrary local file read protection — the datasource short-name syntax
+  // (parquet/csv/text/binaryFile/...) parses as a 2-part UnresolvedRelation
+  // and must always be rejected, even when its first part happens to match a
+  // declared label.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void rejectsCsvShortNameFileRead() {
+    assertThatThrownBy(() -> validate("SELECT * FROM csv.`/etc/passwd`"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("undeclared table");
+  }
+
+  @Test
+  void rejectsTextShortNameFileRead() {
+    assertThatThrownBy(() -> validate("SELECT * FROM text.`/Users/gri306/.ssh/known_hosts`"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("undeclared table");
+  }
+
+  @Test
+  void rejectsBinaryFileShortNameRead() {
+    assertThatThrownBy(
+            () -> validate("SELECT base64(content) FROM binaryFile.`/Users/gri306/.ssh/personal`"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("undeclared table");
+  }
+
+  @Test
+  void rejectsParquetShortNameEvenWhenLabelMatchesDatasource() {
+    // Even when 'Patient' is declared, parquet.`...` parses as parquet/`...`, so the relation
+    // identifier is 'parquet'.'<path>', not 'Patient'. The rule still fires.
+    assertThatThrownBy(
+            () ->
+                validate(
+                    "SELECT id, gender FROM"
+                        + " parquet.`/Users/gri306/Warehouse/default/Patient.parquet`",
+                    "Patient"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("undeclared table");
+  }
+
+  @Test
+  void rejectsBinaryFileGlobShortName() {
+    assertThatThrownBy(() -> validate("SELECT path FROM binaryFile.`/etc/*.conf`"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("undeclared table");
+  }
+
+  @Test
+  void rejectsTwoPartCatalogReference() {
+    assertThatThrownBy(() -> validate("SELECT * FROM default.sometable"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("undeclared table");
+  }
+
+  @Test
+  void rejectsRelationNotInLabelSet() {
+    assertThatThrownBy(() -> validate("SELECT * FROM not_declared", "patients"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("undeclared table");
+  }
+
+  @Test
+  void acceptsRelationInLabelSet() {
+    assertThatCode(() -> validate("SELECT * FROM patients", "patients")).doesNotThrowAnyException();
   }
 
   // -------------------------------------------------------------------------
@@ -294,11 +377,12 @@ class SqlValidatorTest {
     // User SQL is plain ANSI — no UDF reference. The unresolved walk sees only
     // an UnresolvedRelation; the analyzed walk sees the substituted ScalaUDF.
     final String userSql = "SELECT literal FROM " + VIEW_NAME;
-    assertThatCode(() -> sqlValidator.validate(userSql)).doesNotThrowAnyException();
+    assertThatCode(() -> validate(userSql, VIEW_NAME)).doesNotThrowAnyException();
 
     final org.apache.spark.sql.catalyst.plans.logical.LogicalPlan analyzed =
         sparkSession.sql(userSql).queryExecution().analyzed();
-    assertThatCode(() -> sqlValidator.validateAnalyzed(analyzed)).doesNotThrowAnyException();
+    assertThatCode(() -> sqlValidator.validateAnalyzed(analyzed, Set.of(VIEW_NAME)))
+        .doesNotThrowAnyException();
   }
 
   // -------------------------------------------------------------------------
@@ -307,7 +391,7 @@ class SqlValidatorTest {
 
   @Test
   void rejectsInvalidSqlSyntax() {
-    assertThatThrownBy(() -> sqlValidator.validate("NOT VALID SQL AT ALL"))
+    assertThatThrownBy(() -> validate("NOT VALID SQL AT ALL"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("Invalid SQL syntax");
   }
@@ -355,7 +439,7 @@ class SqlValidatorTest {
         "SELECT java_method('java.lang.Math', 'random')"
       })
   void rejectsKnownDangerousQueries(final String sql) {
-    assertThatThrownBy(() -> sqlValidator.validate(sql))
+    assertThatThrownBy(() -> validate(sql))
         .as("validator must reject: %s", sql)
         .isInstanceOf(InvalidRequestException.class);
   }

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
@@ -386,6 +386,50 @@ class SqlValidatorTest {
   }
 
   // -------------------------------------------------------------------------
+  // Table-valued function (TVF) rejection. Built-in TVFs in the FROM clause
+  // (range, explode, json_tuple, ...) are an open denial-of-service lane:
+  // `SELECT count(*) FROM range(0, 1e6) a CROSS JOIN range(0, 1e6) b` is a
+  // 1e12-row Cartesian product. Drop the entire UnresolvedTableValuedFunction
+  // node class from the allow-list.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void rejectsRangeTvfInFromClause() {
+    assertThatThrownBy(() -> validate("SELECT * FROM range(0, 100)"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed plan node");
+  }
+
+  @Test
+  void rejectsRangeCrossJoinTvfDosAttack() {
+    // The literal exploit recorded in the threat model.
+    assertThatThrownBy(
+            () ->
+                validate("SELECT count(*) FROM range(0, 1000000) a CROSS JOIN range(0, 1000000) b"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed plan node");
+  }
+
+  @Test
+  void rejectsExplodeTvfInFromClause() {
+    assertThatThrownBy(() -> validate("SELECT * FROM explode(array(1, 2, 3))"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed plan node");
+  }
+
+  // -------------------------------------------------------------------------
+  // Non-regression: explode in projection position is rewritten by the
+  // analyser to a Generate node with an Explode expression. Both are
+  // allow-listed, so closing the TVF lane must not affect this form.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void acceptsExplodeInProjection() {
+    assertThatCode(() -> validate("SELECT explode(array(1, 2, 3)) AS x"))
+        .doesNotThrowAnyException();
+  }
+
+  // -------------------------------------------------------------------------
   // Invalid SQL syntax.
   // -------------------------------------------------------------------------
 

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import au.csiro.pathling.test.SpringBootUnitTest;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -31,7 +33,16 @@ import org.springframework.context.annotation.Import;
 @SpringBootUnitTest
 class SqlValidatorTest {
 
+  private static final String VIEW_NAME = "sql_validator_test_view";
+
   @Autowired private SqlValidator sqlValidator;
+
+  @Autowired private SparkSession sparkSession;
+
+  @AfterEach
+  void dropView() {
+    sparkSession.catalog().dropTempView(VIEW_NAME);
+  }
 
   // -------------------------------------------------------------------------
   // Valid SQL queries — should not throw.
@@ -218,6 +229,76 @@ class SqlValidatorTest {
             () -> sqlValidator.validate("SELECT java_method('java.lang.Math', 'random') FROM t"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("disallowed function");
+  }
+
+  // -------------------------------------------------------------------------
+  // Invalid SQL — Pathling-registered UDFs are not allowed in user SQL.
+  // The analytic surface stays portable; terminology and FHIRPath helpers
+  // belong in ViewDefinitions.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void rejectsTerminologyUdfMemberOf() {
+    assertThatThrownBy(
+            () ->
+                sqlValidator.validate(
+                    "SELECT member_of(coding, 'http://snomed.info/sct?fhir_vs') FROM t"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("non-built-in function")
+        .hasMessageContaining("member_of");
+  }
+
+  @Test
+  void rejectsTerminologyUdfDisplay() {
+    assertThatThrownBy(() -> sqlValidator.validate("SELECT display(coding) FROM t"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("non-built-in function")
+        .hasMessageContaining("display");
+  }
+
+  @Test
+  void rejectsTerminologyUdfTranslateCoding() {
+    assertThatThrownBy(
+            () ->
+                sqlValidator.validate(
+                    "SELECT translate_coding(coding, 'http://example.org/cm') FROM t"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("non-built-in function");
+  }
+
+  @Test
+  void rejectsFhirpathUdfStringToQuantity() {
+    assertThatThrownBy(() -> sqlValidator.validate("SELECT string_to_quantity('5 mg') FROM t"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("non-built-in function");
+  }
+
+  // -------------------------------------------------------------------------
+  // View-derived Pathling UDFs flow through unaffected. ViewDefinition
+  // FHIRPath expressions compile to Spark plans that contain ScalaUDFs (for
+  // terminology and FHIRPath helpers). When user SQL references the resulting
+  // temp view, Spark substitutes the view's analyzed plan into the user
+  // plan, so those ScalaUDFs appear in the analyzed-plan walk but never in
+  // the unresolved-plan walk where the non-built-in rejection fires.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void permitsViewDerivedScalaUdfInAnalyzedPlan() {
+    // Build a dataset whose plan contains a Pathling ScalaUDF (decimal_to_literal),
+    // simulating what FhirViewExecutor produces when the view's FHIRPath uses one
+    // of these helpers.
+    final org.apache.spark.sql.Dataset<org.apache.spark.sql.Row> viewBacking =
+        sparkSession.sql("SELECT decimal_to_literal(CAST(1.5 AS DECIMAL(10, 2)), 1) AS literal");
+    viewBacking.createOrReplaceTempView(VIEW_NAME);
+
+    // User SQL is plain ANSI — no UDF reference. The unresolved walk sees only
+    // an UnresolvedRelation; the analyzed walk sees the substituted ScalaUDF.
+    final String userSql = "SELECT literal FROM " + VIEW_NAME;
+    assertThatCode(() -> sqlValidator.validate(userSql)).doesNotThrowAnyException();
+
+    final org.apache.spark.sql.catalyst.plans.logical.LogicalPlan analyzed =
+        sparkSession.sql(userSql).queryExecution().analyzed();
+    assertThatCode(() -> sqlValidator.validateAnalyzed(analyzed)).doesNotThrowAnyException();
   }
 
   // -------------------------------------------------------------------------

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
@@ -98,6 +98,18 @@ class ViewRegistrationServiceTest {
     assertThat(a).isNotEqualTo(b);
   }
 
+  @Test
+  void resolveTempViewNameFallsBackToHashWhenSanitisedRequestIdIsEmpty() {
+    // A request id consisting only of unsafe characters would otherwise sanitise to an empty
+    // string and produce the same prefix for every such request (sqlquery__patients), defeating
+    // the namespacing fix.
+    final String dashes = ViewRegistrationService.resolveTempViewName("---", "patients");
+    final String slashes = ViewRegistrationService.resolveTempViewName("///", "patients");
+    assertThat(dashes).startsWith("sqlquery_r").endsWith("_patients");
+    assertThat(slashes).startsWith("sqlquery_r").endsWith("_patients");
+    assertThat(dashes).isNotEqualTo(slashes);
+  }
+
   // ---------------------------------------------------------------------------
   // SQL rewriting.
   // ---------------------------------------------------------------------------

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import au.csiro.pathling.config.ServerConfiguration;
+import ca.uhn.fhir.context.FhirContext;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+/**
+ * Tests for {@link ViewRegistrationService}, with particular attention to the request-id
+ * namespacing that prevents concurrent {@code $sqlquery-run} requests from clobbering one another's
+ * temporary views in Spark's session-global catalog.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+class ViewRegistrationServiceTest {
+
+  private SparkSession spark;
+  private ViewRegistrationService service;
+
+  @BeforeAll
+  void setUp() {
+    spark =
+        SparkSession.builder()
+            .master("local[2]")
+            .appName("ViewRegistrationServiceTest")
+            .config("spark.driver.bindAddress", "localhost")
+            .config("spark.driver.host", "localhost")
+            .config("spark.ui.enabled", false)
+            .config("spark.sql.shuffle.partitions", 1)
+            .getOrCreate();
+    service = new ViewRegistrationService(spark, FhirContext.forR4(), new ServerConfiguration());
+  }
+
+  @AfterAll
+  void tearDown() {
+    if (spark != null) {
+      spark.stop();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Temp view name resolution.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void resolveTempViewNamePrefixesRequestIdAndLabel() {
+    assertThat(ViewRegistrationService.resolveTempViewName("abc123", "patients"))
+        .isEqualTo("sqlquery_abc123_patients");
+  }
+
+  @Test
+  void resolveTempViewNameStripsUnsafeCharactersFromRequestId() {
+    // X-Request-ID may carry arbitrary characters; the resulting identifier must remain a
+    // legal Spark temp view name.
+    assertThat(ViewRegistrationService.resolveTempViewName("req-A:b/c", "patients"))
+        .isEqualTo("sqlquery_reqAbc_patients");
+  }
+
+  @Test
+  void resolveTempViewNameProducesDistinctNamesForDistinctRequestIds() {
+    final String a = ViewRegistrationService.resolveTempViewName("requestA", "patients");
+    final String b = ViewRegistrationService.resolveTempViewName("requestB", "patients");
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  // ---------------------------------------------------------------------------
+  // SQL rewriting.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void rewriteSqlSubstitutesLabelsWithViewNames() {
+    final String rewritten =
+        service.rewriteSql("SELECT * FROM patients", Map.of("patients", "sqlquery_req1_patients"));
+    assertThat(rewritten).isEqualTo("SELECT * FROM sqlquery_req1_patients");
+  }
+
+  @Test
+  void rewriteSqlMatchesOnWordBoundariesOnly() {
+    // The label "patients" should not be substituted inside the unrelated identifier
+    // "patients_archive".
+    final String rewritten =
+        service.rewriteSql(
+            "SELECT * FROM patients JOIN patients_archive ON patients.id = patients_archive.id",
+            Map.of("patients", "sqlquery_req1_patients"));
+    assertThat(rewritten).contains("FROM sqlquery_req1_patients JOIN patients_archive");
+    assertThat(rewritten).contains("ON sqlquery_req1_patients.id = patients_archive.id");
+  }
+
+  @Test
+  void rewriteSqlPrefersLongerLabelsToAvoidPartialReplacement() {
+    final String rewritten =
+        service.rewriteSql(
+            "SELECT * FROM obs JOIN obs_summary ON obs.id = obs_summary.id",
+            Map.of("obs", "sqlquery_req1_obs", "obs_summary", "sqlquery_req1_obs_summary"));
+    // The longer label is rewritten cleanly; the shorter label only matches the bare token.
+    assertThat(rewritten).contains("FROM sqlquery_req1_obs ");
+    assertThat(rewritten).contains("JOIN sqlquery_req1_obs_summary ");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Concurrent registration regression.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Regression test for two concurrent requests registering a view under the same label. Without
+   * request-id namespacing, the second {@code createOrReplaceTempView} call would overwrite the
+   * first, so request A would observe request B's data. With namespacing, each request resolves a
+   * distinct temp view name and the two queries remain isolated.
+   */
+  @Test
+  void concurrentRegistrationsWithSameLabelAreIsolated() throws Exception {
+    final Dataset<Row> datasetA = singleColumnDataset("value", List.of("A1", "A2"));
+    final Dataset<Row> datasetB = singleColumnDataset("value", List.of("B1", "B2", "B3"));
+
+    final ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      final Callable<List<String>> taskA =
+          () -> runRegisterAndRead("requestA", "patients", datasetA);
+      final Callable<List<String>> taskB =
+          () -> runRegisterAndRead("requestB", "patients", datasetB);
+
+      final Future<List<String>> futureA = executor.submit(taskA);
+      final Future<List<String>> futureB = executor.submit(taskB);
+
+      final List<String> resultA = futureA.get(60, TimeUnit.SECONDS);
+      final List<String> resultB = futureB.get(60, TimeUnit.SECONDS);
+
+      assertThat(resultA).containsExactlyInAnyOrder("A1", "A2");
+      assertThat(resultB).containsExactlyInAnyOrder("B1", "B2", "B3");
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  /**
+   * Reads back the registered view through SQL and then drops it, so the test exercises the same
+   * register / query / drop sequence the production code performs for a single request.
+   */
+  private List<String> runRegisterAndRead(
+      final String requestId, final String label, final Dataset<Row> dataset) {
+    final String tempViewName = service.registerDataset(label, dataset, requestId);
+    try {
+      final String rewrittenSql =
+          service.rewriteSql("SELECT value FROM " + label, Map.of(label, tempViewName));
+      return spark.sql(rewrittenSql).collectAsList().stream().map(row -> row.getString(0)).toList();
+    } finally {
+      service.dropViews(List.of(tempViewName));
+    }
+  }
+
+  private Dataset<Row> singleColumnDataset(final String columnName, final List<String> values) {
+    final StructType schema =
+        DataTypes.createStructType(
+            new org.apache.spark.sql.types.StructField[] {
+              DataTypes.createStructField(columnName, DataTypes.StringType, false)
+            });
+    final List<Row> rows =
+        Arrays.stream(values.toArray(new String[0])).map(v -> (Row) RowFactory.create(v)).toList();
+    return spark.createDataFrame(rows, schema);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
@@ -190,7 +190,7 @@ class ViewRegistrationServiceTest {
               DataTypes.createStructField(columnName, DataTypes.StringType, false)
             });
     final List<Row> rows =
-        Arrays.stream(values.toArray(new String[0])).map(v -> (Row) RowFactory.create(v)).toList();
+        Arrays.stream(values.toArray(new String[0])).map(RowFactory::create).toList();
     return spark.createDataFrame(rows, schema);
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
@@ -144,6 +144,75 @@ class ViewRegistrationServiceTest {
     assertThat(rewritten).contains("JOIN sqlquery_req1_obs_summary ");
   }
 
+  @Test
+  void rewriteSqlPreservesSingleQuotedLiteralsContainingLabel() {
+    final String rewritten =
+        service.rewriteSql(
+            "SELECT * FROM patients WHERE name = 'patients'",
+            Map.of("patients", "sqlquery_req1_patients"));
+    assertThat(rewritten).isEqualTo("SELECT * FROM sqlquery_req1_patients WHERE name = 'patients'");
+  }
+
+  @Test
+  void rewriteSqlPreservesDoubleQuotedLiteralsContainingLabel() {
+    final String rewritten =
+        service.rewriteSql(
+            "SELECT * FROM patients WHERE note = \"patients are interesting\"",
+            Map.of("patients", "sqlquery_req1_patients"));
+    assertThat(rewritten)
+        .isEqualTo(
+            "SELECT * FROM sqlquery_req1_patients WHERE note = \"patients are interesting\"");
+  }
+
+  @Test
+  void rewriteSqlPreservesLineCommentMentioningLabel() {
+    final String rewritten =
+        service.rewriteSql(
+            "SELECT * FROM patients -- patients comment\nWHERE x = 1",
+            Map.of("patients", "sqlquery_req1_patients"));
+    assertThat(rewritten)
+        .isEqualTo("SELECT * FROM sqlquery_req1_patients -- patients comment\nWHERE x = 1");
+  }
+
+  @Test
+  void rewriteSqlPreservesBlockCommentMentioningLabel() {
+    final String rewritten =
+        service.rewriteSql(
+            "SELECT /* patients in here */ * FROM patients",
+            Map.of("patients", "sqlquery_req1_patients"));
+    assertThat(rewritten).isEqualTo("SELECT /* patients in here */ * FROM sqlquery_req1_patients");
+  }
+
+  @Test
+  void rewriteSqlHandlesDoubledQuoteEscape() {
+    // Spark accepts doubled single quotes as an embedded apostrophe. The 'pat''s patients'
+    // literal must be preserved including the inner "patients" word.
+    final String rewritten =
+        service.rewriteSql(
+            "SELECT * FROM patients WHERE label = 'pat''s patients'",
+            Map.of("patients", "sqlquery_req1_patients"));
+    assertThat(rewritten)
+        .isEqualTo("SELECT * FROM sqlquery_req1_patients WHERE label = 'pat''s patients'");
+  }
+
+  @Test
+  void rewriteSqlRewritesBacktickQuotedLabel() {
+    final String rewritten =
+        service.rewriteSql(
+            "SELECT * FROM `patients`", Map.of("patients", "sqlquery_req1_patients"));
+    assertThat(rewritten).isEqualTo("SELECT * FROM sqlquery_req1_patients");
+  }
+
+  @Test
+  void rewriteSqlPreservesBacktickIdentifierThatIsNotALabel() {
+    final String rewritten =
+        service.rewriteSql(
+            "SELECT * FROM patients WHERE `random col` = 'x'",
+            Map.of("patients", "sqlquery_req1_patients"));
+    assertThat(rewritten)
+        .isEqualTo("SELECT * FROM sqlquery_req1_patients WHERE `random col` = 'x'");
+  }
+
   // ---------------------------------------------------------------------------
   // Concurrent registration regression.
   // ---------------------------------------------------------------------------

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
@@ -129,8 +129,9 @@ class ViewRegistrationServiceTest {
         service.rewriteSql(
             "SELECT * FROM patients JOIN patients_archive ON patients.id = patients_archive.id",
             Map.of("patients", "sqlquery_req1_patients"));
-    assertThat(rewritten).contains("FROM sqlquery_req1_patients JOIN patients_archive");
-    assertThat(rewritten).contains("ON sqlquery_req1_patients.id = patients_archive.id");
+    assertThat(rewritten)
+        .contains("FROM sqlquery_req1_patients JOIN patients_archive")
+        .contains("ON sqlquery_req1_patients.id = patients_archive.id");
   }
 
   @Test
@@ -140,8 +141,9 @@ class ViewRegistrationServiceTest {
             "SELECT * FROM obs JOIN obs_summary ON obs.id = obs_summary.id",
             Map.of("obs", "sqlquery_req1_obs", "obs_summary", "sqlquery_req1_obs_summary"));
     // The longer label is rewritten cleanly; the shorter label only matches the bare token.
-    assertThat(rewritten).contains("FROM sqlquery_req1_obs ");
-    assertThat(rewritten).contains("JOIN sqlquery_req1_obs_summary ");
+    assertThat(rewritten)
+        .contains("FROM sqlquery_req1_obs ")
+        .contains("JOIN sqlquery_req1_obs_summary ");
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewResolverTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewResolverTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import au.csiro.pathling.config.AuthorizationConfiguration;
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.encoders.ViewDefinitionResource;
+import au.csiro.pathling.encoders.ViewDefinitionResource.ColumnComponent;
+import au.csiro.pathling.encoders.ViewDefinitionResource.SelectComponent;
+import au.csiro.pathling.errors.ResourceNotFoundError;
+import au.csiro.pathling.read.ReadExecutor;
+import au.csiro.pathling.views.FhirView;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import jakarta.annotation.Nonnull;
+import java.util.List;
+import java.util.Map;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ViewResolver} covering id extraction, label-order preservation, and the
+ * read-error and parse-error wrapping paths.
+ */
+class ViewResolverTest {
+
+  private ReadExecutor readExecutor;
+  private ServerConfiguration serverConfiguration;
+  private ViewResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    readExecutor = mock(ReadExecutor.class);
+    serverConfiguration = new ServerConfiguration();
+    final AuthorizationConfiguration auth = new AuthorizationConfiguration();
+    auth.setEnabled(false);
+    serverConfiguration.setAuth(auth);
+    resolver = new ViewResolver(readExecutor, serverConfiguration, FhirContext.forR4());
+  }
+
+  @Test
+  void resolvesEmptyReferenceListToEmptyMap() {
+    final Map<String, FhirView> resolved = resolver.resolve(List.of());
+    assertThat(resolved).isEmpty();
+  }
+
+  @Test
+  void resolvesSingleReferenceByBareId() {
+    when(readExecutor.read("ViewDefinition", "patient-view"))
+        .thenReturn(simpleViewDefinition("patient-view", "Patient"));
+
+    final Map<String, FhirView> resolved =
+        resolver.resolve(List.of(new ViewArtifactReference("patients", "patient-view")));
+
+    assertThat(resolved).containsOnlyKeys("patients");
+    assertThat(resolved.get("patients").getResource()).isEqualTo("Patient");
+  }
+
+  @Test
+  void extractsIdFromCanonicalUrl() {
+    when(readExecutor.read("ViewDefinition", "obs-view"))
+        .thenReturn(simpleViewDefinition("obs-view", "Observation"));
+
+    final Map<String, FhirView> resolved =
+        resolver.resolve(
+            List.of(
+                new ViewArtifactReference("obs", "https://example.org/ViewDefinition/obs-view")));
+
+    assertThat(resolved).containsOnlyKeys("obs");
+    assertThat(resolved.get("obs").getResource()).isEqualTo("Observation");
+  }
+
+  @Test
+  void preservesLabelOrderAcrossMultipleReferences() {
+    when(readExecutor.read("ViewDefinition", "a")).thenReturn(simpleViewDefinition("a", "Patient"));
+    when(readExecutor.read("ViewDefinition", "b"))
+        .thenReturn(simpleViewDefinition("b", "Observation"));
+    when(readExecutor.read("ViewDefinition", "c"))
+        .thenReturn(simpleViewDefinition("c", "Condition"));
+
+    final Map<String, FhirView> resolved =
+        resolver.resolve(
+            List.of(
+                new ViewArtifactReference("first", "a"),
+                new ViewArtifactReference("second", "b"),
+                new ViewArtifactReference("third", "c")));
+
+    assertThat(resolved.keySet()).containsExactly("first", "second", "third");
+  }
+
+  @Test
+  void wrapsReadExecutorFailureWithLabelAndReference() {
+    when(readExecutor.read("ViewDefinition", "missing"))
+        .thenThrow(new ResourceNotFoundError("not there"));
+
+    final List<ViewArtifactReference> refs =
+        List.of(new ViewArtifactReference("patients", "missing"));
+
+    assertThatThrownBy(() -> resolver.resolve(refs))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("patients")
+        .hasMessageContaining("missing");
+  }
+
+  @Nonnull
+  private static ViewDefinitionResource simpleViewDefinition(
+      @Nonnull final String id, @Nonnull final String resourceType) {
+    final ViewDefinitionResource view = new ViewDefinitionResource();
+    view.setId(id);
+    view.setName(new StringType(id + "_view"));
+    view.setResource(new CodeType(resourceType));
+    view.setStatus(new CodeType("active"));
+    final SelectComponent select = new SelectComponent();
+    final ColumnComponent column = new ColumnComponent();
+    column.setName(new StringType("id"));
+    column.setPath(new StringType("id"));
+    select.getColumn().add(column);
+    view.getSelect().add(select);
+    return view;
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/view/ResultStreamingHelperTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/view/ResultStreamingHelperTest.java
@@ -178,10 +178,10 @@ class ResultStreamingHelperTest {
               DataTypes.createStructField(
                   "tags", DataTypes.createArrayType(DataTypes.StringType), true)
             });
-    final List<Row> rows = List.of();
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    final Iterator<Row> rows = List.<Row>of().iterator();
 
-    assertThatThrownBy(
-            () -> helper.streamFhirJson(new ByteArrayOutputStream(), rows.iterator(), schema))
+    assertThatThrownBy(() -> helper.streamFhirJson(out, rows, schema))
         .isInstanceOf(UnprocessableEntityException.class)
         .hasMessageContaining("tags");
   }
@@ -198,11 +198,10 @@ class ResultStreamingHelperTest {
             new org.apache.spark.sql.types.StructField[] {
               DataTypes.createStructField("payload", nested, true)
             });
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    final Iterator<Row> rows = List.<Row>of().iterator();
 
-    assertThatThrownBy(
-            () ->
-                helper.streamFhirJson(
-                    new ByteArrayOutputStream(), List.<Row>of().iterator(), schema))
+    assertThatThrownBy(() -> helper.streamFhirJson(out, rows, schema))
         .isInstanceOf(UnprocessableEntityException.class)
         .hasMessageContaining("payload");
   }

--- a/server/src/test/java/au/csiro/pathling/operations/view/ResultStreamingHelperTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/view/ResultStreamingHelperTest.java
@@ -207,6 +207,146 @@ class ResultStreamingHelperTest {
   }
 
   // ---------------------------------------------------------------------------
+  // NDJSON streaming.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void streamsNdjsonOneLinePerRow() throws Exception {
+    final StructType schema = idNameSchema();
+    final List<Row> rows = List.of(RowFactory.create(1, "alice"), RowFactory.create(2, "bob"));
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    helper.streamNdjson(out, rows.iterator(), schema);
+
+    final String body = out.toString(StandardCharsets.UTF_8);
+    final String[] lines = body.split("\n");
+    assertThat(lines).hasSize(2);
+    assertThat(lines[0]).contains("\"id\":1").contains("\"name\":\"alice\"");
+    assertThat(lines[1]).contains("\"id\":2").contains("\"name\":\"bob\"");
+  }
+
+  @Test
+  void streamsNdjsonOmitsNullValuesPerSpec() throws Exception {
+    final StructType schema = idNameSchema();
+    final List<Row> rows = List.of(RowFactory.create(1, null));
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    helper.streamNdjson(out, rows.iterator(), schema);
+
+    assertThat(out.toString(StandardCharsets.UTF_8)).contains("\"id\":1").doesNotContain("name");
+  }
+
+  // ---------------------------------------------------------------------------
+  // CSV header + body streaming.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void writeCsvHeaderEmitsCommaSeparatedColumnNames() throws Exception {
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    helper.writeCsvHeader(out, List.of("id", "name", "active"));
+
+    assertThat(out.toString(StandardCharsets.UTF_8)).startsWith("id,name,active");
+  }
+
+  @Test
+  void streamsCsvOneRecordPerRow() throws Exception {
+    final StructType schema = idNameSchema();
+    final List<Row> rows = List.of(RowFactory.create(1, "alice"), RowFactory.create(2, "bob"));
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    helper.streamCsv(out, rows.iterator(), schema);
+
+    final String body = out.toString(StandardCharsets.UTF_8);
+    assertThat(body).contains("1,alice").contains("2,bob");
+  }
+
+  @Test
+  void streamsCsvQuotesValueContainingDelimiter() throws Exception {
+    final StructType schema = idNameSchema();
+    final List<Row> rows = List.of(RowFactory.create(1, "smith, john"));
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    helper.streamCsv(out, rows.iterator(), schema);
+
+    assertThat(out.toString(StandardCharsets.UTF_8)).contains("\"smith, john\"");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Single-document JSON.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void writeJsonEmitsArrayOfObjects() throws Exception {
+    final StructType schema = idNameSchema();
+    final List<Row> rows = List.of(RowFactory.create(1, "alice"), RowFactory.create(2, "bob"));
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    helper.writeJson(out, rows.iterator(), schema);
+
+    final JsonArray array =
+        JsonParser.parseString(out.toString(StandardCharsets.UTF_8)).getAsJsonArray();
+    assertThat(array.size()).isEqualTo(2);
+    final JsonObject first = array.get(0).getAsJsonObject();
+    assertThat(first.get("id").getAsInt()).isEqualTo(1);
+    assertThat(first.get("name").getAsString()).isEqualTo("alice");
+  }
+
+  @Test
+  void writeJsonEmitsEmptyArrayForNoRows() throws Exception {
+    final StructType schema = idNameSchema();
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    helper.writeJson(out, List.<Row>of().iterator(), schema);
+
+    assertThat(out.toString(StandardCharsets.UTF_8)).isEqualTo("[]");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Misc value conversion.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void convertValueReturnsNullForNullInput() {
+    assertThat(helper.convertValue(null, DataTypes.StringType)).isNull();
+  }
+
+  @Test
+  void convertValueForCsvJsonifiesNestedRow() {
+    final StructType nested =
+        DataTypes.createStructType(
+            new org.apache.spark.sql.types.StructField[] {
+              DataTypes.createStructField("inner", DataTypes.StringType, true)
+            });
+    final Row nestedRow = RowFactory.create("hello");
+    final Object converted = helper.convertValueForCsv(nestedRow, nested);
+    assertThat(converted).isInstanceOf(String.class);
+    assertThat((String) converted).contains("\"inner\"").contains("\"hello\"");
+  }
+
+  @Test
+  void convertValueForCsvPassesThroughScalars() {
+    assertThat(helper.convertValueForCsv("alice", DataTypes.StringType)).isEqualTo("alice");
+    assertThat(helper.convertValueForCsv(42, DataTypes.IntegerType)).isEqualTo(42);
+    assertThat(helper.convertValueForCsv(null, DataTypes.StringType)).isNull();
+  }
+
+  @Test
+  void rowToListPreservesColumnOrder() {
+    final StructType schema = idNameSchema();
+    final Row row = RowFactory.create(7, "alice");
+    assertThat(helper.rowToList(row, schema)).containsExactly(7, "alice");
+  }
+
+  private static StructType idNameSchema() {
+    return DataTypes.createStructType(
+        new org.apache.spark.sql.types.StructField[] {
+          DataTypes.createStructField("id", DataTypes.IntegerType, false),
+          DataTypes.createStructField("name", DataTypes.StringType, true)
+        });
+  }
+
+  // ---------------------------------------------------------------------------
   // Helpers.
   // ---------------------------------------------------------------------------
 

--- a/server/src/test/java/au/csiro/pathling/operations/view/ResultStreamingHelperTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/view/ResultStreamingHelperTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ResultStreamingHelper#streamFhirJson} — covers the typed Spark→FHIR mapping,
+ * NULL handling, and rejection of unsupported column types.
+ */
+class ResultStreamingHelperTest {
+
+  private ResultStreamingHelper helper;
+
+  @BeforeEach
+  void setUp() {
+    helper = new ResultStreamingHelper(new Gson());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Top-level envelope.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void emitsParametersResourceEnvelope() throws Exception {
+    final StructType schema =
+        DataTypes.createStructType(
+            new org.apache.spark.sql.types.StructField[] {
+              DataTypes.createStructField("name", DataTypes.StringType, false)
+            });
+    final List<Row> rows = List.of(RowFactory.create("alice"));
+
+    final JsonObject result = streamAndParse(rows, schema);
+    assertThat(result.get("resourceType").getAsString()).isEqualTo("Parameters");
+    assertThat(result.has("parameter")).isTrue();
+  }
+
+  @Test
+  void emitsOneRowParameterPerResultRow() throws Exception {
+    final StructType schema =
+        DataTypes.createStructType(
+            new org.apache.spark.sql.types.StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, false)
+            });
+    final List<Row> rows =
+        List.of(RowFactory.create(1), RowFactory.create(2), RowFactory.create(3));
+
+    final JsonArray parameters = streamAndParse(rows, schema).getAsJsonArray("parameter");
+    assertThat(parameters.size()).isEqualTo(3);
+    for (int i = 0; i < parameters.size(); i++) {
+      assertThat(parameters.get(i).getAsJsonObject().get("name").getAsString()).isEqualTo("row");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Type mapping.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void mapsBooleanColumnToValueBoolean() throws Exception {
+    final JsonObject part = onlyPart("active", DataTypes.BooleanType, true);
+    assertThat(part.get("valueBoolean").getAsBoolean()).isTrue();
+  }
+
+  @Test
+  void mapsIntegerColumnToValueInteger() throws Exception {
+    final JsonObject part = onlyPart("age", DataTypes.IntegerType, 42);
+    assertThat(part.get("valueInteger").getAsInt()).isEqualTo(42);
+  }
+
+  @Test
+  void mapsLongColumnToValueDecimal() throws Exception {
+    final JsonObject part = onlyPart("count", DataTypes.LongType, 1234567890123L);
+    assertThat(part.get("valueDecimal").getAsLong()).isEqualTo(1234567890123L);
+  }
+
+  @Test
+  void mapsDoubleColumnToValueDecimal() throws Exception {
+    final JsonObject part = onlyPart("score", DataTypes.DoubleType, 3.14);
+    assertThat(part.get("valueDecimal").getAsDouble()).isEqualTo(3.14);
+  }
+
+  @Test
+  void mapsStringColumnToValueString() throws Exception {
+    final JsonObject part = onlyPart("name", DataTypes.StringType, "alice");
+    assertThat(part.get("valueString").getAsString()).isEqualTo("alice");
+  }
+
+  @Test
+  void mapsDateColumnToValueDate() throws Exception {
+    final JsonObject part = onlyPart("birth_date", DataTypes.DateType, Date.valueOf("1990-05-15"));
+    assertThat(part.get("valueDate").getAsString()).isEqualTo("1990-05-15");
+  }
+
+  @Test
+  void mapsTimestampColumnToValueInstant() throws Exception {
+    final JsonObject part =
+        onlyPart(
+            "created_at",
+            DataTypes.TimestampType,
+            Timestamp.from(java.time.Instant.parse("2026-01-15T10:30:00Z")));
+    assertThat(part.get("valueInstant").getAsString()).isEqualTo("2026-01-15T10:30:00Z");
+  }
+
+  @Test
+  void mapsBinaryColumnToValueBase64Binary() throws Exception {
+    final byte[] bytes = "hello".getBytes(StandardCharsets.UTF_8);
+    final JsonObject part = onlyPart("blob", DataTypes.BinaryType, bytes);
+    assertThat(part.get("valueBase64Binary").getAsString())
+        .isEqualTo(java.util.Base64.getEncoder().encodeToString(bytes));
+  }
+
+  // ---------------------------------------------------------------------------
+  // NULL handling.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void omitsPartForNullValue() throws Exception {
+    final StructType schema =
+        DataTypes.createStructType(
+            new org.apache.spark.sql.types.StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+              DataTypes.createStructField("nickname", DataTypes.StringType, true)
+            });
+    final List<Row> rows = List.of(RowFactory.create(7, null));
+
+    final JsonObject row =
+        streamAndParse(rows, schema).getAsJsonArray("parameter").get(0).getAsJsonObject();
+    final JsonArray parts = row.getAsJsonArray("part");
+
+    assertThat(parts.size()).isEqualTo(1);
+    assertThat(parts.get(0).getAsJsonObject().get("name").getAsString()).isEqualTo("id");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unsupported types.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void rejectsArrayColumn() {
+    final StructType schema =
+        DataTypes.createStructType(
+            new org.apache.spark.sql.types.StructField[] {
+              DataTypes.createStructField(
+                  "tags", DataTypes.createArrayType(DataTypes.StringType), true)
+            });
+    final List<Row> rows = List.of();
+
+    assertThatThrownBy(
+            () -> helper.streamFhirJson(new ByteArrayOutputStream(), rows.iterator(), schema))
+        .isInstanceOf(UnprocessableEntityException.class)
+        .hasMessageContaining("tags");
+  }
+
+  @Test
+  void rejectsStructColumn() {
+    final StructType nested =
+        DataTypes.createStructType(
+            new org.apache.spark.sql.types.StructField[] {
+              DataTypes.createStructField("inner", DataTypes.StringType, true)
+            });
+    final StructType schema =
+        DataTypes.createStructType(
+            new org.apache.spark.sql.types.StructField[] {
+              DataTypes.createStructField("payload", nested, true)
+            });
+
+    assertThatThrownBy(
+            () ->
+                helper.streamFhirJson(
+                    new ByteArrayOutputStream(), List.<Row>of().iterator(), schema))
+        .isInstanceOf(UnprocessableEntityException.class)
+        .hasMessageContaining("payload");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers.
+  // ---------------------------------------------------------------------------
+
+  private JsonObject streamAndParse(final List<Row> rows, final StructType schema)
+      throws Exception {
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    final Iterator<Row> iterator = rows.iterator();
+    helper.streamFhirJson(out, iterator, schema);
+    return JsonParser.parseString(out.toString(StandardCharsets.UTF_8)).getAsJsonObject();
+  }
+
+  private JsonObject onlyPart(
+      final String columnName, final org.apache.spark.sql.types.DataType type, final Object value)
+      throws Exception {
+    final StructType schema =
+        DataTypes.createStructType(
+            new org.apache.spark.sql.types.StructField[] {
+              DataTypes.createStructField(columnName, type, true)
+            });
+    final List<Row> rows = List.of(RowFactory.create(value));
+    final JsonObject root = streamAndParse(rows, schema);
+    final JsonArray parameters = root.getAsJsonArray("parameter");
+    assertThat(parameters.size()).isEqualTo(1);
+    final JsonArray parts = parameters.get(0).getAsJsonObject().getAsJsonArray("part");
+    assertThat(parts.size()).isEqualTo(1);
+    final JsonObject part = parts.get(0).getAsJsonObject();
+    assertThat(part.get("name").getAsString()).isEqualTo(columnName);
+    return part;
+  }
+}

--- a/site/docs/server/configuration.md
+++ b/site/docs/server/configuration.md
@@ -129,6 +129,21 @@ error response and is excluded from the CapabilityStatement.
 - `pathling.operations.bulkSubmitEnabled` - (default: `true`) Enables the
   [$bulk-submit](./operations/bulk-submit) operation.
 
+### SQL query
+
+These settings apply resource limits to the `$sqlquery-run` operation. Both
+limits are always applied; they cannot be disabled per request.
+
+- `pathling.sqlQuery.maxRows` - (default: `1000000`) The maximum number of rows
+  that a single `$sqlquery-run` response may stream. Always applied; clamps the
+  caller-supplied `_limit` when that value is larger.
+- `pathling.sqlQuery.timeoutSeconds` - (default: `60`) The maximum wall-clock
+  time in seconds that a single query may run before its Spark job group is
+  cancelled. A timeout that fires before the response stream begins produces a
+  4xx response; a timeout that fires mid-stream aborts the connection and is
+  recorded as a server warning. Long-running queries should use the
+  asynchronous path.
+
 ### Encoding
 
 - `pathling.encoding.maxNestingLevel` - (default: `3`) Controls the maximum

--- a/ui/e2e/fixtures/fhirData.ts
+++ b/ui/e2e/fixtures/fhirData.ts
@@ -349,6 +349,93 @@ export const mockViewRunNdjson =
 export const mockEmptyViewRunNdjson = "";
 
 // ============================================================================
+// SQL query (sql-query) Library mocks
+// ============================================================================
+
+/**
+ * Mock SQLQuery Library for use in `$sqlquery-run` tests.
+ *
+ * Carries Base64-encoded SQL ("SELECT 1"), references a single
+ * ViewDefinition and declares one runtime parameter.
+ */
+export const mockSqlQueryLibrary1 = {
+  resourceType: "Library",
+  id: "lib-sample",
+  status: "active",
+  title: "Sample SQL query",
+  type: {
+    coding: [
+      {
+        system: "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes",
+        code: "sql-query",
+      },
+    ],
+  },
+  content: [
+    {
+      contentType: "application/sql",
+      data: "U0VMRUNUIDE=",
+    },
+  ],
+  relatedArtifact: [
+    {
+      type: "depends-on",
+      label: "patients",
+      resource: "ViewDefinition/patient-demographics",
+    },
+  ],
+  parameter: [{ name: "patient_id", use: "in", type: "string" }],
+};
+
+/**
+ * Mock Bundle containing SQLQuery Library search results.
+ */
+export const mockSqlQueryLibraryBundle: Bundle = {
+  resourceType: "Bundle",
+  type: "searchset",
+  total: 1,
+  entry: [
+    {
+      resource: mockSqlQueryLibrary1 as Bundle["entry"] extends (infer T)[]
+        ? T extends { resource?: infer R }
+          ? R
+          : never
+        : never,
+    },
+  ],
+};
+
+/**
+ * Mock empty SQLQuery Library Bundle for testing the empty state.
+ */
+export const mockEmptySqlQueryLibraryBundle: Bundle = {
+  resourceType: "Bundle",
+  type: "searchset",
+  total: 0,
+  entry: [],
+};
+
+/**
+ * Mock CSV body for `$sqlquery-run` results.
+ */
+export const mockSqlQueryRunCsv =
+  "patient_id,given_name\npat-1,Alice\npat-2,Bob";
+
+/**
+ * Mock OperationOutcome body for `$sqlquery-run` validation failures.
+ */
+export const mockSqlQueryRunOperationOutcome = {
+  resourceType: "OperationOutcome",
+  issue: [
+    {
+      severity: "error",
+      code: "invalid",
+      diagnostics: "SQL contains a disallowed operation",
+    },
+  ],
+};
+
+// ============================================================================
 // Authentication Mocks
 // ============================================================================
 

--- a/ui/e2e/sqlQuery.spec.ts
+++ b/ui/e2e/sqlQuery.spec.ts
@@ -37,7 +37,8 @@ import type { Page } from "@playwright/test";
 
 /**
  * Mocks the `metadata` endpoint without auth requirements.
- * @param page
+ *
+ * @param page - The Playwright Page to attach the route to.
  */
 async function mockMetadata(page: Page) {
   await page.route("**/metadata", async (route) => {
@@ -53,8 +54,9 @@ async function mockMetadata(page: Page) {
  * Mocks the Library search endpoint, branching on the type filter so the
  * SQLQuery search returns the SQLQuery bundle while other Library
  * searches return an empty bundle.
- * @param page
- * @param bundle
+ *
+ * @param page - The Playwright Page to attach the route to.
+ * @param bundle - The Bundle to return for SQLQuery searches.
  */
 async function mockSqlQueryLibraries(
   page: Page,
@@ -86,7 +88,8 @@ async function mockSqlQueryLibraries(
 /**
  * Mocks the ViewDefinition search endpoint with the standard fixture so
  * the inline tab's table picker has options to render.
- * @param page
+ *
+ * @param page - The Playwright Page to attach the route to.
  */
 async function mockViewDefinitions(page: Page) {
   const fulfill = (route: import("@playwright/test").Route) =>
@@ -101,7 +104,8 @@ async function mockViewDefinitions(page: Page) {
 
 /**
  * Mocks the `$sqlquery-run` endpoint with a CSV response.
- * @param page
+ *
+ * @param page - The Playwright Page to attach the route to.
  */
 async function mockSqlQueryRunCsvResponse(page: Page) {
   await page.route("**/$sqlquery-run", async (route) => {
@@ -115,7 +119,8 @@ async function mockSqlQueryRunCsvResponse(page: Page) {
 
 /**
  * Mocks the `$sqlquery-run` endpoint with a 400 + OperationOutcome response.
- * @param page
+ *
+ * @param page - The Playwright Page to attach the route to.
  */
 async function mockSqlQueryRunFailure(page: Page) {
   await page.route("**/$sqlquery-run", async (route) => {
@@ -129,7 +134,8 @@ async function mockSqlQueryRunFailure(page: Page) {
 
 /**
  * Mocks the Library create endpoint to return a created Library.
- * @param page
+ *
+ * @param page - The Playwright Page to attach the route to.
  */
 async function mockSaveSqlQueryLibrary(page: Page) {
   await page.route(/\/Library$/, async (route) => {
@@ -156,7 +162,8 @@ async function mockSaveSqlQueryLibrary(page: Page) {
 
 /**
  * Switches the page to SQL query mode using the segmented control.
- * @param page
+ *
+ * @param page - The Playwright Page on the SQL on FHIR route.
  */
 async function selectSqlQueryMode(page: Page) {
   await page.getByRole("tab", { name: /^sql query$/i }).click();

--- a/ui/e2e/sqlQuery.spec.ts
+++ b/ui/e2e/sqlQuery.spec.ts
@@ -1,0 +1,288 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * E2E tests for the SQL on FHIR page in `$sqlquery-run` mode.
+ *
+ * @author John Grimes
+ */
+
+import { expect, test } from "@playwright/test";
+
+import {
+  mockCapabilityStatement,
+  mockEmptySqlQueryLibraryBundle,
+  mockSqlQueryLibrary1,
+  mockSqlQueryLibraryBundle,
+  mockSqlQueryRunCsv,
+  mockSqlQueryRunOperationOutcome,
+  mockViewDefinitionBundle,
+} from "./fixtures/fhirData";
+
+import type { Page } from "@playwright/test";
+
+/**
+ * Mocks the `metadata` endpoint without auth requirements.
+ * @param page
+ */
+async function mockMetadata(page: Page) {
+  await page.route("**/metadata", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/fhir+json",
+      body: JSON.stringify(mockCapabilityStatement),
+    });
+  });
+}
+
+/**
+ * Mocks the Library search endpoint, branching on the type filter so the
+ * SQLQuery search returns the SQLQuery bundle while other Library
+ * searches return an empty bundle.
+ * @param page
+ * @param bundle
+ */
+async function mockSqlQueryLibraries(
+  page: Page,
+  bundle: object = mockSqlQueryLibraryBundle,
+) {
+  await page.route(/\/Library\?[^"]*$/, async (route) => {
+    const url = route.request().url();
+    if (url.includes("sql-query")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/fhir+json",
+        body: JSON.stringify(bundle),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/fhir+json",
+      body: JSON.stringify({
+        resourceType: "Bundle",
+        type: "searchset",
+        total: 0,
+        entry: [],
+      }),
+    });
+  });
+}
+
+/**
+ * Mocks the ViewDefinition search endpoint with the standard fixture so
+ * the inline tab's table picker has options to render.
+ * @param page
+ */
+async function mockViewDefinitions(page: Page) {
+  const fulfill = (route: import("@playwright/test").Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/fhir+json",
+      body: JSON.stringify(mockViewDefinitionBundle),
+    });
+  await page.route("**/ViewDefinition?*", fulfill);
+  await page.route(/\/ViewDefinition$/, fulfill);
+}
+
+/**
+ * Mocks the `$sqlquery-run` endpoint with a CSV response.
+ * @param page
+ */
+async function mockSqlQueryRunCsvResponse(page: Page) {
+  await page.route("**/$sqlquery-run", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/csv",
+      body: mockSqlQueryRunCsv,
+    });
+  });
+}
+
+/**
+ * Mocks the `$sqlquery-run` endpoint with a 400 + OperationOutcome response.
+ * @param page
+ */
+async function mockSqlQueryRunFailure(page: Page) {
+  await page.route("**/$sqlquery-run", async (route) => {
+    await route.fulfill({
+      status: 400,
+      contentType: "application/fhir+json",
+      body: JSON.stringify(mockSqlQueryRunOperationOutcome),
+    });
+  });
+}
+
+/**
+ * Mocks the Library create endpoint to return a created Library.
+ * @param page
+ */
+async function mockSaveSqlQueryLibrary(page: Page) {
+  await page.route(/\/Library$/, async (route) => {
+    if (route.request().method() === "POST") {
+      const created = {
+        ...mockSqlQueryLibrary1,
+        id: "newly-created-library",
+        title: "Inline SQL query",
+      };
+      await route.fulfill({
+        status: 201,
+        contentType: "application/fhir+json",
+        body: JSON.stringify(created),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/fhir+json",
+      body: JSON.stringify(mockSqlQueryLibraryBundle),
+    });
+  });
+}
+
+/**
+ * Switches the page to SQL query mode using the segmented control.
+ * @param page
+ */
+async function selectSqlQueryMode(page: Page) {
+  await page.getByRole("tab", { name: /^sql query$/i }).click();
+}
+
+test.describe("SQL on FHIR page - SQL query mode", () => {
+  test("executes a stored Library and renders the result", async ({ page }) => {
+    await mockMetadata(page);
+    await mockSqlQueryLibraries(page);
+    await mockViewDefinitions(page);
+    await mockSqlQueryRunCsvResponse(page);
+
+    await page.goto("/admin/sql-on-fhir");
+    await selectSqlQueryMode(page);
+
+    // Pick the stored library.
+    await page.getByRole("combobox", { name: /sql query library/i }).click();
+    await page
+      .getByRole("option", { name: mockSqlQueryLibrary1.title })
+      .click();
+
+    // Enter a runtime value for the declared parameter.
+    await page
+      .getByRole("textbox", { name: /runtime value for patient_id/i })
+      .fill("Patient/pat-1");
+
+    // Switch the format to CSV so the response branch is deterministic.
+    await page.getByRole("combobox", { name: /output format/i }).click();
+    await page.getByRole("option", { name: "csv" }).click();
+
+    await page.getByRole("button", { name: /^execute$/i }).click();
+
+    await expect(page.getByText("2 rows")).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "patient_id" }),
+    ).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
+  });
+
+  test("authors and executes an inline Library", async ({ page }) => {
+    await mockMetadata(page);
+    await mockSqlQueryLibraries(page, mockEmptySqlQueryLibraryBundle);
+    await mockViewDefinitions(page);
+    await mockSqlQueryRunCsvResponse(page);
+
+    await page.goto("/admin/sql-on-fhir");
+    await selectSqlQueryMode(page);
+
+    // Switch to the Provide Library tab.
+    await page.getByRole("tab", { name: /provide sql/i }).click();
+
+    // Author the SQL.
+    await page.getByRole("textbox", { name: /^sql$/i }).fill("SELECT 1");
+
+    // Add a table row and select the first ViewDefinition.
+    await page.getByRole("button", { name: /add table/i }).click();
+    await page
+      .getByRole("textbox", { name: /label for table 1/i })
+      .fill("patients");
+    await page
+      .getByRole("combobox", { name: /view definition for table 1/i })
+      .click();
+    await page.getByRole("option", { name: "Patient Demographics" }).click();
+
+    // Use CSV output so the result rendering is deterministic.
+    await page.getByRole("combobox", { name: /output format/i }).click();
+    await page.getByRole("option", { name: "csv" }).click();
+
+    await page.getByRole("button", { name: /^execute$/i }).click();
+
+    await expect(page.getByText("2 rows")).toBeVisible();
+    await expect(page.getByRole("cell", { name: "pat-1" })).toBeVisible();
+  });
+
+  test("saves an inline Library and switches to the picker", async ({
+    page,
+  }) => {
+    await mockMetadata(page);
+    await mockSaveSqlQueryLibrary(page);
+    await mockViewDefinitions(page);
+
+    await page.goto("/admin/sql-on-fhir");
+    await selectSqlQueryMode(page);
+
+    await page.getByRole("tab", { name: /provide sql/i }).click();
+    await page
+      .getByRole("textbox", { name: /library title/i })
+      .fill("Inline SQL query");
+    await page.getByRole("textbox", { name: /^sql$/i }).fill("SELECT 1");
+    await page.getByRole("button", { name: /add table/i }).click();
+    await page
+      .getByRole("textbox", { name: /label for table 1/i })
+      .fill("patients");
+    await page
+      .getByRole("combobox", { name: /view definition for table 1/i })
+      .click();
+    await page.getByRole("option", { name: "Patient Demographics" }).click();
+
+    await page.getByRole("button", { name: /save to server/i }).click();
+
+    // The form switches back to the stored tab and selects the new Library.
+    await expect(
+      page.getByRole("tab", { name: /select query/i }),
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("renders a callout when the server returns 400", async ({ page }) => {
+    await mockMetadata(page);
+    await mockSqlQueryLibraries(page);
+    await mockViewDefinitions(page);
+    await mockSqlQueryRunFailure(page);
+
+    await page.goto("/admin/sql-on-fhir");
+    await selectSqlQueryMode(page);
+
+    await page.getByRole("combobox", { name: /sql query library/i }).click();
+    await page
+      .getByRole("option", { name: mockSqlQueryLibrary1.title })
+      .click();
+    await page
+      .getByRole("textbox", { name: /runtime value for patient_id/i })
+      .fill("Patient/pat-1");
+    await page.getByRole("button", { name: /^execute$/i }).click();
+
+    await expect(
+      page.getByText(/sql contains a disallowed operation/i),
+    ).toBeVisible();
+  });
+});

--- a/ui/src/api/__tests__/sqlQuery.test.ts
+++ b/ui/src/api/__tests__/sqlQuery.test.ts
@@ -1,0 +1,368 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OperationOutcomeError, UnauthorizedError } from "../../types/errors";
+import {
+  listSqlQueryLibraries,
+  SQL_QUERY_LIBRARY_TYPE_FILTER,
+  sqlQueryRun,
+} from "../sqlQuery";
+
+import type { SqlQueryLibrary } from "../../types/sqlQuery";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetAllMocks();
+});
+
+const sampleLibrary: SqlQueryLibrary = {
+  resourceType: "Library",
+  status: "active",
+  type: {
+    coding: [
+      {
+        system: "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes",
+        code: "sql-query",
+      },
+    ],
+  },
+  content: [
+    {
+      contentType: "application/sql",
+      data: "U0VMRUNUIDE=",
+    },
+  ],
+  relatedArtifact: [
+    {
+      type: "depends-on",
+      label: "patients",
+      resource: "ViewDefinition/patients",
+    },
+  ],
+};
+
+describe("sqlQueryRun", () => {
+  // The inline mode posts a Parameters body containing a `queryResource`
+  // entry whose value is the assembled Library.
+  it("posts queryResource in inline mode", async () => {
+    const body = new ReadableStream();
+    mockFetch.mockResolvedValueOnce(new Response(body, { status: 200 }));
+
+    await sqlQueryRun("https://example.com/fhir", {
+      mode: "inline",
+      library: sampleLibrary,
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/fhir/$sqlquery-run",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/fhir+json",
+        }),
+      }),
+    );
+    const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(requestBody.resourceType).toBe("Parameters");
+    expect(requestBody.parameter).toContainEqual(
+      expect.objectContaining({
+        name: "queryResource",
+        resource: expect.objectContaining({ resourceType: "Library" }),
+      }),
+    );
+  });
+
+  // The stored mode submits a `queryReference` parameter with a relative
+  // `Library/<id>` reference.
+  it("posts queryReference in stored mode", async () => {
+    const body = new ReadableStream();
+    mockFetch.mockResolvedValueOnce(new Response(body, { status: 200 }));
+
+    await sqlQueryRun("https://example.com/fhir", {
+      mode: "stored",
+      libraryId: "lib-123",
+    });
+
+    const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(requestBody.parameter).toContainEqual({
+      name: "queryReference",
+      valueReference: { reference: "Library/lib-123" },
+    });
+  });
+
+  // The format, limit and header options are translated into Parameters
+  // entries with the appropriate value[x] slots.
+  it("includes _format, _limit and _header parameters when supplied", async () => {
+    const body = new ReadableStream();
+    mockFetch.mockResolvedValueOnce(new Response(body, { status: 200 }));
+
+    await sqlQueryRun("https://example.com/fhir", {
+      mode: "stored",
+      libraryId: "lib-123",
+      format: "csv",
+      limit: 50,
+      header: true,
+    });
+
+    const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(requestBody.parameter).toContainEqual({
+      name: "_format",
+      valueString: "csv",
+    });
+    expect(requestBody.parameter).toContainEqual({
+      name: "_limit",
+      valueInteger: 50,
+    });
+    expect(requestBody.parameter).toContainEqual({
+      name: "_header",
+      valueBoolean: true,
+    });
+  });
+
+  // Empty bindings are omitted; non-empty bindings appear inside a nested
+  // Parameters resource on the `parameters` parameter.
+  it("nests runtime bindings as a Parameters resource", async () => {
+    const body = new ReadableStream();
+    mockFetch.mockResolvedValueOnce(new Response(body, { status: 200 }));
+
+    await sqlQueryRun("https://example.com/fhir", {
+      mode: "stored",
+      libraryId: "lib-123",
+      bindings: { patient_id: "Patient/pat-1", empty: "" },
+      parameterTypes: { patient_id: "string", empty: "string" },
+    });
+
+    const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const paramsParam = requestBody.parameter.find(
+      (p: { name: string }) => p.name === "parameters",
+    );
+    expect(paramsParam).toBeDefined();
+    expect(paramsParam.resource.resourceType).toBe("Parameters");
+    expect(paramsParam.resource.parameter).toEqual([
+      { name: "patient_id", valueString: "Patient/pat-1" },
+    ]);
+  });
+
+  // Bindings of different declared types map to the corresponding
+  // value[x] slot.
+  it("maps bindings to typed value[x] slots", async () => {
+    const body = new ReadableStream();
+    mockFetch.mockResolvedValueOnce(new Response(body, { status: 200 }));
+
+    await sqlQueryRun("https://example.com/fhir", {
+      mode: "stored",
+      libraryId: "lib-123",
+      bindings: {
+        s: "abc",
+        c: "approved",
+        i: "42",
+        d: "1.5",
+        b: "true",
+        date: "2025-01-01",
+        ts: "2025-01-01T12:00:00Z",
+      },
+      parameterTypes: {
+        s: "string",
+        c: "code",
+        i: "integer",
+        d: "decimal",
+        b: "boolean",
+        date: "date",
+        ts: "dateTime",
+      },
+    });
+
+    const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const paramsParam = requestBody.parameter.find(
+      (p: { name: string }) => p.name === "parameters",
+    );
+    expect(paramsParam.resource.parameter).toEqual([
+      { name: "s", valueString: "abc" },
+      { name: "c", valueCode: "approved" },
+      { name: "i", valueInteger: 42 },
+      { name: "d", valueDecimal: 1.5 },
+      { name: "b", valueBoolean: true },
+      { name: "date", valueDate: "2025-01-01" },
+      { name: "ts", valueDateTime: "2025-01-01T12:00:00Z" },
+    ]);
+  });
+
+  // The Authorization header is included when an access token is supplied.
+  it("attaches a bearer token when an access token is provided", async () => {
+    const body = new ReadableStream();
+    mockFetch.mockResolvedValueOnce(new Response(body, { status: 200 }));
+
+    await sqlQueryRun("https://example.com/fhir", {
+      mode: "stored",
+      libraryId: "lib-123",
+      accessToken: "secret",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer secret",
+        }),
+      }),
+    );
+  });
+
+  // The Accept header tracks the requested output format so the server
+  // can pick the right streaming branch.
+  it("sets the Accept header to match the requested format", async () => {
+    const body = new ReadableStream();
+    mockFetch.mockResolvedValueOnce(new Response(body, { status: 200 }));
+
+    await sqlQueryRun("https://example.com/fhir", {
+      mode: "stored",
+      libraryId: "lib-123",
+      format: "csv",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Accept: "text/csv" }),
+      }),
+    );
+  });
+
+  // A 401 response should surface as an UnauthorizedError so the global
+  // session-expired handler can react to it.
+  it("throws UnauthorizedError on a 401 response", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response("Unauthorized", { status: 401 }),
+    );
+    await expect(
+      sqlQueryRun("https://example.com/fhir", {
+        mode: "stored",
+        libraryId: "lib-123",
+      }),
+    ).rejects.toThrow(UnauthorizedError);
+  });
+
+  // A 400 response carrying an OperationOutcome surfaces as a structured
+  // error that preserves the diagnostics text.
+  it("throws OperationOutcomeError on a 400 with an OperationOutcome body", async () => {
+    const outcome = {
+      resourceType: "OperationOutcome",
+      issue: [
+        {
+          severity: "error",
+          code: "invalid",
+          diagnostics: "SQL contains a disallowed operation",
+        },
+      ],
+    };
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(outcome), {
+        status: 400,
+        headers: { "Content-Type": "application/fhir+json" },
+      }),
+    );
+    await expect(
+      sqlQueryRun("https://example.com/fhir", {
+        mode: "stored",
+        libraryId: "lib-123",
+      }),
+    ).rejects.toBeInstanceOf(OperationOutcomeError);
+  });
+});
+
+describe("listSqlQueryLibraries", () => {
+  // The search is scoped by the SQLQuery type code so unrelated Library
+  // resources are excluded.
+  it("queries Library with the SQLQuery type filter", async () => {
+    const bundle = {
+      resourceType: "Bundle",
+      entry: [],
+    };
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(bundle), {
+        status: 200,
+        headers: { "Content-Type": "application/fhir+json" },
+      }),
+    );
+
+    await listSqlQueryLibraries("https://example.com/fhir");
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/Library?");
+    expect(decodeURIComponent(url)).toContain(
+      `type=${SQL_QUERY_LIBRARY_TYPE_FILTER}`,
+    );
+  });
+
+  // Bundle entries are returned as-is so the hook layer can decide how to
+  // shape them for the picker.
+  it("returns the FHIR Bundle on success", async () => {
+    const bundle = {
+      resourceType: "Bundle",
+      entry: [{ resource: { resourceType: "Library", id: "lib-1" } }],
+    };
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(bundle), {
+        status: 200,
+        headers: { "Content-Type": "application/fhir+json" },
+      }),
+    );
+
+    const result = await listSqlQueryLibraries("https://example.com/fhir");
+    expect(result.entry?.[0]?.resource?.resourceType).toBe("Library");
+  });
+
+  // The Authorization header is forwarded for authenticated servers.
+  it("attaches a bearer token when an access token is provided", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ resourceType: "Bundle" }), {
+        status: 200,
+        headers: { "Content-Type": "application/fhir+json" },
+      }),
+    );
+    await listSqlQueryLibraries("https://example.com/fhir", {
+      accessToken: "secret",
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer secret",
+        }),
+      }),
+    );
+  });
+
+  // A 401 propagates as UnauthorizedError, consistent with the rest of
+  // the API layer.
+  it("throws UnauthorizedError on a 401 response", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response("Unauthorized", { status: 401 }),
+    );
+    await expect(
+      listSqlQueryLibraries("https://example.com/fhir"),
+    ).rejects.toThrow(UnauthorizedError);
+  });
+});

--- a/ui/src/api/__tests__/utils.test.ts
+++ b/ui/src/api/__tests__/utils.test.ts
@@ -28,8 +28,11 @@ import {
   checkResponse,
   extractJobIdFromUrl,
   parseProgressHeader,
+  pushOutputParameters,
   resolveUrl,
 } from "../utils";
+
+import type { ParametersParameter } from "fhir/r4";
 
 describe("buildHeaders", () => {
   it("returns Accept header with FHIR JSON by default", () => {
@@ -362,5 +365,44 @@ describe("parseProgressHeader", () => {
 
   it("handles decimal numbers by taking integer part", () => {
     expect(parseProgressHeader("50.5%")).toBe(50);
+  });
+});
+
+describe("pushOutputParameters", () => {
+  it("appends format, limit and header when supplied", () => {
+    const parts: ParametersParameter[] = [];
+    pushOutputParameters(parts, { format: "csv", limit: 100, header: true });
+    expect(parts).toEqual([
+      { name: "_format", valueString: "csv" },
+      { name: "_limit", valueInteger: 100 },
+      { name: "_header", valueBoolean: true },
+    ]);
+  });
+
+  it("omits options that are undefined", () => {
+    const parts: ParametersParameter[] = [];
+    pushOutputParameters(parts, { format: "ndjson" });
+    expect(parts).toEqual([{ name: "_format", valueString: "ndjson" }]);
+  });
+
+  it("preserves a header value of false", () => {
+    const parts: ParametersParameter[] = [];
+    pushOutputParameters(parts, { header: false });
+    expect(parts).toEqual([{ name: "_header", valueBoolean: false }]);
+  });
+
+  it("preserves a limit of zero", () => {
+    const parts: ParametersParameter[] = [];
+    pushOutputParameters(parts, { limit: 0 });
+    expect(parts).toEqual([{ name: "_limit", valueInteger: 0 }]);
+  });
+
+  it("appends to an existing array without removing existing entries", () => {
+    const parts: ParametersParameter[] = [{ name: "viewResource" }];
+    pushOutputParameters(parts, { format: "csv" });
+    expect(parts).toEqual([
+      { name: "viewResource" },
+      { name: "_format", valueString: "csv" },
+    ]);
   });
 });

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -59,3 +59,17 @@ export {
   viewExportDownload,
 } from "./view";
 export type { ViewDefinition } from "./view";
+
+// SQL query operations.
+export {
+  sqlQueryRun,
+  listSqlQueryLibraries,
+  SQL_QUERY_LIBRARY_TYPE_SYSTEM,
+  SQL_QUERY_LIBRARY_TYPE_FILTER,
+  SQL_QUERY_LIBRARY_PROFILE,
+} from "./sqlQuery";
+export type {
+  SqlQueryRunOptions,
+  SqlQueryRunStoredOptions,
+  SqlQueryRunInlineOptions,
+} from "./sqlQuery";

--- a/ui/src/api/sqlQuery.ts
+++ b/ui/src/api/sqlQuery.ts
@@ -22,7 +22,12 @@
  * @author John Grimes
  */
 
-import { buildHeaders, buildUrl, checkResponse } from "./utils";
+import {
+  buildHeaders,
+  buildUrl,
+  checkResponse,
+  pushOutputParameters,
+} from "./utils";
 
 import type { AuthOptions } from "./rest";
 import type {
@@ -154,15 +159,11 @@ export async function sqlQueryRun(
     });
   }
 
-  if (options.format !== undefined) {
-    parameter.push({ name: "_format", valueString: options.format });
-  }
-  if (options.limit !== undefined) {
-    parameter.push({ name: "_limit", valueInteger: options.limit });
-  }
-  if (options.header !== undefined) {
-    parameter.push({ name: "_header", valueBoolean: options.header });
-  }
+  pushOutputParameters(parameter, {
+    format: options.format,
+    limit: options.limit,
+    header: options.header,
+  });
 
   const bindingParam = buildBindingParameter(
     options.bindings,
@@ -218,8 +219,11 @@ export async function listSqlQueryLibraries(
 /**
  * Builds the nested `parameters` Parameters resource carrying runtime
  * bindings, or returns `undefined` if no non-empty bindings exist.
- * @param bindings
- * @param parameterTypes
+ *
+ * @param bindings - Runtime values keyed by declared parameter name.
+ * @param parameterTypes - Declared FHIR primitive types keyed by name.
+ * @returns The wrapping Parameters part, or `undefined` if there is
+ *   nothing to send.
  */
 function buildBindingParameter(
   bindings: SqlQueryRuntimeBindings | undefined,
@@ -259,9 +263,12 @@ function buildBindingParameter(
  * Returns `undefined` if the value cannot be coerced (e.g. non-numeric
  * input for an integer parameter); the form layer is responsible for
  * blocking submission in that case.
- * @param name
- * @param rawValue
- * @param type
+ *
+ * @param name - The parameter name.
+ * @param rawValue - The string captured from the form input.
+ * @param type - The declared FHIR primitive type.
+ * @returns A Parameters part with the matching `value[x]` slot, or
+ *   `undefined` if the value cannot be parsed.
  */
 function bindingToPart(
   name: string,

--- a/ui/src/api/sqlQuery.ts
+++ b/ui/src/api/sqlQuery.ts
@@ -1,0 +1,297 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Client for the SQL on FHIR `$sqlquery-run` operation and the search
+ * endpoint that lists stored SQLQuery Library resources.
+ *
+ * @author John Grimes
+ */
+
+import { buildHeaders, buildUrl, checkResponse } from "./utils";
+
+import type { AuthOptions } from "./rest";
+import type {
+  SqlQueryLibrary,
+  SqlQueryOutputFormat,
+  SqlQueryParameterType,
+  SqlQueryRuntimeBindings,
+} from "../types/sqlQuery";
+import type { Bundle, Parameters, ParametersParameter } from "fhir/r4";
+
+/**
+ * Code system for the SQL on FHIR Library type vocabulary.
+ */
+export const SQL_QUERY_LIBRARY_TYPE_SYSTEM =
+  "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes";
+
+/**
+ * Token-search filter that scopes a Library search to the SQLQuery profile.
+ */
+export const SQL_QUERY_LIBRARY_TYPE_FILTER = `${SQL_QUERY_LIBRARY_TYPE_SYSTEM}|sql-query`;
+
+/**
+ * Profile URL applied to inline SQLQuery Library resources.
+ */
+export const SQL_QUERY_LIBRARY_PROFILE =
+  "https://sql-on-fhir.org/ig/StructureDefinition/SQLQuery";
+
+/**
+ * Maps a {@link SqlQueryOutputFormat} to the matching MIME type, used as
+ * the Accept header on `$sqlquery-run` requests.
+ */
+const FORMAT_TO_MIME: Record<SqlQueryOutputFormat, string> = {
+  ndjson: "application/x-ndjson",
+  csv: "text/csv",
+  json: "application/json",
+  parquet: "application/vnd.apache.parquet",
+  fhir: "application/fhir+json",
+};
+
+/**
+ * Common options for the `$sqlquery-run` request.
+ */
+interface SqlQueryRunCommonOptions extends AuthOptions {
+  /** Output format requested via `_format`. */
+  format?: SqlQueryOutputFormat;
+  /** Maximum rows requested via `_limit`. */
+  limit?: number;
+  /** Whether to include a CSV header (`_header`). Only meaningful for csv. */
+  header?: boolean;
+  /** Runtime parameter values, keyed by declared parameter name. */
+  bindings?: SqlQueryRuntimeBindings;
+  /** Declared parameter types, keyed by name. */
+  parameterTypes?: Record<string, SqlQueryParameterType>;
+}
+
+/**
+ * Stored-mode options: the Library is referenced by ID.
+ */
+export interface SqlQueryRunStoredOptions extends SqlQueryRunCommonOptions {
+  mode: "stored";
+  /** ID of a stored SQLQuery Library. */
+  libraryId: string;
+}
+
+/**
+ * Inline-mode options: the Library is supplied with the request.
+ */
+export interface SqlQueryRunInlineOptions extends SqlQueryRunCommonOptions {
+  mode: "inline";
+  /** Library to send as the `queryResource` parameter. */
+  library: SqlQueryLibrary;
+}
+
+/**
+ * Discriminated request shape for the `$sqlquery-run` operation.
+ */
+export type SqlQueryRunOptions =
+  | SqlQueryRunStoredOptions
+  | SqlQueryRunInlineOptions;
+
+/**
+ * Executes the SQL on FHIR `$sqlquery-run` operation.
+ *
+ * @param baseUrl - The FHIR server base URL.
+ * @param options - The request configuration.
+ * @returns The HTTP `Response` with body still streaming.
+ * @throws {UnauthorizedError} When the request receives a 401 response.
+ * @throws {OperationOutcomeError} When the server returns a FHIR
+ *   OperationOutcome on a non-2xx response.
+ * @throws {Error} For other non-successful responses.
+ *
+ * @example
+ * const response = await sqlQueryRun("https://example.com/fhir", {
+ *   mode: "stored",
+ *   libraryId: "lib-123",
+ *   format: "csv",
+ *   limit: 100,
+ * });
+ */
+export async function sqlQueryRun(
+  baseUrl: string,
+  options: SqlQueryRunOptions,
+): Promise<Response> {
+  const url = buildUrl(baseUrl, "/$sqlquery-run");
+  const accept =
+    options.format !== undefined
+      ? FORMAT_TO_MIME[options.format]
+      : FORMAT_TO_MIME.ndjson;
+  const headers = buildHeaders({
+    accessToken: options.accessToken,
+    contentType: "application/fhir+json",
+    accept,
+  });
+
+  const parameter: ParametersParameter[] = [];
+
+  if (options.mode === "stored") {
+    parameter.push({
+      name: "queryReference",
+      valueReference: { reference: `Library/${options.libraryId}` },
+    });
+  } else {
+    parameter.push({
+      name: "queryResource",
+      // The Library type is structurally compatible with the FHIR Library
+      // resource carried inside Parameters. Cast through unknown to satisfy
+      // the typed `resource` slot without dragging in a deep type.
+      resource: options.library as unknown as ParametersParameter["resource"],
+    });
+  }
+
+  if (options.format !== undefined) {
+    parameter.push({ name: "_format", valueString: options.format });
+  }
+  if (options.limit !== undefined) {
+    parameter.push({ name: "_limit", valueInteger: options.limit });
+  }
+  if (options.header !== undefined) {
+    parameter.push({ name: "_header", valueBoolean: options.header });
+  }
+
+  const bindingParam = buildBindingParameter(
+    options.bindings,
+    options.parameterTypes,
+  );
+  if (bindingParam) {
+    parameter.push(bindingParam);
+  }
+
+  const body: Parameters = { resourceType: "Parameters", parameter };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  await checkResponse(response, "SQL query run");
+
+  return response;
+}
+
+/**
+ * Searches the FHIR server for stored SQLQuery Library resources.
+ *
+ * Uses a `type` token search scoped to the SQL on FHIR Library type code
+ * system and the `sql-query` code, so unrelated Library resources are
+ * excluded.
+ *
+ * @param baseUrl - The FHIR server base URL.
+ * @param options - Optional auth configuration.
+ * @returns A FHIR Bundle containing the matched Library resources.
+ * @throws {UnauthorizedError} When the request receives a 401 response.
+ * @throws {Error} For other non-successful responses.
+ *
+ * @example
+ * const bundle = await listSqlQueryLibraries("https://example.com/fhir");
+ */
+export async function listSqlQueryLibraries(
+  baseUrl: string,
+  options: AuthOptions = {},
+): Promise<Bundle> {
+  const url = buildUrl(baseUrl, "/Library", {
+    type: SQL_QUERY_LIBRARY_TYPE_FILTER,
+  });
+  const headers = buildHeaders({ accessToken: options.accessToken });
+
+  const response = await fetch(url, { method: "GET", headers });
+  await checkResponse(response, "Library search");
+  return (await response.json()) as Bundle;
+}
+
+/**
+ * Builds the nested `parameters` Parameters resource carrying runtime
+ * bindings, or returns `undefined` if no non-empty bindings exist.
+ * @param bindings
+ * @param parameterTypes
+ */
+function buildBindingParameter(
+  bindings: SqlQueryRuntimeBindings | undefined,
+  parameterTypes: Record<string, SqlQueryParameterType> | undefined,
+): ParametersParameter | undefined {
+  if (!bindings) {
+    return undefined;
+  }
+
+  const entries: ParametersParameter[] = [];
+  for (const [name, rawValue] of Object.entries(bindings)) {
+    if (rawValue === undefined || rawValue === null || rawValue === "") {
+      continue;
+    }
+    const declaredType = parameterTypes?.[name] ?? "string";
+    const part = bindingToPart(name, rawValue, declaredType);
+    if (part) {
+      entries.push(part);
+    }
+  }
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return {
+    name: "parameters",
+    resource: {
+      resourceType: "Parameters",
+      parameter: entries,
+    } as unknown as ParametersParameter["resource"],
+  };
+}
+
+/**
+ * Maps a single runtime binding to a typed Parameters part.
+ *
+ * Returns `undefined` if the value cannot be coerced (e.g. non-numeric
+ * input for an integer parameter); the form layer is responsible for
+ * blocking submission in that case.
+ * @param name
+ * @param rawValue
+ * @param type
+ */
+function bindingToPart(
+  name: string,
+  rawValue: string,
+  type: SqlQueryParameterType,
+): ParametersParameter | undefined {
+  switch (type) {
+    case "string":
+      return { name, valueString: rawValue };
+    case "code":
+      return { name, valueCode: rawValue };
+    case "integer": {
+      const parsed = Number.parseInt(rawValue, 10);
+      if (Number.isNaN(parsed)) {
+        return undefined;
+      }
+      return { name, valueInteger: parsed };
+    }
+    case "decimal": {
+      const parsed = Number.parseFloat(rawValue);
+      if (Number.isNaN(parsed)) {
+        return undefined;
+      }
+      return { name, valueDecimal: parsed };
+    }
+    case "boolean":
+      return { name, valueBoolean: rawValue === "true" };
+    case "date":
+      return { name, valueDate: rawValue };
+    case "dateTime":
+      return { name, valueDateTime: rawValue };
+  }
+}

--- a/ui/src/api/utils.ts
+++ b/ui/src/api/utils.ts
@@ -21,6 +21,8 @@ import {
   UnauthorizedError,
 } from "../types/errors";
 
+import type { ParametersParameter } from "fhir/r4";
+
 /**
  * Options for building HTTP headers.
  */
@@ -223,6 +225,45 @@ export function extractJobIdFromUrl(url: string): string {
   }
 
   throw new Error("Could not extract job ID from URL");
+}
+
+/**
+ * Options understood by {@link pushOutputParameters}.
+ */
+export interface OutputParameterOptions {
+  /** Output format requested via `_format`. */
+  format?: string;
+  /** Maximum row count requested via `_limit`. */
+  limit?: number;
+  /** CSV header toggle requested via `_header`. */
+  header?: boolean;
+}
+
+/**
+ * Pushes the standard SQL on FHIR output parameters (`_format`, `_limit`,
+ * `_header`) onto an existing Parameters parts array. Each entry is added
+ * only when the corresponding option is supplied.
+ *
+ * @param parameter - The Parameters parts array to mutate.
+ * @param options - The output options to encode.
+ *
+ * @example
+ * const parts: ParametersParameter[] = [];
+ * pushOutputParameters(parts, { format: "csv", limit: 100, header: true });
+ */
+export function pushOutputParameters(
+  parameter: ParametersParameter[],
+  options: OutputParameterOptions,
+): void {
+  if (options.format !== undefined) {
+    parameter.push({ name: "_format", valueString: options.format });
+  }
+  if (options.limit !== undefined) {
+    parameter.push({ name: "_limit", valueInteger: options.limit });
+  }
+  if (options.header !== undefined) {
+    parameter.push({ name: "_header", valueBoolean: options.header });
+  }
 }
 
 /**

--- a/ui/src/api/view.ts
+++ b/ui/src/api/view.ts
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
-import { buildHeaders, buildUrl, checkResponse } from "./utils";
+import {
+  buildHeaders,
+  buildUrl,
+  checkResponse,
+  pushOutputParameters,
+} from "./utils";
 
 import type { AuthOptions, ResourceType } from "./rest";
 import type { Parameters, ParametersParameter } from "fhir/r4";
@@ -136,17 +141,11 @@ export async function viewRun(
     },
   ];
 
-  if (options.format) {
-    parameter.push({ name: "_format", valueString: options.format });
-  }
-
-  if (options.limit !== undefined) {
-    parameter.push({ name: "_limit", valueInteger: options.limit });
-  }
-
-  if (options.header !== undefined) {
-    parameter.push({ name: "_header", valueBoolean: options.header });
-  }
+  pushOutputParameters(parameter, {
+    format: options.format,
+    limit: options.limit,
+    header: options.header,
+  });
 
   const body: Parameters = {
     resourceType: "Parameters",
@@ -278,13 +277,10 @@ export async function viewExportKickOff(
     parameter.push(viewParam);
   }
 
-  if (options.format) {
-    parameter.push({ name: "_format", valueString: options.format });
-  }
-
-  if (options.header !== undefined) {
-    parameter.push({ name: "_header", valueBoolean: options.header });
-  }
+  pushOutputParameters(parameter, {
+    format: options.format,
+    header: options.header,
+  });
 
   const body: Parameters = {
     resourceType: "Parameters",

--- a/ui/src/components/sqlOnFhir/SqlOnFhirForm.tsx
+++ b/ui/src/components/sqlOnFhir/SqlOnFhirForm.tsx
@@ -68,16 +68,16 @@ interface SqlOnFhirFormProps {
  * Renders the SQL on FHIR mode switch and the active form variant.
  *
  * @param props - The component props.
- * @param props.mode
- * @param props.onModeChange
- * @param props.onExecuteViewDefinition
- * @param props.onSaveViewDefinition
- * @param props.onExecuteSqlQuery
- * @param props.onSaveSqlQueryLibrary
- * @param props.isViewDefinitionExecuting
- * @param props.isViewDefinitionSaving
- * @param props.isSqlQueryExecuting
- * @param props.isSqlQuerySaving
+ * @param props.mode - The currently selected mode.
+ * @param props.onModeChange - Callback fired when the mode changes.
+ * @param props.onExecuteViewDefinition - Callback fired when the user executes a ViewDefinition.
+ * @param props.onSaveViewDefinition - Callback fired when the user saves an inline ViewDefinition to the server.
+ * @param props.onExecuteSqlQuery - Callback fired when the user executes a SQL query.
+ * @param props.onSaveSqlQueryLibrary - Callback fired when the user saves an inline SQL query Library.
+ * @param props.isViewDefinitionExecuting - Whether ViewDefinition execution is in progress.
+ * @param props.isViewDefinitionSaving - Whether ViewDefinition save is in progress.
+ * @param props.isSqlQueryExecuting - Whether SQL query execution is in progress.
+ * @param props.isSqlQuerySaving - Whether SQL query Library save is in progress.
  * @returns The form shell.
  */
 export function SqlOnFhirForm({

--- a/ui/src/components/sqlOnFhir/SqlOnFhirForm.tsx
+++ b/ui/src/components/sqlOnFhir/SqlOnFhirForm.tsx
@@ -16,251 +16,107 @@
  */
 
 /**
- * Form for executing ViewDefinitions.
+ * Top-level shell for the SQL on FHIR page form. Hosts the mode switch
+ * between `$viewdefinition-run` (ViewDefinitionForm) and `$sqlquery-run`
+ * (SqlQueryForm).
  *
  * @author John Grimes
  */
 
-import { CopyIcon, PlayIcon, UploadIcon } from "@radix-ui/react-icons";
-import {
-  Box,
-  Button,
-  Callout,
-  Card,
-  Flex,
-  Heading,
-  IconButton,
-  Select,
-  Spinner,
-  Tabs,
-  Text,
-  TextArea,
-  Tooltip,
-} from "@radix-ui/themes";
-import { useState } from "react";
+import { Box, Tabs } from "@radix-ui/themes";
 
-import { useClipboard } from "../../hooks";
-import { useViewDefinitions } from "../../hooks/useViewDefinitions";
-import { FieldGuidance } from "../FieldGuidance";
-import { FieldLabel } from "../FieldLabel";
+import { SqlQueryForm } from "./SqlQueryForm";
+import { ViewDefinitionForm } from "./ViewDefinitionForm";
 
 import type { ViewRunRequest } from "../../hooks";
 import type { CreateViewDefinitionResult } from "../../types/sqlOnFhir";
-
-interface SqlOnFhirFormProps {
-  onExecute: (request: ViewRunRequest) => void;
-  onSaveToServer: (json: string) => Promise<CreateViewDefinitionResult>;
-  isExecuting: boolean;
-  isSaving: boolean;
-  disabled?: boolean;
-}
-
-const EXAMPLE_VIEW_DEFINITION = `{
-  "resourceType": "ViewDefinition",
-  "name": "example_view",
-  "resource": "Patient",
-  "select": [
-    {
-      "column": [
-        { "path": "id", "name": "patient_id" },
-        { "path": "gender", "name": "gender" }
-      ]
-    }
-  ]
-}`;
+import type {
+  SaveSqlQueryLibraryResult,
+  SqlQueryLibrary,
+  SqlQueryRequest,
+} from "../../types/sqlQuery";
 
 /**
- * Form for selecting and executing ViewDefinitions.
+ * Mode of the SQL on FHIR page form.
+ */
+export type SqlOnFhirMode = "view-definition" | "sql-query";
+
+interface SqlOnFhirFormProps {
+  /** The currently selected mode. */
+  mode: SqlOnFhirMode;
+  /** Callback fired when the mode changes. */
+  onModeChange: (mode: SqlOnFhirMode) => void;
+  /** Callback fired when the user executes a ViewDefinition. */
+  onExecuteViewDefinition: (request: ViewRunRequest) => void;
+  /** Callback fired when the user saves an inline ViewDefinition to the server. */
+  onSaveViewDefinition: (json: string) => Promise<CreateViewDefinitionResult>;
+  /** Callback fired when the user executes a SQL query. */
+  onExecuteSqlQuery: (request: SqlQueryRequest) => void;
+  /** Callback fired when the user saves an inline SQL query Library. */
+  onSaveSqlQueryLibrary: (library: SqlQueryLibrary) => Promise<SaveSqlQueryLibraryResult>;
+  /** Whether ViewDefinition execution is in progress. */
+  isViewDefinitionExecuting: boolean;
+  /** Whether ViewDefinition save is in progress. */
+  isViewDefinitionSaving: boolean;
+  /** Whether SQL query execution is in progress. */
+  isSqlQueryExecuting: boolean;
+  /** Whether SQL query Library save is in progress. */
+  isSqlQuerySaving: boolean;
+}
+
+/**
+ * Renders the SQL on FHIR mode switch and the active form variant.
  *
- * @param root0 - The component props.
- * @param root0.onExecute - Callback when view is executed.
- * @param root0.onSaveToServer - Callback to save view definition to server.
- * @param root0.isExecuting - Whether execution is in progress.
- * @param root0.isSaving - Whether save is in progress.
- * @param root0.disabled - Whether the form is disabled.
- * @returns The SQL on FHIR form component.
+ * @param props - The component props.
+ * @param props.mode
+ * @param props.onModeChange
+ * @param props.onExecuteViewDefinition
+ * @param props.onSaveViewDefinition
+ * @param props.onExecuteSqlQuery
+ * @param props.onSaveSqlQueryLibrary
+ * @param props.isViewDefinitionExecuting
+ * @param props.isViewDefinitionSaving
+ * @param props.isSqlQueryExecuting
+ * @param props.isSqlQuerySaving
+ * @returns The form shell.
  */
 export function SqlOnFhirForm({
-  onExecute,
-  onSaveToServer,
-  isExecuting,
-  isSaving,
-  disabled = false,
-}: SqlOnFhirFormProps) {
-  const [activeTab, setActiveTab] = useState<"stored" | "custom">("stored");
-  const [selectedViewDefinitionId, setSelectedViewDefinitionId] = useState<string>("");
-  const [customJson, setCustomJson] = useState<string>("");
-  const [saveError, setSaveError] = useState<Error | null>(null);
-
-  const { data: viewDefinitions, isLoading: isLoadingViewDefinitions } = useViewDefinitions();
-  const copyToClipboard = useClipboard();
-
-  const handleExecute = () => {
-    if (activeTab === "stored" && selectedViewDefinitionId) {
-      onExecute({
-        mode: "stored",
-        viewDefinitionId: selectedViewDefinitionId,
-      });
-    } else if (activeTab === "custom" && customJson.trim()) {
-      onExecute({
-        mode: "inline",
-        viewDefinitionJson: customJson,
-      });
-    }
-  };
-
-  const canExecute =
-    (activeTab === "stored" && selectedViewDefinitionId) ||
-    (activeTab === "custom" && customJson.trim());
-
-  const handleSaveToServer = async () => {
-    setSaveError(null);
-    try {
-      const result = await onSaveToServer(customJson);
-      // Switch to stored tab and select the new ViewDefinition.
-      setActiveTab("stored");
-      setSelectedViewDefinitionId(result.id);
-    } catch (err) {
-      setSaveError(err instanceof Error ? err : new Error("Failed to save"));
-    }
-  };
-
+  mode,
+  onModeChange,
+  onExecuteViewDefinition,
+  onSaveViewDefinition,
+  onExecuteSqlQuery,
+  onSaveSqlQueryLibrary,
+  isViewDefinitionExecuting,
+  isViewDefinitionSaving,
+  isSqlQueryExecuting,
+  isSqlQuerySaving,
+}: Readonly<SqlOnFhirFormProps>) {
   return (
-    <Card>
-      <Flex direction="column" gap="4">
-        <Heading size="4">SQL on FHIR</Heading>
+    <Tabs.Root value={mode} onValueChange={(value) => onModeChange(value as SqlOnFhirMode)}>
+      <Tabs.List>
+        <Tabs.Trigger value="view-definition">View definition</Tabs.Trigger>
+        <Tabs.Trigger value="sql-query">SQL query</Tabs.Trigger>
+      </Tabs.List>
 
-        <Tabs.Root
-          value={activeTab}
-          onValueChange={(value) => setActiveTab(value as "stored" | "custom")}
-        >
-          <Tabs.List>
-            <Tabs.Trigger value="stored">Select view definition</Tabs.Trigger>
-            <Tabs.Trigger value="custom">Provide JSON</Tabs.Trigger>
-          </Tabs.List>
-
-          <Box pt="4">
-            <Tabs.Content value="stored">
-              <Box>
-                <FieldLabel mb="2">View definition</FieldLabel>
-                {isLoadingViewDefinitions ? (
-                  <Flex align="center" gap="2" py="2">
-                    <Spinner size="1" />
-                    <Text size="2" color="gray">
-                      Loading view definitions...
-                    </Text>
-                  </Flex>
-                ) : viewDefinitions && viewDefinitions.length > 0 ? (
-                  <Select.Root
-                    value={selectedViewDefinitionId}
-                    onValueChange={setSelectedViewDefinitionId}
-                  >
-                    <Select.Trigger
-                      style={{ width: "100%" }}
-                      placeholder="Select a view definition"
-                    />
-                    <Select.Content>
-                      {viewDefinitions.map((vd) => (
-                        <Select.Item key={vd.id} value={vd.id}>
-                          {vd.name}
-                        </Select.Item>
-                      ))}
-                    </Select.Content>
-                  </Select.Root>
-                ) : (
-                  <Text size="2" color="gray" as="p">
-                    No view definitions found on the server. You can use the "Provide JSON" tab to
-                    execute a view definition directly.
-                  </Text>
-                )}
-                {viewDefinitions &&
-                  viewDefinitions.length > 0 &&
-                  (selectedViewDefinitionId ? (
-                    <Box mt="2" style={{ position: "relative" }}>
-                      <Tooltip content="Copy to clipboard">
-                        <IconButton
-                          size="1"
-                          variant="ghost"
-                          aria-label="Copy to clipboard"
-                          onClick={() =>
-                            copyToClipboard(
-                              viewDefinitions.find((vd) => vd.id === selectedViewDefinitionId)
-                                ?.json ?? "",
-                            )
-                          }
-                          style={{ position: "absolute", top: 8, right: 8, zIndex: 1 }}
-                        >
-                          <CopyIcon />
-                        </IconButton>
-                      </Tooltip>
-                      <TextArea
-                        readOnly
-                        size="1"
-                        rows={16}
-                        value={
-                          viewDefinitions.find((vd) => vd.id === selectedViewDefinitionId)?.json ??
-                          ""
-                        }
-                        style={{ fontFamily: "monospace" }}
-                      />
-                    </Box>
-                  ) : (
-                    <FieldGuidance mt="2">
-                      Select a view definition that has been loaded into the server.
-                    </FieldGuidance>
-                  ))}
-              </Box>
-            </Tabs.Content>
-
-            <Tabs.Content value="custom">
-              <Box>
-                <FieldLabel mb="2">View definition JSON</FieldLabel>
-                <TextArea
-                  size="1"
-                  resize="vertical"
-                  rows={16}
-                  placeholder={EXAMPLE_VIEW_DEFINITION}
-                  value={customJson}
-                  onChange={(e) => setCustomJson(e.target.value)}
-                  style={{ fontFamily: "monospace" }}
-                />
-                <FieldGuidance mt="2">
-                  Enter a valid view definition resource in JSON format.
-                </FieldGuidance>
-                {saveError && (
-                  <Callout.Root color="red" mt="2" size="1">
-                    <Callout.Text>{saveError.message}</Callout.Text>
-                  </Callout.Root>
-                )}
-              </Box>
-            </Tabs.Content>
-          </Box>
-        </Tabs.Root>
-
-        <Flex gap="3">
-          <Button
-            size="3"
-            onClick={handleExecute}
-            disabled={disabled || isExecuting || !canExecute}
-            style={{ flex: 1 }}
-          >
-            <PlayIcon />
-            {isExecuting ? "Executing..." : "Execute"}
-          </Button>
-          {activeTab === "custom" && (
-            <Button
-              size="3"
-              variant="soft"
-              onClick={handleSaveToServer}
-              disabled={disabled || isSaving || !customJson.trim()}
-              style={{ flex: 1 }}
-            >
-              <UploadIcon />
-              {isSaving ? "Saving..." : "Save to server"}
-            </Button>
-          )}
-        </Flex>
-      </Flex>
-    </Card>
+      <Box pt="4">
+        <Tabs.Content value="view-definition">
+          <ViewDefinitionForm
+            onExecute={onExecuteViewDefinition}
+            onSaveToServer={onSaveViewDefinition}
+            isExecuting={isViewDefinitionExecuting}
+            isSaving={isViewDefinitionSaving}
+          />
+        </Tabs.Content>
+        <Tabs.Content value="sql-query">
+          <SqlQueryForm
+            onExecute={onExecuteSqlQuery}
+            onSaveToServer={onSaveSqlQueryLibrary}
+            isExecuting={isSqlQueryExecuting}
+            isSaving={isSqlQuerySaving}
+          />
+        </Tabs.Content>
+      </Box>
+    </Tabs.Root>
   );
 }

--- a/ui/src/components/sqlOnFhir/SqlQueryCard.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryCard.tsx
@@ -1,0 +1,341 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Result card for a single SQL query execution.
+ *
+ * Mirrors the lifecycle pattern of `ViewCard`: each card mounts, kicks off
+ * its own `$sqlquery-run` request via `useSqlQueryRun`, and renders the
+ * format-appropriate result body when complete.
+ *
+ * @author John Grimes
+ */
+
+import { Cross2Icon, DownloadIcon, ExclamationTriangleIcon } from "@radix-ui/react-icons";
+import {
+  Badge,
+  Box,
+  Button,
+  Callout,
+  Card,
+  Code,
+  Flex,
+  Spinner,
+  Table,
+  Text,
+} from "@radix-ui/themes";
+import { useEffect } from "react";
+
+import { useSqlQueryRun } from "../../hooks";
+import { OperationOutcomeError } from "../../types/errors";
+import { formatDateTime } from "../../utils";
+
+import type { SqlQueryJob, SqlQueryResult } from "../../types/sqlQuery";
+
+interface SqlQueryCardProps {
+  /** The SQL query job describing the request. */
+  job: SqlQueryJob;
+  /** Callback for surfacing errors to the parent (e.g. for global auth handling). */
+  onError: (message: string) => void;
+  /** Optional callback to remove the card once it has terminated. */
+  onClose?: () => void;
+}
+
+/**
+ * Renders a SQL query result card.
+ *
+ * @param props - The component props.
+ * @param props.job
+ * @param props.onError
+ * @param props.onClose
+ * @returns The card.
+ */
+export function SqlQueryCard({ job, onError, onClose }: Readonly<SqlQueryCardProps>) {
+  const { execute, status, result, error } = useSqlQueryRun();
+
+  const isRunning = status === "pending";
+  const isComplete = status === "success";
+  const isError = status === "error";
+  const canClose = isComplete || isError;
+
+  // Mount-time execution: kick off the request once when the card lands
+  // in idle state. Using the status as the trigger plays nicely with React
+  // Strict Mode's double-render of the mount.
+  useEffect(() => {
+    if (status === "idle") {
+      execute(job.request);
+    }
+  }, [status, execute, job]);
+
+  // Surface errors to the parent for global handling.
+  useEffect(() => {
+    if (error) {
+      onError(error.message);
+    }
+  }, [error, onError]);
+
+  const formatLabel = job.request.format ?? "ndjson";
+
+  return (
+    <Card>
+      <Flex direction="column" gap="3">
+        <Flex justify="between" align="start">
+          <Box>
+            <Text weight="medium" as="div" mb="1">
+              SQL query
+            </Text>
+            <Text size="1" color="gray" as="div" mb="1">
+              Job ID: {job.id}
+            </Text>
+            <Text size="1" color="gray" as="div" mb="1">
+              Mode: {job.mode === "stored" ? "stored library" : "inline library"}
+            </Text>
+            <Text size="1" color="gray" as="div" mb="1">
+              {formatDateTime(job.createdAt)}
+            </Text>
+          </Box>
+          <Flex align="center" gap="2">
+            <Badge color="gray">{formatLabel}</Badge>
+            {canClose && onClose && (
+              <Button
+                size="1"
+                variant="soft"
+                color="gray"
+                onClick={onClose}
+                aria-label="Close result"
+              >
+                <Cross2Icon />
+                Close
+              </Button>
+            )}
+          </Flex>
+        </Flex>
+
+        {isRunning && (
+          <Flex align="center" gap="2">
+            <Spinner size="1" />
+            <Text size="2" color="gray">
+              Executing SQL query...
+            </Text>
+          </Flex>
+        )}
+
+        {isError && error && <SqlQueryErrorBody sql={job.sql} error={error} />}
+
+        {isComplete && result && <SqlQueryResultBody result={result} sql={job.sql} />}
+      </Flex>
+    </Card>
+  );
+}
+
+interface SqlQueryResultBodyProps {
+  result: SqlQueryResult;
+  sql: string;
+}
+
+/**
+ * Renders the body for a successful SQL query response, branching on the
+ * result kind.
+ * @param root0
+ * @param root0.result
+ * @param root0.sql
+ */
+function SqlQueryResultBody({ result, sql }: Readonly<SqlQueryResultBodyProps>) {
+  if (result.kind === "binary") {
+    return (
+      <Flex direction="column" gap="2">
+        <Text size="2" color="gray">
+          {humanFileSize(result.blob.size)} of binary data ready to download.
+        </Text>
+        <Flex>
+          <Button
+            size="2"
+            variant="solid"
+            onClick={() => downloadBlob(result.blob, "sql-query.parquet")}
+          >
+            <DownloadIcon />
+            Download .parquet
+          </Button>
+        </Flex>
+      </Flex>
+    );
+  }
+
+  if (result.rows.length === 0) {
+    return (
+      <Text size="2" color="gray">
+        No rows returned.
+      </Text>
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="3">
+      <Flex align="center" justify="between">
+        <Badge color="gray">{result.rows.length} rows</Badge>
+        <Button
+          size="1"
+          variant="soft"
+          color="gray"
+          onClick={() => downloadBlob(result.rawBody, `sql-query.${result.format}`)}
+          aria-label={`Download .${result.format}`}
+        >
+          <DownloadIcon />
+          Download .{result.format}
+        </Button>
+      </Flex>
+      <Box style={{ width: "100%", overflowX: "auto" }}>
+        <Table.Root size="1">
+          <Table.Header>
+            <Table.Row>
+              {result.columns.map((column) => (
+                <Table.ColumnHeaderCell key={column} style={{ whiteSpace: "nowrap" }}>
+                  <Text weight="medium" size="1">
+                    {column}
+                  </Text>
+                </Table.ColumnHeaderCell>
+              ))}
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {result.rows.map((row, rowIndex) => (
+              // eslint-disable-next-line @eslint-react/no-array-index-key -- Query result rows have no stable identifier.
+              <Table.Row key={rowIndex}>
+                {result.columns.map((column) => (
+                  <Table.Cell key={column} style={{ whiteSpace: "nowrap" }}>
+                    <Code size="1" title={formatCellValue(row[column])}>
+                      {formatCellValue(row[column])}
+                    </Code>
+                  </Table.Cell>
+                ))}
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      </Box>
+      <Text size="1" color="gray">
+        Submitted SQL:
+      </Text>
+      <Box
+        style={{
+          fontFamily: "monospace",
+          fontSize: "0.85em",
+          background: "var(--gray-2)",
+          padding: "0.5rem",
+          borderRadius: "4px",
+          whiteSpace: "pre-wrap",
+        }}
+      >
+        {sql}
+      </Box>
+    </Flex>
+  );
+}
+
+interface SqlQueryErrorBodyProps {
+  sql: string;
+  error: Error;
+}
+
+/**
+ * Renders the error body, including the submitted SQL above the callout.
+ * @param root0
+ * @param root0.sql
+ * @param root0.error
+ */
+function SqlQueryErrorBody({ sql, error }: Readonly<SqlQueryErrorBodyProps>) {
+  const message =
+    error instanceof OperationOutcomeError ? extractOutcomeText(error) : error.message;
+  return (
+    <Flex direction="column" gap="2">
+      <Text size="1" color="gray">
+        Submitted SQL:
+      </Text>
+      <Box
+        style={{
+          fontFamily: "monospace",
+          fontSize: "0.85em",
+          background: "var(--gray-2)",
+          padding: "0.5rem",
+          borderRadius: "4px",
+          whiteSpace: "pre-wrap",
+        }}
+      >
+        {sql || "(empty)"}
+      </Box>
+      <Callout.Root color="red" size="1">
+        <Callout.Icon>
+          <ExclamationTriangleIcon />
+        </Callout.Icon>
+        <Callout.Text>{message}</Callout.Text>
+      </Callout.Root>
+    </Flex>
+  );
+}
+
+/**
+ * Extracts the most useful display text from an OperationOutcome.
+ * @param error
+ */
+function extractOutcomeText(error: OperationOutcomeError): string {
+  const issue = error.operationOutcome.issue?.[0];
+  return issue?.diagnostics ?? issue?.details?.text ?? "Server returned an error.";
+}
+
+/**
+ * Formats a cell value for display.
+ * @param value
+ */
+function formatCellValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+/**
+ * Triggers a browser download for the given Blob.
+ * @param blob
+ * @param filename
+ */
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Renders a byte count as a short human-readable string.
+ * @param size
+ */
+function humanFileSize(size: number): string {
+  if (size < 1024) {
+    return `${size} B`;
+  }
+  if (size < 1024 * 1024) {
+    return `${(size / 1024).toFixed(1)} KB`;
+  }
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/ui/src/components/sqlOnFhir/SqlQueryCard.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryCard.tsx
@@ -59,9 +59,9 @@ interface SqlQueryCardProps {
  * Renders a SQL query result card.
  *
  * @param props - The component props.
- * @param props.job
- * @param props.onError
- * @param props.onClose
+ * @param props.job - The SQL query job describing the request.
+ * @param props.onError - Callback for surfacing errors to the parent.
+ * @param props.onClose - Optional callback to remove the card once it has terminated.
  * @returns The card.
  */
 export function SqlQueryCard({ job, onError, onClose }: Readonly<SqlQueryCardProps>) {
@@ -150,9 +150,11 @@ interface SqlQueryResultBodyProps {
 /**
  * Renders the body for a successful SQL query response, branching on the
  * result kind.
- * @param root0
- * @param root0.result
- * @param root0.sql
+ *
+ * @param props - The component props.
+ * @param props.result - The successful execution result.
+ * @param props.sql - The submitted SQL text, displayed beneath the table.
+ * @returns The result body.
  */
 function SqlQueryResultBody({ result, sql }: Readonly<SqlQueryResultBodyProps>) {
   if (result.kind === "binary") {
@@ -253,9 +255,11 @@ interface SqlQueryErrorBodyProps {
 
 /**
  * Renders the error body, including the submitted SQL above the callout.
- * @param root0
- * @param root0.sql
- * @param root0.error
+ *
+ * @param props - The component props.
+ * @param props.sql - The submitted SQL text to render above the callout.
+ * @param props.error - The error returned by the request.
+ * @returns The error body.
  */
 function SqlQueryErrorBody({ sql, error }: Readonly<SqlQueryErrorBodyProps>) {
   const message =
@@ -289,7 +293,9 @@ function SqlQueryErrorBody({ sql, error }: Readonly<SqlQueryErrorBodyProps>) {
 
 /**
  * Extracts the most useful display text from an OperationOutcome.
- * @param error
+ *
+ * @param error - The OperationOutcome error to render.
+ * @returns The first available diagnostic or details text.
  */
 function extractOutcomeText(error: OperationOutcomeError): string {
   const issue = error.operationOutcome.issue?.[0];
@@ -298,7 +304,9 @@ function extractOutcomeText(error: OperationOutcomeError): string {
 
 /**
  * Formats a cell value for display.
- * @param value
+ *
+ * @param value - The cell value to render.
+ * @returns A string suitable for display in a table cell.
  */
 function formatCellValue(value: unknown): string {
   if (value === null || value === undefined) {
@@ -312,8 +320,9 @@ function formatCellValue(value: unknown): string {
 
 /**
  * Triggers a browser download for the given Blob.
- * @param blob
- * @param filename
+ *
+ * @param blob - The Blob to download.
+ * @param filename - The filename to suggest to the browser.
  */
 function downloadBlob(blob: Blob, filename: string) {
   const url = URL.createObjectURL(blob);
@@ -328,7 +337,9 @@ function downloadBlob(blob: Blob, filename: string) {
 
 /**
  * Renders a byte count as a short human-readable string.
- * @param size
+ *
+ * @param size - The byte count.
+ * @returns A short string with an appropriate unit suffix.
  */
 function humanFileSize(size: number): string {
   if (size < 1024) {

--- a/ui/src/components/sqlOnFhir/SqlQueryCard.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryCard.tsx
@@ -25,7 +25,7 @@
  * @author John Grimes
  */
 
-import { Cross2Icon, DownloadIcon, ExclamationTriangleIcon } from "@radix-ui/react-icons";
+import { Cross2Icon, ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import {
   Badge,
   Box,
@@ -88,8 +88,6 @@ export function SqlQueryCard({ job, onError, onClose }: Readonly<SqlQueryCardPro
     }
   }, [error, onError]);
 
-  const formatLabel = job.request.format ?? "ndjson";
-
   return (
     <Card>
       <Flex direction="column" gap="3">
@@ -109,7 +107,6 @@ export function SqlQueryCard({ job, onError, onClose }: Readonly<SqlQueryCardPro
             </Text>
           </Box>
           <Flex align="center" gap="2">
-            <Badge color="gray">{formatLabel}</Badge>
             {canClose && onClose && (
               <Button
                 size="1"
@@ -159,21 +156,10 @@ interface SqlQueryResultBodyProps {
 function SqlQueryResultBody({ result, sql }: Readonly<SqlQueryResultBodyProps>) {
   if (result.kind === "binary") {
     return (
-      <Flex direction="column" gap="2">
-        <Text size="2" color="gray">
-          {humanFileSize(result.blob.size)} of binary data ready to download.
-        </Text>
-        <Flex>
-          <Button
-            size="2"
-            variant="solid"
-            onClick={() => downloadBlob(result.blob, "sql-query.parquet")}
-          >
-            <DownloadIcon />
-            Download .parquet
-          </Button>
-        </Flex>
-      </Flex>
+      <Text size="2" color="gray">
+        Binary results cannot be previewed. Download will be supported by a future SQL query export
+        operation.
+      </Text>
     );
   }
 
@@ -185,20 +171,12 @@ function SqlQueryResultBody({ result, sql }: Readonly<SqlQueryResultBodyProps>) 
     );
   }
 
+  const previewRows = result.rows.slice(0, 10);
+
   return (
     <Flex direction="column" gap="3">
       <Flex align="center" justify="between">
-        <Badge color="gray">{result.rows.length} rows</Badge>
-        <Button
-          size="1"
-          variant="soft"
-          color="gray"
-          onClick={() => downloadBlob(result.rawBody, `sql-query.${result.format}`)}
-          aria-label={`Download .${result.format}`}
-        >
-          <DownloadIcon />
-          Download .{result.format}
-        </Button>
+        <Badge color="gray">{previewRows.length} rows</Badge>
       </Flex>
       <Box style={{ width: "100%", overflowX: "auto" }}>
         <Table.Root size="1">
@@ -214,7 +192,7 @@ function SqlQueryResultBody({ result, sql }: Readonly<SqlQueryResultBodyProps>) 
             </Table.Row>
           </Table.Header>
           <Table.Body>
-            {result.rows.map((row, rowIndex) => (
+            {previewRows.map((row, rowIndex) => (
               // eslint-disable-next-line @eslint-react/no-array-index-key -- Query result rows have no stable identifier.
               <Table.Row key={rowIndex}>
                 {result.columns.map((column) => (
@@ -316,37 +294,4 @@ function formatCellValue(value: unknown): string {
     return JSON.stringify(value);
   }
   return String(value);
-}
-
-/**
- * Triggers a browser download for the given Blob.
- *
- * @param blob - The Blob to download.
- * @param filename - The filename to suggest to the browser.
- */
-function downloadBlob(blob: Blob, filename: string) {
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-  URL.revokeObjectURL(url);
-}
-
-/**
- * Renders a byte count as a short human-readable string.
- *
- * @param size - The byte count.
- * @returns A short string with an appropriate unit suffix.
- */
-function humanFileSize(size: number): string {
-  if (size < 1024) {
-    return `${size} B`;
-  }
-  if (size < 1024 * 1024) {
-    return `${(size / 1024).toFixed(1)} KB`;
-  }
-  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/ui/src/components/sqlOnFhir/SqlQueryForm.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryForm.tsx
@@ -126,13 +126,20 @@ export function SqlQueryForm({
 
   const inlineInput = { title, sql, tables, parameters };
 
-  const baseRequestOptions = () => ({
-    format,
-    limit: limit.trim() === "" ? undefined : Number.parseInt(limit, 10),
-    header: format === "csv" ? csvHeader : undefined,
-    bindings,
-    parameterTypes: buildParameterTypes(declaredParameters),
-  });
+  const baseRequestOptions = () => {
+    // The result card shows at most 10 rows as a preview, so cap the request
+    // accordingly. Full-result downloads will be handled by a future SQL
+    // query export operation.
+    const parsedLimit = limit.trim() === "" ? undefined : Number.parseInt(limit, 10);
+    const requestLimit = parsedLimit === undefined ? 10 : Math.min(parsedLimit, 10);
+    return {
+      format,
+      limit: requestLimit,
+      header: format === "csv" ? csvHeader : undefined,
+      bindings,
+      parameterTypes: buildParameterTypes(declaredParameters),
+    };
+  };
 
   const handleExecute = () => {
     if (source === "stored") {

--- a/ui/src/components/sqlOnFhir/SqlQueryForm.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryForm.tsx
@@ -1,0 +1,272 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Form for executing the SQL on FHIR `$sqlquery-run` operation.
+ *
+ * Hosts a stored/inline tab pair, runtime bindings and output controls,
+ * then dispatches Execute and Save actions through the supplied
+ * callbacks.
+ *
+ * @author John Grimes
+ */
+
+import { PlayIcon, UploadIcon } from "@radix-ui/react-icons";
+import { Box, Button, Callout, Card, Flex, Heading, Tabs } from "@radix-ui/themes";
+import { useState } from "react";
+
+import { useSqlQueryLibraries, useViewDefinitions } from "../../hooks";
+import { FieldLabel } from "../FieldLabel";
+import {
+  areRuntimeBindingsValid,
+  buildInlineSqlQueryLibrary,
+  buildParameterTypes,
+  canExecuteInlineForm,
+  canSaveInlineForm,
+} from "./sqlQueryFormHelpers";
+import { SqlQueryInlineTab } from "./SqlQueryInlineTab";
+import { SqlQueryOutputControls } from "./SqlQueryOutputControls";
+import { SqlQueryRuntimeBindings } from "./SqlQueryRuntimeBindings";
+import { SqlQueryStoredTab } from "./SqlQueryStoredTab";
+
+import type {
+  SaveSqlQueryLibraryResult,
+  SqlQueryLibrary,
+  SqlQueryOutputFormat,
+  SqlQueryParameterDeclaration,
+  SqlQueryParameterType,
+  SqlQueryRelatedArtifact,
+  SqlQueryRequest,
+  SqlQueryRuntimeBindings as SqlQueryRuntimeBindingsState,
+} from "../../types/sqlQuery";
+
+type LibrarySource = "stored" | "inline";
+
+interface SqlQueryFormProps {
+  /** Callback fired when the user clicks Execute. */
+  onExecute: (request: SqlQueryRequest) => void;
+  /** Callback fired to save an inline Library to the server. */
+  onSaveToServer: (library: SqlQueryLibrary) => Promise<SaveSqlQueryLibraryResult>;
+  /** Whether a query is currently executing. */
+  isExecuting: boolean;
+  /** Whether a save is currently in progress. */
+  isSaving: boolean;
+  /** Optional disable for the whole form. */
+  disabled?: boolean;
+}
+
+/**
+ * Renders the SQL query form.
+ *
+ * @param props - The component props.
+ * @param props.onExecute
+ * @param props.onSaveToServer
+ * @param props.isExecuting
+ * @param props.isSaving
+ * @param props.disabled
+ * @returns The form card.
+ */
+export function SqlQueryForm({
+  onExecute,
+  onSaveToServer,
+  isExecuting,
+  isSaving,
+  disabled = false,
+}: Readonly<SqlQueryFormProps>) {
+  const [source, setSource] = useState<LibrarySource>("stored");
+  const [selectedLibraryId, setSelectedLibraryId] = useState<string>("");
+
+  // Inline-mode authoring state.
+  const [title, setTitle] = useState<string>("");
+  const [sql, setSql] = useState<string>("");
+  const [tables, setTables] = useState<SqlQueryRelatedArtifact[]>([]);
+  const [parameters, setParameters] = useState<SqlQueryParameterDeclaration[]>([]);
+
+  // Runtime bindings, output format and execution options.
+  const [bindings, setBindings] = useState<SqlQueryRuntimeBindingsState>({});
+  const [format, setFormat] = useState<SqlQueryOutputFormat>("ndjson");
+  const [limit, setLimit] = useState<string>("");
+  const [csvHeader, setCsvHeader] = useState<boolean>(true);
+
+  // Save error to surface inline (Execute errors are surfaced in the result card).
+  const [saveError, setSaveError] = useState<Error | null>(null);
+
+  const { data: storedLibraries, isLoading: isLoadingLibraries } = useSqlQueryLibraries();
+  const { data: viewDefinitions } = useViewDefinitions();
+
+  // Derived: declared parameters surfaced through the runtime bindings panel.
+  const activeStoredLibrary = storedLibraries?.find((lib) => lib.id === selectedLibraryId);
+  const declaredParameters: Array<{
+    name: string;
+    type: SqlQueryParameterType;
+  }> =
+    source === "stored"
+      ? (activeStoredLibrary?.parameters ?? [])
+      : parameters
+          .filter((p) => p.name.trim() !== "")
+          .map((p) => ({ name: p.name.trim(), type: p.type }));
+
+  const handleBindingChange = (name: string, value: string) => {
+    setBindings((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const inlineInput = { title, sql, tables, parameters };
+
+  const baseRequestOptions = () => ({
+    format,
+    limit: limit.trim() === "" ? undefined : Number.parseInt(limit, 10),
+    header: format === "csv" ? csvHeader : undefined,
+    bindings,
+    parameterTypes: buildParameterTypes(declaredParameters),
+  });
+
+  const handleExecute = () => {
+    if (source === "stored") {
+      if (!selectedLibraryId) return;
+      const request: SqlQueryRequest = {
+        mode: "stored",
+        libraryId: selectedLibraryId,
+        ...baseRequestOptions(),
+      };
+      onExecute(request);
+      return;
+    }
+    if (!canExecuteInlineForm(inlineInput)) return;
+    const library = buildInlineSqlQueryLibrary(inlineInput);
+    const request: SqlQueryRequest = {
+      mode: "inline",
+      library,
+      ...baseRequestOptions(),
+    };
+    onExecute(request);
+  };
+
+  const handleSaveToServer = async () => {
+    setSaveError(null);
+    if (!canSaveInlineForm(inlineInput)) return;
+    try {
+      const library = buildInlineSqlQueryLibrary(inlineInput);
+      const result = await onSaveToServer(library);
+      setSource("stored");
+      setSelectedLibraryId(result.id);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err : new Error("Failed to save"));
+    }
+  };
+
+  const limitInvalid =
+    limit.trim() !== "" && (!/^[0-9]+$/.test(limit.trim()) || Number.parseInt(limit, 10) <= 0);
+
+  const bindingsValid = areRuntimeBindingsValid(declaredParameters, bindings);
+
+  const canExecute =
+    !disabled &&
+    !isExecuting &&
+    !limitInvalid &&
+    bindingsValid &&
+    (source === "stored" ? selectedLibraryId !== "" : canExecuteInlineForm(inlineInput));
+
+  const canSave = !disabled && !isSaving && source === "inline" && canSaveInlineForm(inlineInput);
+
+  return (
+    <Card>
+      <Flex direction="column" gap="4">
+        <Heading size="4">SQL query</Heading>
+
+        <Tabs.Root value={source} onValueChange={(value) => setSource(value as LibrarySource)}>
+          <Tabs.List>
+            <Tabs.Trigger value="stored">Select query</Tabs.Trigger>
+            <Tabs.Trigger value="inline">Provide SQL</Tabs.Trigger>
+          </Tabs.List>
+
+          <Box pt="4">
+            <Tabs.Content value="stored">
+              <SqlQueryStoredTab
+                libraries={storedLibraries}
+                isLoading={isLoadingLibraries}
+                selectedId={selectedLibraryId}
+                onSelect={setSelectedLibraryId}
+                disabled={disabled || isExecuting}
+              />
+            </Tabs.Content>
+            <Tabs.Content value="inline">
+              <SqlQueryInlineTab
+                title={title}
+                onTitleChange={setTitle}
+                sql={sql}
+                onSqlChange={setSql}
+                tables={tables}
+                onTablesChange={setTables}
+                parameters={parameters}
+                onParametersChange={setParameters}
+                viewDefinitions={(viewDefinitions ?? []).map((vd) => ({
+                  id: vd.id,
+                  name: vd.name,
+                }))}
+                disabled={disabled || isExecuting}
+              />
+              {saveError && (
+                <Callout.Root color="red" mt="3" size="1">
+                  <Callout.Text>{saveError.message}</Callout.Text>
+                </Callout.Root>
+              )}
+            </Tabs.Content>
+          </Box>
+        </Tabs.Root>
+
+        <Box>
+          <FieldLabel mb="2">Runtime parameter values</FieldLabel>
+          <SqlQueryRuntimeBindings
+            parameters={declaredParameters}
+            bindings={bindings}
+            onChange={handleBindingChange}
+            disabled={disabled || isExecuting}
+          />
+        </Box>
+
+        <SqlQueryOutputControls
+          format={format}
+          onFormatChange={setFormat}
+          limit={limit}
+          onLimitChange={setLimit}
+          header={csvHeader}
+          onHeaderChange={setCsvHeader}
+          disabled={disabled || isExecuting}
+        />
+
+        <Flex gap="3">
+          <Button size="3" onClick={handleExecute} disabled={!canExecute} style={{ flex: 1 }}>
+            <PlayIcon />
+            {isExecuting ? "Executing..." : "Execute"}
+          </Button>
+          {source === "inline" && (
+            <Button
+              size="3"
+              variant="soft"
+              onClick={handleSaveToServer}
+              disabled={!canSave}
+              style={{ flex: 1 }}
+            >
+              <UploadIcon />
+              {isSaving ? "Saving..." : "Save to server"}
+            </Button>
+          )}
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}

--- a/ui/src/components/sqlOnFhir/SqlQueryForm.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryForm.tsx
@@ -73,11 +73,11 @@ interface SqlQueryFormProps {
  * Renders the SQL query form.
  *
  * @param props - The component props.
- * @param props.onExecute
- * @param props.onSaveToServer
- * @param props.isExecuting
- * @param props.isSaving
- * @param props.disabled
+ * @param props.onExecute - Callback fired when the user clicks Execute.
+ * @param props.onSaveToServer - Callback fired to save an inline Library to the server.
+ * @param props.isExecuting - Whether a query is currently executing.
+ * @param props.isSaving - Whether a save is currently in progress.
+ * @param props.disabled - Optional disable for the whole form.
  * @returns The form card.
  */
 export function SqlQueryForm({

--- a/ui/src/components/sqlOnFhir/SqlQueryInlineTab.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryInlineTab.tsx
@@ -76,16 +76,16 @@ interface SqlQueryInlineTabProps {
  * Renders the "Provide Library" tab body.
  *
  * @param props - The component props.
- * @param props.title
- * @param props.onTitleChange
- * @param props.sql
- * @param props.onSqlChange
- * @param props.tables
- * @param props.onTablesChange
- * @param props.parameters
- * @param props.onParametersChange
- * @param props.viewDefinitions
- * @param props.disabled
+ * @param props.title - Library title (used for `Library.title` on save).
+ * @param props.onTitleChange - Callback fired when the title changes.
+ * @param props.sql - SQL text.
+ * @param props.onSqlChange - Callback fired when the SQL changes.
+ * @param props.tables - Configured tables (related artefacts).
+ * @param props.onTablesChange - Callback fired when the tables list changes.
+ * @param props.parameters - Configured declared parameters.
+ * @param props.onParametersChange - Callback fired when the parameters list changes.
+ * @param props.viewDefinitions - Available stored ViewDefinitions for the table selector.
+ * @param props.disabled - Whether the controls should be disabled.
  * @returns The tab body.
  */
 export function SqlQueryInlineTab({

--- a/ui/src/components/sqlOnFhir/SqlQueryInlineTab.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryInlineTab.tsx
@@ -1,0 +1,355 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * "Provide Library" tab body for the SQL query form: SQL editor, tables
+ * editor and parameter declarations editor.
+ *
+ * @author John Grimes
+ */
+
+import { PlusIcon, TrashIcon } from "@radix-ui/react-icons";
+import { Box, Button, Flex, IconButton, Select, Text, TextArea, TextField } from "@radix-ui/themes";
+
+import { FieldGuidance } from "../FieldGuidance";
+import { FieldLabel } from "../FieldLabel";
+
+import type {
+  SqlQueryParameterDeclaration,
+  SqlQueryParameterType,
+  SqlQueryRelatedArtifact,
+} from "../../types/sqlQuery";
+
+const PARAMETER_TYPES: SqlQueryParameterType[] = [
+  "string",
+  "code",
+  "integer",
+  "decimal",
+  "boolean",
+  "date",
+  "dateTime",
+];
+
+interface ViewDefinitionOption {
+  id: string;
+  name: string;
+}
+
+interface SqlQueryInlineTabProps {
+  /** Library title (used for `Library.title` on save). */
+  title: string;
+  /** Callback fired when the title changes. */
+  onTitleChange: (title: string) => void;
+  /** SQL text. */
+  sql: string;
+  /** Callback fired when the SQL changes. */
+  onSqlChange: (sql: string) => void;
+  /** Configured tables (related artefacts). */
+  tables: SqlQueryRelatedArtifact[];
+  /** Callback fired when the tables list changes. */
+  onTablesChange: (tables: SqlQueryRelatedArtifact[]) => void;
+  /** Configured declared parameters. */
+  parameters: SqlQueryParameterDeclaration[];
+  /** Callback fired when the parameters list changes. */
+  onParametersChange: (parameters: SqlQueryParameterDeclaration[]) => void;
+  /** Available stored ViewDefinitions for the table selector. */
+  viewDefinitions: ViewDefinitionOption[];
+  /** Whether the controls should be disabled. */
+  disabled?: boolean;
+}
+
+/**
+ * Renders the "Provide Library" tab body.
+ *
+ * @param props - The component props.
+ * @param props.title
+ * @param props.onTitleChange
+ * @param props.sql
+ * @param props.onSqlChange
+ * @param props.tables
+ * @param props.onTablesChange
+ * @param props.parameters
+ * @param props.onParametersChange
+ * @param props.viewDefinitions
+ * @param props.disabled
+ * @returns The tab body.
+ */
+export function SqlQueryInlineTab({
+  title,
+  onTitleChange,
+  sql,
+  onSqlChange,
+  tables,
+  onTablesChange,
+  parameters,
+  onParametersChange,
+  viewDefinitions,
+  disabled = false,
+}: Readonly<SqlQueryInlineTabProps>) {
+  const handleAddTable = () => {
+    onTablesChange([
+      ...tables,
+      {
+        rowId: crypto.randomUUID(),
+        label: "",
+        viewDefinitionId: "",
+      },
+    ]);
+  };
+
+  const handleRemoveTable = (rowId: string) => {
+    onTablesChange(tables.filter((t) => t.rowId !== rowId));
+  };
+
+  const handleUpdateTable = (rowId: string, update: Partial<SqlQueryRelatedArtifact>) => {
+    onTablesChange(tables.map((t) => (t.rowId === rowId ? { ...t, ...update } : t)));
+  };
+
+  const handleAddParameter = () => {
+    onParametersChange([
+      ...parameters,
+      {
+        rowId: crypto.randomUUID(),
+        name: "",
+        type: "string",
+      },
+    ]);
+  };
+
+  const handleRemoveParameter = (rowId: string) => {
+    onParametersChange(parameters.filter((p) => p.rowId !== rowId));
+  };
+
+  const handleUpdateParameter = (rowId: string, update: Partial<SqlQueryParameterDeclaration>) => {
+    onParametersChange(parameters.map((p) => (p.rowId === rowId ? { ...p, ...update } : p)));
+  };
+
+  return (
+    <Flex direction="column" gap="4">
+      <Box>
+        <FieldLabel mb="1" optional>
+          Title
+        </FieldLabel>
+        <TextField.Root
+          value={title}
+          placeholder="e.g. patients-by-condition"
+          onChange={(e) => onTitleChange(e.target.value)}
+          disabled={disabled}
+          aria-label="Library title"
+        />
+        <FieldGuidance>
+          Used as `Library.title` when saving to the server. Required to enable the Save action.
+        </FieldGuidance>
+      </Box>
+
+      <Box>
+        <FieldLabel mb="1">SQL</FieldLabel>
+        <TextArea
+          size="1"
+          resize="vertical"
+          rows={10}
+          placeholder="SELECT ..."
+          value={sql}
+          onChange={(e) => onSqlChange(e.target.value)}
+          disabled={disabled}
+          style={{ fontFamily: "monospace" }}
+          aria-label="SQL"
+        />
+        <FieldGuidance>
+          The SQL is encoded as Base64 in `Library.content[0].data`. The plain text is also kept in
+          the `sql-text` extension.
+        </FieldGuidance>
+      </Box>
+
+      <Box>
+        <FieldLabel mb="1">Tables</FieldLabel>
+        {tables.length === 0 && (
+          <FieldGuidance>
+            Add at least one table; each maps a label to a stored ViewDefinition.
+          </FieldGuidance>
+        )}
+        <Flex direction="column" gap="2" mt="1">
+          {tables.map((table, index) => (
+            <Flex key={table.rowId} gap="2" align="end" wrap="wrap">
+              <Box style={{ flex: 1, minWidth: "10rem" }}>
+                {index === 0 && (
+                  <Text size="1" color="gray" as="div" mb="1">
+                    Label
+                  </Text>
+                )}
+                <TextField.Root
+                  value={table.label}
+                  placeholder="e.g. patients"
+                  onChange={(e) => handleUpdateTable(table.rowId, { label: e.target.value })}
+                  disabled={disabled}
+                  aria-label={`Label for table ${index + 1}`}
+                />
+              </Box>
+              <Box style={{ flex: 1, minWidth: "12rem" }}>
+                {index === 0 && (
+                  <Text size="1" color="gray" as="div" mb="1">
+                    View definition
+                  </Text>
+                )}
+                <Select.Root
+                  value={table.viewDefinitionId === "" ? undefined : table.viewDefinitionId}
+                  onValueChange={(value) =>
+                    handleUpdateTable(table.rowId, {
+                      viewDefinitionId: value,
+                    })
+                  }
+                  disabled={disabled || viewDefinitions.length === 0}
+                >
+                  <Select.Trigger
+                    style={{ width: "100%" }}
+                    placeholder={
+                      viewDefinitions.length === 0
+                        ? "No view definitions"
+                        : "Select view definition"
+                    }
+                    aria-label={`View definition for table ${index + 1}`}
+                  />
+                  <Select.Content>
+                    {viewDefinitions.map((vd) => (
+                      <Select.Item key={vd.id} value={vd.id}>
+                        {vd.name}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select.Root>
+              </Box>
+              <IconButton
+                size="2"
+                variant="soft"
+                color="gray"
+                aria-label={`Remove table ${index + 1}`}
+                onClick={() => handleRemoveTable(table.rowId)}
+                disabled={disabled}
+              >
+                <TrashIcon />
+              </IconButton>
+            </Flex>
+          ))}
+        </Flex>
+        <Box mt="2">
+          <Button size="2" variant="soft" onClick={handleAddTable} disabled={disabled}>
+            <PlusIcon />
+            Add table
+          </Button>
+        </Box>
+      </Box>
+
+      <Box>
+        <FieldLabel mb="1" optional>
+          Parameters
+        </FieldLabel>
+        {parameters.length === 0 && (
+          <FieldGuidance>
+            Declare runtime parameters for the SQL. Each becomes a `Library.parameter` entry with
+            `use=in`.
+          </FieldGuidance>
+        )}
+        <Flex direction="column" gap="2" mt="1">
+          {parameters.map((param, index) => (
+            <Flex key={param.rowId} gap="2" align="end" wrap="wrap">
+              <Box style={{ flex: 1, minWidth: "9rem" }}>
+                {index === 0 && (
+                  <Text size="1" color="gray" as="div" mb="1">
+                    Name
+                  </Text>
+                )}
+                <TextField.Root
+                  value={param.name}
+                  placeholder="e.g. patient_id"
+                  onChange={(e) =>
+                    handleUpdateParameter(param.rowId, {
+                      name: e.target.value,
+                    })
+                  }
+                  disabled={disabled}
+                  aria-label={`Name for parameter ${index + 1}`}
+                />
+              </Box>
+              <Box style={{ width: "9rem" }}>
+                {index === 0 && (
+                  <Text size="1" color="gray" as="div" mb="1">
+                    Type
+                  </Text>
+                )}
+                <Select.Root
+                  value={param.type}
+                  onValueChange={(value) =>
+                    handleUpdateParameter(param.rowId, {
+                      type: value as SqlQueryParameterType,
+                    })
+                  }
+                  disabled={disabled}
+                >
+                  <Select.Trigger
+                    style={{ width: "100%" }}
+                    aria-label={`Type for parameter ${index + 1}`}
+                  />
+                  <Select.Content>
+                    {PARAMETER_TYPES.map((type) => (
+                      <Select.Item key={type} value={type}>
+                        {type}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select.Root>
+              </Box>
+              <Box style={{ flex: 1, minWidth: "9rem" }}>
+                {index === 0 && (
+                  <Text size="1" color="gray" as="div" mb="1">
+                    Default (optional)
+                  </Text>
+                )}
+                <TextField.Root
+                  value={param.defaultValue ?? ""}
+                  placeholder="(none)"
+                  onChange={(e) =>
+                    handleUpdateParameter(param.rowId, {
+                      defaultValue: e.target.value,
+                    })
+                  }
+                  disabled={disabled}
+                  aria-label={`Default value for parameter ${index + 1}`}
+                />
+              </Box>
+              <IconButton
+                size="2"
+                variant="soft"
+                color="gray"
+                aria-label={`Remove parameter ${index + 1}`}
+                onClick={() => handleRemoveParameter(param.rowId)}
+                disabled={disabled}
+              >
+                <TrashIcon />
+              </IconButton>
+            </Flex>
+          ))}
+        </Flex>
+        <Box mt="2">
+          <Button size="2" variant="soft" onClick={handleAddParameter} disabled={disabled}>
+            <PlusIcon />
+            Add parameter
+          </Button>
+        </Box>
+      </Box>
+    </Flex>
+  );
+}

--- a/ui/src/components/sqlOnFhir/SqlQueryOutputControls.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryOutputControls.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Output format, row-limit and CSV-header controls for the SQL query
+ * form.
+ *
+ * @author John Grimes
+ */
+
+import { Box, Flex, Select, Switch, TextField } from "@radix-ui/themes";
+
+import { FieldGuidance } from "../FieldGuidance";
+import { FieldLabel } from "../FieldLabel";
+
+import type { SqlQueryOutputFormat } from "../../types/sqlQuery";
+
+interface SqlQueryOutputControlsProps {
+  /** The currently selected output format. */
+  format: SqlQueryOutputFormat;
+  /** Callback fired when the format changes. */
+  onFormatChange: (format: SqlQueryOutputFormat) => void;
+  /** Row limit captured as a string so empty input is preserved. */
+  limit: string;
+  /** Callback fired when the limit changes. */
+  onLimitChange: (limit: string) => void;
+  /** Whether the CSV header switch is on. */
+  header: boolean;
+  /** Callback fired when the header switch toggles. */
+  onHeaderChange: (header: boolean) => void;
+  /** Whether the controls should be disabled (e.g. while executing). */
+  disabled?: boolean;
+}
+
+const OUTPUT_FORMATS: SqlQueryOutputFormat[] = ["ndjson", "csv", "json", "parquet", "fhir"];
+
+/**
+ * Renders the output format select, row-limit input and (for CSV) the
+ * header switch.
+ *
+ * @param props - The component props.
+ * @param props.format
+ * @param props.onFormatChange
+ * @param props.limit
+ * @param props.onLimitChange
+ * @param props.header
+ * @param props.onHeaderChange
+ * @param props.disabled
+ * @returns The output controls.
+ */
+export function SqlQueryOutputControls({
+  format,
+  onFormatChange,
+  limit,
+  onLimitChange,
+  header,
+  onHeaderChange,
+  disabled = false,
+}: Readonly<SqlQueryOutputControlsProps>) {
+  return (
+    <Flex direction="column" gap="3">
+      <Flex gap="3" wrap="wrap" align="end">
+        <Box style={{ minWidth: "12rem" }}>
+          <FieldLabel mb="1">Output format</FieldLabel>
+          <Select.Root
+            value={format}
+            onValueChange={(value) => onFormatChange(value as SqlQueryOutputFormat)}
+            disabled={disabled}
+          >
+            <Select.Trigger aria-label="Output format" style={{ width: "100%" }} />
+            <Select.Content>
+              {OUTPUT_FORMATS.map((f) => (
+                <Select.Item key={f} value={f}>
+                  {f}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </Box>
+        <Box style={{ width: "8rem" }}>
+          <FieldLabel mb="1" optional>
+            Row limit
+          </FieldLabel>
+          <TextField.Root
+            inputMode="numeric"
+            placeholder="(none)"
+            value={limit}
+            onChange={(e) => onLimitChange(e.target.value)}
+            disabled={disabled}
+            aria-label="Row limit"
+          />
+        </Box>
+        {format === "csv" && (
+          <Box>
+            <FieldLabel mb="1">CSV header row</FieldLabel>
+            <Flex align="center" gap="2">
+              <Switch
+                checked={header}
+                onCheckedChange={onHeaderChange}
+                disabled={disabled}
+                aria-label="Include CSV header row"
+              />
+            </Flex>
+          </Box>
+        )}
+      </Flex>
+      <FieldGuidance>
+        Output format is one of csv, ndjson, json, parquet or fhir. The CSV header switch is shown
+        only for csv.
+      </FieldGuidance>
+    </Flex>
+  );
+}

--- a/ui/src/components/sqlOnFhir/SqlQueryOutputControls.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryOutputControls.tsx
@@ -53,13 +53,13 @@ const OUTPUT_FORMATS: SqlQueryOutputFormat[] = ["ndjson", "csv", "json", "parque
  * header switch.
  *
  * @param props - The component props.
- * @param props.format
- * @param props.onFormatChange
- * @param props.limit
- * @param props.onLimitChange
- * @param props.header
- * @param props.onHeaderChange
- * @param props.disabled
+ * @param props.format - The currently selected output format.
+ * @param props.onFormatChange - Callback fired when the format changes.
+ * @param props.limit - Row limit captured as a string so empty input is preserved.
+ * @param props.onLimitChange - Callback fired when the limit changes.
+ * @param props.header - Whether the CSV header switch is on.
+ * @param props.onHeaderChange - Callback fired when the header switch toggles.
+ * @param props.disabled - Whether the controls should be disabled.
  * @returns The output controls.
  */
 export function SqlQueryOutputControls({

--- a/ui/src/components/sqlOnFhir/SqlQueryRuntimeBindings.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryRuntimeBindings.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Runtime parameter bindings for the SQL query form.
+ *
+ * @author John Grimes
+ */
+
+import { Box, Code, Flex, Switch, Text, TextField } from "@radix-ui/themes";
+
+import { FieldGuidance } from "../FieldGuidance";
+import { isRuntimeValueValid } from "./sqlQueryFormHelpers";
+
+import type { SqlQueryParameterType, SqlQueryRuntimeBindings } from "../../types/sqlQuery";
+
+interface SqlQueryRuntimeBindingsProps {
+  /** Declared parameters for the active Library. */
+  parameters: Array<{ name: string; type: SqlQueryParameterType }>;
+  /** Current runtime bindings, keyed by parameter name. */
+  bindings: SqlQueryRuntimeBindings;
+  /** Callback fired when a binding changes. */
+  onChange: (name: string, value: string) => void;
+  /** Whether the inputs should be disabled. */
+  disabled?: boolean;
+}
+
+/**
+ * Renders one input per declared parameter, typed against the parameter's
+ * declared FHIR primitive type.
+ *
+ * If no parameters are declared, a short hint is shown instead.
+ *
+ * @param props - The component props.
+ * @param props.parameters
+ * @param props.bindings
+ * @param props.onChange
+ * @param props.disabled
+ * @returns The runtime bindings panel.
+ */
+export function SqlQueryRuntimeBindings({
+  parameters,
+  bindings,
+  onChange,
+  disabled = false,
+}: Readonly<SqlQueryRuntimeBindingsProps>) {
+  if (parameters.length === 0) {
+    return <FieldGuidance>This Library declares no runtime parameters.</FieldGuidance>;
+  }
+
+  return (
+    <Flex direction="column" gap="2">
+      {parameters.map((param) => {
+        const value = bindings[param.name] ?? "";
+        const valid = value === "" || isRuntimeValueValid(value, param.type);
+        return (
+          <Flex key={param.name} align="start" gap="3" wrap="wrap">
+            <Box style={{ width: "10rem", paddingTop: "0.4rem" }}>
+              <Code size="2">{param.name}</Code>
+              <Text size="1" color="gray" as="div">
+                {param.type}
+              </Text>
+            </Box>
+            <Box style={{ flex: 1, minWidth: "12rem" }}>
+              {param.type === "boolean" ? (
+                <Flex align="center" gap="2" pt="2">
+                  <Switch
+                    checked={value === "true"}
+                    onCheckedChange={(checked) => onChange(param.name, checked ? "true" : "false")}
+                    disabled={disabled}
+                    aria-label={`Runtime value for ${param.name}`}
+                  />
+                  <Text size="2" color="gray">
+                    {value === "true" ? "true" : "false"}
+                  </Text>
+                </Flex>
+              ) : (
+                <TextField.Root
+                  value={value}
+                  placeholder={placeholderForType(param.type)}
+                  onChange={(e) => onChange(param.name, e.target.value)}
+                  disabled={disabled}
+                  aria-label={`Runtime value for ${param.name}`}
+                  color={valid ? undefined : "red"}
+                />
+              )}
+              {!valid && (
+                <Text size="1" color="red" as="div" mt="1">
+                  Expected a {describeType(param.type)} value.
+                </Text>
+              )}
+            </Box>
+          </Flex>
+        );
+      })}
+    </Flex>
+  );
+}
+
+/**
+ * Returns placeholder text appropriate for a parameter type.
+ * @param type
+ */
+function placeholderForType(type: SqlQueryParameterType): string {
+  switch (type) {
+    case "string":
+    case "code":
+      return "";
+    case "integer":
+      return "e.g. 42";
+    case "decimal":
+      return "e.g. 1.5";
+    case "boolean":
+      return "";
+    case "date":
+      return "YYYY-MM-DD";
+    case "dateTime":
+      return "YYYY-MM-DDTHH:MM:SSZ";
+  }
+}
+
+/**
+ * Returns a human-readable label used in error messages.
+ * @param type
+ */
+function describeType(type: SqlQueryParameterType): string {
+  switch (type) {
+    case "integer":
+      return "integer";
+    case "decimal":
+      return "decimal";
+    case "boolean":
+      return "boolean";
+    case "date":
+      return "ISO 8601 date (YYYY-MM-DD)";
+    case "dateTime":
+      return "ISO 8601 dateTime";
+    case "string":
+    case "code":
+      return "string";
+  }
+}

--- a/ui/src/components/sqlOnFhir/SqlQueryRuntimeBindings.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryRuntimeBindings.tsx
@@ -46,10 +46,10 @@ interface SqlQueryRuntimeBindingsProps {
  * If no parameters are declared, a short hint is shown instead.
  *
  * @param props - The component props.
- * @param props.parameters
- * @param props.bindings
- * @param props.onChange
- * @param props.disabled
+ * @param props.parameters - Declared parameters for the active Library.
+ * @param props.bindings - Current runtime bindings, keyed by parameter name.
+ * @param props.onChange - Callback fired when a binding changes.
+ * @param props.disabled - Whether the inputs should be disabled.
  * @returns The runtime bindings panel.
  */
 export function SqlQueryRuntimeBindings({
@@ -113,7 +113,9 @@ export function SqlQueryRuntimeBindings({
 
 /**
  * Returns placeholder text appropriate for a parameter type.
- * @param type
+ *
+ * @param type - The declared parameter type.
+ * @returns A short example string used as the input's placeholder.
  */
 function placeholderForType(type: SqlQueryParameterType): string {
   switch (type) {
@@ -135,7 +137,9 @@ function placeholderForType(type: SqlQueryParameterType): string {
 
 /**
  * Returns a human-readable label used in error messages.
- * @param type
+ *
+ * @param type - The declared parameter type.
+ * @returns A short label naming the expected value form.
  */
 function describeType(type: SqlQueryParameterType): string {
   switch (type) {

--- a/ui/src/components/sqlOnFhir/SqlQueryStoredTab.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryStoredTab.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * "Select Library" tab body for the SQL query form: picker, decoded SQL
+ * preview and read-only summaries of related artefacts and declared
+ * parameters.
+ *
+ * @author John Grimes
+ */
+
+import { CopyIcon } from "@radix-ui/react-icons";
+import {
+  Badge,
+  Box,
+  Code,
+  Flex,
+  IconButton,
+  Select,
+  Spinner,
+  Text,
+  TextArea,
+  Tooltip,
+} from "@radix-ui/themes";
+
+import { useClipboard } from "../../hooks";
+import { FieldGuidance } from "../FieldGuidance";
+import { FieldLabel } from "../FieldLabel";
+
+import type { SqlQueryLibrarySummary } from "../../types/sqlQuery";
+
+interface SqlQueryStoredTabProps {
+  /** Stored SQLQuery Library summaries; undefined while loading. */
+  libraries: SqlQueryLibrarySummary[] | undefined;
+  /** Whether the libraries query is loading. */
+  isLoading: boolean;
+  /** Currently selected Library ID, or empty string when nothing is selected. */
+  selectedId: string;
+  /** Callback fired when the user picks a Library. */
+  onSelect: (id: string) => void;
+  /** Whether the controls should be disabled. */
+  disabled?: boolean;
+}
+
+/**
+ * Renders the "Select Library" tab body.
+ *
+ * @param props - The component props.
+ * @param props.libraries
+ * @param props.isLoading
+ * @param props.selectedId
+ * @param props.onSelect
+ * @param props.disabled
+ * @returns The tab body.
+ */
+export function SqlQueryStoredTab({
+  libraries,
+  isLoading,
+  selectedId,
+  onSelect,
+  disabled = false,
+}: Readonly<SqlQueryStoredTabProps>) {
+  const copyToClipboard = useClipboard();
+
+  const selectedLibrary = libraries?.find((lib) => lib.id === selectedId);
+
+  if (isLoading) {
+    return (
+      <Flex align="center" gap="2" py="2">
+        <Spinner size="1" />
+        <Text size="2" color="gray">
+          Loading SQL query libraries...
+        </Text>
+      </Flex>
+    );
+  }
+
+  if (!libraries || libraries.length === 0) {
+    return (
+      <FieldGuidance>
+        No SQL query libraries found on the server. Use the "Provide SQL" tab to author one.
+      </FieldGuidance>
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="3">
+      <Box>
+        <FieldLabel mb="2">SQL query library</FieldLabel>
+        <Select.Root
+          value={selectedId === "" ? undefined : selectedId}
+          onValueChange={onSelect}
+          disabled={disabled}
+        >
+          <Select.Trigger
+            style={{ width: "100%" }}
+            placeholder="Select a SQL query library"
+            aria-label="SQL query library"
+          />
+          <Select.Content>
+            {libraries.map((lib) => (
+              <Select.Item key={lib.id} value={lib.id}>
+                {lib.title}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Root>
+      </Box>
+
+      {selectedLibrary ? (
+        <>
+          <Box>
+            <FieldLabel mb="1">SQL preview</FieldLabel>
+            <Box style={{ position: "relative" }}>
+              <Tooltip content="Copy SQL to clipboard">
+                <IconButton
+                  size="1"
+                  variant="ghost"
+                  aria-label="Copy SQL to clipboard"
+                  onClick={() => copyToClipboard(selectedLibrary.sql)}
+                  style={{
+                    position: "absolute",
+                    top: 8,
+                    right: 8,
+                    zIndex: 1,
+                  }}
+                >
+                  <CopyIcon />
+                </IconButton>
+              </Tooltip>
+              <TextArea
+                readOnly
+                size="1"
+                rows={10}
+                value={selectedLibrary.sql}
+                style={{ fontFamily: "monospace" }}
+                aria-label="Decoded SQL preview"
+              />
+            </Box>
+          </Box>
+
+          <Box>
+            <FieldLabel mb="1">Tables</FieldLabel>
+            {selectedLibrary.relatedArtifacts.length > 0 ? (
+              <Flex direction="column" gap="1">
+                {selectedLibrary.relatedArtifacts.map((ra) => (
+                  <Flex key={`${ra.label}|${ra.reference}`} align="center" gap="2">
+                    <Code size="2">{ra.label}</Code>
+                    <Text size="2" color="gray">
+                      &rarr;
+                    </Text>
+                    <Code size="2">{ra.reference}</Code>
+                  </Flex>
+                ))}
+              </Flex>
+            ) : (
+              <FieldGuidance>None.</FieldGuidance>
+            )}
+          </Box>
+
+          <Box>
+            <FieldLabel mb="1">Declared parameters</FieldLabel>
+            {selectedLibrary.parameters.length > 0 ? (
+              <Flex gap="1" wrap="wrap">
+                {selectedLibrary.parameters.map((p) => (
+                  <Badge key={p.name} color="gray">
+                    {p.name}
+                    <Text size="1" color="gray">
+                      :{p.type}
+                    </Text>
+                  </Badge>
+                ))}
+              </Flex>
+            ) : (
+              <FieldGuidance>None.</FieldGuidance>
+            )}
+          </Box>
+        </>
+      ) : (
+        <FieldGuidance>
+          Select a stored SQL query library to preview its SQL and bind runtime parameters.
+        </FieldGuidance>
+      )}
+    </Flex>
+  );
+}

--- a/ui/src/components/sqlOnFhir/SqlQueryStoredTab.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryStoredTab.tsx
@@ -60,11 +60,11 @@ interface SqlQueryStoredTabProps {
  * Renders the "Select Library" tab body.
  *
  * @param props - The component props.
- * @param props.libraries
- * @param props.isLoading
- * @param props.selectedId
- * @param props.onSelect
- * @param props.disabled
+ * @param props.libraries - Stored SQLQuery Library summaries.
+ * @param props.isLoading - Whether the libraries query is loading.
+ * @param props.selectedId - The currently selected Library ID.
+ * @param props.onSelect - Callback fired when the user picks a Library.
+ * @param props.disabled - Whether the controls should be disabled.
  * @returns The tab body.
  */
 export function SqlQueryStoredTab({

--- a/ui/src/components/sqlOnFhir/ViewDefinitionForm.tsx
+++ b/ui/src/components/sqlOnFhir/ViewDefinitionForm.tsx
@@ -1,0 +1,268 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Form for executing ViewDefinitions via `$viewdefinition-run`.
+ *
+ * Hosted by `SqlOnFhirForm` alongside `SqlQueryForm`.
+ *
+ * @author John Grimes
+ */
+
+import { CopyIcon, PlayIcon, UploadIcon } from "@radix-ui/react-icons";
+import {
+  Box,
+  Button,
+  Callout,
+  Card,
+  Flex,
+  Heading,
+  IconButton,
+  Select,
+  Spinner,
+  Tabs,
+  Text,
+  TextArea,
+  Tooltip,
+} from "@radix-ui/themes";
+import { useState } from "react";
+
+import { useClipboard } from "../../hooks";
+import { useViewDefinitions } from "../../hooks/useViewDefinitions";
+import { FieldGuidance } from "../FieldGuidance";
+import { FieldLabel } from "../FieldLabel";
+
+import type { ViewRunRequest } from "../../hooks";
+import type { CreateViewDefinitionResult } from "../../types/sqlOnFhir";
+
+interface ViewDefinitionFormProps {
+  onExecute: (request: ViewRunRequest) => void;
+  onSaveToServer: (json: string) => Promise<CreateViewDefinitionResult>;
+  isExecuting: boolean;
+  isSaving: boolean;
+  disabled?: boolean;
+}
+
+const EXAMPLE_VIEW_DEFINITION = `{
+  "resourceType": "ViewDefinition",
+  "name": "example_view",
+  "resource": "Patient",
+  "select": [
+    {
+      "column": [
+        { "path": "id", "name": "patient_id" },
+        { "path": "gender", "name": "gender" }
+      ]
+    }
+  ]
+}`;
+
+/**
+ * Form for selecting and executing ViewDefinitions.
+ *
+ * @param root0 - The component props.
+ * @param root0.onExecute - Callback when view is executed.
+ * @param root0.onSaveToServer - Callback to save view definition to server.
+ * @param root0.isExecuting - Whether execution is in progress.
+ * @param root0.isSaving - Whether save is in progress.
+ * @param root0.disabled - Whether the form is disabled.
+ * @returns The view definition form component.
+ */
+export function ViewDefinitionForm({
+  onExecute,
+  onSaveToServer,
+  isExecuting,
+  isSaving,
+  disabled = false,
+}: ViewDefinitionFormProps) {
+  const [activeTab, setActiveTab] = useState<"stored" | "custom">("stored");
+  const [selectedViewDefinitionId, setSelectedViewDefinitionId] = useState<string>("");
+  const [customJson, setCustomJson] = useState<string>("");
+  const [saveError, setSaveError] = useState<Error | null>(null);
+
+  const { data: viewDefinitions, isLoading: isLoadingViewDefinitions } = useViewDefinitions();
+  const copyToClipboard = useClipboard();
+
+  const handleExecute = () => {
+    if (activeTab === "stored" && selectedViewDefinitionId) {
+      onExecute({
+        mode: "stored",
+        viewDefinitionId: selectedViewDefinitionId,
+      });
+    } else if (activeTab === "custom" && customJson.trim()) {
+      onExecute({
+        mode: "inline",
+        viewDefinitionJson: customJson,
+      });
+    }
+  };
+
+  const canExecute =
+    (activeTab === "stored" && selectedViewDefinitionId) ||
+    (activeTab === "custom" && customJson.trim());
+
+  const handleSaveToServer = async () => {
+    setSaveError(null);
+    try {
+      const result = await onSaveToServer(customJson);
+      // Switch to stored tab and select the new ViewDefinition.
+      setActiveTab("stored");
+      setSelectedViewDefinitionId(result.id);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err : new Error("Failed to save"));
+    }
+  };
+
+  return (
+    <Card>
+      <Flex direction="column" gap="4">
+        <Heading size="4">View definition</Heading>
+
+        <Tabs.Root
+          value={activeTab}
+          onValueChange={(value) => setActiveTab(value as "stored" | "custom")}
+        >
+          <Tabs.List>
+            <Tabs.Trigger value="stored">Select view definition</Tabs.Trigger>
+            <Tabs.Trigger value="custom">Provide JSON</Tabs.Trigger>
+          </Tabs.List>
+
+          <Box pt="4">
+            <Tabs.Content value="stored">
+              <Box>
+                <FieldLabel mb="2">View definition</FieldLabel>
+                {isLoadingViewDefinitions ? (
+                  <Flex align="center" gap="2" py="2">
+                    <Spinner size="1" />
+                    <Text size="2" color="gray">
+                      Loading view definitions...
+                    </Text>
+                  </Flex>
+                ) : viewDefinitions && viewDefinitions.length > 0 ? (
+                  <Select.Root
+                    value={selectedViewDefinitionId}
+                    onValueChange={setSelectedViewDefinitionId}
+                  >
+                    <Select.Trigger
+                      style={{ width: "100%" }}
+                      placeholder="Select a view definition"
+                    />
+                    <Select.Content>
+                      {viewDefinitions.map((vd) => (
+                        <Select.Item key={vd.id} value={vd.id}>
+                          {vd.name}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Root>
+                ) : (
+                  <Text size="2" color="gray" as="p">
+                    No view definitions found on the server. You can use the "Provide JSON" tab to
+                    execute a view definition directly.
+                  </Text>
+                )}
+                {viewDefinitions &&
+                  viewDefinitions.length > 0 &&
+                  (selectedViewDefinitionId ? (
+                    <Box mt="2" style={{ position: "relative" }}>
+                      <Tooltip content="Copy to clipboard">
+                        <IconButton
+                          size="1"
+                          variant="ghost"
+                          aria-label="Copy to clipboard"
+                          onClick={() =>
+                            copyToClipboard(
+                              viewDefinitions.find((vd) => vd.id === selectedViewDefinitionId)
+                                ?.json ?? "",
+                            )
+                          }
+                          style={{ position: "absolute", top: 8, right: 8, zIndex: 1 }}
+                        >
+                          <CopyIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <TextArea
+                        readOnly
+                        size="1"
+                        rows={16}
+                        value={
+                          viewDefinitions.find((vd) => vd.id === selectedViewDefinitionId)?.json ??
+                          ""
+                        }
+                        style={{ fontFamily: "monospace" }}
+                      />
+                    </Box>
+                  ) : (
+                    <FieldGuidance mt="2">
+                      Select a view definition that has been loaded into the server.
+                    </FieldGuidance>
+                  ))}
+              </Box>
+            </Tabs.Content>
+
+            <Tabs.Content value="custom">
+              <Box>
+                <FieldLabel mb="2">View definition JSON</FieldLabel>
+                <TextArea
+                  size="1"
+                  resize="vertical"
+                  rows={16}
+                  placeholder={EXAMPLE_VIEW_DEFINITION}
+                  value={customJson}
+                  onChange={(e) => setCustomJson(e.target.value)}
+                  style={{ fontFamily: "monospace" }}
+                />
+                <FieldGuidance mt="2">
+                  Enter a valid view definition resource in JSON format.
+                </FieldGuidance>
+                {saveError && (
+                  <Callout.Root color="red" mt="2" size="1">
+                    <Callout.Text>{saveError.message}</Callout.Text>
+                  </Callout.Root>
+                )}
+              </Box>
+            </Tabs.Content>
+          </Box>
+        </Tabs.Root>
+
+        <Flex gap="3">
+          <Button
+            size="3"
+            onClick={handleExecute}
+            disabled={disabled || isExecuting || !canExecute}
+            style={{ flex: 1 }}
+          >
+            <PlayIcon />
+            {isExecuting ? "Executing..." : "Execute"}
+          </Button>
+          {activeTab === "custom" && (
+            <Button
+              size="3"
+              variant="soft"
+              onClick={handleSaveToServer}
+              disabled={disabled || isSaving || !customJson.trim()}
+              style={{ flex: 1 }}
+            >
+              <UploadIcon />
+              {isSaving ? "Saving..." : "Save to server"}
+            </Button>
+          )}
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}

--- a/ui/src/components/sqlOnFhir/__tests__/SqlQueryCard.test.tsx
+++ b/ui/src/components/sqlOnFhir/__tests__/SqlQueryCard.test.tsx
@@ -19,8 +19,8 @@
  * Tests for the SqlQueryCard component.
  *
  * Verifies the format-aware result branching: tabular formats render a
- * table with a download button, parquet renders a download-only body and
- * errors surface in a Callout with the submitted SQL above.
+ * preview table (capped at 10 rows), parquet renders an export-pending
+ * notice and errors surface in a Callout with the submitted SQL above.
  *
  * @author John Grimes
  */
@@ -139,7 +139,34 @@ describe("SqlQueryCard", () => {
     expect(screen.getByText("given_name")).toBeInTheDocument();
     expect(screen.getByText("pat-1")).toBeInTheDocument();
     expect(screen.getByText("Alice")).toBeInTheDocument();
-    expect(screen.getByLabelText(/download \.csv/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/download/i)).not.toBeInTheDocument();
+  });
+
+  // The card is a preview only and clamps the rendered rows to 10, with
+  // full-result downloads deferred to a future SQL query export operation.
+  it("clamps the rendered rows to 10 even if the result has more", () => {
+    mockStatus = "success";
+    mockResult = {
+      ...TABULAR_RESULT,
+      rows: Array.from({ length: 25 }, (_, i) => ({
+        patient_id: `pat-${i + 1}`,
+        given_name: `Name ${i + 1}`,
+      })),
+    };
+    render(<SqlQueryCard job={createJob()} onError={onError} onClose={onClose} />);
+    expect(screen.getByText(/10 rows/i)).toBeInTheDocument();
+    expect(screen.getByText("pat-10")).toBeInTheDocument();
+    expect(screen.queryByText("pat-11")).not.toBeInTheDocument();
+  });
+
+  // The format indicator (e.g. "ndjson") is not rendered alongside the
+  // close button - format selection is owned by the form.
+  it("does not render a format badge in the header", () => {
+    mockStatus = "success";
+    mockResult = TABULAR_RESULT;
+    render(<SqlQueryCard job={createJob()} onError={onError} onClose={onClose} />);
+    expect(screen.queryByText(/^csv$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^ndjson$/i)).not.toBeInTheDocument();
   });
 
   // Empty tabular results show "No rows returned" instead of an empty
@@ -154,8 +181,10 @@ describe("SqlQueryCard", () => {
     expect(screen.getByText(/no rows returned/i)).toBeInTheDocument();
   });
 
-  // The parquet branch renders only a download button and no table.
-  it("renders a download-only body for parquet results", () => {
+  // Binary (parquet) results cannot be previewed in the card; the body
+  // explains that downloads will be supported by a future export
+  // operation.
+  it("renders an export-pending notice for parquet results", () => {
     mockStatus = "success";
     mockResult = BINARY_RESULT;
     render(
@@ -167,7 +196,8 @@ describe("SqlQueryCard", () => {
         onClose={onClose}
       />,
     );
-    expect(screen.getByRole("button", { name: /download \.parquet/i })).toBeInTheDocument();
+    expect(screen.getByText(/binary results cannot be previewed/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /download/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 

--- a/ui/src/components/sqlOnFhir/__tests__/SqlQueryCard.test.tsx
+++ b/ui/src/components/sqlOnFhir/__tests__/SqlQueryCard.test.tsx
@@ -1,0 +1,228 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the SqlQueryCard component.
+ *
+ * Verifies the format-aware result branching: tabular formats render a
+ * table with a download button, parquet renders a download-only body and
+ * errors surface in a Callout with the submitted SQL above.
+ *
+ * @author John Grimes
+ */
+
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "../../../test/testUtils";
+import { OperationOutcomeError } from "../../../types/errors";
+import { SqlQueryCard } from "../SqlQueryCard";
+
+import type { SqlQueryJob, SqlQueryResult } from "../../../types/sqlQuery";
+
+const mockExecute = vi.fn();
+let mockStatus: "idle" | "pending" | "success" | "error" = "idle";
+let mockResult: SqlQueryResult | undefined;
+let mockError: Error | undefined;
+
+vi.mock("../../../hooks", () => ({
+  useSqlQueryRun: () => ({
+    execute: mockExecute,
+    status: mockStatus,
+    result: mockResult,
+    error: mockError,
+  }),
+}));
+
+vi.mock("../../../utils", () => ({
+  formatDateTime: () => "15 Jan 2026, 10:00 AM",
+}));
+
+const TABULAR_RESULT: SqlQueryResult = {
+  kind: "tabular",
+  format: "csv",
+  columns: ["patient_id", "given_name"],
+  rows: [
+    { patient_id: "pat-1", given_name: "Alice" },
+    { patient_id: "pat-2", given_name: "Bob" },
+  ],
+  rawBody: new Blob(["patient_id,given_name\npat-1,Alice\npat-2,Bob"], {
+    type: "text/csv",
+  }),
+};
+
+const BINARY_RESULT: SqlQueryResult = {
+  kind: "binary",
+  format: "parquet",
+  blob: new Blob([new Uint8Array([1, 2, 3, 4])], {
+    type: "application/vnd.apache.parquet",
+  }),
+};
+
+function createJob(overrides: Partial<SqlQueryJob> = {}): SqlQueryJob {
+  return {
+    id: "job-1",
+    mode: "inline",
+    request: {
+      mode: "inline",
+      library: {
+        resourceType: "Library",
+        status: "active",
+        type: {
+          coding: [
+            {
+              system: "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes",
+              code: "sql-query",
+            },
+          ],
+        },
+        content: [
+          {
+            contentType: "application/sql",
+            data: "U0VMRUNUIDE=",
+          },
+        ],
+      },
+      format: "csv",
+    },
+    sql: "SELECT 1",
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("SqlQueryCard", () => {
+  const onError = vi.fn();
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStatus = "idle";
+    mockResult = undefined;
+    mockError = undefined;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The pending state is communicated via a spinner and a status message
+  // so the user knows the request is in flight.
+  it("shows a spinner and pending message while the request is in flight", () => {
+    mockStatus = "pending";
+    render(<SqlQueryCard job={createJob()} onError={onError} onClose={onClose} />);
+    expect(screen.getByText(/executing sql query/i)).toBeInTheDocument();
+  });
+
+  // A successful tabular result renders a Table with one column per CSV
+  // column and a row count badge.
+  it("renders a table for a successful tabular result", () => {
+    mockStatus = "success";
+    mockResult = TABULAR_RESULT;
+    render(<SqlQueryCard job={createJob()} onError={onError} onClose={onClose} />);
+    expect(screen.getByText(/2 rows/i)).toBeInTheDocument();
+    expect(screen.getByText("patient_id")).toBeInTheDocument();
+    expect(screen.getByText("given_name")).toBeInTheDocument();
+    expect(screen.getByText("pat-1")).toBeInTheDocument();
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByLabelText(/download \.csv/i)).toBeInTheDocument();
+  });
+
+  // Empty tabular results show "No rows returned" instead of an empty
+  // table.
+  it("shows a no-rows message when the tabular result is empty", () => {
+    mockStatus = "success";
+    mockResult = {
+      ...TABULAR_RESULT,
+      rows: [],
+    };
+    render(<SqlQueryCard job={createJob()} onError={onError} onClose={onClose} />);
+    expect(screen.getByText(/no rows returned/i)).toBeInTheDocument();
+  });
+
+  // The parquet branch renders only a download button and no table.
+  it("renders a download-only body for parquet results", () => {
+    mockStatus = "success";
+    mockResult = BINARY_RESULT;
+    render(
+      <SqlQueryCard
+        job={createJob({
+          request: { ...createJob().request, format: "parquet" },
+        })}
+        onError={onError}
+        onClose={onClose}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /download \.parquet/i })).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  // OperationOutcome errors are shown in a callout with the submitted SQL
+  // displayed alongside.
+  it("renders an OperationOutcome error in a callout above the submitted SQL", () => {
+    mockStatus = "error";
+    mockError = new OperationOutcomeError(
+      {
+        resourceType: "OperationOutcome",
+        issue: [
+          {
+            severity: "error",
+            code: "invalid",
+            diagnostics: "SQL contains a disallowed operation",
+          },
+        ],
+      },
+      400,
+      "SQL query run",
+    );
+    render(
+      <SqlQueryCard
+        job={createJob({ sql: "DROP TABLE conditions" })}
+        onError={onError}
+        onClose={onClose}
+      />,
+    );
+    expect(screen.getByText(/sql contains a disallowed operation/i)).toBeInTheDocument();
+    expect(screen.getByText(/drop table conditions/i)).toBeInTheDocument();
+  });
+
+  // Generic errors fall back to the message text.
+  it("renders a generic error message when the error is not an OperationOutcome", () => {
+    mockStatus = "error";
+    mockError = new Error("Network error");
+    render(<SqlQueryCard job={createJob()} onError={onError} onClose={onClose} />);
+    expect(screen.getByText(/network error/i)).toBeInTheDocument();
+  });
+
+  // The close button only appears once the request has terminated.
+  it("hides the close button while the request is pending", () => {
+    mockStatus = "pending";
+    render(<SqlQueryCard job={createJob()} onError={onError} onClose={onClose} />);
+    expect(screen.queryByRole("button", { name: /close result/i })).not.toBeInTheDocument();
+  });
+
+  // The close button surfaces after success and triggers the onClose
+  // callback when clicked.
+  it("calls onClose when the close button is clicked after success", async () => {
+    mockStatus = "success";
+    mockResult = TABULAR_RESULT;
+    const user = userEvent.setup();
+    render(<SqlQueryCard job={createJob()} onError={onError} onClose={onClose} />);
+    await user.click(screen.getByRole("button", { name: /close result/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/sqlOnFhir/__tests__/ViewDefinitionForm.test.tsx
+++ b/ui/src/components/sqlOnFhir/__tests__/ViewDefinitionForm.test.tsx
@@ -16,7 +16,7 @@
  */
 
 /**
- * Tests for the SqlOnFhirForm component which handles ViewDefinition execution
+ * Tests for the ViewDefinitionForm component which handles ViewDefinition execution
  * and saving.
  *
  * These tests verify that the form correctly renders tabs for stored and custom
@@ -31,7 +31,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fireEvent, render, screen, waitFor } from "../../../test/testUtils";
-import { SqlOnFhirForm } from "../SqlOnFhirForm";
+import { ViewDefinitionForm } from "../ViewDefinitionForm";
 
 import type { ViewRunRequest } from "../../../hooks";
 import type { CreateViewDefinitionResult } from "../../../types/sqlOnFhir";
@@ -48,7 +48,7 @@ vi.mock("../../../hooks", () => ({
   useClipboard: () => mockCopyToClipboard,
 }));
 
-describe("SqlOnFhirForm", () => {
+describe("ViewDefinitionForm", () => {
   const mockOnExecute = vi.fn();
   const mockOnSaveToServer = vi.fn();
 
@@ -80,7 +80,7 @@ describe("SqlOnFhirForm", () => {
   describe("initial render", () => {
     it("renders the form heading", () => {
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -88,12 +88,12 @@ describe("SqlOnFhirForm", () => {
         />,
       );
 
-      expect(screen.getByRole("heading", { name: /sql on fhir/i })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /view definition/i })).toBeInTheDocument();
     });
 
     it("renders tabs for stored and custom ViewDefinitions", () => {
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -107,7 +107,7 @@ describe("SqlOnFhirForm", () => {
 
     it("renders the execute button", () => {
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -120,7 +120,7 @@ describe("SqlOnFhirForm", () => {
 
     it("defaults to stored tab", () => {
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -141,7 +141,7 @@ describe("SqlOnFhirForm", () => {
       });
 
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -159,7 +159,7 @@ describe("SqlOnFhirForm", () => {
       });
 
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -172,7 +172,7 @@ describe("SqlOnFhirForm", () => {
 
     it("renders view definition selector when definitions exist", () => {
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -186,7 +186,7 @@ describe("SqlOnFhirForm", () => {
     it("shows view definition options in the selector", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -203,7 +203,7 @@ describe("SqlOnFhirForm", () => {
 
     it("shows selection hint when no view definition is selected", () => {
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -219,7 +219,7 @@ describe("SqlOnFhirForm", () => {
     it("shows JSON preview when a view definition is selected", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -239,7 +239,7 @@ describe("SqlOnFhirForm", () => {
     it("shows copy button when a view definition is selected", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -257,7 +257,7 @@ describe("SqlOnFhirForm", () => {
     it("copies JSON to clipboard when copy button is clicked", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -282,7 +282,7 @@ describe("SqlOnFhirForm", () => {
     it("switches to custom tab when clicked", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -299,7 +299,7 @@ describe("SqlOnFhirForm", () => {
     it("renders JSON textarea in custom tab", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -315,7 +315,7 @@ describe("SqlOnFhirForm", () => {
     it("shows save to server button in custom tab", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -330,7 +330,7 @@ describe("SqlOnFhirForm", () => {
 
     it("does not show save to server button in stored tab", () => {
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -344,7 +344,7 @@ describe("SqlOnFhirForm", () => {
     it("allows entering custom JSON", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -366,7 +366,7 @@ describe("SqlOnFhirForm", () => {
     it("executes stored ViewDefinition when execute is clicked", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -391,7 +391,7 @@ describe("SqlOnFhirForm", () => {
     it("executes inline ViewDefinition when execute is clicked in custom tab", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -424,7 +424,7 @@ describe("SqlOnFhirForm", () => {
       mockOnSaveToServer.mockResolvedValue(saveResult);
 
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -453,7 +453,7 @@ describe("SqlOnFhirForm", () => {
       mockOnSaveToServer.mockRejectedValue(new Error("Save failed"));
 
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -482,7 +482,7 @@ describe("SqlOnFhirForm", () => {
       mockOnSaveToServer.mockResolvedValue(saveResult);
 
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -513,7 +513,7 @@ describe("SqlOnFhirForm", () => {
   describe("button disabled states", () => {
     it("disables execute button when no stored ViewDefinition is selected", () => {
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -528,7 +528,7 @@ describe("SqlOnFhirForm", () => {
     it("enables execute button when a stored ViewDefinition is selected", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -547,7 +547,7 @@ describe("SqlOnFhirForm", () => {
     it("disables execute button when no custom JSON is entered", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -564,7 +564,7 @@ describe("SqlOnFhirForm", () => {
     it("enables execute button when custom JSON is entered", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -584,7 +584,7 @@ describe("SqlOnFhirForm", () => {
     it("disables execute button when isExecuting is true", async () => {
       const user = userEvent.setup();
       const { rerender } = render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -597,7 +597,7 @@ describe("SqlOnFhirForm", () => {
       await user.click(screen.getByRole("option", { name: "Patient View" }));
 
       rerender(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={true}
@@ -612,7 +612,7 @@ describe("SqlOnFhirForm", () => {
     it("disables execute button when disabled is true", async () => {
       const user = userEvent.setup();
       const { rerender } = render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -625,7 +625,7 @@ describe("SqlOnFhirForm", () => {
       await user.click(screen.getByRole("option", { name: "Patient View" }));
 
       rerender(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -641,7 +641,7 @@ describe("SqlOnFhirForm", () => {
     it("disables save button when no custom JSON is entered", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -658,7 +658,7 @@ describe("SqlOnFhirForm", () => {
     it("disables save button when isSaving is true", async () => {
       const user = userEvent.setup();
       const { rerender } = render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -672,7 +672,7 @@ describe("SqlOnFhirForm", () => {
       fireEvent.change(textarea, { target: { value: '{"resourceType": "ViewDefinition"}' } });
 
       rerender(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -687,7 +687,7 @@ describe("SqlOnFhirForm", () => {
     it("shows executing text when isExecuting is true", async () => {
       const user = userEvent.setup();
       const { rerender } = render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -700,7 +700,7 @@ describe("SqlOnFhirForm", () => {
       await user.click(screen.getByRole("option", { name: "Patient View" }));
 
       rerender(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={true}
@@ -714,7 +714,7 @@ describe("SqlOnFhirForm", () => {
     it("shows saving text when isSaving is true", async () => {
       const user = userEvent.setup();
       const { rerender } = render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -728,7 +728,7 @@ describe("SqlOnFhirForm", () => {
       fireEvent.change(textarea, { target: { value: '{"resourceType": "ViewDefinition"}' } });
 
       rerender(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}
@@ -744,7 +744,7 @@ describe("SqlOnFhirForm", () => {
     it("displays JSON input help text in custom tab", async () => {
       const user = userEvent.setup();
       render(
-        <SqlOnFhirForm
+        <ViewDefinitionForm
           onExecute={mockOnExecute}
           onSaveToServer={mockOnSaveToServer}
           isExecuting={false}

--- a/ui/src/components/sqlOnFhir/__tests__/sqlQueryFormHelpers.test.ts
+++ b/ui/src/components/sqlOnFhir/__tests__/sqlQueryFormHelpers.test.ts
@@ -1,0 +1,265 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { decodeSql } from "../../../utils/sqlBase64";
+import {
+  areRuntimeBindingsValid,
+  buildInlineSqlQueryLibrary,
+  buildParameterTypes,
+  canExecuteInlineForm,
+  canSaveInlineForm,
+  isRuntimeValueValid,
+} from "../sqlQueryFormHelpers";
+
+describe("buildInlineSqlQueryLibrary", () => {
+  // The assembled Library carries the SQL on FHIR profile, the
+  // sql-query type code and the SQL both Base64-encoded and as plain
+  // text via the `sql-text` extension.
+  it("assembles a Library conforming to the SQLQuery profile", () => {
+    const library = buildInlineSqlQueryLibrary({
+      title: "patients-by-condition",
+      sql: "SELECT 1",
+      tables: [
+        {
+          rowId: "r1",
+          label: "patients",
+          viewDefinitionId: "vd-patients",
+        },
+      ],
+      parameters: [{ rowId: "p1", name: "patient_id", type: "string" }],
+    });
+
+    expect(library.resourceType).toBe("Library");
+    expect(library.status).toBe("active");
+    expect(library.meta?.profile).toContain(
+      "https://sql-on-fhir.org/ig/StructureDefinition/SQLQuery",
+    );
+    expect(library.type.coding[0].code).toBe("sql-query");
+    expect(library.title).toBe("patients-by-condition");
+    expect(library.name).toBe("patients-by-condition");
+    expect(library.content[0].contentType).toBe("application/sql");
+    expect(decodeSql(library.content[0].data)).toBe("SELECT 1");
+    const sqlExt = library.content[0].extension?.find((e) =>
+      e.url.endsWith("/sql-text"),
+    );
+    expect(sqlExt?.valueString).toBe("SELECT 1");
+    expect(library.relatedArtifact).toEqual([
+      {
+        type: "depends-on",
+        label: "patients",
+        resource: "ViewDefinition/vd-patients",
+      },
+    ]);
+    expect(library.parameter).toEqual([
+      { name: "patient_id", use: "in", type: "string" },
+    ]);
+  });
+
+  // Empty title and url do not introduce empty slots on the resource.
+  it("omits empty title and url", () => {
+    const library = buildInlineSqlQueryLibrary({
+      sql: "SELECT 1",
+      tables: [],
+      parameters: [],
+    });
+    expect(library.title).toBeUndefined();
+    expect(library.name).toBeUndefined();
+    expect(library.url).toBeUndefined();
+    expect(library.relatedArtifact).toBeUndefined();
+    expect(library.parameter).toBeUndefined();
+  });
+
+  // Title with whitespace is normalised into the `name` slot using
+  // hyphens and lower-case, while the original string is preserved on
+  // the `title` slot.
+  it("normalises the title into a slug for the name slot", () => {
+    const library = buildInlineSqlQueryLibrary({
+      title: "Patients By Condition",
+      sql: "SELECT 1",
+      tables: [],
+      parameters: [],
+    });
+    expect(library.title).toBe("Patients By Condition");
+    expect(library.name).toBe("patients-by-condition");
+  });
+});
+
+describe("canExecuteInlineForm", () => {
+  // Empty SQL prevents execution.
+  it("returns false when SQL is blank", () => {
+    expect(
+      canExecuteInlineForm({
+        sql: "   ",
+        tables: [{ rowId: "r1", label: "patients", viewDefinitionId: "vd1" }],
+        parameters: [],
+      }),
+    ).toBe(false);
+  });
+
+  // Zero tables prevents execution because the server requires at least
+  // one related artefact.
+  it("returns false when there are no tables", () => {
+    expect(
+      canExecuteInlineForm({
+        sql: "SELECT 1",
+        tables: [],
+        parameters: [],
+      }),
+    ).toBe(false);
+  });
+
+  // Tables with empty labels or unselected ViewDefinitions are invalid.
+  it("returns false when a table row is incomplete", () => {
+    expect(
+      canExecuteInlineForm({
+        sql: "SELECT 1",
+        tables: [{ rowId: "r1", label: "", viewDefinitionId: "vd1" }],
+        parameters: [],
+      }),
+    ).toBe(false);
+    expect(
+      canExecuteInlineForm({
+        sql: "SELECT 1",
+        tables: [{ rowId: "r1", label: "patients", viewDefinitionId: "" }],
+        parameters: [],
+      }),
+    ).toBe(false);
+  });
+
+  // Minimum valid input has SQL and at least one well-formed table.
+  it("returns true for the minimum valid input", () => {
+    expect(
+      canExecuteInlineForm({
+        sql: "SELECT 1",
+        tables: [{ rowId: "r1", label: "patients", viewDefinitionId: "vd1" }],
+        parameters: [],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("canSaveInlineForm", () => {
+  // Save additionally requires a non-empty title.
+  it("returns false without a title", () => {
+    expect(
+      canSaveInlineForm({
+        sql: "SELECT 1",
+        tables: [{ rowId: "r1", label: "patients", viewDefinitionId: "vd1" }],
+        parameters: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when execute is valid and a title is supplied", () => {
+    expect(
+      canSaveInlineForm({
+        title: "patients-by-condition",
+        sql: "SELECT 1",
+        tables: [{ rowId: "r1", label: "patients", viewDefinitionId: "vd1" }],
+        parameters: [],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isRuntimeValueValid", () => {
+  // Strings always pass.
+  it("accepts any string for type=string", () => {
+    expect(isRuntimeValueValid("foo bar", "string")).toBe(true);
+  });
+
+  // Integer rejects non-integer input.
+  it("rejects non-integer input for type=integer", () => {
+    expect(isRuntimeValueValid("42", "integer")).toBe(true);
+    expect(isRuntimeValueValid("-3", "integer")).toBe(true);
+    expect(isRuntimeValueValid("3.14", "integer")).toBe(false);
+    expect(isRuntimeValueValid("abc", "integer")).toBe(false);
+  });
+
+  // Decimal accepts integer and decimal forms.
+  it("accepts decimal input for type=decimal", () => {
+    expect(isRuntimeValueValid("3.14", "decimal")).toBe(true);
+    expect(isRuntimeValueValid("3", "decimal")).toBe(true);
+    expect(isRuntimeValueValid("abc", "decimal")).toBe(false);
+  });
+
+  // Boolean only accepts the string "true" or "false".
+  it("only accepts true/false for type=boolean", () => {
+    expect(isRuntimeValueValid("true", "boolean")).toBe(true);
+    expect(isRuntimeValueValid("false", "boolean")).toBe(true);
+    expect(isRuntimeValueValid("yes", "boolean")).toBe(false);
+  });
+
+  // Date requires the ISO 8601 calendar form.
+  it("validates ISO 8601 dates for type=date", () => {
+    expect(isRuntimeValueValid("2025-01-15", "date")).toBe(true);
+    expect(isRuntimeValueValid("2025-1-15", "date")).toBe(false);
+  });
+
+  // DateTime accepts the canonical and zoned forms.
+  it("validates ISO 8601 dateTimes for type=dateTime", () => {
+    expect(isRuntimeValueValid("2025-01-15T12:00:00Z", "dateTime")).toBe(true);
+    expect(isRuntimeValueValid("2025-01-15T12:00:00+10:00", "dateTime")).toBe(
+      true,
+    );
+    expect(isRuntimeValueValid("yesterday", "dateTime")).toBe(false);
+  });
+});
+
+describe("areRuntimeBindingsValid", () => {
+  // Empty bindings pass for declared-but-not-bound parameters.
+  it("accepts empty bindings", () => {
+    expect(
+      areRuntimeBindingsValid([{ name: "x", type: "integer" }], { x: "" }),
+    ).toBe(true);
+    expect(areRuntimeBindingsValid([{ name: "x", type: "integer" }], {})).toBe(
+      true,
+    );
+  });
+
+  it("rejects when any binding fails type validation", () => {
+    expect(
+      areRuntimeBindingsValid([{ name: "x", type: "integer" }], { x: "abc" }),
+    ).toBe(false);
+  });
+
+  it("accepts when all bindings pass type validation", () => {
+    expect(
+      areRuntimeBindingsValid(
+        [
+          { name: "x", type: "integer" },
+          { name: "y", type: "string" },
+        ],
+        { x: "42", y: "hello" },
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("buildParameterTypes", () => {
+  // Builds a name-keyed map suitable for the API client.
+  it("maps declared parameters to a type lookup", () => {
+    expect(
+      buildParameterTypes([
+        { name: "patient_id", type: "string" },
+        { name: "active", type: "boolean" },
+      ]),
+    ).toEqual({ patient_id: "string", active: "boolean" });
+  });
+});

--- a/ui/src/components/sqlOnFhir/sqlQueryFormHelpers.ts
+++ b/ui/src/components/sqlOnFhir/sqlQueryFormHelpers.ts
@@ -1,0 +1,245 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Pure helpers for the SQL query form: assembling inline Library
+ * resources, validating runtime bindings, and shaping derived state.
+ *
+ * @author John Grimes
+ */
+
+import {
+  SQL_QUERY_LIBRARY_PROFILE,
+  SQL_QUERY_LIBRARY_TYPE_SYSTEM,
+} from "../../api";
+import { encodeSql } from "../../utils";
+
+import type {
+  SqlQueryLibrary,
+  SqlQueryParameterDeclaration,
+  SqlQueryParameterType,
+  SqlQueryRelatedArtifact,
+  SqlQueryRuntimeBindings,
+} from "../../types/sqlQuery";
+
+/**
+ * Extension URL for the plain-text SQL companion of `Library.content[0]`.
+ */
+const SQL_TEXT_EXTENSION =
+  "https://sql-on-fhir.org/ig/StructureDefinition/sql-text";
+
+/**
+ * Inputs to {@link buildInlineSqlQueryLibrary}.
+ */
+export interface BuildInlineLibraryInput {
+  /** Optional title; falls back to undefined when blank. */
+  title?: string;
+  /** Optional canonical URL. */
+  url?: string;
+  /** Plain-text SQL the user wrote. */
+  sql: string;
+  /** Tables (related artefacts) configured by the user. */
+  tables: SqlQueryRelatedArtifact[];
+  /** Declared runtime parameters. */
+  parameters: SqlQueryParameterDeclaration[];
+}
+
+/**
+ * Builds an inline SQLQuery Library resource from the form's authored
+ * state.
+ *
+ * The Library carries the SQL both Base64-encoded (per the profile) and
+ * as plain text via the `sql-text` extension, mirroring the canonical
+ * examples in the operation definition.
+ *
+ * @param input - The authored state to assemble.
+ * @returns The Library resource ready to send as `queryResource` or
+ *   POST to `/Library`.
+ *
+ * @example
+ * buildInlineSqlQueryLibrary({
+ *   sql: "SELECT 1",
+ *   tables: [],
+ *   parameters: [],
+ * });
+ */
+export function buildInlineSqlQueryLibrary(
+  input: BuildInlineLibraryInput,
+): SqlQueryLibrary {
+  const trimmedTitle = input.title?.trim();
+  const trimmedUrl = input.url?.trim();
+  const library: SqlQueryLibrary = {
+    resourceType: "Library",
+    status: "active",
+    meta: { profile: [SQL_QUERY_LIBRARY_PROFILE] },
+    type: {
+      coding: [{ system: SQL_QUERY_LIBRARY_TYPE_SYSTEM, code: "sql-query" }],
+    },
+    content: [
+      {
+        contentType: "application/sql",
+        data: encodeSql(input.sql),
+        extension: [{ url: SQL_TEXT_EXTENSION, valueString: input.sql }],
+      },
+    ],
+  };
+
+  if (trimmedTitle) {
+    library.title = trimmedTitle;
+    library.name = trimmedTitle.replace(/\s+/g, "-").toLowerCase();
+  }
+  if (trimmedUrl) {
+    library.url = trimmedUrl;
+  }
+
+  if (input.tables.length > 0) {
+    library.relatedArtifact = input.tables.map((table) => ({
+      type: "depends-on" as const,
+      label: table.label,
+      resource: `ViewDefinition/${table.viewDefinitionId}`,
+    }));
+  }
+
+  if (input.parameters.length > 0) {
+    library.parameter = input.parameters.map((param) => ({
+      name: param.name,
+      use: "in" as const,
+      type: param.type,
+    }));
+  }
+
+  return library;
+}
+
+/**
+ * Returns true when the inline form has the minimum data required to
+ * execute a query.
+ *
+ * The server requires a Library with non-empty SQL and at least one
+ * related artefact; the form blocks the Execute button otherwise.
+ *
+ * @param input - The authored state to validate.
+ * @returns Whether Execute should be enabled.
+ */
+export function canExecuteInlineForm(input: BuildInlineLibraryInput): boolean {
+  if (input.sql.trim().length === 0) {
+    return false;
+  }
+  if (input.tables.length === 0) {
+    return false;
+  }
+  if (input.tables.some((t) => t.label.trim() === "" || !t.viewDefinitionId)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Returns true when the inline form has the minimum data required to
+ * save the assembled Library to the server.
+ *
+ * Save requires what Execute requires, plus a non-blank title (so the
+ * Library is referrable in the picker afterwards).
+ *
+ * @param input - The authored state to validate.
+ * @returns Whether Save should be enabled.
+ */
+export function canSaveInlineForm(input: BuildInlineLibraryInput): boolean {
+  if (!canExecuteInlineForm(input)) {
+    return false;
+  }
+  if (!input.title || input.title.trim() === "") {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Returns true when each runtime binding parses cleanly to its declared
+ * FHIR primitive type.
+ *
+ * Empty values are allowed and pass validation; the API client will omit
+ * them from the request.
+ *
+ * @param parameters - The declared parameters in the active Library.
+ * @param bindings - The runtime values entered by the user.
+ * @returns Whether the bindings are submittable.
+ */
+export function areRuntimeBindingsValid(
+  parameters: Array<{ name: string; type: SqlQueryParameterType }>,
+  bindings: SqlQueryRuntimeBindings,
+): boolean {
+  for (const param of parameters) {
+    const raw = bindings[param.name];
+    if (raw === undefined || raw === "") {
+      continue;
+    }
+    if (!isRuntimeValueValid(raw, param.type)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Validates a single runtime value against its declared FHIR primitive
+ * type. Used for both per-field guidance and overall form validity.
+ *
+ * @param raw - The string captured from the input.
+ * @param type - The declared parameter type.
+ * @returns True if the value is parseable as the declared type.
+ */
+export function isRuntimeValueValid(
+  raw: string,
+  type: SqlQueryParameterType,
+): boolean {
+  switch (type) {
+    case "string":
+    case "code":
+      return true;
+    case "integer":
+      return /^-?\d+$/.test(raw);
+    case "decimal":
+      return /^-?\d+(\.\d+)?$/.test(raw);
+    case "boolean":
+      return raw === "true" || raw === "false";
+    case "date":
+      return /^\d{4}-\d{2}-\d{2}$/.test(raw);
+    case "dateTime":
+      return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?$/.test(
+        raw,
+      );
+  }
+}
+
+/**
+ * Builds a `parameterTypes` map from a list of declared parameters.
+ *
+ * @param parameters - The declared parameter list.
+ * @returns A name-keyed map of parameter types.
+ */
+export function buildParameterTypes(
+  parameters: Array<{ name: string; type: SqlQueryParameterType }>,
+): Record<string, SqlQueryParameterType> {
+  const map: Record<string, SqlQueryParameterType> = {};
+  for (const param of parameters) {
+    if (param.name) {
+      map[param.name] = param.type;
+    }
+  }
+  return map;
+}

--- a/ui/src/hooks/__tests__/sqlQueryHelpers.test.ts
+++ b/ui/src/hooks/__tests__/sqlQueryHelpers.test.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  libraryToSummary,
+  mapLibraryBundle,
+  parseTabularBody,
+  readSqlQueryResponse,
+} from "../sqlQueryHelpers";
+
+import type { Bundle, Library } from "fhir/r4";
+
+const libraryFixture: Library = {
+  resourceType: "Library",
+  id: "lib-1",
+  name: "patients-by-condition",
+  title: "Patients by condition",
+  status: "active",
+  type: {
+    coding: [
+      {
+        system: "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes",
+        code: "sql-query",
+      },
+    ],
+  },
+  content: [
+    {
+      contentType: "application/sql",
+      // "SELECT 1".
+      data: "U0VMRUNUIDE=",
+    },
+  ],
+  relatedArtifact: [
+    {
+      type: "depends-on",
+      label: "patients",
+      resource: "ViewDefinition/patients",
+    },
+  ],
+  parameter: [
+    { name: "patient_id", use: "in", type: "string" },
+    { name: "_unsupported", use: "in", type: "Quantity" },
+  ],
+};
+
+describe("libraryToSummary", () => {
+  // The summary surfaces decoded SQL and known parameter types, with
+  // unsupported declared types coerced to `string` so the form can still
+  // render an input.
+  it("decodes SQL and maps parameters and related artefacts", () => {
+    const summary = libraryToSummary(libraryFixture);
+    expect(summary).toBeDefined();
+    expect(summary?.id).toBe("lib-1");
+    expect(summary?.title).toBe("Patients by condition");
+    expect(summary?.sql).toBe("SELECT 1");
+    expect(summary?.relatedArtifacts).toEqual([
+      { label: "patients", reference: "ViewDefinition/patients" },
+    ]);
+    expect(summary?.parameters).toEqual([
+      { name: "patient_id", type: "string" },
+      { name: "_unsupported", type: "string" },
+    ]);
+  });
+
+  // Resources without an ID or SQL content cannot be rendered, so they
+  // are skipped at the summary layer.
+  it("returns undefined when the resource lacks an ID", () => {
+    const noId: Library = { ...libraryFixture, id: undefined };
+    expect(libraryToSummary(noId)).toBeUndefined();
+  });
+
+  it("returns undefined when no application/sql content exists", () => {
+    const noSql: Library = { ...libraryFixture, content: [] };
+    expect(libraryToSummary(noSql)).toBeUndefined();
+  });
+
+  // The summary falls back to `name` then `id` when no `title` is set.
+  it("falls back to name then id for the title", () => {
+    const noTitle: Library = { ...libraryFixture, title: undefined };
+    expect(libraryToSummary(noTitle)?.title).toBe("patients-by-condition");
+    const onlyId: Library = {
+      ...libraryFixture,
+      title: undefined,
+      name: undefined,
+    };
+    expect(libraryToSummary(onlyId)?.title).toBe("lib-1");
+  });
+});
+
+describe("mapLibraryBundle", () => {
+  // Empty bundles produce no summaries.
+  it("returns an empty array for an empty bundle", () => {
+    const bundle: Bundle = { resourceType: "Bundle", type: "searchset" };
+    expect(mapLibraryBundle(bundle)).toEqual([]);
+  });
+
+  // Non-Library entries and Libraries that fail to summarise are skipped.
+  it("skips non-Library entries and unsummarisable Libraries", () => {
+    const bundle: Bundle = {
+      resourceType: "Bundle",
+      type: "searchset",
+      entry: [
+        { resource: { resourceType: "Patient", id: "x" } },
+        {
+          resource: {
+            resourceType: "Library",
+            // Missing id and content so libraryToSummary returns undefined.
+            status: "active",
+          } as Library,
+        },
+        { resource: libraryFixture },
+      ],
+    };
+    const summaries = mapLibraryBundle(bundle);
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].id).toBe("lib-1");
+  });
+});
+
+describe("parseTabularBody", () => {
+  // CSV bodies are parsed using the dedicated CSV utility.
+  it("parses a CSV body", () => {
+    const body = "id,name\n1,Alice\n2,Bob";
+    const { columns, rows } = parseTabularBody(body, "csv");
+    expect(columns).toEqual(["id", "name"]);
+    expect(rows).toEqual([
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+    ]);
+  });
+
+  // NDJSON bodies are parsed line by line.
+  it("parses an NDJSON body", () => {
+    const body = '{"id":1,"name":"Alice"}\n{"id":2,"name":"Bob"}';
+    const { columns, rows } = parseTabularBody(body, "ndjson");
+    expect(columns).toEqual(["id", "name"]);
+    expect(rows).toEqual([
+      { id: 1, name: "Alice" },
+      { id: 2, name: "Bob" },
+    ]);
+  });
+
+  // JSON bodies parse into a single array.
+  it("parses a JSON body", () => {
+    const body = '[{"id":1},{"id":2}]';
+    const { columns, rows } = parseTabularBody(body, "json");
+    expect(columns).toEqual(["id"]);
+    expect(rows).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  // FHIR-format bodies are flattened from a Parameters resource.
+  it("flattens a FHIR-format body", () => {
+    const body = JSON.stringify({
+      resourceType: "Parameters",
+      parameter: [
+        {
+          name: "row",
+          part: [{ name: "id", valueInteger: 1 }],
+        },
+      ],
+    });
+    const { columns, rows } = parseTabularBody(body, "fhir");
+    expect(columns).toEqual(["id"]);
+    expect(rows).toEqual([{ id: "1" }]);
+  });
+
+  // An empty body yields zero rows for any tabular format.
+  it("returns no rows for an empty JSON body", () => {
+    expect(parseTabularBody("", "json")).toEqual({
+      columns: [],
+      rows: [],
+    });
+  });
+});
+
+describe("readSqlQueryResponse", () => {
+  // CSV branch uses the response text and returns a tabular result with
+  // a Blob for verbatim download.
+  it("returns a tabular result for csv", async () => {
+    const response = new Response("id,name\n1,Alice", {
+      status: 200,
+      headers: { "Content-Type": "text/csv" },
+    });
+    const result = await readSqlQueryResponse(response, "csv");
+    expect(result.kind).toBe("tabular");
+    if (result.kind !== "tabular") return;
+    expect(result.columns).toEqual(["id", "name"]);
+    expect(result.rows).toEqual([{ id: "1", name: "Alice" }]);
+    expect(result.rawBody).toBeInstanceOf(Blob);
+  });
+
+  // Parquet branch returns a binary blob and does not attempt to parse.
+  it("returns a binary result for parquet", async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    const response = new Response(data, {
+      status: 200,
+      headers: { "Content-Type": "application/vnd.apache.parquet" },
+    });
+    const result = await readSqlQueryResponse(response, "parquet");
+    expect(result.kind).toBe("binary");
+    if (result.kind !== "binary") return;
+    expect(result.blob.size).toBe(3);
+  });
+});

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -50,6 +50,15 @@ export { useViewDefinitions } from "./useViewDefinitions";
 export type { ViewDefinitionSummary } from "./useViewDefinitions";
 export { useSaveViewDefinition } from "./useSaveViewDefinition";
 
+// SQL query operations.
+export { useSqlQueryLibraries } from "./useSqlQueryLibraries";
+export { useSaveSqlQueryLibrary } from "./useSaveSqlQueryLibrary";
+export { useSqlQueryRun } from "./useSqlQueryRun";
+export type {
+  UseSqlQueryRunOptions,
+  UseSqlQueryRunResult,
+} from "./useSqlQueryRun";
+
 // Other operations.
 export { useClipboard } from "./useClipboard";
 export { useDownloadFile } from "./useDownloadFile";

--- a/ui/src/hooks/sqlQueryHelpers.ts
+++ b/ui/src/hooks/sqlQueryHelpers.ts
@@ -91,7 +91,10 @@ export function mapLibraryBundle(bundle: Bundle): SqlQueryLibrarySummary[] {
  *
  * Returns `undefined` if the resource is missing the data the form
  * requires (an ID or any SQL content).
- * @param library
+ *
+ * @param library - The Library resource to summarise.
+ * @returns The picker-friendly summary, or `undefined` when the resource
+ *   is unusable.
  */
 export function libraryToSummary(
   library: Library,
@@ -230,7 +233,9 @@ export function parseTabularBody(
  *
  * Columns appear in first-seen order so the rendered table follows the
  * server's natural column ordering when present.
- * @param rows
+ *
+ * @param rows - The parsed result rows.
+ * @returns The column names in first-seen order.
  */
 function extractColumns(rows: Record<string, unknown>[]): string[] {
   const columns: string[] = [];
@@ -249,7 +254,9 @@ function extractColumns(rows: Record<string, unknown>[]): string[] {
 /**
  * Returns the MIME type to attach to the downloadable Blob produced from
  * a tabular response body.
- * @param format
+ *
+ * @param format - The output format the body was produced with.
+ * @returns The MIME type to attach to the Blob.
  */
 function tabularContentType(
   format: Exclude<SqlQueryOutputFormat, "parquet">,

--- a/ui/src/hooks/sqlQueryHelpers.ts
+++ b/ui/src/hooks/sqlQueryHelpers.ts
@@ -1,0 +1,267 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Pure helpers for the SQL query hooks.
+ *
+ * Splitting these out keeps the hooks themselves as thin wrappers and lets
+ * us unit-test the request/response logic without mounting React.
+ *
+ * @author John Grimes
+ */
+
+import {
+  decodeSql,
+  flattenFhirParameters,
+  parseCsvResponse,
+  parseNdjsonResponse,
+} from "../utils";
+
+import type {
+  SqlQueryBinaryResult,
+  SqlQueryLibrary,
+  SqlQueryLibrarySummary,
+  SqlQueryOutputFormat,
+  SqlQueryParameterType,
+  SqlQueryResult,
+  SqlQueryTabularResult,
+} from "../types/sqlQuery";
+import type { Bundle, Library } from "fhir/r4";
+
+/**
+ * Allowed FHIR primitive types for declared SQL parameters in the UI.
+ */
+const SUPPORTED_PARAMETER_TYPES = new Set<SqlQueryParameterType>([
+  "string",
+  "code",
+  "integer",
+  "decimal",
+  "boolean",
+  "date",
+  "dateTime",
+]);
+
+/**
+ * Maps a FHIR Bundle of Library resources into the picker-friendly summary
+ * shape consumed by the SQL query form.
+ *
+ * Resources missing the SQL on FHIR `content` slot or a usable ID are
+ * skipped so the picker only ever offers Libraries that the form can
+ * actually render.
+ *
+ * @param bundle - The FHIR search Bundle to map.
+ * @returns The library summaries in Bundle order.
+ *
+ * @example
+ * mapLibraryBundle({ resourceType: "Bundle", entry: [{ resource: lib }] });
+ */
+export function mapLibraryBundle(bundle: Bundle): SqlQueryLibrarySummary[] {
+  const summaries: SqlQueryLibrarySummary[] = [];
+  for (const entry of bundle.entry ?? []) {
+    const resource = entry.resource;
+    if (!resource || resource.resourceType !== "Library") {
+      continue;
+    }
+    const summary = libraryToSummary(resource);
+    if (summary) {
+      summaries.push(summary);
+    }
+  }
+  return summaries;
+}
+
+/**
+ * Converts a FHIR Library resource into a {@link SqlQueryLibrarySummary},
+ * decoding the embedded SQL and surfacing parameter declarations and
+ * related artefacts in their form-friendly shape.
+ *
+ * Returns `undefined` if the resource is missing the data the form
+ * requires (an ID or any SQL content).
+ * @param library
+ */
+export function libraryToSummary(
+  library: Library,
+): SqlQueryLibrarySummary | undefined {
+  const id = library.id;
+  if (!id) {
+    return undefined;
+  }
+  const sqlContent = (library.content ?? []).find(
+    (c) => c.contentType === "application/sql",
+  );
+  if (!sqlContent || !sqlContent.data) {
+    return undefined;
+  }
+
+  const sql = decodeSql(sqlContent.data);
+  const title = library.title || library.name || id;
+  const relatedArtifacts = (library.relatedArtifact ?? [])
+    .filter((ra) => ra.type === "depends-on")
+    .map((ra) => ({
+      label: ra.label ?? "",
+      reference: ra.resource ?? "",
+    }));
+  const parameters: Array<{ name: string; type: SqlQueryParameterType }> = [];
+  for (const declared of library.parameter ?? []) {
+    if (!declared.name || !declared.type) {
+      continue;
+    }
+    if (declared.use !== undefined && declared.use !== "in") {
+      continue;
+    }
+    const declaredType = declared.type as SqlQueryParameterType;
+    parameters.push({
+      name: declared.name,
+      type: SUPPORTED_PARAMETER_TYPES.has(declaredType)
+        ? declaredType
+        : "string",
+    });
+  }
+
+  return {
+    id,
+    title,
+    sql,
+    relatedArtifacts,
+    parameters,
+    resource: library as unknown as SqlQueryLibrary,
+  };
+}
+
+/**
+ * Reads the body of a `$sqlquery-run` response and assembles it into a
+ * format-aware result.
+ *
+ * Tabular formats (`csv`, `ndjson`, `json`, `fhir`) are parsed into a
+ * `{columns, rows}` shape and the original body is preserved as a Blob so
+ * the UI can offer a verbatim download. Parquet is not parsed; the body
+ * is returned as a Blob only.
+ *
+ * @param response - The fetch Response from `sqlQueryRun`.
+ * @param format - The output format requested with the request.
+ * @returns The parsed and/or downloadable result.
+ *
+ * @example
+ * const result = await readSqlQueryResponse(response, "csv");
+ */
+export async function readSqlQueryResponse(
+  response: Response,
+  format: SqlQueryOutputFormat,
+): Promise<SqlQueryResult> {
+  if (format === "parquet") {
+    const blob = await response.blob();
+    const binary: SqlQueryBinaryResult = {
+      kind: "binary",
+      format: "parquet",
+      blob,
+    };
+    return binary;
+  }
+
+  const text = await response.text();
+  const tabular = parseTabularBody(text, format);
+  const blob = new Blob([text], { type: tabularContentType(format) });
+  const result: SqlQueryTabularResult = {
+    kind: "tabular",
+    format,
+    columns: tabular.columns,
+    rows: tabular.rows,
+    rawBody: blob,
+  };
+  return result;
+}
+
+/**
+ * Parses a tabular body into `{columns, rows}` based on the requested
+ * format. Empty bodies produce zero rows.
+ *
+ * @param body - The response body text.
+ * @param format - The format the server was asked to produce.
+ * @returns The parsed `{columns, rows}` view.
+ */
+export function parseTabularBody(
+  body: string,
+  format: Exclude<SqlQueryOutputFormat, "parquet">,
+): { columns: string[]; rows: Record<string, unknown>[] } {
+  if (format === "csv") {
+    const rows = parseCsvResponse(body);
+    return { columns: extractColumns(rows), rows };
+  }
+  if (format === "ndjson") {
+    const rows = parseNdjsonResponse(body);
+    return { columns: extractColumns(rows), rows };
+  }
+  if (format === "json") {
+    const trimmed = body.trim();
+    if (trimmed.length === 0) {
+      return { columns: [], rows: [] };
+    }
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>[];
+    const rows = Array.isArray(parsed) ? parsed : [];
+    return { columns: extractColumns(rows), rows };
+  }
+  // FHIR format: parse a Parameters resource and flatten one row per
+  // `row` parameter.
+  const trimmed = body.trim();
+  if (trimmed.length === 0) {
+    return { columns: [], rows: [] };
+  }
+  const parameters = JSON.parse(trimmed);
+  const flattened = flattenFhirParameters(parameters);
+  return flattened;
+}
+
+/**
+ * Extracts column names from the union of keys seen across the rows.
+ *
+ * Columns appear in first-seen order so the rendered table follows the
+ * server's natural column ordering when present.
+ * @param rows
+ */
+function extractColumns(rows: Record<string, unknown>[]): string[] {
+  const columns: string[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        columns.push(key);
+      }
+    }
+  }
+  return columns;
+}
+
+/**
+ * Returns the MIME type to attach to the downloadable Blob produced from
+ * a tabular response body.
+ * @param format
+ */
+function tabularContentType(
+  format: Exclude<SqlQueryOutputFormat, "parquet">,
+): string {
+  switch (format) {
+    case "csv":
+      return "text/csv";
+    case "ndjson":
+      return "application/x-ndjson";
+    case "json":
+      return "application/json";
+    case "fhir":
+      return "application/fhir+json";
+  }
+}

--- a/ui/src/hooks/useSaveSqlQueryLibrary.ts
+++ b/ui/src/hooks/useSaveSqlQueryLibrary.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { create } from "../api";
+import { config } from "../config";
+import { libraryToSummary } from "./sqlQueryHelpers";
+import { SQL_QUERY_LIBRARIES_QUERY_KEY } from "./useSqlQueryLibraries";
+import { useAuth } from "../contexts/AuthContext";
+
+import type {
+  SaveSqlQueryLibraryResult,
+  SqlQueryLibrary,
+} from "../types/sqlQuery";
+import type { UseMutationResult } from "@tanstack/react-query";
+import type { Library } from "fhir/r4";
+
+/**
+ * Options for {@link useSaveSqlQueryLibrary}.
+ */
+export interface UseSaveSqlQueryLibraryOptions {
+  /** Callback fired on a successful save. */
+  onSuccess?: (result: SaveSqlQueryLibraryResult) => void;
+  /** Callback fired on error. */
+  onError?: (error: Error) => void;
+}
+
+/**
+ * Result type for {@link useSaveSqlQueryLibrary}.
+ */
+export type UseSaveSqlQueryLibraryResult = UseMutationResult<
+  SaveSqlQueryLibraryResult,
+  Error,
+  SqlQueryLibrary
+>;
+
+/**
+ * Saves an inline SQLQuery Library to the server.
+ *
+ * On success, the new resource is appended to the cached
+ * `SQL_QUERY_LIBRARIES_QUERY_KEY` list and a background refresh is
+ * triggered so other consumers see the update.
+ *
+ * @param options - Optional callbacks for success and error.
+ * @returns Mutation result for saving SQLQuery Libraries.
+ */
+export function useSaveSqlQueryLibrary(
+  options?: UseSaveSqlQueryLibraryOptions,
+): UseSaveSqlQueryLibraryResult {
+  const { fhirBaseUrl } = config;
+  const { client } = useAuth();
+  const accessToken = client?.state.tokenResponse?.access_token;
+  const queryClient = useQueryClient();
+
+  return useMutation<SaveSqlQueryLibraryResult, Error, SqlQueryLibrary>({
+    mutationFn: async (library) => {
+      const created = (await create(fhirBaseUrl!, {
+        resourceType: "Library",
+        resource: library as unknown as Library,
+        accessToken,
+      })) as Library;
+      const summary = libraryToSummary(created);
+      const id = created.id;
+      if (!id || !summary) {
+        throw new Error(
+          "Server returned a Library without an ID or content; cannot reference it.",
+        );
+      }
+      return { id, title: summary.title };
+    },
+    onSuccess: (result) => {
+      void queryClient.invalidateQueries({
+        queryKey: SQL_QUERY_LIBRARIES_QUERY_KEY,
+      });
+      options?.onSuccess?.(result);
+    },
+    onError: options?.onError,
+  });
+}

--- a/ui/src/hooks/useSqlQueryLibraries.ts
+++ b/ui/src/hooks/useSqlQueryLibraries.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import { listSqlQueryLibraries } from "../api";
+import { config } from "../config";
+import { mapLibraryBundle } from "./sqlQueryHelpers";
+import { useAuth } from "../contexts/AuthContext";
+
+import type { SqlQueryLibrarySummary } from "../types/sqlQuery";
+import type { UseQueryResult } from "@tanstack/react-query";
+
+/**
+ * TanStack Query key shared by readers and mutators of the SQL query
+ * Library list.
+ */
+export const SQL_QUERY_LIBRARIES_QUERY_KEY = ["sqlQueryLibraries"] as const;
+
+/**
+ * Options for {@link useSqlQueryLibraries}.
+ */
+export interface UseSqlQueryLibrariesOptions {
+  /** Whether to enable the query. Defaults to `true`. */
+  enabled?: boolean;
+}
+
+/**
+ * Hook result type for {@link useSqlQueryLibraries}.
+ */
+export type UseSqlQueryLibrariesResult = UseQueryResult<
+  SqlQueryLibrarySummary[],
+  Error
+>;
+
+/**
+ * Fetches stored SQLQuery Library resources from the FHIR server.
+ *
+ * @param options - Optional query options.
+ * @returns Query result with summaries of stored SQLQuery Libraries.
+ */
+export function useSqlQueryLibraries(
+  options?: UseSqlQueryLibrariesOptions,
+): UseSqlQueryLibrariesResult {
+  const { fhirBaseUrl } = config;
+  const { client } = useAuth();
+  const accessToken = client?.state.tokenResponse?.access_token;
+
+  return useQuery<SqlQueryLibrarySummary[], Error>({
+    queryKey: SQL_QUERY_LIBRARIES_QUERY_KEY,
+    queryFn: async () => {
+      const bundle = await listSqlQueryLibraries(fhirBaseUrl!, {
+        accessToken,
+      });
+      return mapLibraryBundle(bundle);
+    },
+    enabled: options?.enabled !== false && !!fhirBaseUrl,
+  });
+}

--- a/ui/src/hooks/useSqlQueryRun.ts
+++ b/ui/src/hooks/useSqlQueryRun.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMutation } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+
+import { sqlQueryRun } from "../api";
+import { config } from "../config";
+import { readSqlQueryResponse } from "./sqlQueryHelpers";
+import { useAuth } from "../contexts/AuthContext";
+
+import type { SqlQueryRequest, SqlQueryResult } from "../types/sqlQuery";
+
+/**
+ * Options for {@link useSqlQueryRun}.
+ */
+export interface UseSqlQueryRunOptions {
+  /** Callback fired on a successful execution. */
+  onSuccess?: (result: SqlQueryResult) => void;
+  /** Callback fired on error. */
+  onError?: (error: Error) => void;
+}
+
+/**
+ * Result of {@link useSqlQueryRun}.
+ */
+export interface UseSqlQueryRunResult {
+  /** Current status of the underlying mutation. */
+  status: "idle" | "pending" | "success" | "error";
+  /** The execution result when successful. */
+  result: SqlQueryResult | undefined;
+  /** Error object when failed. */
+  error: Error | null;
+  /** Snapshot of the request that produced the current state. */
+  lastRequest: SqlQueryRequest | undefined;
+  /** Execute a SQL query. */
+  execute: (request: SqlQueryRequest) => void;
+  /** Reset all state to idle. */
+  reset: () => void;
+  /** Whether execution is in progress. */
+  isPending: boolean;
+}
+
+/**
+ * Executes a SQL on FHIR `$sqlquery-run` request and returns a parsed,
+ * format-aware result.
+ *
+ * The hook is a thin wrapper over {@link sqlQueryRun} and
+ * {@link readSqlQueryResponse}; the bulk of the logic lives in those pure
+ * helpers, in line with the project's React rules.
+ *
+ * @param options - Optional callbacks for success and error events.
+ * @returns Hook result with status, result, error, and control functions.
+ */
+export function useSqlQueryRun(
+  options?: UseSqlQueryRunOptions,
+): UseSqlQueryRunResult {
+  const { fhirBaseUrl } = config;
+  const { client } = useAuth();
+  const accessToken = client?.state.tokenResponse?.access_token;
+  const [lastRequest, setLastRequest] = useState<SqlQueryRequest | undefined>(
+    undefined,
+  );
+
+  const mutation = useMutation<SqlQueryResult, Error, SqlQueryRequest>({
+    mutationFn: async (request: SqlQueryRequest) => {
+      if (!fhirBaseUrl) {
+        throw new Error("FHIR base URL is not configured");
+      }
+      setLastRequest(request);
+      const response =
+        request.mode === "stored"
+          ? await sqlQueryRun(fhirBaseUrl, {
+              mode: "stored",
+              libraryId: request.libraryId,
+              format: request.format,
+              limit: request.limit,
+              header: request.header,
+              bindings: request.bindings,
+              parameterTypes: request.parameterTypes,
+              accessToken,
+            })
+          : await sqlQueryRun(fhirBaseUrl, {
+              mode: "inline",
+              library: request.library,
+              format: request.format,
+              limit: request.limit,
+              header: request.header,
+              bindings: request.bindings,
+              parameterTypes: request.parameterTypes,
+              accessToken,
+            });
+
+      const format = request.format ?? "ndjson";
+      return readSqlQueryResponse(response, format);
+    },
+    onSuccess: options?.onSuccess,
+    onError: options?.onError,
+  });
+
+  const execute = useCallback(
+    (request: SqlQueryRequest) => {
+      mutation.mutate(request);
+    },
+    [mutation],
+  );
+
+  const reset = useCallback(() => {
+    mutation.reset();
+    setLastRequest(undefined);
+  }, [mutation]);
+
+  return {
+    status: mutation.status,
+    result: mutation.data,
+    error: mutation.error,
+    lastRequest,
+    execute,
+    reset,
+    isPending: mutation.isPending,
+  };
+}

--- a/ui/src/pages/SqlOnFhir.tsx
+++ b/ui/src/pages/SqlOnFhir.tsx
@@ -108,7 +108,8 @@ export function SqlOnFhir() {
 
   /**
    * Removes a result card from the column.
-   * @param id
+   *
+   * @param id - The job ID of the card to remove.
    */
   const handleCloseJob = (id: string) => {
     setPageJobs((prev) => prev.filter((entry) => entry.job.id !== id));
@@ -186,7 +187,10 @@ export function SqlOnFhir() {
  * Looks at the `sql-text` extension on `Library.content[0]` first, then
  * falls back to decoding `Library.content[0].data`. Returns the empty
  * string when neither is available.
- * @param request
+ *
+ * @param request - The SQL query request to inspect.
+ * @returns The plain SQL text, or an empty string if it cannot be
+ *   recovered.
  */
 function extractSqlText(request: SqlQueryRequest): string {
   if (request.mode !== "inline") {

--- a/ui/src/pages/SqlOnFhir.tsx
+++ b/ui/src/pages/SqlOnFhir.tsx
@@ -16,54 +16,69 @@
  */
 
 /**
- * Page for executing SQL on FHIR ViewDefinitions.
+ * Page for executing the SQL on FHIR `$viewdefinition-run` and
+ * `$sqlquery-run` operations.
  *
  * @author John Grimes
  */
 
-import { Box, Flex, Spinner, Text } from "@radix-ui/themes";
+import { Box, Flex, Heading, Spinner, Text } from "@radix-ui/themes";
 import { useState } from "react";
 
 import { LoginRequired } from "../components/auth/LoginRequired";
 import { SessionExpiredDialog } from "../components/auth/SessionExpiredDialog";
 import { SqlOnFhirForm } from "../components/sqlOnFhir/SqlOnFhirForm";
+import { SqlQueryCard } from "../components/sqlOnFhir/SqlQueryCard";
 import { ViewCard } from "../components/sqlOnFhir/ViewCard";
 import { config } from "../config";
 import { useAuth } from "../contexts/AuthContext";
-import { useSaveViewDefinition, useServerCapabilities } from "../hooks";
+import { useSaveSqlQueryLibrary, useSaveViewDefinition, useServerCapabilities } from "../hooks";
 
+import type { SqlOnFhirMode } from "../components/sqlOnFhir/SqlOnFhirForm";
 import type { ViewRunRequest } from "../hooks";
+import type { SqlQueryJob, SqlQueryRequest } from "../types/sqlQuery";
 import type { ViewJob } from "../types/viewJob";
 
+interface PageJob {
+  type: "view" | "sql-query";
+  /** Underlying job. */
+  job: ViewJob | SqlQueryJob;
+}
+
 /**
- * Page component for executing SQL on FHIR ViewDefinitions.
+ * Page component for executing SQL on FHIR operations.
  *
- * @returns The SQL on FHIR page component.
+ * @returns The SQL on FHIR page.
  */
 export function SqlOnFhir() {
   const { fhirBaseUrl } = config;
   const { isAuthenticated } = useAuth();
 
-  // Track all view query jobs.
-  const [queries, setQueries] = useState<ViewJob[]>([]);
+  const [mode, setMode] = useState<SqlOnFhirMode>("view-definition");
 
-  // Track error messages for display.
+  // Track all view query jobs and SQL query jobs as a single timeline so
+  // they can be sorted by createdAt regardless of source.
+  const [pageJobs, setPageJobs] = useState<PageJob[]>([]);
+
   const [, setError] = useState<string | null>(null);
 
   // Fetch server capabilities to determine if auth is required.
   const { data: capabilities, isLoading: isLoadingCapabilities } =
     useServerCapabilities(fhirBaseUrl);
 
-  // Mutation for saving a ViewDefinition to the server. 401 errors handled globally.
-  const { mutateAsync: saveViewDefinition, isPending: isSaving } = useSaveViewDefinition();
+  // Mutations: ViewDefinition save and SQL query Library save.
+  const { mutateAsync: saveViewDefinition, isPending: isSavingViewDefinition } =
+    useSaveViewDefinition();
+  const { mutateAsync: saveSqlQueryLibrary, isPending: isSavingSqlQueryLibrary } =
+    useSaveSqlQueryLibrary();
 
   /**
-   * Handles execution of a ViewDefinition query.
+   * Adds a ViewDefinition execution to the result column.
    *
    * @param request - The view run request configuration.
    */
-  const handleExecute = (request: ViewRunRequest) => {
-    const newQuery: ViewJob = {
+  const handleExecuteViewDefinition = (request: ViewRunRequest) => {
+    const newJob: ViewJob = {
       id: crypto.randomUUID(),
       mode: request.mode,
       viewDefinitionId: request.viewDefinitionId,
@@ -71,17 +86,32 @@ export function SqlOnFhir() {
       limit: request.limit,
       createdAt: new Date(),
     };
-    // Prepend new queries so most recent appears first.
-    setQueries((prev) => [newQuery, ...prev]);
+    setPageJobs((prev) => [{ type: "view", job: newJob }, ...prev]);
   };
 
   /**
-   * Handles closing/removing a query card.
+   * Adds a SQL query execution to the result column.
    *
-   * @param id - The ID of the query to close.
+   * @param request - The SQL query request.
    */
-  const handleCloseQuery = (id: string) => {
-    setQueries((prev) => prev.filter((query) => query.id !== id));
+  const handleExecuteSqlQuery = (request: SqlQueryRequest) => {
+    const sql = request.mode === "inline" ? extractSqlText(request) : "";
+    const newJob: SqlQueryJob = {
+      id: crypto.randomUUID(),
+      mode: request.mode,
+      request,
+      sql,
+      createdAt: new Date(),
+    };
+    setPageJobs((prev) => [{ type: "sql-query", job: newJob }, ...prev]);
+  };
+
+  /**
+   * Removes a result card from the column.
+   * @param id
+   */
+  const handleCloseJob = (id: string) => {
+    setPageJobs((prev) => prev.filter((entry) => entry.job.id !== id));
   };
 
   // Show loading state while checking server capabilities.
@@ -104,29 +134,71 @@ export function SqlOnFhir() {
 
   return (
     <>
-      <Flex gap="6" direction={{ initial: "column", md: "row" }}>
-        <Box style={{ flex: 1 }}>
-          <SqlOnFhirForm
-            onExecute={handleExecute}
-            onSaveToServer={saveViewDefinition}
-            isExecuting={false}
-            isSaving={isSaving}
-          />
-        </Box>
+      <Flex direction="column" gap="4">
+        <Heading size="6">SQL on FHIR</Heading>
 
-        <Flex direction="column" gap="3" style={{ flex: 1, overflow: "hidden" }}>
-          {queries.map((job) => (
-            <ViewCard
-              key={job.id}
-              job={job}
-              onError={(message) => setError(message)}
-              onClose={() => handleCloseQuery(job.id)}
+        <Flex gap="6" direction={{ initial: "column", md: "row" }}>
+          <Box style={{ flex: 1 }}>
+            <SqlOnFhirForm
+              mode={mode}
+              onModeChange={setMode}
+              onExecuteViewDefinition={handleExecuteViewDefinition}
+              onSaveViewDefinition={saveViewDefinition}
+              onExecuteSqlQuery={handleExecuteSqlQuery}
+              onSaveSqlQueryLibrary={saveSqlQueryLibrary}
+              isViewDefinitionExecuting={false}
+              isViewDefinitionSaving={isSavingViewDefinition}
+              isSqlQueryExecuting={false}
+              isSqlQuerySaving={isSavingSqlQueryLibrary}
             />
-          ))}
+          </Box>
+
+          <Flex direction="column" gap="3" style={{ flex: 1, overflow: "hidden" }}>
+            {pageJobs.map((entry) =>
+              entry.type === "view" ? (
+                <ViewCard
+                  key={entry.job.id}
+                  job={entry.job as ViewJob}
+                  onError={(message) => setError(message)}
+                  onClose={() => handleCloseJob(entry.job.id)}
+                />
+              ) : (
+                <SqlQueryCard
+                  key={entry.job.id}
+                  job={entry.job as SqlQueryJob}
+                  onError={(message) => setError(message)}
+                  onClose={() => handleCloseJob(entry.job.id)}
+                />
+              ),
+            )}
+          </Flex>
         </Flex>
       </Flex>
 
       <SessionExpiredDialog />
     </>
   );
+}
+
+/**
+ * Extracts the plain SQL text from an inline `SqlQueryRequest`.
+ *
+ * Looks at the `sql-text` extension on `Library.content[0]` first, then
+ * falls back to decoding `Library.content[0].data`. Returns the empty
+ * string when neither is available.
+ * @param request
+ */
+function extractSqlText(request: SqlQueryRequest): string {
+  if (request.mode !== "inline") {
+    return "";
+  }
+  const content = request.library.content?.[0];
+  if (!content) {
+    return "";
+  }
+  const ext = content.extension?.find((e) => e.url.endsWith("/sql-text"));
+  if (ext?.valueString) {
+    return ext.valueString;
+  }
+  return "";
 }

--- a/ui/src/types/sqlQuery.ts
+++ b/ui/src/types/sqlQuery.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Type definitions for the SQL query (`$sqlquery-run`) UI flow.
+ *
+ * @author John Grimes
+ */
+
+/**
+ * Output formats accepted by the `$sqlquery-run` operation.
+ */
+export type SqlQueryOutputFormat =
+  | "ndjson"
+  | "csv"
+  | "json"
+  | "parquet"
+  | "fhir";
+
+/**
+ * FHIR primitive types supported as runtime parameter values in the UI.
+ *
+ * The server's request parser handles a wider range of types, but the UI
+ * limits authoring to these primitives (see the design doc for rationale).
+ */
+export type SqlQueryParameterType =
+  | "string"
+  | "code"
+  | "integer"
+  | "decimal"
+  | "boolean"
+  | "date"
+  | "dateTime";
+
+/**
+ * A `relatedArtifact` entry on a SQLQuery Library, expressed in form-state
+ * terms.
+ */
+export interface SqlQueryRelatedArtifact {
+  /** Stable identifier for use as a React `key`. */
+  rowId: string;
+  /** Table name referenced by the SQL. */
+  label: string;
+  /** ID of the referenced ViewDefinition (becomes `ViewDefinition/<id>`). */
+  viewDefinitionId: string;
+}
+
+/**
+ * A declared parameter on a SQLQuery Library, expressed in form-state terms.
+ */
+export interface SqlQueryParameterDeclaration {
+  /** Stable identifier for use as a React `key`. */
+  rowId: string;
+  /** Parameter name, used both in the SQL and to bind a runtime value. */
+  name: string;
+  /** Declared FHIR primitive type. */
+  type: SqlQueryParameterType;
+  /** Optional default value supplied as a string; coerced on submit. */
+  defaultValue?: string;
+}
+
+/**
+ * Runtime parameter bindings supplied at execution time.
+ *
+ * Keyed by declared parameter name. A missing or empty entry causes the
+ * parameter to be omitted from the request's nested Parameters resource.
+ */
+export type SqlQueryRuntimeBindings = Record<string, string>;
+
+/**
+ * Decoded summary of a stored SQLQuery Library, surfaced to the form.
+ */
+export interface SqlQueryLibrarySummary {
+  /** Server-assigned ID. */
+  id: string;
+  /** Human-readable title (`title` or `name`, falling back to the ID). */
+  title: string;
+  /** Decoded SQL text from `Library.content[0].data`. */
+  sql: string;
+  /** Related-artifact entries with label and ViewDefinition reference. */
+  relatedArtifacts: Array<{ label: string; reference: string }>;
+  /** Declared parameters extracted from `Library.parameter`. */
+  parameters: Array<{ name: string; type: SqlQueryParameterType }>;
+  /** The original Library resource, kept for execution by reference. */
+  resource: SqlQueryLibrary;
+}
+
+/**
+ * Library resource conforming to the SQLQuery profile, in the shape used by
+ * the API client and form state. This is a structurally-narrower view of
+ * `fhir/r4`'s Library; only the slots used by the UI are typed.
+ */
+export interface SqlQueryLibrary {
+  resourceType: "Library";
+  id?: string;
+  url?: string;
+  name?: string;
+  title?: string;
+  status: "active" | "draft" | "retired" | "unknown";
+  meta?: { profile?: string[] };
+  type: {
+    coding: Array<{
+      system: string;
+      code: "sql-query";
+    }>;
+  };
+  content: Array<{
+    contentType: "application/sql";
+    data: string;
+    extension?: Array<{ url: string; valueString?: string }>;
+  }>;
+  relatedArtifact?: Array<{
+    type: "depends-on";
+    label?: string;
+    resource?: string;
+  }>;
+  parameter?: Array<{
+    name: string;
+    use: "in" | "out";
+    type: string;
+    extension?: Array<{ url: string; [key: string]: unknown }>;
+  }>;
+}
+
+/**
+ * Common execution options that apply regardless of how the Library is
+ * supplied.
+ */
+export interface SqlQueryExecutionOptions {
+  /** Output format (defaults to ndjson on the server when omitted). */
+  format?: SqlQueryOutputFormat;
+  /** Maximum number of rows to return. */
+  limit?: number;
+  /** Whether to include a header row when format is `csv`. */
+  header?: boolean;
+  /** Runtime parameter values, keyed by declared parameter name. */
+  bindings?: SqlQueryRuntimeBindings;
+  /**
+   * Declared parameter types, keyed by name. Used to pick the correct
+   * `value[x]` slot for each binding.
+   */
+  parameterTypes?: Record<string, SqlQueryParameterType>;
+}
+
+/**
+ * A `$sqlquery-run` request, distinguished by how the Library is supplied.
+ */
+export type SqlQueryRequest =
+  | (SqlQueryExecutionOptions & {
+      mode: "stored";
+      /** ID of a stored Library conforming to the SQLQuery profile. */
+      libraryId: string;
+    })
+  | (SqlQueryExecutionOptions & {
+      mode: "inline";
+      /** Inline Library to send as the `queryResource` parameter. */
+      library: SqlQueryLibrary;
+    });
+
+/**
+ * Successful tabular result from a `$sqlquery-run` execution.
+ */
+export interface SqlQueryTabularResult {
+  /** Discriminator. */
+  kind: "tabular";
+  /** Output format that produced this result. */
+  format: Exclude<SqlQueryOutputFormat, "parquet">;
+  /** Column names in display order. */
+  columns: string[];
+  /** Parsed result rows. */
+  rows: Record<string, unknown>[];
+  /** Raw response body, retained for download. */
+  rawBody: Blob;
+}
+
+/**
+ * Successful binary (parquet) result from a `$sqlquery-run` execution.
+ */
+export interface SqlQueryBinaryResult {
+  /** Discriminator. */
+  kind: "binary";
+  /** Output format that produced this result. */
+  format: "parquet";
+  /** Response body as a Blob, ready for download. */
+  blob: Blob;
+}
+
+/**
+ * Either form of successful result.
+ */
+export type SqlQueryResult = SqlQueryTabularResult | SqlQueryBinaryResult;
+
+/**
+ * Active or completed SQL query job tracked in the page's job list.
+ */
+export interface SqlQueryJob {
+  /** Stable identifier for the in-page card. */
+  id: string;
+  /** Whether the Library was supplied by reference or inline. */
+  mode: "stored" | "inline";
+  /** Snapshot of the request used at execution time. */
+  request: SqlQueryRequest;
+  /** Original SQL text, displayed in error states and used as a download seed. */
+  sql: string;
+  /** Wall-clock submission time. */
+  createdAt: Date;
+}
+
+/**
+ * Result of saving an inline SQLQuery Library to the server.
+ */
+export interface SaveSqlQueryLibraryResult {
+  id: string;
+  title: string;
+}

--- a/ui/src/utils/__tests__/csv.test.ts
+++ b/ui/src/utils/__tests__/csv.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { parseCsvResponse } from "../csv";
+
+describe("parseCsvResponse", () => {
+  // Basic parsing: a header row drives the column order and a single data
+  // row produces a populated record.
+  it("parses a header row plus one data row", () => {
+    const csv = "id,name\n1,Alice";
+    const rows = parseCsvResponse(csv);
+    expect(rows).toEqual([{ id: "1", name: "Alice" }]);
+  });
+
+  // CRLF line endings are common in CSV exports from Windows tooling, so
+  // they must be supported alongside LF.
+  it("handles CRLF line endings", () => {
+    const csv = "id,name\r\n1,Alice\r\n2,Bob";
+    const rows = parseCsvResponse(csv);
+    expect(rows).toEqual([
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+    ]);
+  });
+
+  // Quoted values may contain commas; the comma should not be treated as
+  // a field separator inside a quoted region.
+  it("preserves commas inside quoted values", () => {
+    const csv = 'id,name\n1,"Smith, John"';
+    const rows = parseCsvResponse(csv);
+    expect(rows).toEqual([{ id: "1", name: "Smith, John" }]);
+  });
+
+  // Quoted values may also contain newlines; these must not split the row.
+  it("preserves newlines inside quoted values", () => {
+    const csv = 'id,note\n1,"line one\nline two"';
+    const rows = parseCsvResponse(csv);
+    expect(rows).toEqual([{ id: "1", note: "line one\nline two" }]);
+  });
+
+  // Embedded double-quote characters are encoded as a doubled quote; the
+  // parser collapses each pair to a single literal quote.
+  it("decodes doubled quotes inside a quoted value", () => {
+    const csv = 'id,note\n1,"He said ""hi"""';
+    const rows = parseCsvResponse(csv);
+    expect(rows).toEqual([{ id: "1", note: 'He said "hi"' }]);
+  });
+
+  // Empty cells should be retained as empty strings; the column count is
+  // governed by the header row.
+  it("preserves empty cells", () => {
+    const csv = "id,middle,last\n1,,Smith";
+    const rows = parseCsvResponse(csv);
+    expect(rows).toEqual([{ id: "1", middle: "", last: "Smith" }]);
+  });
+
+  // A trailing newline should not produce a phantom row.
+  it("ignores a trailing newline", () => {
+    const csv = "id,name\n1,Alice\n";
+    const rows = parseCsvResponse(csv);
+    expect(rows).toEqual([{ id: "1", name: "Alice" }]);
+  });
+
+  // A header-only payload yields zero rows.
+  it("returns no rows for header-only input", () => {
+    const csv = "id,name\n";
+    const rows = parseCsvResponse(csv);
+    expect(rows).toEqual([]);
+  });
+
+  // An entirely empty payload returns no rows.
+  it("returns no rows for empty input", () => {
+    expect(parseCsvResponse("")).toEqual([]);
+  });
+});

--- a/ui/src/utils/__tests__/fhirParametersFlatten.test.ts
+++ b/ui/src/utils/__tests__/fhirParametersFlatten.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { flattenFhirParameters } from "../fhirParametersFlatten";
+
+import type { Parameters } from "fhir/r4";
+
+describe("flattenFhirParameters", () => {
+  // A single row with two typed parts produces one record and the columns
+  // appear in first-seen order.
+  it("flattens a typed row into a record", () => {
+    const params: Parameters = {
+      resourceType: "Parameters",
+      parameter: [
+        {
+          name: "row",
+          part: [
+            { name: "patient_id", valueString: "pat-1" },
+            { name: "age", valueInteger: 42 },
+          ],
+        },
+      ],
+    };
+    const result = flattenFhirParameters(params);
+    expect(result.columns).toEqual(["patient_id", "age"]);
+    expect(result.rows).toEqual([{ patient_id: "pat-1", age: "42" }]);
+  });
+
+  // Missing parts (representing SQL NULL) appear as empty strings in the
+  // flattened row but the union of seen columns is preserved across rows.
+  it("treats missing parts as empty cells and unions columns across rows", () => {
+    const params: Parameters = {
+      resourceType: "Parameters",
+      parameter: [
+        {
+          name: "row",
+          part: [
+            { name: "id", valueInteger: 1 },
+            { name: "name", valueString: "Alice" },
+          ],
+        },
+        {
+          name: "row",
+          part: [{ name: "id", valueInteger: 2 }],
+        },
+        {
+          name: "row",
+          part: [
+            { name: "id", valueInteger: 3 },
+            { name: "name", valueString: "Charlie" },
+            { name: "active", valueBoolean: true },
+          ],
+        },
+      ],
+    };
+    const result = flattenFhirParameters(params);
+    expect(result.columns).toEqual(["id", "name", "active"]);
+    expect(result.rows).toEqual([
+      { id: "1", name: "Alice", active: "" },
+      { id: "2", name: "", active: "" },
+      { id: "3", name: "Charlie", active: "true" },
+    ]);
+  });
+
+  // A response with no `row` parameters yields an empty result (zero rows
+  // and zero columns).
+  it("returns empty columns and rows when there are no row parameters", () => {
+    const params: Parameters = {
+      resourceType: "Parameters",
+      parameter: [],
+    };
+    const result = flattenFhirParameters(params);
+    expect(result.columns).toEqual([]);
+    expect(result.rows).toEqual([]);
+  });
+
+  // Decimal values are stringified using `String()`, preserving the JSON
+  // numeric form returned by the server.
+  it("renders decimal values as strings", () => {
+    const params: Parameters = {
+      resourceType: "Parameters",
+      parameter: [
+        {
+          name: "row",
+          part: [{ name: "amount", valueDecimal: 1.5 }],
+        },
+      ],
+    };
+    const result = flattenFhirParameters(params);
+    expect(result.rows).toEqual([{ amount: "1.5" }]);
+  });
+
+  // Date and dateTime values pass through as-is from their string `value[x]`.
+  it("preserves date and dateTime string values", () => {
+    const params: Parameters = {
+      resourceType: "Parameters",
+      parameter: [
+        {
+          name: "row",
+          part: [
+            { name: "dob", valueDate: "1990-05-15" },
+            { name: "ts", valueDateTime: "2025-10-01T12:00:00Z" },
+          ],
+        },
+      ],
+    };
+    const result = flattenFhirParameters(params);
+    expect(result.rows).toEqual([
+      { dob: "1990-05-15", ts: "2025-10-01T12:00:00Z" },
+    ]);
+  });
+});

--- a/ui/src/utils/__tests__/sqlBase64.test.ts
+++ b/ui/src/utils/__tests__/sqlBase64.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { decodeSql, encodeSql } from "../sqlBase64";
+
+describe("encodeSql / decodeSql", () => {
+  // ASCII SQL is the common case.
+  it("round-trips an ASCII SQL string", () => {
+    const sql = "SELECT * FROM patients WHERE id = 1";
+    expect(decodeSql(encodeSql(sql))).toBe(sql);
+  });
+
+  // Encoding must produce the expected canonical Base64 for a known string,
+  // so the server sees the exact bytes a Bash one-liner would produce.
+  it("matches the canonical Base64 for an ASCII SQL string", () => {
+    expect(encodeSql("SELECT 1")).toBe("U0VMRUNUIDE=");
+  });
+
+  // Unicode characters must be UTF-8 encoded before Base64; otherwise the
+  // browser's `btoa` raises an error.
+  it("round-trips a string containing non-ASCII characters", () => {
+    const sql = "SELECT 'café' AS name";
+    expect(decodeSql(encodeSql(sql))).toBe(sql);
+  });
+
+  // Whitespace, including newlines, should round-trip unchanged.
+  it("round-trips multi-line SQL with embedded whitespace", () => {
+    const sql = "SELECT a,\n       b\nFROM t\nWHERE x = 1";
+    expect(decodeSql(encodeSql(sql))).toBe(sql);
+  });
+
+  // Empty SQL must encode to the empty string and round-trip cleanly.
+  it("round-trips an empty string", () => {
+    expect(encodeSql("")).toBe("");
+    expect(decodeSql("")).toBe("");
+  });
+
+  // The decoder should be tolerant of base64 strings that lack padding,
+  // which is common when servers strip `=` characters.
+  it("decodes a Base64 string without padding", () => {
+    expect(decodeSql("U0VMRUNUIDE")).toBe("SELECT 1");
+  });
+});

--- a/ui/src/utils/csv.ts
+++ b/ui/src/utils/csv.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Minimal CSV parser used to render `$sqlquery-run` results in a table.
+ *
+ * Mirrors the public surface of `parseNdjsonResponse` from `./ndjson`.
+ *
+ * @author John Grimes
+ */
+
+/**
+ * Parses a CSV string with a leading header row into an array of records.
+ *
+ * Supports double-quoted values containing commas, newlines and doubled
+ * quotes. Treats the first non-empty line as the header.
+ *
+ * @param csv - The CSV text to parse.
+ * @returns An array of records keyed by the header row's column names.
+ *
+ * @example
+ * parseCsvResponse("id,name\\n1,Alice");
+ * // [{ id: "1", name: "Alice" }]
+ */
+export function parseCsvResponse(csv: string): Record<string, string>[] {
+  const rows = parseCsvRows(csv);
+  if (rows.length === 0) {
+    return [];
+  }
+  const [header, ...dataRows] = rows;
+  return dataRows.map((row) => {
+    const record: Record<string, string> = {};
+    for (let i = 0; i < header.length; i++) {
+      record[header[i]] = row[i] ?? "";
+    }
+    return record;
+  });
+}
+
+/**
+ * Parses a CSV string into raw row arrays, without applying a header.
+ *
+ * @param csv - The CSV text to parse.
+ * @returns The parsed rows, each row being an array of cell values.
+ */
+function parseCsvRows(csv: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+  let i = 0;
+
+  while (i < csv.length) {
+    const ch = csv[i];
+
+    if (inQuotes) {
+      if (ch === '"') {
+        // A doubled quote inside a quoted value is an escaped literal quote.
+        if (i + 1 < csv.length && csv[i + 1] === '"') {
+          cell += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i++;
+        continue;
+      }
+      cell += ch;
+      i++;
+      continue;
+    }
+
+    if (ch === '"') {
+      inQuotes = true;
+      i++;
+      continue;
+    }
+
+    if (ch === ",") {
+      row.push(cell);
+      cell = "";
+      i++;
+      continue;
+    }
+
+    if (ch === "\r") {
+      // Treat \r\n as a single newline; bare \r is also a row break.
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+      i++;
+      if (i < csv.length && csv[i] === "\n") {
+        i++;
+      }
+      continue;
+    }
+
+    if (ch === "\n") {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+      i++;
+      continue;
+    }
+
+    cell += ch;
+    i++;
+  }
+
+  // Emit any pending cell unless the string ended cleanly on a newline.
+  if (cell.length > 0 || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+
+  return rows;
+}

--- a/ui/src/utils/fhirParametersFlatten.ts
+++ b/ui/src/utils/fhirParametersFlatten.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Flattens the FHIR-format response from the `$sqlquery-run` operation
+ * (`_format=fhir`) into a tabular `{columns, rows}` shape.
+ *
+ * The operation emits a `Parameters` resource with one repeating `row`
+ * parameter per result row, and one part per column. Each part carries
+ * the value in the appropriate `value[x]` slot.
+ *
+ * @author John Grimes
+ */
+
+import type {
+  Parameters,
+  ParametersParameter,
+  Quantity,
+  Coding,
+} from "fhir/r4";
+
+/**
+ * Result of flattening a FHIR-format `$sqlquery-run` response.
+ */
+export interface FlattenedFhirResult {
+  /** Column names in first-seen order. */
+  columns: string[];
+  /** Row records keyed by column name, with values rendered as strings. */
+  rows: Record<string, string>[];
+}
+
+/**
+ * Flattens a Parameters resource from `_format=fhir` into a tabular shape.
+ *
+ * @param parameters - The Parameters response body to flatten.
+ * @returns A `{columns, rows}` view of the response.
+ *
+ * @example
+ * flattenFhirParameters({
+ *   resourceType: "Parameters",
+ *   parameter: [
+ *     { name: "row", part: [{ name: "id", valueInteger: 1 }] },
+ *   ],
+ * });
+ * // { columns: ["id"], rows: [{ id: "1" }] }
+ */
+export function flattenFhirParameters(
+  parameters: Parameters,
+): FlattenedFhirResult {
+  const rowParts = (parameters.parameter ?? []).filter((p) => p.name === "row");
+
+  // First pass: collect column names in first-seen order.
+  const seen = new Set<string>();
+  const columns: string[] = [];
+  for (const rowParam of rowParts) {
+    for (const part of rowParam.part ?? []) {
+      if (part.name && !seen.has(part.name)) {
+        seen.add(part.name);
+        columns.push(part.name);
+      }
+    }
+  }
+
+  // Second pass: project each row into a string-keyed record using the
+  // canonical column order, filling missing parts with empty strings.
+  const rows = rowParts.map<Record<string, string>>((rowParam) => {
+    const record: Record<string, string> = {};
+    const partsByName = new Map<string, ParametersParameter>();
+    for (const part of rowParam.part ?? []) {
+      if (part.name) {
+        partsByName.set(part.name, part);
+      }
+    }
+    for (const column of columns) {
+      const part = partsByName.get(column);
+      record[column] = part ? renderPartValue(part) : "";
+    }
+    return record;
+  });
+
+  return { columns, rows };
+}
+
+/**
+ * Renders a Parameters part's `value[x]` as a display string.
+ *
+ * Handles the FHIR primitive types emitted by the SQL on FHIR FHIR-format
+ * implementation: boolean, integer, decimal, string, code, date, dateTime,
+ * instant, quantity and coding. Unknown shapes fall back to a JSON dump.
+ * @param part
+ */
+function renderPartValue(part: ParametersParameter): string {
+  if (part.valueBoolean !== undefined) {
+    return part.valueBoolean ? "true" : "false";
+  }
+  if (part.valueInteger !== undefined) {
+    return String(part.valueInteger);
+  }
+  if (part.valueDecimal !== undefined) {
+    return String(part.valueDecimal);
+  }
+  if (part.valueString !== undefined) {
+    return part.valueString;
+  }
+  if (part.valueCode !== undefined) {
+    return part.valueCode;
+  }
+  if (part.valueDate !== undefined) {
+    return part.valueDate;
+  }
+  if (part.valueDateTime !== undefined) {
+    return part.valueDateTime;
+  }
+  if (part.valueInstant !== undefined) {
+    return part.valueInstant;
+  }
+  if (part.valueQuantity !== undefined) {
+    return renderQuantity(part.valueQuantity);
+  }
+  if (part.valueCoding !== undefined) {
+    return renderCoding(part.valueCoding);
+  }
+  return "";
+}
+
+/**
+ * Renders a FHIR Quantity as `<value> <unit>` or just `<value>`.
+ * @param quantity
+ */
+function renderQuantity(quantity: Quantity): string {
+  const value = quantity.value !== undefined ? String(quantity.value) : "";
+  const unit = quantity.unit ?? quantity.code ?? "";
+  return unit ? `${value} ${unit}`.trim() : value;
+}
+
+/**
+ * Renders a FHIR Coding as its display, falling back to `system|code`.
+ * @param coding
+ */
+function renderCoding(coding: Coding): string {
+  if (coding.display) {
+    return coding.display;
+  }
+  if (coding.system && coding.code) {
+    return `${coding.system}|${coding.code}`;
+  }
+  return coding.code ?? "";
+}

--- a/ui/src/utils/fhirParametersFlatten.ts
+++ b/ui/src/utils/fhirParametersFlatten.ts
@@ -101,7 +101,9 @@ export function flattenFhirParameters(
  * Handles the FHIR primitive types emitted by the SQL on FHIR FHIR-format
  * implementation: boolean, integer, decimal, string, code, date, dateTime,
  * instant, quantity and coding. Unknown shapes fall back to a JSON dump.
- * @param part
+ *
+ * @param part - The Parameters part to render.
+ * @returns A display string for the part's `value[x]`.
  */
 function renderPartValue(part: ParametersParameter): string {
   if (part.valueBoolean !== undefined) {
@@ -139,7 +141,9 @@ function renderPartValue(part: ParametersParameter): string {
 
 /**
  * Renders a FHIR Quantity as `<value> <unit>` or just `<value>`.
- * @param quantity
+ *
+ * @param quantity - The Quantity to render.
+ * @returns A short display string.
  */
 function renderQuantity(quantity: Quantity): string {
   const value = quantity.value !== undefined ? String(quantity.value) : "";
@@ -149,7 +153,9 @@ function renderQuantity(quantity: Quantity): string {
 
 /**
  * Renders a FHIR Coding as its display, falling back to `system|code`.
- * @param coding
+ *
+ * @param coding - The Coding to render.
+ * @returns A short display string.
  */
 function renderCoding(coding: Coding): string {
   if (coding.display) {

--- a/ui/src/utils/index.ts
+++ b/ui/src/utils/index.ts
@@ -22,3 +22,8 @@
  */
 
 export { formatDateTime } from "./formatDateTime";
+export { parseCsvResponse } from "./csv";
+export { decodeSql, encodeSql } from "./sqlBase64";
+export { flattenFhirParameters } from "./fhirParametersFlatten";
+export type { FlattenedFhirResult } from "./fhirParametersFlatten";
+export { streamToText, parseNdjsonResponse, extractColumns } from "./ndjson";

--- a/ui/src/utils/sqlBase64.ts
+++ b/ui/src/utils/sqlBase64.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unicode-safe Base64 helpers for SQL strings carried in
+ * `Library.content[0].data`.
+ *
+ * @author John Grimes
+ */
+
+/**
+ * Encodes a SQL string as Base64.
+ *
+ * Wraps `btoa` with a UTF-8 conversion so that strings containing
+ * non-ASCII characters (e.g. accented identifiers) encode correctly.
+ *
+ * @param sql - The SQL text to encode.
+ * @returns The Base64-encoded representation of `sql`.
+ *
+ * @example
+ * encodeSql("SELECT 1");
+ * // "U0VMRUNUIDE="
+ */
+export function encodeSql(sql: string): string {
+  if (sql.length === 0) {
+    return "";
+  }
+  const bytes = new TextEncoder().encode(sql);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return globalThis.btoa(binary);
+}
+
+/**
+ * Decodes a Base64-encoded SQL string.
+ *
+ * Tolerant of unpadded Base64 input (some servers strip trailing `=`
+ * characters).
+ *
+ * @param data - The Base64 text to decode.
+ * @returns The decoded UTF-8 string.
+ *
+ * @example
+ * decodeSql("U0VMRUNUIDE=");
+ * // "SELECT 1"
+ */
+export function decodeSql(data: string): string {
+  if (data.length === 0) {
+    return "";
+  }
+  const padded = data + "===".slice((data.length + 3) % 4);
+  const binary = globalThis.atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}


### PR DESCRIPTION
replaces https://github.com/aehrc/pathling/pull/2579

This pull request introduces support for a new `$sqlquery-run` FHIR operation, enabling execution of SQL queries defined in FHIR `Library` resources. The changes add the necessary configuration, operation registration, and implementation classes for parsing, resolving, and executing SQL queries, as well as referencing stored query definitions. The most important changes are grouped below:

**Core Feature: SQL Query Operation**

* Added new configuration flag `sqlQueryRunEnabled` to `OperationConfiguration` and logic to register SQL query run providers in `FhirServer`, enabling the `$sqlquery-run` operation. This includes wiring new providers and registering them based on configuration. [[1]](diffhunk://#diff-d253d305020a8cff17b5936c099e7e2e7d731120bcc273135f5973795605eaccR73-R75) [[2]](diffhunk://#diff-7441f4e261837a0c47fe3ba576c977a207bbdc04c5aaadb30c844232af85cdebR177-R184) [[3]](diffhunk://#diff-7441f4e261837a0c47fe3ba576c977a207bbdc04c5aaadb30c844232af85cdebR214-R217) [[4]](diffhunk://#diff-7441f4e261837a0c47fe3ba576c977a207bbdc04c5aaadb30c844232af85cdebL233-R248) [[5]](diffhunk://#diff-7441f4e261837a0c47fe3ba576c977a207bbdc04c5aaadb30c844232af85cdebR277-R278) [[6]](diffhunk://#diff-7441f4e261837a0c47fe3ba576c977a207bbdc04c5aaadb30c844232af85cdebR397-R402)
* Updated `ConformanceProvider` to advertise the `$sqlquery-run` operation in the FHIR capability statement when enabled.

**Implementation: SQL Query Execution Pipeline**

* Introduced `SqlQueryExecutionHelper`, a component orchestrating the parsing, view resolution, execution, and result streaming for SQL queries, including logic for handling inline and referenced query definitions.
* Added `LibraryReferenceResolver` to resolve FHIR `Reference` objects to stored `Library` resources, supporting both relative and canonical references with version selection logic.

**Supporting Data Structures**

* Added `ParsedSqlQuery` to represent a parsed SQL query, including the SQL text, referenced views, and declared parameters.
* Added `SqlParameterDeclaration` to represent a declared parameter in a SQL query, including its name and FHIR type.