### PR TITLE
Add per-resource authority checks to typed CRUD and batch providers

### DIFF
--- a/server/src/main/java/au/csiro/pathling/operations/create/CreateProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/create/CreateProvider.java
@@ -17,10 +17,14 @@
 
 package au.csiro.pathling.operations.create;
 
+import static au.csiro.pathling.security.SecurityAspect.checkHasAuthority;
 import static au.csiro.pathling.utilities.Preconditions.checkUserInput;
 
+import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.operations.update.UpdateExecutor;
 import au.csiro.pathling.security.OperationAccess;
+import au.csiro.pathling.security.PathlingAuthority;
+import au.csiro.pathling.security.ResourceAccess;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.annotation.Create;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
@@ -48,6 +52,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class CreateProvider implements IResourceProvider {
 
+  @Nonnull private final ServerConfiguration configuration;
+
   @Nonnull private final UpdateExecutor updateExecutor;
 
   @Nonnull private final Class<? extends IBaseResource> resourceClass;
@@ -57,14 +63,17 @@ public class CreateProvider implements IResourceProvider {
   /**
    * Constructs a new CreateProvider for a specific resource type.
    *
+   * @param configuration the server configuration
    * @param updateExecutor the executor for performing update operations
    * @param fhirContext the FHIR context for resource definitions
    * @param resourceClass the class of the resource type this provider handles
    */
   public CreateProvider(
+      @Nonnull final ServerConfiguration configuration,
       @Nonnull final UpdateExecutor updateExecutor,
       @Nonnull final FhirContext fhirContext,
       @Nonnull final Class<? extends IBaseResource> resourceClass) {
+    this.configuration = configuration;
     this.updateExecutor = updateExecutor;
     this.resourceClass = resourceClass;
     this.resourceTypeCode = fhirContext.getResourceDefinition(resourceClass).getName();
@@ -88,6 +97,11 @@ public class CreateProvider implements IResourceProvider {
   @SuppressWarnings("UnusedReturnValue")
   public MethodOutcome create(@Nullable @ResourceParam final IBaseResource resource) {
     checkUserInput(resource != null, "Resource must be supplied");
+
+    if (configuration.getAuth().isEnabled()) {
+      checkHasAuthority(
+          PathlingAuthority.resourceAccess(ResourceAccess.AccessType.WRITE, resourceTypeCode));
+    }
 
     // Always generate a new UUID, ignoring any client-provided ID.
     final String generatedId = UUID.randomUUID().toString();

--- a/server/src/main/java/au/csiro/pathling/operations/create/CreateProviderFactory.java
+++ b/server/src/main/java/au/csiro/pathling/operations/create/CreateProviderFactory.java
@@ -17,6 +17,7 @@
 
 package au.csiro.pathling.operations.create;
 
+import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.operations.update.UpdateExecutor;
 import ca.uhn.fhir.context.FhirContext;
 import jakarta.annotation.Nonnull;
@@ -37,6 +38,8 @@ public class CreateProviderFactory {
 
   @Nonnull private final ApplicationContext applicationContext;
 
+  @Nonnull private final ServerConfiguration configuration;
+
   @Nonnull private final FhirContext fhirContext;
 
   @Nonnull private final UpdateExecutor updateExecutor;
@@ -45,14 +48,17 @@ public class CreateProviderFactory {
    * Constructs a new CreateProviderFactory.
    *
    * @param applicationContext the Spring application context for bean creation
+   * @param configuration the server configuration
    * @param fhirContext the FHIR context for resource definitions
    * @param updateExecutor the executor for performing update operations
    */
   public CreateProviderFactory(
       @Nonnull final ApplicationContext applicationContext,
+      @Nonnull final ServerConfiguration configuration,
       @Nonnull final FhirContext fhirContext,
       @Nonnull final UpdateExecutor updateExecutor) {
     this.applicationContext = applicationContext;
+    this.configuration = configuration;
     this.fhirContext = fhirContext;
     this.updateExecutor = updateExecutor;
   }
@@ -69,7 +75,7 @@ public class CreateProviderFactory {
         fhirContext.getResourceDefinition(resourceType.name()).getImplementingClass();
 
     return applicationContext.getBean(
-        CreateProvider.class, updateExecutor, fhirContext, resourceTypeClass);
+        CreateProvider.class, configuration, updateExecutor, fhirContext, resourceTypeClass);
   }
 
   /**
@@ -85,6 +91,6 @@ public class CreateProviderFactory {
         fhirContext.getResourceDefinition(resourceTypeCode).getImplementingClass();
 
     return applicationContext.getBean(
-        CreateProvider.class, updateExecutor, fhirContext, resourceTypeClass);
+        CreateProvider.class, configuration, updateExecutor, fhirContext, resourceTypeClass);
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/delete/DeleteProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/delete/DeleteProvider.java
@@ -17,9 +17,13 @@
 
 package au.csiro.pathling.operations.delete;
 
+import static au.csiro.pathling.security.SecurityAspect.checkHasAuthority;
 import static au.csiro.pathling.utilities.Preconditions.checkUserInput;
 
+import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.security.OperationAccess;
+import au.csiro.pathling.security.PathlingAuthority;
+import au.csiro.pathling.security.ResourceAccess;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
@@ -45,6 +49,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class DeleteProvider implements IResourceProvider {
 
+  @Nonnull private final ServerConfiguration configuration;
+
   @Nonnull private final DeleteExecutor deleteExecutor;
 
   @Nonnull private final Class<? extends IBaseResource> resourceClass;
@@ -54,14 +60,17 @@ public class DeleteProvider implements IResourceProvider {
   /**
    * Constructs a new DeleteProvider for a specific resource type.
    *
+   * @param configuration the server configuration
    * @param deleteExecutor the executor for performing delete operations
    * @param fhirContext the FHIR context for resource definitions
    * @param resourceClass the class of the resource type this provider handles
    */
   public DeleteProvider(
+      @Nonnull final ServerConfiguration configuration,
       @Nonnull final DeleteExecutor deleteExecutor,
       @Nonnull final FhirContext fhirContext,
       @Nonnull final Class<? extends IBaseResource> resourceClass) {
+    this.configuration = configuration;
     this.deleteExecutor = deleteExecutor;
     this.resourceClass = resourceClass;
     this.resourceTypeCode = fhirContext.getResourceDefinition(resourceClass).getName();
@@ -84,6 +93,11 @@ public class DeleteProvider implements IResourceProvider {
   @SuppressWarnings("UnusedReturnValue")
   public MethodOutcome delete(@Nullable @IdParam final IdType id) {
     checkUserInput(id != null && !id.isEmpty(), "ID must be supplied");
+
+    if (configuration.getAuth().isEnabled()) {
+      checkHasAuthority(
+          PathlingAuthority.resourceAccess(ResourceAccess.AccessType.WRITE, resourceTypeCode));
+    }
 
     final String resourceId = id.getIdPart();
     log.debug("Deleting {} with ID: {}", resourceTypeCode, resourceId);

--- a/server/src/main/java/au/csiro/pathling/operations/delete/DeleteProviderFactory.java
+++ b/server/src/main/java/au/csiro/pathling/operations/delete/DeleteProviderFactory.java
@@ -17,6 +17,7 @@
 
 package au.csiro.pathling.operations.delete;
 
+import au.csiro.pathling.config.ServerConfiguration;
 import ca.uhn.fhir.context.FhirContext;
 import jakarta.annotation.Nonnull;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -36,6 +37,8 @@ public class DeleteProviderFactory {
 
   @Nonnull private final ApplicationContext applicationContext;
 
+  @Nonnull private final ServerConfiguration configuration;
+
   @Nonnull private final FhirContext fhirContext;
 
   @Nonnull private final DeleteExecutor deleteExecutor;
@@ -44,14 +47,17 @@ public class DeleteProviderFactory {
    * Constructs a new DeleteProviderFactory.
    *
    * @param applicationContext the Spring application context for bean creation
+   * @param configuration the server configuration
    * @param fhirContext the FHIR context for resource definitions
    * @param deleteExecutor the executor for performing delete operations
    */
   public DeleteProviderFactory(
       @Nonnull final ApplicationContext applicationContext,
+      @Nonnull final ServerConfiguration configuration,
       @Nonnull final FhirContext fhirContext,
       @Nonnull final DeleteExecutor deleteExecutor) {
     this.applicationContext = applicationContext;
+    this.configuration = configuration;
     this.fhirContext = fhirContext;
     this.deleteExecutor = deleteExecutor;
   }
@@ -68,7 +74,7 @@ public class DeleteProviderFactory {
         fhirContext.getResourceDefinition(resourceType.name()).getImplementingClass();
 
     return applicationContext.getBean(
-        DeleteProvider.class, deleteExecutor, fhirContext, resourceTypeClass);
+        DeleteProvider.class, configuration, deleteExecutor, fhirContext, resourceTypeClass);
   }
 
   /**
@@ -84,6 +90,6 @@ public class DeleteProviderFactory {
         fhirContext.getResourceDefinition(resourceTypeCode).getImplementingClass();
 
     return applicationContext.getBean(
-        DeleteProvider.class, deleteExecutor, fhirContext, resourceTypeClass);
+        DeleteProvider.class, configuration, deleteExecutor, fhirContext, resourceTypeClass);
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/update/BatchProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/update/BatchProvider.java
@@ -28,6 +28,7 @@ import au.csiro.pathling.errors.InvalidUserInputError;
 import au.csiro.pathling.operations.delete.DeleteExecutor;
 import au.csiro.pathling.security.OperationAccess;
 import au.csiro.pathling.security.PathlingAuthority;
+import au.csiro.pathling.security.ResourceAccess;
 import ca.uhn.fhir.rest.annotation.Transaction;
 import ca.uhn.fhir.rest.annotation.TransactionParam;
 import jakarta.annotation.Nonnull;
@@ -163,6 +164,11 @@ public class BatchProvider {
     final ResourceType resourceType =
         validateResourceTypeForCreate(entry, resourceTypeCode, urlErrorMessage);
 
+    if (configuration.getAuth().isEnabled()) {
+      checkHasAuthority(
+          PathlingAuthority.resourceAccess(ResourceAccess.AccessType.WRITE, resourceTypeCode));
+    }
+
     // Generate a new UUID, ignoring any client-provided ID.
     final String generatedId = UUID.randomUUID().toString();
     resource.setId(generatedId);
@@ -189,6 +195,12 @@ public class BatchProvider {
     final String urlId = urlComponents.get(1);
     final ResourceType resourceType =
         validateResourceType(entry, resourceTypeCode, urlErrorMessage);
+
+    if (configuration.getAuth().isEnabled()) {
+      checkHasAuthority(
+          PathlingAuthority.resourceAccess(ResourceAccess.AccessType.WRITE, resourceTypeCode));
+    }
+
     final IBaseResource preparedResource = prepareResourceForUpdate(resource, urlId);
     addToResourceMap(resourcesForUpdate, resourceType, preparedResource);
     addUpdateResponse(response, preparedResource);
@@ -210,6 +222,8 @@ public class BatchProvider {
 
     if (configuration.getAuth().isEnabled()) {
       checkHasAuthority(PathlingAuthority.operationAccess("delete"));
+      checkHasAuthority(
+          PathlingAuthority.resourceAccess(ResourceAccess.AccessType.WRITE, resourceTypeCode));
     }
 
     log.debug("Batch deleting {} with ID: {}", resourceTypeCode, resourceId);

--- a/server/src/main/java/au/csiro/pathling/operations/update/UpdateProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/update/UpdateProvider.java
@@ -18,9 +18,13 @@
 package au.csiro.pathling.operations.update;
 
 import static au.csiro.pathling.operations.update.UpdateExecutor.prepareResourceForUpdate;
+import static au.csiro.pathling.security.SecurityAspect.checkHasAuthority;
 import static au.csiro.pathling.utilities.Preconditions.checkUserInput;
 
+import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.security.OperationAccess;
+import au.csiro.pathling.security.PathlingAuthority;
+import au.csiro.pathling.security.ResourceAccess;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
@@ -47,6 +51,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class UpdateProvider implements IResourceProvider {
 
+  @Nonnull private final ServerConfiguration configuration;
+
   @Nonnull private final UpdateExecutor updateExecutor;
 
   @Nonnull private final Class<? extends IBaseResource> resourceClass;
@@ -56,14 +62,17 @@ public class UpdateProvider implements IResourceProvider {
   /**
    * Constructs a new UpdateProvider for a specific resource type.
    *
+   * @param configuration the server configuration
    * @param updateExecutor the executor for performing update operations
    * @param fhirContext the FHIR context for resource definitions
    * @param resourceClass the class of the resource type this provider handles
    */
   public UpdateProvider(
+      @Nonnull final ServerConfiguration configuration,
       @Nonnull final UpdateExecutor updateExecutor,
       @Nonnull final FhirContext fhirContext,
       @Nonnull final Class<? extends IBaseResource> resourceClass) {
+    this.configuration = configuration;
     this.updateExecutor = updateExecutor;
     this.resourceClass = resourceClass;
     this.resourceTypeCode = fhirContext.getResourceDefinition(resourceClass).getName();
@@ -89,6 +98,11 @@ public class UpdateProvider implements IResourceProvider {
       @Nullable @IdParam final IdType id, @Nullable @ResourceParam final IBaseResource resource) {
     checkUserInput(id != null && !id.isEmpty(), "ID must be supplied");
     checkUserInput(resource != null, "Resource must be supplied");
+
+    if (configuration.getAuth().isEnabled()) {
+      checkHasAuthority(
+          PathlingAuthority.resourceAccess(ResourceAccess.AccessType.WRITE, resourceTypeCode));
+    }
 
     final String resourceId = id.getIdPart();
     final IBaseResource preparedResource = prepareResourceForUpdate(resource, resourceId);

--- a/server/src/main/java/au/csiro/pathling/operations/update/UpdateProviderFactory.java
+++ b/server/src/main/java/au/csiro/pathling/operations/update/UpdateProviderFactory.java
@@ -17,6 +17,7 @@
 
 package au.csiro.pathling.operations.update;
 
+import au.csiro.pathling.config.ServerConfiguration;
 import ca.uhn.fhir.context.FhirContext;
 import jakarta.annotation.Nonnull;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -36,6 +37,8 @@ public class UpdateProviderFactory {
 
   @Nonnull private final ApplicationContext applicationContext;
 
+  @Nonnull private final ServerConfiguration configuration;
+
   @Nonnull private final FhirContext fhirContext;
 
   @Nonnull private final UpdateExecutor updateExecutor;
@@ -44,14 +47,17 @@ public class UpdateProviderFactory {
    * Constructs a new UpdateProviderFactory.
    *
    * @param applicationContext the Spring application context for bean creation
+   * @param configuration the server configuration
    * @param fhirContext the FHIR context for resource definitions
    * @param updateExecutor the executor for performing update operations
    */
   public UpdateProviderFactory(
       @Nonnull final ApplicationContext applicationContext,
+      @Nonnull final ServerConfiguration configuration,
       @Nonnull final FhirContext fhirContext,
       @Nonnull final UpdateExecutor updateExecutor) {
     this.applicationContext = applicationContext;
+    this.configuration = configuration;
     this.fhirContext = fhirContext;
     this.updateExecutor = updateExecutor;
   }
@@ -68,7 +74,7 @@ public class UpdateProviderFactory {
         fhirContext.getResourceDefinition(resourceType.name()).getImplementingClass();
 
     return applicationContext.getBean(
-        UpdateProvider.class, updateExecutor, fhirContext, resourceTypeClass);
+        UpdateProvider.class, configuration, updateExecutor, fhirContext, resourceTypeClass);
   }
 
   /**
@@ -84,6 +90,6 @@ public class UpdateProviderFactory {
         fhirContext.getResourceDefinition(resourceTypeCode).getImplementingClass();
 
     return applicationContext.getBean(
-        UpdateProvider.class, updateExecutor, fhirContext, resourceTypeClass);
+        UpdateProvider.class, configuration, updateExecutor, fhirContext, resourceTypeClass);
   }
 }

--- a/server/src/main/java/au/csiro/pathling/read/ReadProvider.java
+++ b/server/src/main/java/au/csiro/pathling/read/ReadProvider.java
@@ -17,9 +17,13 @@
 
 package au.csiro.pathling.read;
 
+import static au.csiro.pathling.security.SecurityAspect.checkHasAuthority;
 import static au.csiro.pathling.utilities.Preconditions.checkUserInput;
 
+import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.security.OperationAccess;
+import au.csiro.pathling.security.PathlingAuthority;
+import au.csiro.pathling.security.ResourceAccess;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.Read;
@@ -43,6 +47,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class ReadProvider implements IResourceProvider {
 
+  @Nonnull private final ServerConfiguration configuration;
+
   @Nonnull private final ReadExecutor readExecutor;
 
   @Nonnull private final Class<? extends IBaseResource> resourceClass;
@@ -52,14 +58,17 @@ public class ReadProvider implements IResourceProvider {
   /**
    * Constructs a new ReadProvider for a specific resource type.
    *
+   * @param configuration the server configuration
    * @param readExecutor the executor for performing read operations
    * @param fhirContext the FHIR context for resource definitions
    * @param resourceClass the class of the resource type this provider handles
    */
   public ReadProvider(
+      @Nonnull final ServerConfiguration configuration,
       @Nonnull final ReadExecutor readExecutor,
       @Nonnull final FhirContext fhirContext,
       @Nonnull final Class<? extends IBaseResource> resourceClass) {
+    this.configuration = configuration;
     this.readExecutor = readExecutor;
     this.resourceClass = resourceClass;
     this.resourceTypeCode = fhirContext.getResourceDefinition(resourceClass).getName();
@@ -82,6 +91,11 @@ public class ReadProvider implements IResourceProvider {
   @SuppressWarnings("UnusedReturnValue")
   public IBaseResource read(@Nullable @IdParam final IdType id) {
     checkUserInput(id != null && !id.isEmpty(), "ID must be supplied");
+
+    if (configuration.getAuth().isEnabled()) {
+      checkHasAuthority(
+          PathlingAuthority.resourceAccess(ResourceAccess.AccessType.READ, resourceTypeCode));
+    }
 
     final String resourceId = id.getIdPart();
     log.debug("Reading {} with ID: {}", resourceTypeCode, resourceId);

--- a/server/src/main/java/au/csiro/pathling/read/ReadProviderFactory.java
+++ b/server/src/main/java/au/csiro/pathling/read/ReadProviderFactory.java
@@ -17,6 +17,7 @@
 
 package au.csiro.pathling.read;
 
+import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.io.source.DataSource;
 import ca.uhn.fhir.context.FhirContext;
@@ -33,6 +34,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class ReadProviderFactory {
 
+  @Nonnull private final ServerConfiguration configuration;
+
   @Nonnull private final FhirContext fhirContext;
 
   @Nonnull private final DataSource dataSource;
@@ -42,14 +45,17 @@ public class ReadProviderFactory {
   /**
    * Constructs a new ReadProviderFactory.
    *
+   * @param configuration the server configuration
    * @param fhirContext the FHIR context for resource definitions
    * @param dataSource the data source containing the resources to read
    * @param fhirEncoders the encoders for converting Spark rows to FHIR resources
    */
   public ReadProviderFactory(
+      @Nonnull final ServerConfiguration configuration,
       @Nonnull final FhirContext fhirContext,
       @Nonnull final DataSource dataSource,
       @Nonnull final FhirEncoders fhirEncoders) {
+    this.configuration = configuration;
     this.fhirContext = fhirContext;
     this.dataSource = dataSource;
     this.fhirEncoders = fhirEncoders;
@@ -67,7 +73,7 @@ public class ReadProviderFactory {
         fhirContext.getResourceDefinition(resourceType.name()).getImplementingClass();
 
     final ReadExecutor readExecutor = new ReadExecutor(dataSource, fhirEncoders);
-    return new ReadProvider(readExecutor, fhirContext, resourceTypeClass);
+    return new ReadProvider(configuration, readExecutor, fhirContext, resourceTypeClass);
   }
 
   /**
@@ -83,6 +89,6 @@ public class ReadProviderFactory {
         fhirContext.getResourceDefinition(resourceTypeCode).getImplementingClass();
 
     final ReadExecutor readExecutor = new ReadExecutor(dataSource, fhirEncoders);
-    return new ReadProvider(readExecutor, fhirContext, resourceTypeClass);
+    return new ReadProvider(configuration, readExecutor, fhirContext, resourceTypeClass);
   }
 }

--- a/server/src/main/java/au/csiro/pathling/search/SearchProvider.java
+++ b/server/src/main/java/au/csiro/pathling/search/SearchProvider.java
@@ -17,10 +17,14 @@
 
 package au.csiro.pathling.search;
 
+import static au.csiro.pathling.security.SecurityAspect.checkHasAuthority;
+
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.io.source.DataSource;
 import au.csiro.pathling.security.OperationAccess;
+import au.csiro.pathling.security.PathlingAuthority;
+import au.csiro.pathling.security.ResourceAccess;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.RawParam;
@@ -109,6 +113,10 @@ public class SearchProvider implements IResourceProvider {
   @OperationAccess("search")
   @SuppressWarnings("UnusedReturnValue")
   public IBundleProvider search(@Nullable @RawParam final Map<String, List<String>> rawParams) {
+    if (configuration.getAuth().isEnabled()) {
+      checkHasAuthority(
+          PathlingAuthority.resourceAccess(ResourceAccess.AccessType.READ, resourceTypeCode));
+    }
     final String queryString = buildQueryString(rawParams);
     return buildSearchExecutor(queryString, Optional.empty());
   }
@@ -127,6 +135,10 @@ public class SearchProvider implements IResourceProvider {
   public IBundleProvider search(
       @Nullable @OptionalParam(name = FILTER_PARAM) final StringAndListParam filters,
       @Nullable @RawParam final Map<String, List<String>> rawParams) {
+    if (configuration.getAuth().isEnabled()) {
+      checkHasAuthority(
+          PathlingAuthority.resourceAccess(ResourceAccess.AccessType.READ, resourceTypeCode));
+    }
     final String queryString = buildQueryString(rawParams);
     return buildSearchExecutor(queryString, Optional.ofNullable(filters));
   }

--- a/server/src/test/java/au/csiro/pathling/operations/create/CreateProviderAuthTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/create/CreateProviderAuthTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.create;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import au.csiro.pathling.config.AuthorizationConfiguration;
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.errors.AccessDeniedError;
+import au.csiro.pathling.operations.update.UpdateExecutor;
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Security tests for {@link CreateProvider} verifying per-resource write authority enforcement.
+ *
+ * @author John Grimes
+ */
+@Tag("UnitTest")
+@ExtendWith(MockitoExtension.class)
+class CreateProviderAuthTest {
+
+  @Mock private ServerConfiguration configuration;
+  @Mock private UpdateExecutor updateExecutor;
+
+  private CreateProvider createProvider;
+  private FhirContext fhirContext;
+  private AuthorizationConfiguration authConfig;
+
+  @BeforeEach
+  void setUp() {
+    fhirContext = FhirContext.forR4();
+    authConfig = new AuthorizationConfiguration();
+    when(configuration.getAuth()).thenReturn(authConfig);
+    createProvider = new CreateProvider(configuration, updateExecutor, fhirContext, Patient.class);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void setSecurityContext(final String... authorities) {
+    final Jwt jwt = Jwt.withTokenValue("mock").header("alg", "none").claim("sub", "user").build();
+    final JwtAuthenticationToken auth =
+        new JwtAuthenticationToken(jwt, AuthorityUtils.createAuthorityList(authorities));
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+
+  @Test
+  void createSucceedsWhenAuthDisabled() {
+    authConfig.setEnabled(false);
+    assertThat(createProvider.create(new Patient())).isNotNull();
+  }
+
+  @Test
+  void createSucceedsWithCorrectResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:create", "pathling:write:Patient");
+    assertThat(createProvider.create(new Patient())).isNotNull();
+  }
+
+  @Test
+  void createThrowsWhenMissingResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:create");
+    assertThatThrownBy(() -> createProvider.create(new Patient()))
+        .isInstanceOf(AccessDeniedError.class)
+        .hasMessageContaining("pathling:write:Patient");
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/create/CreateProviderFactoryTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/create/CreateProviderFactoryTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.operations.update.UpdateExecutor;
 import ca.uhn.fhir.context.FhirContext;
 import org.hl7.fhir.r4.model.Enumerations.ResourceType;
@@ -47,6 +48,7 @@ import org.springframework.context.ApplicationContext;
 class CreateProviderFactoryTest {
 
   @Mock private ApplicationContext applicationContext;
+  @Mock private ServerConfiguration configuration;
   @Mock private UpdateExecutor updateExecutor;
 
   private CreateProviderFactory factory;
@@ -55,34 +57,35 @@ class CreateProviderFactoryTest {
   @BeforeEach
   void setUp() {
     fhirContext = FhirContext.forR4();
-    factory = new CreateProviderFactory(applicationContext, fhirContext, updateExecutor);
+    factory =
+        new CreateProviderFactory(applicationContext, configuration, fhirContext, updateExecutor);
   }
 
   @Test
   void createsProviderForResourceType() {
     // The factory should request a CreateProvider bean for the resolved resource class.
     final CreateProvider mockProvider = mock(CreateProvider.class);
-    when(applicationContext.getBean(eq(CreateProvider.class), any(), any(), any()))
+    when(applicationContext.getBean(eq(CreateProvider.class), any(), any(), any(), any()))
         .thenReturn(mockProvider);
 
     final CreateProvider result = factory.createCreateProvider(ResourceType.PATIENT);
 
     assertNotNull(result);
     verify(applicationContext)
-        .getBean(CreateProvider.class, updateExecutor, fhirContext, Patient.class);
+        .getBean(CreateProvider.class, configuration, updateExecutor, fhirContext, Patient.class);
   }
 
   @Test
   void createsProviderForResourceTypeCode() {
     // The factory should also support creation by string resource type code.
     final CreateProvider mockProvider = mock(CreateProvider.class);
-    when(applicationContext.getBean(eq(CreateProvider.class), any(), any(), any()))
+    when(applicationContext.getBean(eq(CreateProvider.class), any(), any(), any(), any()))
         .thenReturn(mockProvider);
 
     final CreateProvider result = factory.createCreateProvider("Patient");
 
     assertNotNull(result);
     verify(applicationContext)
-        .getBean(CreateProvider.class, updateExecutor, fhirContext, Patient.class);
+        .getBean(CreateProvider.class, configuration, updateExecutor, fhirContext, Patient.class);
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/create/CreateProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/create/CreateProviderTest.java
@@ -70,6 +70,8 @@ class CreateProviderTest {
 
   @Autowired private FhirContext fhirContext;
 
+  @Autowired private au.csiro.pathling.config.ServerConfiguration configuration;
+
   @Autowired private CacheableDatabase cacheableDatabase;
 
   private Path tempDatabasePath;
@@ -90,7 +92,7 @@ class CreateProviderTest {
             cacheableDatabase);
 
     // Create the CreateProvider.
-    createProvider = new CreateProvider(updateExecutor, fhirContext, Patient.class);
+    createProvider = new CreateProvider(configuration, updateExecutor, fhirContext, Patient.class);
   }
 
   @AfterEach

--- a/server/src/test/java/au/csiro/pathling/operations/delete/DeleteProviderAuthTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/delete/DeleteProviderAuthTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.delete;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import au.csiro.pathling.config.AuthorizationConfiguration;
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.errors.AccessDeniedError;
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Security tests for {@link DeleteProvider} verifying per-resource write authority enforcement.
+ *
+ * @author John Grimes
+ */
+@Tag("UnitTest")
+@ExtendWith(MockitoExtension.class)
+class DeleteProviderAuthTest {
+
+  @Mock private ServerConfiguration configuration;
+  @Mock private DeleteExecutor deleteExecutor;
+
+  private DeleteProvider deleteProvider;
+  private FhirContext fhirContext;
+  private AuthorizationConfiguration authConfig;
+
+  @BeforeEach
+  void setUp() {
+    fhirContext = FhirContext.forR4();
+    authConfig = new AuthorizationConfiguration();
+    when(configuration.getAuth()).thenReturn(authConfig);
+    deleteProvider = new DeleteProvider(configuration, deleteExecutor, fhirContext, Patient.class);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void setSecurityContext(final String... authorities) {
+    final Jwt jwt = Jwt.withTokenValue("mock").header("alg", "none").claim("sub", "user").build();
+    final JwtAuthenticationToken auth =
+        new JwtAuthenticationToken(jwt, AuthorityUtils.createAuthorityList(authorities));
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+
+  @Test
+  void deleteSucceedsWhenAuthDisabled() {
+    authConfig.setEnabled(false);
+    assertThat(deleteProvider.delete(new IdType("Patient/patient-1"))).isNotNull();
+  }
+
+  @Test
+  void deleteSucceedsWithCorrectResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:delete", "pathling:write:Patient");
+    assertThat(deleteProvider.delete(new IdType("Patient/patient-1"))).isNotNull();
+  }
+
+  @Test
+  void deleteThrowsWhenMissingResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:delete");
+    assertThatThrownBy(() -> deleteProvider.delete(new IdType("Patient/patient-1")))
+        .isInstanceOf(AccessDeniedError.class)
+        .hasMessageContaining("pathling:write:Patient");
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/delete/DeleteProviderFactoryTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/delete/DeleteProviderFactoryTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import au.csiro.pathling.config.ServerConfiguration;
 import ca.uhn.fhir.context.FhirContext;
 import org.hl7.fhir.r4.model.Enumerations.ResourceType;
 import org.hl7.fhir.r4.model.Patient;
@@ -46,6 +47,7 @@ import org.springframework.context.ApplicationContext;
 class DeleteProviderFactoryTest {
 
   @Mock private ApplicationContext applicationContext;
+  @Mock private ServerConfiguration configuration;
   @Mock private DeleteExecutor deleteExecutor;
 
   private DeleteProviderFactory factory;
@@ -54,34 +56,35 @@ class DeleteProviderFactoryTest {
   @BeforeEach
   void setUp() {
     fhirContext = FhirContext.forR4();
-    factory = new DeleteProviderFactory(applicationContext, fhirContext, deleteExecutor);
+    factory =
+        new DeleteProviderFactory(applicationContext, configuration, fhirContext, deleteExecutor);
   }
 
   @Test
   void createsProviderForResourceType() {
     // The factory should request a DeleteProvider bean for the resolved resource class.
     final DeleteProvider mockProvider = mock(DeleteProvider.class);
-    when(applicationContext.getBean(eq(DeleteProvider.class), any(), any(), any()))
+    when(applicationContext.getBean(eq(DeleteProvider.class), any(), any(), any(), any()))
         .thenReturn(mockProvider);
 
     final DeleteProvider result = factory.createDeleteProvider(ResourceType.PATIENT);
 
     assertNotNull(result);
     verify(applicationContext)
-        .getBean(DeleteProvider.class, deleteExecutor, fhirContext, Patient.class);
+        .getBean(DeleteProvider.class, configuration, deleteExecutor, fhirContext, Patient.class);
   }
 
   @Test
   void createsProviderForResourceTypeCode() {
     // The factory should also support creation by string resource type code.
     final DeleteProvider mockProvider = mock(DeleteProvider.class);
-    when(applicationContext.getBean(eq(DeleteProvider.class), any(), any(), any()))
+    when(applicationContext.getBean(eq(DeleteProvider.class), any(), any(), any(), any()))
         .thenReturn(mockProvider);
 
     final DeleteProvider result = factory.createDeleteProvider("Patient");
 
     assertNotNull(result);
     verify(applicationContext)
-        .getBean(DeleteProvider.class, deleteExecutor, fhirContext, Patient.class);
+        .getBean(DeleteProvider.class, configuration, deleteExecutor, fhirContext, Patient.class);
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/delete/DeleteProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/delete/DeleteProviderTest.java
@@ -67,6 +67,8 @@ class DeleteProviderTest {
 
   @Autowired private FhirContext fhirContext;
 
+  @Autowired private au.csiro.pathling.config.ServerConfiguration configuration;
+
   @Autowired private CacheableDatabase cacheableDatabase;
 
   private Path tempDatabasePath;
@@ -92,7 +94,7 @@ class DeleteProviderTest {
             pathlingContext, tempDatabasePath.toAbsolutePath().toString(), cacheableDatabase);
 
     // Create the DeleteProvider.
-    deleteProvider = new DeleteProvider(deleteExecutor, fhirContext, Patient.class);
+    deleteProvider = new DeleteProvider(configuration, deleteExecutor, fhirContext, Patient.class);
   }
 
   @AfterEach

--- a/server/src/test/java/au/csiro/pathling/operations/update/BatchProviderAuthTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/BatchProviderAuthTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import au.csiro.pathling.config.AuthorizationConfiguration;
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.errors.AccessDeniedError;
+import au.csiro.pathling.operations.delete.DeleteExecutor;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryRequestComponent;
+import org.hl7.fhir.r4.model.Bundle.BundleType;
+import org.hl7.fhir.r4.model.Bundle.HTTPVerb;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Security tests for {@link BatchProvider} verifying per-resource write authority enforcement for
+ * create, update, and delete entries.
+ *
+ * @author John Grimes
+ */
+@Tag("UnitTest")
+@ExtendWith(MockitoExtension.class)
+class BatchProviderAuthTest {
+
+  @Mock private ServerConfiguration configuration;
+  @Mock private UpdateExecutor updateExecutor;
+  @Mock private DeleteExecutor deleteExecutor;
+
+  private BatchProvider batchProvider;
+  private AuthorizationConfiguration authConfig;
+
+  @BeforeEach
+  void setUp() {
+    authConfig = new AuthorizationConfiguration();
+    when(configuration.getAuth()).thenReturn(authConfig);
+    batchProvider = new BatchProvider(updateExecutor, deleteExecutor, configuration);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void setSecurityContext(final String... authorities) {
+    final Jwt jwt = Jwt.withTokenValue("mock").header("alg", "none").claim("sub", "user").build();
+    final JwtAuthenticationToken auth =
+        new JwtAuthenticationToken(jwt, AuthorityUtils.createAuthorityList(authorities));
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+
+  @Test
+  void batchCreateSucceedsWhenAuthDisabled() {
+    authConfig.setEnabled(false);
+    final Bundle bundle = createBundleWithCreateEntry();
+    assertThat(batchProvider.batch(bundle)).isNotNull();
+  }
+
+  @Test
+  void batchCreateSucceedsWithCorrectResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:batch", "pathling:write:Patient", "pathling:update");
+    final Bundle bundle = createBundleWithCreateEntry();
+    assertThat(batchProvider.batch(bundle)).isNotNull();
+  }
+
+  @Test
+  void batchCreateThrowsWhenMissingResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:batch", "pathling:update");
+    final Bundle bundle = createBundleWithCreateEntry();
+    assertThatThrownBy(() -> batchProvider.batch(bundle))
+        .isInstanceOf(AccessDeniedError.class)
+        .hasMessageContaining("pathling:write:Patient");
+  }
+
+  @Test
+  void batchUpdateSucceedsWhenAuthDisabled() {
+    authConfig.setEnabled(false);
+    final Bundle bundle = createBundleWithUpdateEntry();
+    assertThat(batchProvider.batch(bundle)).isNotNull();
+  }
+
+  @Test
+  void batchUpdateSucceedsWithCorrectResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:batch", "pathling:write:Patient", "pathling:update");
+    final Bundle bundle = createBundleWithUpdateEntry();
+    assertThat(batchProvider.batch(bundle)).isNotNull();
+  }
+
+  @Test
+  void batchUpdateThrowsWhenMissingResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:batch", "pathling:update");
+    final Bundle bundle = createBundleWithUpdateEntry();
+    assertThatThrownBy(() -> batchProvider.batch(bundle))
+        .isInstanceOf(AccessDeniedError.class)
+        .hasMessageContaining("pathling:write:Patient");
+  }
+
+  @Test
+  void batchDeleteSucceedsWhenAuthDisabled() {
+    authConfig.setEnabled(false);
+    final Bundle bundle = createBundleWithDeleteEntry();
+    assertThat(batchProvider.batch(bundle)).isNotNull();
+  }
+
+  @Test
+  void batchDeleteSucceedsWithCorrectResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:batch", "pathling:write:Patient", "pathling:delete");
+    final Bundle bundle = createBundleWithDeleteEntry();
+    assertThat(batchProvider.batch(bundle)).isNotNull();
+  }
+
+  @Test
+  void batchDeleteThrowsWhenMissingResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:batch", "pathling:delete");
+    final Bundle bundle = createBundleWithDeleteEntry();
+    assertThatThrownBy(() -> batchProvider.batch(bundle))
+        .isInstanceOf(AccessDeniedError.class)
+        .hasMessageContaining("pathling:write:Patient");
+  }
+
+  private Bundle createBundleWithCreateEntry() {
+    final Bundle bundle = new Bundle();
+    bundle.setType(BundleType.BATCH);
+
+    final Patient patient = new Patient();
+    final BundleEntryComponent entry = bundle.addEntry();
+    entry.setResource(patient);
+    final BundleEntryRequestComponent request = new BundleEntryRequestComponent();
+    request.setMethod(HTTPVerb.POST);
+    request.setUrl("Patient");
+    entry.setRequest(request);
+
+    return bundle;
+  }
+
+  private Bundle createBundleWithUpdateEntry() {
+    final Bundle bundle = new Bundle();
+    bundle.setType(BundleType.BATCH);
+
+    final Patient patient = new Patient();
+    patient.setId("patient-1");
+    final BundleEntryComponent entry = bundle.addEntry();
+    entry.setResource(patient);
+    final BundleEntryRequestComponent request = new BundleEntryRequestComponent();
+    request.setMethod(HTTPVerb.PUT);
+    request.setUrl("Patient/patient-1");
+    entry.setRequest(request);
+
+    return bundle;
+  }
+
+  private Bundle createBundleWithDeleteEntry() {
+    final Bundle bundle = new Bundle();
+    bundle.setType(BundleType.BATCH);
+
+    final BundleEntryComponent entry = bundle.addEntry();
+    final BundleEntryRequestComponent request = new BundleEntryRequestComponent();
+    request.setMethod(HTTPVerb.DELETE);
+    request.setUrl("Patient/patient-1");
+    entry.setRequest(request);
+
+    return bundle;
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/update/UpdateProviderAuthTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/UpdateProviderAuthTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import au.csiro.pathling.config.AuthorizationConfiguration;
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.errors.AccessDeniedError;
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Security tests for {@link UpdateProvider} verifying per-resource write authority enforcement.
+ *
+ * @author John Grimes
+ */
+@Tag("UnitTest")
+@ExtendWith(MockitoExtension.class)
+class UpdateProviderAuthTest {
+
+  @Mock private ServerConfiguration configuration;
+  @Mock private UpdateExecutor updateExecutor;
+
+  private UpdateProvider updateProvider;
+  private FhirContext fhirContext;
+  private AuthorizationConfiguration authConfig;
+
+  @BeforeEach
+  void setUp() {
+    fhirContext = FhirContext.forR4();
+    authConfig = new AuthorizationConfiguration();
+    when(configuration.getAuth()).thenReturn(authConfig);
+    updateProvider = new UpdateProvider(configuration, updateExecutor, fhirContext, Patient.class);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void setSecurityContext(final String... authorities) {
+    final Jwt jwt = Jwt.withTokenValue("mock").header("alg", "none").claim("sub", "user").build();
+    final JwtAuthenticationToken auth =
+        new JwtAuthenticationToken(jwt, AuthorityUtils.createAuthorityList(authorities));
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+
+  @Test
+  void updateSucceedsWhenAuthDisabled() {
+    authConfig.setEnabled(false);
+    final Patient patient = new Patient();
+    patient.setId("patient-1");
+    assertThat(updateProvider.update(new IdType("Patient/patient-1"), patient)).isNotNull();
+  }
+
+  @Test
+  void updateSucceedsWithCorrectResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:update", "pathling:write:Patient");
+    final Patient patient = new Patient();
+    patient.setId("patient-1");
+    assertThat(updateProvider.update(new IdType("Patient/patient-1"), patient)).isNotNull();
+  }
+
+  @Test
+  void updateThrowsWhenMissingResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:update");
+    final Patient patient = new Patient();
+    patient.setId("patient-1");
+    assertThatThrownBy(() -> updateProvider.update(new IdType("Patient/patient-1"), patient))
+        .isInstanceOf(AccessDeniedError.class)
+        .hasMessageContaining("pathling:write:Patient");
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/update/UpdateProviderFactoryTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/UpdateProviderFactoryTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import au.csiro.pathling.config.ServerConfiguration;
 import ca.uhn.fhir.context.FhirContext;
 import org.hl7.fhir.r4.model.Enumerations.ResourceType;
 import org.hl7.fhir.r4.model.Patient;
@@ -46,6 +47,7 @@ import org.springframework.context.ApplicationContext;
 class UpdateProviderFactoryTest {
 
   @Mock private ApplicationContext applicationContext;
+  @Mock private ServerConfiguration configuration;
   @Mock private UpdateExecutor updateExecutor;
 
   private UpdateProviderFactory factory;
@@ -54,34 +56,35 @@ class UpdateProviderFactoryTest {
   @BeforeEach
   void setUp() {
     fhirContext = FhirContext.forR4();
-    factory = new UpdateProviderFactory(applicationContext, fhirContext, updateExecutor);
+    factory =
+        new UpdateProviderFactory(applicationContext, configuration, fhirContext, updateExecutor);
   }
 
   @Test
   void createsProviderForResourceType() {
     // The factory should request an UpdateProvider bean for the resolved resource class.
     final UpdateProvider mockProvider = mock(UpdateProvider.class);
-    when(applicationContext.getBean(eq(UpdateProvider.class), any(), any(), any()))
+    when(applicationContext.getBean(eq(UpdateProvider.class), any(), any(), any(), any()))
         .thenReturn(mockProvider);
 
     final UpdateProvider result = factory.createUpdateProvider(ResourceType.PATIENT);
 
     assertNotNull(result);
     verify(applicationContext)
-        .getBean(UpdateProvider.class, updateExecutor, fhirContext, Patient.class);
+        .getBean(UpdateProvider.class, configuration, updateExecutor, fhirContext, Patient.class);
   }
 
   @Test
   void createsProviderForResourceTypeCode() {
     // The factory should also support creation by string resource type code.
     final UpdateProvider mockProvider = mock(UpdateProvider.class);
-    when(applicationContext.getBean(eq(UpdateProvider.class), any(), any(), any()))
+    when(applicationContext.getBean(eq(UpdateProvider.class), any(), any(), any(), any()))
         .thenReturn(mockProvider);
 
     final UpdateProvider result = factory.createUpdateProvider("Patient");
 
     assertNotNull(result);
     verify(applicationContext)
-        .getBean(UpdateProvider.class, updateExecutor, fhirContext, Patient.class);
+        .getBean(UpdateProvider.class, configuration, updateExecutor, fhirContext, Patient.class);
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/update/UpdateProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/UpdateProviderTest.java
@@ -21,8 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
+import au.csiro.pathling.config.AuthorizationConfiguration;
+import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.errors.InvalidUserInputError;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.api.MethodOutcome;
@@ -46,12 +49,15 @@ class UpdateProviderTest {
 
   @Mock private UpdateExecutor updateExecutor;
 
+  @Mock private ServerConfiguration configuration;
+
   private UpdateProvider provider;
 
   @BeforeEach
   void setUp() {
     final FhirContext fhirContext = FhirContext.forR4();
-    provider = new UpdateProvider(updateExecutor, fhirContext, Patient.class);
+    lenient().when(configuration.getAuth()).thenReturn(new AuthorizationConfiguration());
+    provider = new UpdateProvider(configuration, updateExecutor, fhirContext, Patient.class);
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionCreateTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionCreateTest.java
@@ -67,6 +67,8 @@ class ViewDefinitionCreateTest {
 
   @Autowired private FhirContext fhirContext;
 
+  @Autowired private au.csiro.pathling.config.ServerConfiguration configuration;
+
   @Autowired private CacheableDatabase cacheableDatabase;
 
   private Path tempDatabasePath;
@@ -86,7 +88,9 @@ class ViewDefinitionCreateTest {
             cacheableDatabase);
 
     // Create the CreateProvider for ViewDefinition.
-    createProvider = new CreateProvider(updateExecutor, fhirContext, ViewDefinitionResource.class);
+    createProvider =
+        new CreateProvider(
+            configuration, updateExecutor, fhirContext, ViewDefinitionResource.class);
   }
 
   @AfterEach

--- a/server/src/test/java/au/csiro/pathling/read/ReadProviderAuthTest.java
+++ b/server/src/test/java/au/csiro/pathling/read/ReadProviderAuthTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.read;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import au.csiro.pathling.config.AuthorizationConfiguration;
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.errors.AccessDeniedError;
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Security tests for {@link ReadProvider} verifying per-resource read authority enforcement.
+ *
+ * @author John Grimes
+ */
+@Tag("UnitTest")
+@ExtendWith(MockitoExtension.class)
+class ReadProviderAuthTest {
+
+  @Mock private ServerConfiguration configuration;
+  @Mock private ReadExecutor readExecutor;
+
+  private ReadProvider readProvider;
+  private FhirContext fhirContext;
+  private AuthorizationConfiguration authConfig;
+
+  @BeforeEach
+  void setUp() {
+    fhirContext = FhirContext.forR4();
+    authConfig = new AuthorizationConfiguration();
+    when(configuration.getAuth()).thenReturn(authConfig);
+    readProvider = new ReadProvider(configuration, readExecutor, fhirContext, Patient.class);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void setSecurityContext(final String... authorities) {
+    final Jwt jwt = Jwt.withTokenValue("mock").header("alg", "none").claim("sub", "user").build();
+    final JwtAuthenticationToken auth =
+        new JwtAuthenticationToken(jwt, AuthorityUtils.createAuthorityList(authorities));
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+
+  @Test
+  void readSucceedsWhenAuthDisabled() {
+    authConfig.setEnabled(false);
+    when(readExecutor.read("Patient", "patient-1")).thenReturn(new Patient());
+    assertThat(readProvider.read(new IdType("Patient/patient-1"))).isNotNull();
+  }
+
+  @Test
+  void readSucceedsWithCorrectResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:read", "pathling:read:Patient");
+    when(readExecutor.read("Patient", "patient-1")).thenReturn(new Patient());
+    assertThat(readProvider.read(new IdType("Patient/patient-1"))).isNotNull();
+  }
+
+  @Test
+  void readThrowsWhenMissingResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:search");
+    assertThatThrownBy(() -> readProvider.read(new IdType("Patient/patient-1")))
+        .isInstanceOf(AccessDeniedError.class)
+        .hasMessageContaining("pathling:read:Patient");
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/read/ReadProviderFactoryTest.java
+++ b/server/src/test/java/au/csiro/pathling/read/ReadProviderFactoryTest.java
@@ -55,6 +55,8 @@ class ReadProviderFactoryTest {
 
   @Autowired private FhirEncoders fhirEncoders;
 
+  @Autowired private au.csiro.pathling.config.ServerConfiguration configuration;
+
   private ReadProviderFactory readProviderFactory;
 
   @BeforeEach
@@ -64,7 +66,8 @@ class ReadProviderFactoryTest {
     final CustomObjectDataSource dataSource =
         new CustomObjectDataSource(sparkSession, pathlingContext, fhirEncoders, resources);
 
-    readProviderFactory = new ReadProviderFactory(fhirContext, dataSource, fhirEncoders);
+    readProviderFactory =
+        new ReadProviderFactory(configuration, fhirContext, dataSource, fhirEncoders);
   }
 
   // -------------------------------------------------------------------------

--- a/server/src/test/java/au/csiro/pathling/read/ReadProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/read/ReadProviderTest.java
@@ -62,6 +62,8 @@ class ReadProviderTest {
 
   @Autowired private FhirContext fhirContext;
 
+  @Autowired private au.csiro.pathling.config.ServerConfiguration configuration;
+
   private CustomObjectDataSource dataSource;
   private ReadProvider readProvider;
 
@@ -75,7 +77,7 @@ class ReadProviderTest {
     dataSource = new CustomObjectDataSource(sparkSession, pathlingContext, fhirEncoders, resources);
 
     final ReadExecutor readExecutor = new ReadExecutor(dataSource, fhirEncoders);
-    readProvider = new ReadProvider(readExecutor, fhirContext, Patient.class);
+    readProvider = new ReadProvider(configuration, readExecutor, fhirContext, Patient.class);
   }
 
   // -------------------------------------------------------------------------

--- a/server/src/test/java/au/csiro/pathling/search/SearchProviderAuthTest.java
+++ b/server/src/test/java/au/csiro/pathling/search/SearchProviderAuthTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import au.csiro.pathling.config.AuthorizationConfiguration;
+import au.csiro.pathling.config.QueryConfiguration;
+import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.errors.AccessDeniedError;
+import au.csiro.pathling.io.source.DataSource;
+import ca.uhn.fhir.context.FhirContext;
+import java.util.Map;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Security tests for {@link SearchProvider} verifying per-resource read authority enforcement.
+ *
+ * @author John Grimes
+ */
+@Tag("UnitTest")
+@ExtendWith(MockitoExtension.class)
+class SearchProviderAuthTest {
+
+  @Mock private ServerConfiguration configuration;
+  @Mock private DataSource dataSource;
+  @Mock private FhirEncoders fhirEncoders;
+  @Mock private Dataset<Row> dataset;
+
+  private SearchProvider searchProvider;
+  private FhirContext fhirContext;
+  private AuthorizationConfiguration authConfig;
+
+  @BeforeEach
+  void setUp() {
+    fhirContext = FhirContext.forR4();
+    authConfig = new AuthorizationConfiguration();
+    when(configuration.getAuth()).thenReturn(authConfig);
+    lenient()
+        .when(configuration.getQuery())
+        .thenReturn(QueryConfiguration.builder().cacheResults(false).build());
+    lenient().when(dataSource.read("Patient")).thenReturn(dataset);
+
+    searchProvider =
+        new SearchProvider(configuration, fhirContext, dataSource, fhirEncoders, Patient.class);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void setSecurityContext(final String... authorities) {
+    final Jwt jwt = Jwt.withTokenValue("mock").header("alg", "none").claim("sub", "user").build();
+    final JwtAuthenticationToken auth =
+        new JwtAuthenticationToken(jwt, AuthorityUtils.createAuthorityList(authorities));
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+
+  @Test
+  void searchSucceedsWhenAuthDisabled() {
+    authConfig.setEnabled(false);
+    assertThat(searchProvider.search(Map.of())).isNotNull();
+  }
+
+  @Test
+  void searchSucceedsWithCorrectResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:search", "pathling:read:Patient");
+    assertThat(searchProvider.search(Map.of())).isNotNull();
+  }
+
+  @Test
+  void searchThrowsWhenMissingResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:search");
+    assertThatThrownBy(() -> searchProvider.search(Map.of()))
+        .isInstanceOf(AccessDeniedError.class)
+        .hasMessageContaining("pathling:read:Patient");
+  }
+
+  @Test
+  void searchWithFiltersSucceedsWithCorrectResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:search", "pathling:read:Patient");
+    assertThat(searchProvider.search(null, Map.of())).isNotNull();
+  }
+
+  @Test
+  void searchWithFiltersThrowsWhenMissingResourceAuthority() {
+    authConfig.setEnabled(true);
+    setSecurityContext("pathling:search");
+    assertThatThrownBy(() -> searchProvider.search(null, Map.of()))
+        .isInstanceOf(AccessDeniedError.class)
+        .hasMessageContaining("pathling:read:Patient");
+  }
+}


### PR DESCRIPTION
Typed FHIR resource providers (Search, Read, Create, Update, Delete) and the Batch provider previously only enforced operation-level authorities (e.g. `pathling:search`, `pathling:update`) but did not check per-resource read/write authority. This allowed a caller with a coarse-grained token to access any resource type.

Adds explicit `SecurityAspect.checkHasAuthority()` calls gated by `auth.enabled` to each provider method, and injects `ServerConfiguration` into the providers and their factories that lacked it.

Includes focused auth unit tests for all six providers.