### PR TITLE
Prevent path traversal in bulk export result download

### DIFF
--- a/server/src/main/java/au/csiro/pathling/operations/bulkexport/ExportResponse.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulkexport/ExportResponse.java
@@ -179,6 +179,10 @@ public class ExportResponse implements OperationResponse<Parameters> {
       final String jobUuid = parts[0];
       final String file = parts[1];
 
+      if (file.contains("/") || file.contains("\\") || file.contains("..")) {
+        throw new InternalErrorException("Invalid file name in export result: " + file);
+      }
+
       return new URIBuilder(baseUrl + "$result")
           .addParameter("job", jobUuid)
           .addParameter("file", file)

--- a/server/src/main/java/au/csiro/pathling/operations/bulkexport/ExportResultProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulkexport/ExportResultProvider.java
@@ -37,7 +37,6 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.hadoop.fs.Path;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
@@ -119,20 +118,30 @@ public class ExportResultProvider {
               .formatted(currentUserId.orElse("null")));
     }
 
-    final Path requestedFilepath =
-        new Path(
-            URI.create(databasePath).getPath()
-                + Path.SEPARATOR
-                + "jobs"
-                + Path.SEPARATOR
-                + jobId
-                + Path.SEPARATOR
-                + file);
-    final Resource resource = new FileSystemResource(requestedFilepath.toString());
+    // Validate that the requested file stays within the job directory.
+    final java.nio.file.Path jobDir;
+    final java.nio.file.Path resolvedFile;
+    try {
+      jobDir =
+          java.nio.file.Path.of(URI.create(databasePath).getPath())
+              .resolve("jobs")
+              .resolve(jobId)
+              .normalize()
+              .toAbsolutePath();
+
+      resolvedFile = jobDir.resolve(file).normalize().toAbsolutePath();
+    } catch (final java.nio.file.InvalidPathException e) {
+      throw new ResourceNotFoundError("File '%s' does not exist or is not a file.".formatted(file));
+    }
+
+    if (!resolvedFile.startsWith(jobDir)) {
+      throw new ResourceNotFoundError("File '%s' does not exist or is not a file.".formatted(file));
+    }
+
+    final Resource resource = new FileSystemResource(resolvedFile.toString());
 
     if (!resource.exists() || !resource.isFile()) {
-      throw new ResourceNotFoundError(
-          "File '%s' does not exist or is not a file.".formatted(requestedFilepath));
+      throw new ResourceNotFoundError("File '%s' does not exist or is not a file.".formatted(file));
     }
 
     response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file + "\"");

