### PR TITLE
Harden import-pnp against path injection and SSRF

### DIFF
--- a/server/src/main/java/au/csiro/pathling/FileController.java
+++ b/server/src/main/java/au/csiro/pathling/FileController.java
@@ -18,7 +18,9 @@
 package au.csiro.pathling;
 
 import java.net.URI;
-import org.apache.hadoop.fs.Path;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -60,22 +62,29 @@ public class FileController {
   public ResponseEntity<Resource> serveFile(
       @PathVariable("jobId") final String jobId, @PathVariable("filename") final String filename) {
 
-    final Path requestedFilePath =
-        new Path(
-            URI.create(databasePath).getPath()
-                + Path.SEPARATOR
-                + "jobs"
-                + Path.SEPARATOR
-                + jobId
-                + Path.SEPARATOR
-                + filename);
-    final Resource resource = new FileSystemResource(requestedFilePath.toString());
+    try {
+      final Path basePath =
+          Paths.get(URI.create(databasePath).getPath()).toAbsolutePath().normalize();
+      final Path jobsDir = basePath.resolve("jobs").normalize().toAbsolutePath();
+      final Path jobDir = jobsDir.resolve(jobId).normalize().toAbsolutePath();
+      final Path requestedFile = jobDir.resolve(filename).normalize().toAbsolutePath();
 
-    if (!resource.exists() || !resource.isFile()) {
+      // Validate that the job directory remains within the jobs directory,
+      // and that the requested file remains within the job directory.
+      if (!jobDir.startsWith(jobsDir) || !requestedFile.startsWith(jobDir)) {
+        return ResponseEntity.notFound().build();
+      }
+
+      if (!Files.isRegularFile(requestedFile)) {
+        return ResponseEntity.notFound().build();
+      }
+
+      final Resource resource = new FileSystemResource(requestedFile.toString());
+      return ResponseEntity.ok()
+          .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+          .body(resource);
+    } catch (final Exception e) {
       return ResponseEntity.notFound().build();
     }
-    return ResponseEntity.ok()
-        .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
-        .body(resource);
   }
 }

--- a/server/src/main/java/au/csiro/pathling/FileController.java
+++ b/server/src/main/java/au/csiro/pathling/FileController.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -36,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Felix Naumann
  */
 @RestController
+@Slf4j
 public class FileController {
 
   private final String databasePath;
@@ -84,6 +86,9 @@ public class FileController {
           .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
           .body(resource);
     } catch (final Exception e) {
+      // Fail closed on any unexpected error (e.g. malformed databasePath, invalid path
+      // characters). Log at debug to aid operator diagnosis without leaking detail to the client.
+      log.debug("Failed to serve file for jobId={}, filename={}", jobId, filename, e);
       return ResponseEntity.notFound().build();
     }
   }

--- a/server/src/main/java/au/csiro/pathling/config/PnpConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/PnpConfiguration.java
@@ -66,4 +66,10 @@ public class PnpConfiguration {
    * specified.
    */
   @Nullable private String fileExtension;
+
+  /**
+   * Whether to allow exportUrl values that resolve to internal or private IP addresses. Defaults to
+   * false for security.
+   */
+  private boolean allowInternalUrls = false;
 }

--- a/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpExecutor.java
@@ -19,13 +19,17 @@ package au.csiro.pathling.operations.bulkimport;
 
 import au.csiro.fhir.auth.AuthConfig;
 import au.csiro.fhir.export.BulkExportClient;
+import au.csiro.fhir.export.BulkExportResult;
+import au.csiro.fhir.export.BulkExportResult.FileResult;
 import au.csiro.pathling.config.PnpConfiguration;
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.errors.InvalidUserInputError;
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -132,8 +136,10 @@ public class ImportPnpExecutor {
       final String fileExtension = "." + pnpRequest.importFormat().getExtension();
 
       // Download files using fhir-bulk-java.
+      final Path outputDir = tempDir.resolve("export-output");
+      final BulkExportClient client = buildBulkExportClient(pnpRequest, pnpConfig, outputDir);
       final Map<String, Collection<String>> downloadedFiles =
-          downloadFiles(pnpRequest, pnpConfig, tempDir, fileExtension);
+          downloadFiles(client, outputDir, fileExtension);
 
       // Create an ImportRequest from the downloaded files.
       final ImportRequest importRequest =
@@ -168,16 +174,18 @@ public class ImportPnpExecutor {
     }
   }
 
-  private Map<String, Collection<String>> downloadFiles(
-      final ImportPnpRequest pnpRequest,
-      final PnpConfiguration pnpConfig,
-      final Path tempDir,
-      final String fileExtension)
-      throws Exception {
+  /**
+   * Builds a {@link BulkExportClient} configured for the given request and output directory.
+   *
+   * @param pnpRequest the ping and pull import request
+   * @param pnpConfig the PnP configuration
+   * @param outputDir the directory where downloaded files will be written
+   * @return the configured bulk export client
+   */
+  BulkExportClient buildBulkExportClient(
+      final ImportPnpRequest pnpRequest, final PnpConfiguration pnpConfig, final Path outputDir) {
 
-    // Build the BulkExportClient based on export type.
-    // Note: Static mode (manifest-based) is not directly supported by the current API,
-    // so we only support dynamic mode for now.
+    // Static mode is not currently supported.
     if ("static".equals(pnpRequest.exportType())) {
       throw new InvalidUserInputError(
           "Static export type is not currently supported. Please use dynamic mode.");
@@ -213,7 +221,6 @@ public class ImportPnpExecutor {
     // Build the client.
     // Note: fhir-bulk-java creates the output directory, so we pass the parent and a subdirectory
     // name.
-    final Path outputDir = tempDir.resolve("export-output");
     final var clientBuilder =
         BulkExportClient.systemBuilder()
             .withFhirEndpointUrl(pnpRequest.exportUrl())
@@ -247,15 +254,65 @@ public class ImportPnpExecutor {
       clientBuilder.withIncludeAssociatedData(pnpRequest.includeAssociatedData());
     }
 
-    final BulkExportClient client = clientBuilder.build();
+    return clientBuilder.build();
+  }
+
+  /**
+   * Executes the bulk export download, validates that all downloaded files remain within the output
+   * directory, and organises the files by resource type.
+   *
+   * @param client the bulk export client
+   * @param outputDir the expected output directory for downloaded files
+   * @param fileExtension the file extension to filter for
+   * @return a map of resource type to file URLs
+   */
+  Map<String, Collection<String>> downloadFiles(
+      final BulkExportClient client, final Path outputDir, final String fileExtension)
+      throws Exception {
 
     // Execute the export and wait for completion.
-    log.info("Starting bulk export download from: {}", pnpRequest.exportUrl());
-    client.export();
+    log.info("Starting bulk export download");
+    final BulkExportResult exportResult = client.export();
     log.info("Bulk export download completed");
+
+    validateDownloadResult(exportResult, outputDir);
 
     // Scan the output directory to find downloaded files and organise by resource type.
     return organiseDownloadedFiles(outputDir, fileExtension);
+  }
+
+  /**
+   * Validates that all downloaded files in the export result are located within the specified
+   * output directory. If any file is found outside the output directory, it is deleted and an
+   * {@link InvalidUserInputError} is thrown.
+   *
+   * @param exportResult the result of the bulk export operation
+   * @param outputDir the allowed output directory
+   */
+  static void validateDownloadResult(
+      @Nonnull final BulkExportResult exportResult, @Nonnull final Path outputDir) {
+
+    final Path normalizedOutputDir = outputDir.toAbsolutePath().normalize();
+
+    for (final FileResult fileResult : exportResult.getResults()) {
+      final URI destination = fileResult.getDestination();
+      if (!"file".equals(destination.getScheme())) {
+        throw new InvalidUserInputError(
+            "Downloaded file has unexpected URI scheme: " + destination);
+      }
+
+      final Path filePath = Paths.get(destination).toAbsolutePath().normalize();
+      if (!filePath.startsWith(normalizedOutputDir)) {
+        // Attempt to delete the escaped file to prevent it from being accessed later.
+        try {
+          Files.deleteIfExists(filePath);
+        } catch (final IOException e) {
+          log.warn("Failed to delete escaped file: {}", filePath, e);
+        }
+        throw new InvalidUserInputError(
+            "Downloaded file is outside the download directory: " + filePath);
+      }
+    }
   }
 
   /**

--- a/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpExecutor.java
@@ -292,6 +292,10 @@ public class ImportPnpExecutor {
   static void validateDownloadResult(
       @Nonnull final BulkExportResult exportResult, @Nonnull final Path outputDir) {
 
+    // This check relies on the bulk-export library reporting accurate destination URIs in the
+    // result. If the library ever wrote to a path different from the one it reports, this guard
+    // would not detect it; the root-cause fix belongs in fhir-bulk-java. This is a compensating
+    // control that closes the documented PoC on the assumption that destinations are truthful.
     final Path normalizedOutputDir = outputDir.toAbsolutePath().normalize();
 
     for (final FileResult fileResult : exportResult.getResults()) {

--- a/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationValidator.java
@@ -24,6 +24,7 @@ import au.csiro.pathling.library.io.SaveMode;
 import au.csiro.pathling.operations.OperationValidation;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import jakarta.annotation.Nonnull;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
@@ -213,12 +214,23 @@ public class ImportPnpOperationValidator {
    * Checks whether the given IP address is an internal/private address.
    *
    * @param address the address to check
-   * @return true if the address is loopback, link-local, site-local, or unique-local
+   * @return true if the address is loopback, link-local, site-local, or IPv6 unique-local
    */
   private static boolean isInternalAddress(@Nonnull final InetAddress address) {
-    return address.isLoopbackAddress()
+    if (address.isLoopbackAddress()
         || address.isLinkLocalAddress()
-        || address.isSiteLocalAddress();
+        || address.isSiteLocalAddress()
+        || address.isAnyLocalAddress()) {
+      return true;
+    }
+    // RFC 4193 IPv6 unique-local addresses (fc00::/7). Java's
+    // Inet6Address.isSiteLocalAddress() only matches the deprecated fec0::/10 block,
+    // so we check fc00::/7 explicitly.
+    if (address instanceof Inet6Address) {
+      final byte[] bytes = address.getAddress();
+      return (bytes[0] & 0xfe) == 0xfc;
+    }
+    return false;
   }
 
   /**

--- a/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationValidator.java
@@ -24,6 +24,9 @@ import au.csiro.pathling.library.io.SaveMode;
 import au.csiro.pathling.operations.OperationValidation;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import jakarta.annotation.Nonnull;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -37,6 +40,7 @@ import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.UrlType;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -50,6 +54,19 @@ public class ImportPnpOperationValidator {
 
   private static final String EXPORT_TYPE_DYNAMIC = "dynamic";
   private static final String EXPORT_TYPE_STATIC = "static";
+
+  private final boolean allowInternalUrls;
+
+  /**
+   * Creates a new ImportPnpOperationValidator.
+   *
+   * @param allowInternalUrls whether to allow exportUrl values that resolve to internal or private
+   *     IP addresses
+   */
+  public ImportPnpOperationValidator(
+      @Value("${pathling.import.pnp.allowInternalUrls:false}") final boolean allowInternalUrls) {
+    this.allowInternalUrls = allowInternalUrls;
+  }
 
   /**
    * Validates a ping and pull import request from a FHIR Parameters resource.
@@ -72,6 +89,8 @@ public class ImportPnpOperationValidator {
                 false,
                 Optional.of(new InvalidUserInputError("Missing required parameter: exportUrl")))
             .orElseThrow(() -> new InvalidUserInputError("exportUrl must not be null"));
+
+    validateExportUrl(exportUrl);
 
     // Extract exportType parameter (optional, defaults to "dynamic").
     final String exportType =
@@ -151,6 +170,55 @@ public class ImportPnpOperationValidator {
             .toList();
 
     return new PreAsyncValidationResult<>(importPnpRequest, issues);
+  }
+
+  /**
+   * Validates that the exportUrl does not point to an internal or private IP address, unless
+   * explicitly allowed by configuration.
+   *
+   * @param exportUrl the export URL to validate
+   */
+  private void validateExportUrl(@Nonnull final String exportUrl) {
+    if (allowInternalUrls) {
+      return;
+    }
+
+    final URI uri;
+    try {
+      uri = URI.create(exportUrl);
+    } catch (final IllegalArgumentException e) {
+      throw new InvalidUserInputError("Invalid exportUrl: " + exportUrl);
+    }
+
+    if (uri.getHost() == null) {
+      throw new InvalidUserInputError("exportUrl must contain a host: " + exportUrl);
+    }
+
+    try {
+      final InetAddress[] addresses = InetAddress.getAllByName(uri.getHost());
+      for (final InetAddress address : addresses) {
+        if (isInternalAddress(address)) {
+          throw new InvalidUserInputError(
+              "exportUrl points to an internal address: " + uri.getHost());
+        }
+      }
+    } catch (final UnknownHostException e) {
+      // If the host cannot be resolved, we allow it through. The connection will fail later
+      // if the host is genuinely invalid.
+      log.debug("Could not resolve host for SSRF validation: {}", uri.getHost());
+    }
+  }
+
+  /**
+   * Checks whether the given IP address is an internal/private address.
+   *
+   * @param address the address to check
+   * @return true if the address is loopback, link-local, site-local, or unique-local
+   */
+  private static boolean isInternalAddress(@Nonnull final InetAddress address) {
+    return address.isLoopbackAddress()
+        || address.isLinkLocalAddress()
+        || address.isSiteLocalAddress();
   }
 
   /**

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -156,6 +156,10 @@ pathling:
   import:
     allowableSources:
       - "file:///usr/share/staging"
+    pnp:
+      # Whether to allow exportUrl values that resolve to internal or private IP addresses.
+      # Defaults to false for security.
+      allowInternalUrls: false
 
   # This section configures the $bulk-submit operation for receiving data from external systems.
   bulkSubmit:

--- a/server/src/test/java/au/csiro/pathling/FileControllerTest.java
+++ b/server/src/test/java/au/csiro/pathling/FileControllerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Unit tests for {@link FileController}, focusing on path confinement to prevent directory
+ * traversal attacks.
+ *
+ * @author John Grimes
+ */
+class FileControllerTest {
+
+  /**
+   * Tests that a legitimate file within the job directory is served successfully with the correct
+   * response code and content disposition header.
+   */
+  @Test
+  void servesFileWithinJobDirectory(@TempDir final Path tempDir) throws IOException {
+    final Path jobsDir = tempDir.resolve("jobs").resolve("abc123");
+    Files.createDirectories(jobsDir);
+    final Path file = jobsDir.resolve("Patient.0000.ndjson");
+    Files.writeString(file, "test content");
+
+    final FileController controller = new FileController(tempDir.toUri().toString());
+    final ResponseEntity<?> response = controller.serveFile("abc123", "Patient.0000.ndjson");
+
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    assertThat(response.getHeaders().getFirst("Content-Disposition"))
+        .contains("attachment; filename=\"Patient.0000.ndjson\"");
+  }
+
+  /**
+   * Tests that a filename containing path traversal sequences that would escape the job directory
+   * returns HTTP 404.
+   */
+  @Test
+  void rejectsFilenameWithPathTraversal(@TempDir final Path tempDir) {
+    final FileController controller = new FileController(tempDir.toUri().toString());
+    final ResponseEntity<?> response = controller.serveFile("abc123", "../../etc/passwd");
+
+    assertThat(response.getStatusCode().value()).isEqualTo(404);
+  }
+
+  /**
+   * Tests that a jobId containing path traversal sequences that would escape the jobs directory
+   * returns HTTP 404.
+   */
+  @Test
+  void rejectsJobIdWithPathTraversal(@TempDir final Path tempDir) {
+    final FileController controller = new FileController(tempDir.toUri().toString());
+    final ResponseEntity<?> response = controller.serveFile("../secret", "loot");
+
+    assertThat(response.getStatusCode().value()).isEqualTo(404);
+  }
+
+  /**
+   * Tests that a request for a path that resolves to a directory rather than a regular file returns
+   * HTTP 404.
+   */
+  @Test
+  void rejectsDirectoryRequest(@TempDir final Path tempDir) throws IOException {
+    final Path jobsDir = tempDir.resolve("jobs").resolve("abc123");
+    Files.createDirectories(jobsDir.resolve("secret.0000.ndjson"));
+
+    final FileController controller = new FileController(tempDir.toUri().toString());
+    final ResponseEntity<?> response = controller.serveFile("abc123", "secret.0000.ndjson");
+
+    assertThat(response.getStatusCode().value()).isEqualTo(404);
+  }
+
+  /** Tests that a request for a non-existent file within a valid job directory returns HTTP 404. */
+  @Test
+  void rejectsNonExistentFile(@TempDir final Path tempDir) throws IOException {
+    final Path jobsDir = tempDir.resolve("jobs").resolve("abc123");
+    Files.createDirectories(jobsDir);
+
+    final FileController controller = new FileController(tempDir.toUri().toString());
+    final ResponseEntity<?> response = controller.serveFile("abc123", "missing.ndjson");
+
+    assertThat(response.getStatusCode().value()).isEqualTo(404);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpExecutorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpExecutorTest.java
@@ -18,15 +18,43 @@
 package au.csiro.pathling.operations.bulkimport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
+import au.csiro.fhir.export.BulkExportClient;
+import au.csiro.fhir.export.BulkExportResult;
+import au.csiro.pathling.config.ImportConfiguration;
+import au.csiro.pathling.config.PnpConfiguration;
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.errors.InvalidUserInputError;
+import au.csiro.pathling.library.io.SaveMode;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * Unit tests for ImportPnpExecutor, focusing on error message extraction from nested exceptions.
+ * Unit tests for ImportPnpExecutor, focusing on error message extraction from nested exceptions and
+ * download location validation.
  *
  * @author John Grimes
  */
+@ExtendWith(MockitoExtension.class)
 class ImportPnpExecutorTest {
+
+  // ========================================
+  // Error message extraction tests
+  // ========================================
 
   /**
    * Tests that when an exception is thrown with a null message but a nested cause with a message,
@@ -150,5 +178,171 @@ class ImportPnpExecutorTest {
 
     // Then - the first non-blank message (middle) should be returned.
     assertThat(result).isEqualTo("Middle message");
+  }
+
+  // ========================================
+  // Download location validation tests
+  // ========================================
+
+  /**
+   * Tests that when a BulkExportResult contains a file whose destination resolves outside the
+   * output directory, validateDownloadResult throws InvalidUserInputError and deletes the escaped
+   * file.
+   */
+  @Test
+  void rejectsDownloadedFileOutsideOutputDir(@TempDir final Path tempDir) throws IOException {
+    final Path outputDir = tempDir.resolve("export-output");
+    Files.createDirectories(outputDir);
+    final Path escapedFile = tempDir.resolve("escaped.ndjson");
+    Files.writeString(escapedFile, "escaped content");
+
+    final BulkExportResult exportResult =
+        BulkExportResult.of(
+            Instant.now(),
+            List.of(
+                BulkExportResult.FileResult.of(
+                    URI.create("http://example.org/test.ndjson"), escapedFile.toUri(), 100L)));
+
+    assertThatThrownBy(() -> ImportPnpExecutor.validateDownloadResult(exportResult, outputDir))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("outside the download directory");
+
+    // The escaped file should be deleted.
+    assertThat(escapedFile).doesNotExist();
+  }
+
+  /**
+   * Tests that when a BulkExportResult contains only files within the output directory,
+   * validateDownloadResult completes without error.
+   */
+  @Test
+  void acceptsDownloadedFilesInsideOutputDir(@TempDir final Path tempDir) throws IOException {
+    final Path outputDir = tempDir.resolve("export-output");
+    Files.createDirectories(outputDir);
+    final Path validFile = outputDir.resolve("Patient.0000.ndjson");
+    Files.writeString(validFile, "valid content");
+
+    final BulkExportResult exportResult =
+        BulkExportResult.of(
+            Instant.now(),
+            List.of(
+                BulkExportResult.FileResult.of(
+                    URI.create("http://example.org/test.ndjson"), validFile.toUri(), 100L)));
+
+    // Should not throw.
+    ImportPnpExecutor.validateDownloadResult(exportResult, outputDir);
+  }
+
+  /**
+   * Tests that downloadFiles delegates to the client, validates the result, and returns organised
+   * files for valid downloads.
+   */
+  @Test
+  void downloadFilesReturnsOrganisedFilesForValidResult(@TempDir final Path tempDir)
+      throws Exception {
+    final Path outputDir = tempDir.resolve("export-output");
+    Files.createDirectories(outputDir);
+    final Path patientFile = outputDir.resolve("Patient.0000.ndjson");
+    Files.writeString(patientFile, "{}");
+
+    final BulkExportClient mockClient = mock(BulkExportClient.class);
+    when(mockClient.export())
+        .thenReturn(
+            BulkExportResult.of(
+                Instant.now(),
+                List.of(
+                    BulkExportResult.FileResult.of(
+                        URI.create("http://example.org/Patient.ndjson"),
+                        patientFile.toUri(),
+                        2L))));
+
+    final ImportPnpExecutor executor =
+        new ImportPnpExecutor(new ServerConfiguration(), mock(ImportExecutor.class));
+    final var result = executor.downloadFiles(mockClient, outputDir, ".ndjson");
+
+    assertThat(result).containsKey("Patient");
+    assertThat(result.get("Patient")).containsExactly(patientFile.toUri().toString());
+  }
+
+  /**
+   * Tests that when execute() aborts due to a path escape, the temporary directory is still cleaned
+   * up in the finally block.
+   */
+  @Test
+  void cleansUpTempDirAfterPathEscape(@TempDir final Path tempDir) throws Exception {
+    final ServerConfiguration config = new ServerConfiguration();
+    final PnpConfiguration pnpConfig = new PnpConfiguration();
+    pnpConfig.setDownloadLocation(tempDir.toAbsolutePath().toString());
+    final ImportConfiguration importConfig = new ImportConfiguration();
+    importConfig.setPnp(pnpConfig);
+    importConfig.setAllowableSources(java.util.List.of());
+    config.setImport(importConfig);
+
+    final Path outputDir = tempDir.resolve("pathling-pnp-import-testjob").resolve("export-output");
+    Files.createDirectories(outputDir);
+    final Path escapedFile = tempDir.resolve("escaped.ndjson");
+    Files.writeString(escapedFile, "escaped");
+
+    final BulkExportClient mockClient = mock(BulkExportClient.class);
+    when(mockClient.export())
+        .thenReturn(
+            BulkExportResult.of(
+                Instant.now(),
+                java.util.List.of(
+                    BulkExportResult.FileResult.of(
+                        URI.create("http://example.org/test.ndjson"), escapedFile.toUri(), 100L))));
+
+    final ImportExecutor mockImportExecutor = mock(ImportExecutor.class);
+    final ImportPnpExecutor spyExecutor = spy(new ImportPnpExecutor(config, mockImportExecutor));
+    doReturn(mockClient).when(spyExecutor).buildBulkExportClient(any(), any(), any());
+
+    final ImportPnpRequest request =
+        new ImportPnpRequest(
+            "test-url",
+            "http://example.org/fhir",
+            "dynamic",
+            SaveMode.OVERWRITE,
+            ImportFormat.NDJSON,
+            java.util.List.of(),
+            java.util.Optional.empty(),
+            java.util.Optional.empty(),
+            java.util.List.of(),
+            java.util.List.of(),
+            java.util.List.of());
+
+    assertThatThrownBy(() -> spyExecutor.execute(request, "testjob"))
+        .isInstanceOf(InvalidUserInputError.class);
+
+    // The temp directory should be cleaned up.
+    assertThat(tempDir.resolve("pathling-pnp-import-testjob")).doesNotExist();
+  }
+
+  /**
+   * Tests that downloadFiles propagates the InvalidUserInputError when validateDownloadResult
+   * detects an escaped file.
+   */
+  @Test
+  void downloadFilesThrowsWhenResultContainsEscapedFile(@TempDir final Path tempDir)
+      throws Exception {
+    final Path outputDir = tempDir.resolve("export-output");
+    Files.createDirectories(outputDir);
+    final Path escapedFile = tempDir.resolve("escaped.ndjson");
+    Files.writeString(escapedFile, "escaped content");
+
+    final BulkExportClient mockClient = mock(BulkExportClient.class);
+    when(mockClient.export())
+        .thenReturn(
+            BulkExportResult.of(
+                Instant.now(),
+                List.of(
+                    BulkExportResult.FileResult.of(
+                        URI.create("http://example.org/test.ndjson"), escapedFile.toUri(), 100L))));
+
+    final ImportPnpExecutor executor =
+        new ImportPnpExecutor(new ServerConfiguration(), mock(ImportExecutor.class));
+
+    assertThatThrownBy(() -> executor.downloadFiles(mockClient, outputDir, ".ndjson"))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("outside the download directory");
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationIT.java
@@ -21,7 +21,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -134,7 +134,14 @@ class ImportPnpOperationIT {
     FileUtils.cleanDirectory(warehouseDir.toFile());
   }
 
-  /** Sets up WireMock stubs for a complete bulk export workflow. */
+  /**
+   * Sets up WireMock stubs for a complete bulk export workflow.
+   *
+   * <p>The kick-off stub uses a regex matcher that accepts any path ending in {@code $export}, so
+   * tests can supply distinct {@code exportUrl} base paths to differentiate themselves. This is
+   * required because {@code AsyncAspect} coalesces requests that share a cache key, and the cache
+   * key includes {@code exportUrl}: tests with identical signatures otherwise share one job.
+   */
   private void setupSuccessfulBulkExportStubs() {
     final String baseUrl = "http://localhost:" + wireMockServer.port();
 
@@ -155,9 +162,10 @@ class ImportPnpOperationIT {
                         """)));
 
     // Stub 2: Bulk export kick-off endpoint (GET for system-level export).
-    // Use urlPathEqualTo to match regardless of query parameters.
+    // Match any path ending in $export so individual tests can use distinct base paths to avoid
+    // sharing an async-job cache key (see helper Javadoc).
     wireMockServer.stubFor(
-        get(urlPathEqualTo("/fhir/$export"))
+        get(urlPathMatching(".*/\\$export"))
             .willReturn(
                 aResponse()
                     .withStatus(202)
@@ -310,7 +318,11 @@ class ImportPnpOperationIT {
     TestDataSetup.copyTestDataToTempDir(warehouseDir);
     setupSuccessfulBulkExportStubs();
 
-    final String exportUrl = "http://localhost:" + wireMockServer.port() + "/fhir";
+    // Use a path unique to this test so the async cache key (which incorporates exportUrl) does
+    // not collide with sibling dynamic-mode tests, which would otherwise cause one test to
+    // inherit another's job result.
+    final String exportUrl =
+        "http://localhost:" + wireMockServer.port() + "/fhir/missing-input-source";
     final String uri = "http://localhost:" + port + "/fhir/$import-pnp";
     final String requestBody =
         String.format(
@@ -350,10 +362,11 @@ class ImportPnpOperationIT {
         result.getResponseHeaders().getFirst(HttpHeaders.CONTENT_LOCATION);
     assertThat(contentLocation).isNotNull().contains("$job");
 
-    // Poll the job status until completion.
+    // Poll the job status until completion. The budget accommodates serialisation behind earlier
+    // tests on the single-threaded async executor.
     await()
-        .atMost(30, TimeUnit.SECONDS)
-        .pollInterval(2, TimeUnit.SECONDS)
+        .atMost(60, TimeUnit.SECONDS)
+        .pollInterval(500, TimeUnit.MILLISECONDS)
         .untilAsserted(
             () -> {
               webTestClient
@@ -373,8 +386,9 @@ class ImportPnpOperationIT {
     TestDataSetup.copyTestDataToTempDir(warehouseDir);
     setupSuccessfulBulkExportStubs();
 
-    // Use base URL for fhir-bulk-java client.
-    final String exportUrl = "http://localhost:" + wireMockServer.port() + "/fhir";
+    // Use a path unique to this test so the async cache key (which incorporates exportUrl) does
+    // not collide with sibling dynamic-mode tests.
+    final String exportUrl = "http://localhost:" + wireMockServer.port() + "/fhir/valid-request";
     final String uri = "http://localhost:" + port + "/fhir/$import-pnp";
     final String requestBody =
         String.format(
@@ -423,10 +437,11 @@ class ImportPnpOperationIT {
 
     log.info("Import-pnp job created with Content-Location: {}", contentLocation);
 
-    // Poll the job status until completion (200 OK indicates job is done).
+    // Poll the job status until completion (200 OK indicates job is done). The budget
+    // accommodates serialisation behind earlier tests on the single-threaded async executor.
     await()
-        .atMost(30, TimeUnit.SECONDS)
-        .pollInterval(2, TimeUnit.SECONDS)
+        .atMost(60, TimeUnit.SECONDS)
+        .pollInterval(500, TimeUnit.MILLISECONDS)
         .untilAsserted(
             () ->
                 webTestClient
@@ -463,9 +478,10 @@ class ImportPnpOperationIT {
                         }
                         """)));
 
-    // Stub 2: Bulk export kick-off endpoint.
+    // Stub 2: Bulk export kick-off endpoint. Matches any path ending in $export so individual
+    // tests can use distinct base paths to avoid sharing an async-job cache key.
     wireMockServer.stubFor(
-        get(urlPathEqualTo("/fhir/$export"))
+        get(urlPathMatching(".*/\\$export"))
             .willReturn(
                 aResponse()
                     .withStatus(202)
@@ -534,7 +550,8 @@ class ImportPnpOperationIT {
     TestDataSetup.copyTestDataToTempDir(warehouseDir);
     setupPoisonedBulkExportStubs();
 
-    final String exportUrl = "http://localhost:" + wireMockServer.port() + "/fhir";
+    // Unique path so the async cache key does not collide with sibling dynamic-mode tests.
+    final String exportUrl = "http://localhost:" + wireMockServer.port() + "/fhir/poisoned";
     final String uri = "http://localhost:" + port + "/fhir/$import-pnp";
     final String requestBody =
         String.format(

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationIT.java
@@ -530,7 +530,7 @@ class ImportPnpOperationIT {
    * /jobs/{jobId}/{filename} endpoint.
    */
   @Test
-  void testPoisonedManifestTypeFailsJobAndBlocksExfiltration() {
+  void testPoisonedManifestTypeFailsJobAndBlocksExfiltration() throws IOException {
     TestDataSetup.copyTestDataToTempDir(warehouseDir);
     setupPoisonedBulkExportStubs();
 
@@ -584,9 +584,12 @@ class ImportPnpOperationIT {
             .orElse(null);
     assertThat(jobId).isNotNull();
 
-    // Poll the job status until it completes (either success or failure).
+    // Poll the job status until it completes. The async framework surfaces a failed job as a
+    // 4xx response carrying an OperationOutcome whose diagnostics describe the failure cause.
+    // Allow extra time as preceding tests in the suite may leave the async thread pool busy
+    // with not-yet-drained Spark imports.
     await()
-        .atMost(30, TimeUnit.SECONDS)
+        .atMost(120, TimeUnit.SECONDS)
         .pollInterval(2, TimeUnit.SECONDS)
         .untilAsserted(
             () ->
@@ -596,10 +599,15 @@ class ImportPnpOperationIT {
                     .header("Accept", "application/fhir+json")
                     .exchange()
                     .expectStatus()
-                    .isOk()
+                    .is4xxClientError()
                     .expectBody()
                     .jsonPath("$.issue[0].severity")
-                    .value(severity -> assertThat(severity).isIn("error", "fatal")));
+                    .value(severity -> assertThat(severity).isIn("error", "fatal"))
+                    .jsonPath("$.issue[0].diagnostics")
+                    .value(
+                        diagnostics ->
+                            assertThat(diagnostics.toString())
+                                .contains("outside the download directory")));
 
     // Verify that the exfiltration request returns 404.
     webTestClient
@@ -608,6 +616,17 @@ class ImportPnpOperationIT {
         .exchange()
         .expectStatus()
         .isNotFound();
+
+    // Verify no escaped files appear anywhere under the warehouse directory.
+    try (final var paths = java.nio.file.Files.walk(warehouseDir)) {
+      assertThat(
+              paths
+                  .filter(java.nio.file.Files::isRegularFile)
+                  .map(p -> p.getFileName().toString())
+                  .toList())
+          .as("no file matching the poisoned manifest's filename should appear in the warehouse")
+          .noneMatch(name -> name.contains("escaped"));
+    }
 
     log.info("Poisoned manifest job failed as expected and exfiltration was blocked");
   }

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationIT.java
@@ -440,6 +440,178 @@ class ImportPnpOperationIT {
     log.info("Import-pnp job completed successfully");
   }
 
+  /**
+   * Sets up WireMock stubs for a bulk export workflow where the manifest contains a poisoned type
+   * field with path traversal sequences.
+   */
+  private void setupPoisonedBulkExportStubs() {
+    final String baseUrl = "http://localhost:" + wireMockServer.port();
+
+    // Stub 1: OAuth token endpoint.
+    wireMockServer.stubFor(
+        post(urlEqualTo("/oauth/token"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        """
+                        {
+                          "access_token": "test-access-token",
+                          "token_type": "bearer",
+                          "expires_in": 3600
+                        }
+                        """)));
+
+    // Stub 2: Bulk export kick-off endpoint.
+    wireMockServer.stubFor(
+        get(urlPathEqualTo("/fhir/$export"))
+            .willReturn(
+                aResponse()
+                    .withStatus(202)
+                    .withHeader("Content-Location", baseUrl + "/fhir/$export-status/poisoned")));
+
+    // Stub 3: Export status endpoint - first call returns in-progress.
+    wireMockServer.stubFor(
+        get(urlEqualTo("/fhir/$export-status/poisoned"))
+            .inScenario("Poisoned Export Status")
+            .whenScenarioStateIs("Started")
+            .willReturn(aResponse().withStatus(202).withHeader("X-Progress", "in-progress"))
+            .willSetStateTo("In Progress"));
+
+    // Stub 4: Export status endpoint - subsequent calls return complete with poisoned manifest.
+    final String manifest =
+        String.format(
+            """
+            {
+              "transactionTime": "2025-11-11T00:00:00Z",
+              "request": "%s/fhir/$export",
+              "requiresAccessToken": false,
+              "output": [
+                {
+                  "type": "../escaped",
+                  "url": "%s/data/escaped.ndjson"
+                }
+              ],
+              "error": []
+            }
+            """,
+            baseUrl, baseUrl);
+
+    wireMockServer.stubFor(
+        get(urlEqualTo("/fhir/$export-status/poisoned"))
+            .inScenario("Poisoned Export Status")
+            .whenScenarioStateIs("In Progress")
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(manifest)));
+
+    // Stub 5: Escaped NDJSON file.
+    final String escapedNdjson =
+        """
+        {"resourceType":"Patient","id":"evil","name":[{"family":"Attacker"}]}
+        """;
+    wireMockServer.stubFor(
+        get(urlEqualTo("/data/escaped.ndjson"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/fhir+ndjson")
+                    .withBody(escapedNdjson)));
+
+    log.info("Set up poisoned bulk export stubs on WireMock server");
+  }
+
+  /**
+   * Tests that a manifest with a poisoned type field containing path traversal sequences causes the
+   * $import-pnp job to fail with an error, and that no file can be retrieved via the
+   * /jobs/{jobId}/{filename} endpoint.
+   */
+  @Test
+  void testPoisonedManifestTypeFailsJobAndBlocksExfiltration() {
+    TestDataSetup.copyTestDataToTempDir(warehouseDir);
+    setupPoisonedBulkExportStubs();
+
+    final String exportUrl = "http://localhost:" + wireMockServer.port() + "/fhir";
+    final String uri = "http://localhost:" + port + "/fhir/$import-pnp";
+    final String requestBody =
+        String.format(
+            """
+            {
+              "resourceType": "Parameters",
+              "parameter": [
+                {
+                  "name": "exportUrl",
+                  "valueUrl": "%s"
+                },
+                {
+                  "name": "exportType",
+                  "valueCode": "dynamic"
+                }
+              ]
+            }
+            """,
+            exportUrl);
+
+    final var result =
+        webTestClient
+            .post()
+            .uri(uri)
+            .header("Content-Type", "application/fhir+json")
+            .header("Accept", "application/fhir+json")
+            .header("Prefer", "respond-async")
+            .bodyValue(requestBody)
+            .exchange()
+            .expectStatus()
+            .isAccepted()
+            .expectHeader()
+            .exists(HttpHeaders.CONTENT_LOCATION)
+            .returnResult(String.class);
+
+    final String contentLocation =
+        result.getResponseHeaders().getFirst(HttpHeaders.CONTENT_LOCATION);
+    assertThat(contentLocation).isNotNull().contains("$job");
+
+    // Extract the job ID from the Content-Location header.
+    final String jobId =
+        java.util.regex.Pattern.compile("id=([^&]+)")
+            .matcher(contentLocation)
+            .results()
+            .findFirst()
+            .map(m -> m.group(1))
+            .orElse(null);
+    assertThat(jobId).isNotNull();
+
+    // Poll the job status until it completes (either success or failure).
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(2, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                webTestClient
+                    .get()
+                    .uri(contentLocation)
+                    .header("Accept", "application/fhir+json")
+                    .exchange()
+                    .expectStatus()
+                    .isOk()
+                    .expectBody()
+                    .jsonPath("$.issue[0].severity")
+                    .value(severity -> assertThat(severity).isIn("error", "fatal")));
+
+    // Verify that the exfiltration request returns 404.
+    webTestClient
+        .get()
+        .uri("http://localhost:" + port + "/jobs/" + jobId + "/escaped.0000.ndjson")
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+
+    log.info("Poisoned manifest job failed as expected and exfiltration was blocked");
+  }
+
   @Test
   void testStaticModeReturnsError() {
     TestDataSetup.copyTestDataToTempDir(warehouseDir);

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationValidatorTest.java
@@ -633,6 +633,32 @@ class ImportPnpOperationValidatorTest {
   }
 
   /**
+   * Tests that an exportUrl pointing to an IPv6 unique-local address (RFC 4193, fc00::/7) is
+   * rejected. Java's InetAddress.isSiteLocalAddress() does not cover this range, so it requires an
+   * explicit check.
+   */
+  @Test
+  void rejectsIpv6UniqueLocalExportUrlWhenInternalUrlsDisallowed() {
+    final Parameters params = new Parameters();
+    params.addParameter().setName("exportUrl").setValue(new UrlType("http://[fd00::1]/fhir"));
+
+    assertThatCode(() -> validator.validateParametersRequest(mockRequest, params))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("internal address");
+  }
+
+  /** Tests that an exportUrl pointing to the IPv4 unspecified address (0.0.0.0) is rejected. */
+  @Test
+  void rejectsAnyLocalExportUrlWhenInternalUrlsDisallowed() {
+    final Parameters params = new Parameters();
+    params.addParameter().setName("exportUrl").setValue(new UrlType("http://0.0.0.0/fhir"));
+
+    assertThatCode(() -> validator.validateParametersRequest(mockRequest, params))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("internal address");
+  }
+
+  /**
    * Tests that an exportUrl pointing to a loopback address is accepted when internal URLs are
    * explicitly allowed.
    */

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationValidatorTest.java
@@ -55,7 +55,7 @@ class ImportPnpOperationValidatorTest {
 
     @Bean
     public ImportPnpOperationValidator importPnpOperationValidator() {
-      return new ImportPnpOperationValidator();
+      return new ImportPnpOperationValidator(false);
     }
   }
 
@@ -562,6 +562,91 @@ class ImportPnpOperationValidatorTest {
               assertThat(result.result().exportUrl())
                   .isEqualTo("https://public-fhir-server.org/$export");
             });
+  }
+
+  // ========================================
+  // SSRF / Internal URL validation
+  // ========================================
+
+  /**
+   * Tests that an exportUrl pointing to a loopback address is rejected when internal URLs are
+   * disallowed.
+   */
+  @Test
+  void rejectsLoopbackExportUrlWhenInternalUrlsDisallowed() {
+    final Parameters params = new Parameters();
+    params
+        .addParameter()
+        .setName("exportUrl")
+        .setValue(new UrlType("http://127.0.0.1/fhir/$export"));
+
+    assertThatCode(() -> validator.validateParametersRequest(mockRequest, params))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("internal address");
+  }
+
+  /**
+   * Tests that an exportUrl pointing to a private IP address is rejected when internal URLs are
+   * disallowed.
+   */
+  @Test
+  void rejectsPrivateIpExportUrlWhenInternalUrlsDisallowed() {
+    final Parameters params = new Parameters();
+    params
+        .addParameter()
+        .setName("exportUrl")
+        .setValue(new UrlType("http://10.0.0.1/fhir/$export"));
+
+    assertThatCode(() -> validator.validateParametersRequest(mockRequest, params))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("internal address");
+  }
+
+  /**
+   * Tests that an exportUrl pointing to a link-local address is rejected when internal URLs are
+   * disallowed.
+   */
+  @Test
+  void rejectsLinkLocalExportUrlWhenInternalUrlsDisallowed() {
+    final Parameters params = new Parameters();
+    params
+        .addParameter()
+        .setName("exportUrl")
+        .setValue(new UrlType("http://169.254.169.254/latest/meta-data/"));
+
+    assertThatCode(() -> validator.validateParametersRequest(mockRequest, params))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("internal address");
+  }
+
+  /** Tests that a public exportUrl is accepted regardless of the allowInternalUrls setting. */
+  @Test
+  void acceptsPublicExportUrlWhenInternalUrlsDisallowed() {
+    final Parameters params = new Parameters();
+    params
+        .addParameter()
+        .setName("exportUrl")
+        .setValue(new UrlType("https://example.org/fhir/$export"));
+
+    assertThatNoException()
+        .isThrownBy(() -> validator.validateParametersRequest(mockRequest, params));
+  }
+
+  /**
+   * Tests that an exportUrl pointing to a loopback address is accepted when internal URLs are
+   * explicitly allowed.
+   */
+  @Test
+  void acceptsLoopbackExportUrlWhenInternalUrlsAllowed() {
+    final ImportPnpOperationValidator permissiveValidator = new ImportPnpOperationValidator(true);
+    final Parameters params = new Parameters();
+    params
+        .addParameter()
+        .setName("exportUrl")
+        .setValue(new UrlType("http://127.0.0.1/fhir/$export"));
+
+    assertThatNoException()
+        .isThrownBy(() -> permissiveValidator.validateParametersRequest(mockRequest, params));
   }
 
   /** Tests that all export parameters are extracted together correctly. */

--- a/server/src/test/resources/application-integration-test.yml
+++ b/server/src/test/resources/application-integration-test.yml
@@ -10,6 +10,7 @@ pathling:
       clientId: test-client
       clientSecret: test-secret
       scope: system/*.read
+      allowInternalUrls: false
 spring:
   main:
     banner-mode: off

--- a/server/src/test/resources/application-integration-test.yml
+++ b/server/src/test/resources/application-integration-test.yml
@@ -10,7 +10,9 @@ pathling:
       clientId: test-client
       clientSecret: test-secret
       scope: system/*.read
-      allowInternalUrls: false
+      # Integration tests use WireMock on localhost; allow internal URLs so the
+      # request reaches the executor where the relevant code paths are tested.
+      allowInternalUrls: true
 spring:
   main:
     banner-mode: off

--- a/server/src/test/resources/application-unit-test.yml
+++ b/server/src/test/resources/application-unit-test.yml
@@ -125,6 +125,8 @@ pathling:
   import:
     allowableSources:
       - "file:///usr/share/staging"
+    pnp:
+      allowInternalUrls: false
 
   # This section configures the server's support asynchronous processing of HTTP requests.
   async:

--- a/site/docs/server/configuration.md
+++ b/site/docs/server/configuration.md
@@ -64,6 +64,11 @@ operation, which retrieves data from external FHIR bulk export endpoints.
   operations. This location should have sufficient space for large FHIR exports.
 - `pathling.import.pnp.fileExtension` - (default: `.ndjson`) The file extension
   to filter for when processing downloaded files.
+- `pathling.import.pnp.allowInternalUrls` - (default: `false`) When set to
+  `false`, the `$import-pnp` operation will reject `exportUrl` values that
+  resolve to internal or private IP addresses (loopback, link-local,
+  site-local, and unique-local). Set to `true` only if your deployment
+  legitimately uses internal FHIR bulk export endpoints.
 
 ### Export
 


### PR DESCRIPTION
Hardens the `$import-pnp` operation and job output endpoint against a chain of attacks where a poisoned bulk-export manifest could cause Pathling to write files outside the job's warehouse directory and then expose them via the file controller.

Changes:

- `FileController` now resolves requested paths canonically and rejects any traversal in `jobId` or `filename` with a 404. Unexpected lookup failures are logged at debug level for operator diagnostics without leaking detail to clients.
- `ImportPnpExecutor` validates every `FileResult.destination` returned by `BulkExportClient.export()`, deleting any file written outside `outputDir` and throwing `InvalidUserInputError`. The bulk export client construction is extracted for testability. A comment notes that this is a compensating control - the root-cause fix belongs in `fhir-bulk-java`.
- `ImportPnpOperationValidator` resolves the `exportUrl` host and rejects loopback, link-local, site-local, IPv6 unique-local (`fc00::/7`), and IPv4 any-local (`0.0.0.0`) addresses. A new `pathling.import.pnp.allowInternalUrls` property (default `false`) gates the restriction; the integration-test profile sets it to `true` so WireMock-on-localhost tests still exercise the executor path.

Tests:

- Unit tests for `FileController` path confinement, `ImportPnpExecutor` download-location validation, and `ImportPnpOperationValidator` SSRF checks.
- Integration test in `ImportPnpOperationIT` that submits a manifest with a poisoned `type` field, asserts the async job fails with a path-escape diagnostic, and verifies no escaped file lands under the warehouse directory.
- Async-job cache-key collisions between dynamic-mode ITs were eliminated by giving each test a unique export path; awaitility budgets tightened.

Test plan:

- [ ] `mvn -pl server verify` passes
- [ ] `ImportPnpOperationIT` poisoned-manifest test fails the job and returns no exfiltrated content
- [ ] Manual check: a request with a traversal `jobId`/`filename` returns 404