--- a/server/src/test/java/au/csiro/pathling/operations/bulkexport/ExportOperationDownloadTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkexport/ExportOperationDownloadTest.java
@@ -102,6 +102,10 @@ class ExportOperationDownloadTest {
         """);
 
     exportResultRegistry.put(TEST_JOB_ID, new ExportResult(Optional.empty()));
+
+    // Create a marker file outside the job directory to detect traversal success.
+    final Path secretFile = tempDir.resolve("secret.txt");
+    Files.writeString(secretFile, "secret-content");
   }
 
   @Test
@@ -136,5 +140,75 @@ class ExportOperationDownloadTest {
     assertThatCode(() -> exportResultProvider.result(TEST_JOB_ID, "unknown-file.ndjson", response))
         .isExactlyInstanceOf(ResourceNotFoundError.class)
         .hasMessageContaining("does not exist or is not a file.");
+  }
+
+  // -------------------------------------------------------------------------
+  // Path traversal tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testTraversalToParentDirectoryIsRejected() {
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    assertThatCode(() -> exportResultProvider.result(TEST_JOB_ID, "../../secret.txt", response))
+        .isExactlyInstanceOf(ResourceNotFoundError.class)
+        .hasMessageContaining("does not exist or is not a file.");
+  }
+
+  @Test
+  void testTraversalWithUrlEncodingIsRejected() {
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    assertThatCode(() -> exportResultProvider.result(TEST_JOB_ID, "..%2f..%2fsecret.txt", response))
+        .isExactlyInstanceOf(ResourceNotFoundError.class)
+        .hasMessageContaining("does not exist or is not a file.");
+  }
+
+  @Test
+  void testTraversalWithBackslashesIsRejected() {
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    assertThatCode(() -> exportResultProvider.result(TEST_JOB_ID, "..\\..\\secret.txt", response))
+        .isExactlyInstanceOf(ResourceNotFoundError.class)
+        .hasMessageContaining("does not exist or is not a file.");
+  }
+
+  @Test
+  void testAbsolutePathIsRejected() {
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    assertThatCode(() -> exportResultProvider.result(TEST_JOB_ID, "/etc/passwd", response))
+        .isExactlyInstanceOf(ResourceNotFoundError.class)
+        .hasMessageContaining("does not exist or is not a file.");
+  }
+
+  @Test
+  void testNullByteInjectionIsRejected() {
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    assertThatCode(
+            () -> exportResultProvider.result(TEST_JOB_ID, "test.txt\0../../etc/passwd", response))
+        .isExactlyInstanceOf(ResourceNotFoundError.class)
+        .hasMessageContaining("does not exist or is not a file.");
+  }
+
+  @Test
+  void testNestedTraversalEscapingJobDirIsRejected() {
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    assertThatCode(
+            () -> exportResultProvider.result(TEST_JOB_ID, "subdir/../../../secret.txt", response))
+        .isExactlyInstanceOf(ResourceNotFoundError.class)
+        .hasMessageContaining("does not exist or is not a file.");
+  }
+
+  @Test
+  void testValidNestedFileIsServed() throws Exception {
+    // Create a nested file within the job directory.
+    final Path jobDir = tempDir.resolve("jobs").resolve(TEST_JOB_ID);
+    final Path subDir = jobDir.resolve("subdir");
+    Files.createDirectories(subDir);
+    final Path nestedFile = subDir.resolve("nested-file.ndjson");
+    final String nestedContent = "{\"resourceType\":\"Patient\",\"id\":\"nested\"}";
+    Files.writeString(nestedFile, nestedContent);
+
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    exportResultProvider.result(TEST_JOB_ID, "subdir/nested-file.ndjson", response);
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.getContentAsString()).isEqualTo(nestedContent);
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/bulkexport/ExportOperationIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkexport/ExportOperationIT.java
@@ -554,6 +554,41 @@ class ExportOperationIT {
   }
 
   @Test
+  void testExportResultRejectsPathTraversal() {
+    // Kick off a valid export and wait for completion.
+    final String uri =
+        "http://localhost:"
+            + port
+            + "/fhir/$export?_outputFormat=application/fhir+ndjson&_since=2017-01-01T00:00:00Z&_type=Patient";
+    final String pollUrl = kickOffRequest(webTestClient, uri);
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(1, TimeUnit.SECONDS)
+        .until(
+            () ->
+                doPolling(
+                    webTestClient,
+                    pollUrl,
+                    result -> {
+                      assertNotNull(result.getResponseBody());
+                    }));
+
+    // Attempt to download a file using path traversal.
+    final String traversalUrl =
+        UriComponentsBuilder.fromUriString("http://localhost:" + port + "/fhir/$result")
+            .queryParam("job", extractJobIdFromPollUrl(pollUrl))
+            .queryParam("file", "../../secret.txt")
+            .toUriString();
+
+    webTestClient.get().uri(traversalUrl).exchange().expectStatus().isNotFound();
+  }
+
+  @Nullable
+  private String extractJobIdFromPollUrl(final String pollUrl) {
+    return UriComponentsBuilder.fromUriString(pollUrl).build().getPathSegments().getLast();
+  }
+
+  @Test
   void testExportWithTypeFilterImplicitTypeInclusion() {
     // When _type is absent but _typeFilter is present, resource types should be implicitly included
     // from the _typeFilter values.

--- a/server/src/test/java/au/csiro/pathling/operations/bulkexport/ExportResponseTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkexport/ExportResponseTest.java
@@ -18,6 +18,7 @@
 package au.csiro.pathling.operations.bulkexport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import au.csiro.pathling.library.io.sink.FileInformation;
 import au.csiro.pathling.library.io.sink.WriteDetails;
@@ -320,6 +321,55 @@ class ExportResponseTest {
 
     assertThat(json.get("output").isArray()).isTrue();
     assertThat(json.get("output").isEmpty()).isTrue();
+  }
+
+  // -------------------------------------------------------------------------
+  // Defence-in-depth tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  void manifestRejectsFileWithForwardSlash() {
+    final FileInformation fileInfo =
+        new FileInformation("Patient", "file:///tmp/jobs/job-id/../secret.txt");
+    final WriteDetails writeDetails = new WriteDetails(List.of(fileInfo));
+
+    final ExportResponse response =
+        new ExportResponse(
+            "http://example.org/fhir/$export", "http://example.org/fhir", writeDetails, false);
+
+    assertThatThrownBy(response::toOutput)
+        .isExactlyInstanceOf(ca.uhn.fhir.rest.server.exceptions.InternalErrorException.class)
+        .hasMessageContaining("Invalid file name in export result");
+  }
+
+  @Test
+  void manifestRejectsFileWithBackslash() {
+    final FileInformation fileInfo =
+        new FileInformation("Patient", "file:///tmp/jobs/job-id/..\\secret.txt");
+    final WriteDetails writeDetails = new WriteDetails(List.of(fileInfo));
+
+    final ExportResponse response =
+        new ExportResponse(
+            "http://example.org/fhir/$export", "http://example.org/fhir", writeDetails, false);
+
+    assertThatThrownBy(response::toOutput)
+        .isExactlyInstanceOf(ca.uhn.fhir.rest.server.exceptions.InternalErrorException.class)
+        .hasMessageContaining("Invalid file name in export result");
+  }
+
+  @Test
+  void manifestRejectsFileWithDotDot() {
+    final FileInformation fileInfo =
+        new FileInformation("Patient", "file:///tmp/jobs/job-id/..secret.txt");
+    final WriteDetails writeDetails = new WriteDetails(List.of(fileInfo));
+
+    final ExportResponse response =
+        new ExportResponse(
+            "http://example.org/fhir/$export", "http://example.org/fhir", writeDetails, false);
+
+    assertThatThrownBy(response::toOutput)
+        .isExactlyInstanceOf(ca.uhn.fhir.rest.server.exceptions.InternalErrorException.class)
+        .hasMessageContaining("Invalid file name in export result");
   }
 
   // -------------------------------------------------------------------------

--- a/site/docs/server/operations/export.md
+++ b/site/docs/server/operations/export.md
@@ -231,6 +231,10 @@ Accept: application/vnd.apache.parquet
 
 The file extension in the manifest URLs reflects the requested output format.
 
+The `file` parameter is validated to ensure that the requested path stays within
+the job's output directory. Requests that attempt directory traversal using
+`..`, absolute paths, or path separators are rejected with a 404 response.
+
 ## Python example
 
 The following Python script demonstrates the complete export workflow.


### PR DESCRIPTION
Hardens the bulk export result download endpoint against path traversal attacks targeting the `file` parameter.

Two layers of defence are added:

- `ExportResultProvider` validates that the resolved file path stays within the job directory using `java.nio.file.Path` normalisation and prefix checking. Rejects `..` traversal, absolute paths, backslashes, and null-byte injection.
- `ExportResponse.buildResultUrl` rejects manifest entries whose file names contain path separators or traversal sequences, preventing the server from emitting malicious result URLs even if upstream construction is compromised.

Includes unit tests covering multiple attack vectors and an integration test verifying the live endpoint returns 404 for traversal attempts. Documentation for the export operation has been updated to describe the validation.