### PR TITLE
Add security controls for $import-pnp operation

### DIFF
--- a/server/src/main/java/au/csiro/pathling/config/PnpConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/PnpConfiguration.java
@@ -18,6 +18,7 @@
 package au.csiro.pathling.config;
 
 import jakarta.annotation.Nullable;
+import java.util.List;
 import lombok.Data;
 import lombok.ToString;
 
@@ -28,6 +29,13 @@ import lombok.ToString;
  */
 @Data
 public class PnpConfiguration {
+
+  /**
+   * A list of URL prefixes which are allowable for use as export URLs within the $import-pnp
+   * operation. When this list is non-empty, any exportUrl that does not start with one of these
+   * prefixes will be rejected.
+   */
+  @Nullable private List<String> allowableExportUrls;
 
   /** The client identifier for SMART Backend Services authentication. */
   @Nullable private String clientId;

--- a/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportOperationValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportOperationValidator.java
@@ -142,7 +142,7 @@ public class ImportOperationValidator {
     final SaveMode saveMode =
         manifest.saveMode() != null && !manifest.saveMode().isBlank()
             ? SaveMode.fromCode(manifest.saveMode())
-            : SaveMode.OVERWRITE; // Default to OVERWRITE.
+            : SaveMode.MERGE; // Default to MERGE.
 
     final ImportRequest importRequest =
         new ImportRequest(requestDetails.getCompleteUrl(), input, saveMode, importFormat);
@@ -194,7 +194,7 @@ public class ImportOperationValidator {
             CodeType.class,
             code -> SaveMode.fromCode(code.getCode()),
             true,
-            Optional.of(SaveMode.OVERWRITE), // Default to OVERWRITE.
+            Optional.of(SaveMode.MERGE), // Default to MERGE.
             false,
             Optional.of(new InvalidUserInputError("Unknown saveMode.")))
         .orElseThrow();

--- a/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpExecutor.java
@@ -19,11 +19,14 @@ package au.csiro.pathling.operations.bulkimport;
 
 import au.csiro.fhir.auth.AuthConfig;
 import au.csiro.fhir.export.BulkExportClient;
+import au.csiro.fhir.export.BulkExportResult;
+import au.csiro.fhir.export.BulkExportResult.FileResult;
 import au.csiro.pathling.config.PnpConfiguration;
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.errors.InvalidUserInputError;
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -251,8 +254,11 @@ public class ImportPnpExecutor {
 
     // Execute the export and wait for completion.
     log.info("Starting bulk export download from: {}", pnpRequest.exportUrl());
-    client.export();
+    final BulkExportResult exportResult = client.export();
     log.info("Bulk export download completed");
+
+    // Validate that all downloaded files came from the same origin as the export URL.
+    validateManifestUrls(pnpRequest.exportUrl(), exportResult);
 
     // Scan the output directory to find downloaded files and organise by resource type.
     return organiseDownloadedFiles(outputDir, fileExtension);
@@ -306,6 +312,53 @@ public class ImportPnpExecutor {
 
     log.info("Organised downloaded files by resource type: {}", result.keySet());
     return result;
+  }
+
+  /**
+   * Validates that all manifest download URLs share the same origin as the export URL.
+   *
+   * @param exportUrl the original export URL
+   * @param exportResult the bulk export result containing downloaded file sources
+   * @throws InvalidUserInputError if any download URL originates from a different host
+   */
+  static void validateManifestUrls(
+      @Nonnull final String exportUrl, @Nonnull final BulkExportResult exportResult) {
+    final URI exportUri = URI.create(exportUrl);
+    final String exportOrigin = originOf(exportUri);
+
+    for (final FileResult fileResult : exportResult.getResults()) {
+      final String sourceOrigin = originOf(fileResult.getSource());
+      if (!exportOrigin.equalsIgnoreCase(sourceOrigin)) {
+        throw new InvalidUserInputError(
+            "Manifest download URL origin does not match export URL origin: "
+                + fileResult.getSource()
+                + " (expected origin: "
+                + exportOrigin
+                + ")");
+      }
+    }
+  }
+
+  /**
+   * Extracts the origin (scheme + host + port) from a URI.
+   *
+   * @param uri the URI to extract the origin from
+   * @return the origin string in the form scheme://host:port (or scheme://host if default port)
+   */
+  @Nonnull
+  static String originOf(@Nonnull final URI uri) {
+    final String scheme = uri.getScheme();
+    final String host = uri.getHost();
+    final int port = uri.getPort();
+    if (scheme == null || host == null) {
+      throw new InvalidUserInputError("Invalid URL: " + uri);
+    }
+    final boolean isDefaultPort =
+        ("http".equalsIgnoreCase(scheme) && port == 80)
+            || ("https".equalsIgnoreCase(scheme) && port == 443);
+    return isDefaultPort || port == -1
+        ? scheme.toLowerCase() + "://" + host.toLowerCase()
+        : scheme.toLowerCase() + "://" + host.toLowerCase() + ":" + port;
   }
 
   /**

--- a/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationValidator.java
@@ -19,11 +19,14 @@ package au.csiro.pathling.operations.bulkimport;
 
 import au.csiro.pathling.ParamUtil;
 import au.csiro.pathling.async.PreAsyncValidation.PreAsyncValidationResult;
+import au.csiro.pathling.config.PnpConfiguration;
+import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.errors.InvalidUserInputError;
 import au.csiro.pathling.library.io.SaveMode;
 import au.csiro.pathling.operations.OperationValidation;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.PostConstruct;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -50,6 +53,27 @@ public class ImportPnpOperationValidator {
 
   private static final String EXPORT_TYPE_DYNAMIC = "dynamic";
   private static final String EXPORT_TYPE_STATIC = "static";
+
+  @Nonnull private final ServerConfiguration serverConfiguration;
+
+  /**
+   * Constructor for ImportPnpOperationValidator.
+   *
+   * @param serverConfiguration the server configuration
+   */
+  public ImportPnpOperationValidator(@Nonnull final ServerConfiguration serverConfiguration) {
+    this.serverConfiguration = serverConfiguration;
+  }
+
+  /** Logs a warning at startup if PNP credentials are configured without authentication enabled. */
+  @PostConstruct
+  public void checkAuthConfiguration() {
+    if (pnpCredentialsConfigured() && !serverConfiguration.getAuth().isEnabled()) {
+      log.warn(
+          "PNP credentials are configured but authentication is disabled. "
+              + "The $import-pnp operation will reject requests until authentication is enabled.");
+    }
+  }
 
   /**
    * Validates a ping and pull import request from a FHIR Parameters resource.
@@ -94,7 +118,7 @@ public class ImportPnpOperationValidator {
 
     // Note: inputSource parameter is accepted but ignored for backwards compatibility.
 
-    // Extract saveMode parameter (optional, defaults to OVERWRITE).
+    // Extract saveMode parameter (optional, defaults to MERGE).
     final SaveMode saveMode =
         ParamUtil.extractFromPart(
                 parameters.getParameter(),
@@ -102,7 +126,7 @@ public class ImportPnpOperationValidator {
                 CodeType.class,
                 code -> SaveMode.fromCode(code.getCode()),
                 true,
-                Optional.of(SaveMode.OVERWRITE),
+                Optional.of(SaveMode.MERGE),
                 false,
                 Optional.of(new InvalidUserInputError("Unknown saveMode.")))
             .orElseThrow();
@@ -129,6 +153,9 @@ public class ImportPnpOperationValidator {
     final List<String> includeAssociatedData =
         extractCodeList(parameters.getParameter(), "includeAssociatedData");
 
+    validateExportUrl(exportUrl);
+    validateAuthConfiguration();
+
     final ImportPnpRequest importPnpRequest =
         new ImportPnpRequest(
             requestDetails.getCompleteUrl(),
@@ -151,6 +178,66 @@ public class ImportPnpOperationValidator {
             .toList();
 
     return new PreAsyncValidationResult<>(importPnpRequest, issues);
+  }
+
+  /**
+   * Validates that the exportUrl is allowed based on the configured allowableExportUrls.
+   *
+   * @param exportUrl the export URL to validate
+   * @throws InvalidUserInputError if the URL is not allowed
+   */
+  private void validateExportUrl(@Nonnull final String exportUrl) {
+    final PnpConfiguration pnpConfig =
+        serverConfiguration.getImport() != null ? serverConfiguration.getImport().getPnp() : null;
+    final List<String> allowableExportUrls =
+        pnpConfig != null && pnpConfig.getAllowableExportUrls() != null
+            ? pnpConfig.getAllowableExportUrls()
+            : List.of();
+
+    if (allowableExportUrls.isEmpty()) {
+      if (pnpCredentialsConfigured()) {
+        throw new InvalidUserInputError(
+            "No trusted export URLs are configured. "
+                + "Set pathling.import.pnp.allowableExportUrls to enable $import-pnp.");
+      }
+      return;
+    }
+
+    final boolean allowed = allowableExportUrls.stream().anyMatch(exportUrl::startsWith);
+    if (!allowed) {
+      throw new InvalidUserInputError("exportUrl not in allowableExportUrls: " + exportUrl);
+    }
+  }
+
+  /**
+   * Validates that authentication is enabled when PNP credentials are configured.
+   *
+   * @throws InvalidUserInputError if auth is disabled but PNP credentials are present
+   */
+  private void validateAuthConfiguration() {
+    if (pnpCredentialsConfigured() && !serverConfiguration.getAuth().isEnabled()) {
+      throw new InvalidUserInputError(
+          "Authentication is required when PNP credentials are configured.");
+    }
+  }
+
+  /**
+   * Checks whether PNP credentials are configured.
+   *
+   * @return true if clientId and either clientSecret or privateKeyJwk are configured
+   */
+  private boolean pnpCredentialsConfigured() {
+    final PnpConfiguration pnpConfig =
+        serverConfiguration.getImport() != null ? serverConfiguration.getImport().getPnp() : null;
+    if (pnpConfig == null) {
+      return false;
+    }
+    final String clientId = pnpConfig.getClientId();
+    if (clientId == null || clientId.isBlank()) {
+      return false;
+    }
+    return (pnpConfig.getClientSecret() != null && !pnpConfig.getClientSecret().isBlank())
+        || (pnpConfig.getPrivateKeyJwk() != null && !pnpConfig.getPrivateKeyJwk().isBlank());
   }
 
   /**

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportOperationValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportOperationValidatorTest.java
@@ -158,7 +158,7 @@ class ImportOperationValidatorTest {
 
   private static Stream<Arguments> provide_mode_params() {
     return Stream.of(
-        arguments(minimalValidParams(), SaveMode.OVERWRITE),
+        arguments(minimalValidParams(), SaveMode.MERGE),
         arguments(paramsWithMode("overwrite"), SaveMode.OVERWRITE),
         arguments(paramsWithMode("merge"), SaveMode.MERGE),
         arguments(paramsWithMode("error"), SaveMode.ERROR_IF_EXISTS),
@@ -230,6 +230,24 @@ class ImportOperationValidatorTest {
             "https://example.org/source",
             List.of(new ImportManifestInput("Patient", "s3://bucket/patients.ndjson")),
             "merge");
+    final RequestDetails mockRequest =
+        MockUtil.mockRequest("application/fhir+json", "respond-async", false);
+
+    final PreAsyncValidationResult<ImportRequest> result =
+        importOperationValidator.validateJsonRequest(mockRequest, manifest);
+
+    assertThat(result.result().saveMode()).isEqualTo(SaveMode.MERGE);
+  }
+
+  /** Tests that the default saveMode is MERGE when omitted from a JSON manifest. */
+  @Test
+  void defaultsSaveModeToMergeForJsonManifest() {
+    final ImportManifest manifest =
+        new ImportManifest(
+            "application/fhir+ndjson",
+            "https://example.org/source",
+            List.of(new ImportManifestInput("Patient", "s3://bucket/patients.ndjson")),
+            null);
     final RequestDetails mockRequest =
         MockUtil.mockRequest("application/fhir+json", "respond-async", false);
 

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpExecutorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpExecutorTest.java
@@ -18,7 +18,15 @@
 package au.csiro.pathling.operations.bulkimport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import au.csiro.fhir.export.BulkExportResult;
+import au.csiro.fhir.export.BulkExportResult.FileResult;
+import au.csiro.pathling.errors.InvalidUserInputError;
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -150,5 +158,66 @@ class ImportPnpExecutorTest {
 
     // Then - the first non-blank message (middle) should be returned.
     assertThat(result).isEqualTo("Middle message");
+  }
+
+  // ========================================
+  // Manifest URL Validation Tests
+  // ========================================
+
+  /** Tests that manifest URLs on the same origin as the export URL are accepted. */
+  @Test
+  void acceptsManifestUrlsOnSameOrigin() {
+    final BulkExportResult result =
+        BulkExportResult.of(
+            Instant.now(),
+            List.of(
+                FileResult.of(
+                    URI.create("https://trusted.example.com/data/Patient.ndjson"),
+                    URI.create("file:/tmp/Patient.ndjson"),
+                    100L)));
+
+    assertThatCode(
+            () ->
+                ImportPnpExecutor.validateManifestUrls("https://trusted.example.com/fhir", result))
+        .doesNotThrowAnyException();
+  }
+
+  /** Tests that manifest URLs on a different origin than the export URL are rejected. */
+  @Test
+  void rejectsManifestUrlsOnDifferentOrigin() {
+    final BulkExportResult result =
+        BulkExportResult.of(
+            Instant.now(),
+            List.of(
+                FileResult.of(
+                    URI.create("https://evil.com/data/Patient.ndjson"),
+                    URI.create("file:/tmp/Patient.ndjson"),
+                    100L)));
+
+    assertThatThrownBy(
+            () ->
+                ImportPnpExecutor.validateManifestUrls("https://trusted.example.com/fhir", result))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("Manifest download URL origin does not match export URL origin");
+  }
+
+  /** Tests that origin extraction works correctly for standard HTTP and HTTPS URLs. */
+  @Test
+  void extractsOriginCorrectly() {
+    assertThat(ImportPnpExecutor.originOf(URI.create("https://example.com/path")))
+        .isEqualTo("https://example.com");
+    assertThat(ImportPnpExecutor.originOf(URI.create("http://example.com/path")))
+        .isEqualTo("http://example.com");
+    assertThat(ImportPnpExecutor.originOf(URI.create("https://example.com:8443/path")))
+        .isEqualTo("https://example.com:8443");
+    assertThat(ImportPnpExecutor.originOf(URI.create("http://example.com:8080/path")))
+        .isEqualTo("http://example.com:8080");
+  }
+
+  /** Tests that origin extraction normalises scheme and host to lowercase. */
+  @Test
+  void normalisesOriginToLowercase() {
+    assertThat(ImportPnpExecutor.originOf(URI.create("HTTPS://EXAMPLE.COM/path")))
+        .isEqualTo("https://example.com");
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationIT.java
@@ -18,14 +18,19 @@
 package au.csiro.pathling.operations.bulkimport;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.security.OidcConfiguration;
 import au.csiro.pathling.util.TestDataSetup;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
@@ -33,6 +38,8 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
@@ -49,9 +56,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 /**
@@ -64,7 +74,11 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ResourceLock(value = "wiremock", mode = ResourceAccessMode.READ_WRITE)
 @ActiveProfiles({"integration-test"})
+@MockitoBean(types = JwtDecoder.class)
+@MockitoBean(types = OidcConfiguration.class)
 class ImportPnpOperationIT {
+
+  private static final String AUTH_TOKEN = "mock-token";
 
   private static WireMockServer wireMockServer;
 
@@ -81,6 +95,8 @@ class ImportPnpOperationIT {
   @Autowired private FhirContext fhirContext;
 
   @Autowired private PathlingContext pathlingContext;
+
+  @Autowired private JwtDecoder jwtDecoder;
 
   private IParser parser;
 
@@ -104,6 +120,10 @@ class ImportPnpOperationIT {
     TestDataSetup.copyTestDataToTempDir(warehouseDir);
     registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir.toAbsolutePath());
 
+    // Enable authentication since PNP credentials are configured.
+    registry.add("pathling.auth.enabled", () -> "true");
+    registry.add("pathling.auth.issuer", () -> "https://auth.example.com/fhir");
+
     // Configure PnP settings for testing with WireMock token endpoint.
     registry.add("pathling.import.pnp.clientId", () -> "test-client");
     registry.add("pathling.import.pnp.clientSecret", () -> "test-secret");
@@ -113,6 +133,9 @@ class ImportPnpOperationIT {
         () -> "http://localhost:" + wireMockServer.port() + "/oauth/token");
     registry.add(
         "pathling.import.pnp.downloadLocation", () -> pnpDownloadDir.toAbsolutePath().toString());
+    registry.add(
+        "pathling.import.pnp.allowableExportUrls",
+        () -> "http://localhost:" + wireMockServer.port() + "/fhir");
   }
 
   @BeforeEach
@@ -127,6 +150,24 @@ class ImportPnpOperationIT {
 
     // Reset WireMock stubs before each test.
     wireMockServer.resetAll();
+
+    // Configure the mock JWT decoder to accept our test token and return a JWT with the required
+    // authorities.
+    final Jwt jwt =
+        Jwt.withTokenValue(AUTH_TOKEN)
+            .header("alg", "none")
+            .claim("sub", "test-user")
+            .claim(
+                "authorities",
+                List.of(
+                    "pathling:import-pnp",
+                    "pathling:write",
+                    "pathling:write:Patient",
+                    "pathling:write:Observation"))
+            .issuedAt(Instant.now())
+            .expiresAt(Instant.now().plusSeconds(3600))
+            .build();
+    when(jwtDecoder.decode(any())).thenReturn(jwt);
   }
 
   @AfterEach
@@ -234,6 +275,79 @@ class ImportPnpOperationIT {
     log.info("Set up successful bulk export stubs on WireMock server");
   }
 
+  /** Sets up WireMock stubs where the manifest references an off-host download URL. */
+  private void setupOffHostManifestStubs() {
+    final String baseUrl = "http://localhost:" + wireMockServer.port();
+
+    // Stub 1: OAuth token endpoint.
+    wireMockServer.stubFor(
+        post(urlEqualTo("/oauth/token"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        """
+                        {
+                          "access_token": "test-access-token",
+                          "token_type": "bearer",
+                          "expires_in": 3600
+                        }
+                        """)));
+
+    // Stub 2: Bulk export kick-off endpoint.
+    wireMockServer.stubFor(
+        get(urlPathEqualTo("/fhir/$export"))
+            .willReturn(
+                aResponse()
+                    .withStatus(202)
+                    .withHeader("Content-Location", baseUrl + "/fhir/$export-status/job456")));
+
+    // Stub 3: Export status endpoint - returns complete with off-host manifest.
+    // Use 127.0.0.1 instead of localhost to create a different origin while still hitting the
+    // same WireMock server.
+    final String manifest =
+        String.format(
+            """
+            {
+              "transactionTime": "2025-11-11T00:00:00Z",
+              "request": "%s/fhir/$export",
+              "requiresAccessToken": false,
+              "output": [
+                {
+                  "type": "Patient",
+                  "url": "http://127.0.0.1:%d/data/Patient-1.ndjson"
+                }
+              ],
+              "error": []
+            }
+            """,
+            baseUrl, wireMockServer.port());
+
+    wireMockServer.stubFor(
+        get(urlEqualTo("/fhir/$export-status/job456"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(manifest)));
+
+    // Stub 4: Patient NDJSON file accessible via 127.0.0.1 (different origin).
+    final String patientNdjson =
+        """
+        {"resourceType":"Patient","id":"patient1","name":[{"family":"Smith","given":["John"]}]}
+        """;
+    wireMockServer.stubFor(
+        get(urlEqualTo("/data/Patient-1.ndjson"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/fhir+ndjson")
+                    .withBody(patientNdjson)));
+
+    log.info("Set up off-host manifest stubs on WireMock server");
+  }
+
   @Test
   void testMissingRespondAsyncHeaderReturnsError() {
     TestDataSetup.copyTestDataToTempDir(warehouseDir);
@@ -261,15 +375,12 @@ class ImportPnpOperationIT {
         .uri(uri)
         .header("Content-Type", "application/fhir+json")
         .header("Accept", "application/fhir+json")
+        .header("Authorization", "Bearer " + AUTH_TOKEN)
         .bodyValue(requestBody)
         .exchange()
         .expectStatus()
         .is4xxClientError();
   }
-
-  // Note: Missing PnP configuration no longer causes an error. The operation now uses sensible
-  // defaults when no configuration is provided, enabling use against unauthenticated FHIR servers
-  // without requiring any explicit configuration.
 
   @Test
   void testMissingExportUrlReturnsError() {
@@ -295,6 +406,7 @@ class ImportPnpOperationIT {
         .header("Content-Type", "application/fhir+json")
         .header("Accept", "application/fhir+json")
         .header("Prefer", "respond-async")
+        .header("Authorization", "Bearer " + AUTH_TOKEN)
         .bodyValue(requestBody)
         .exchange()
         .expectStatus()
@@ -338,6 +450,7 @@ class ImportPnpOperationIT {
             .header("Content-Type", "application/fhir+json")
             .header("Accept", "application/fhir+json")
             .header("Prefer", "respond-async")
+            .header("Authorization", "Bearer " + AUTH_TOKEN)
             .bodyValue(requestBody)
             .exchange()
             .expectStatus()
@@ -360,6 +473,7 @@ class ImportPnpOperationIT {
                   .get()
                   .uri(contentLocation)
                   .header("Accept", "application/fhir+json")
+                  .header("Authorization", "Bearer " + AUTH_TOKEN)
                   .exchange()
                   .expectStatus()
                   .isOk();
@@ -406,6 +520,7 @@ class ImportPnpOperationIT {
             .header("Content-Type", "application/fhir+json")
             .header("Accept", "application/fhir+json")
             .header("Prefer", "respond-async")
+            .header("Authorization", "Bearer " + AUTH_TOKEN)
             .bodyValue(requestBody)
             .exchange()
             .expectStatus()
@@ -433,6 +548,7 @@ class ImportPnpOperationIT {
                     .get()
                     .uri(contentLocation)
                     .header("Accept", "application/fhir+json")
+                    .header("Authorization", "Bearer " + AUTH_TOKEN)
                     .exchange()
                     .expectStatus()
                     .isOk());
@@ -476,6 +592,7 @@ class ImportPnpOperationIT {
             .header("Content-Type", "application/fhir+json")
             .header("Accept", "application/fhir+json")
             .header("Prefer", "respond-async")
+            .header("Authorization", "Bearer " + AUTH_TOKEN)
             .bodyValue(requestBody)
             .exchange()
             .expectStatus()
@@ -501,8 +618,127 @@ class ImportPnpOperationIT {
                     .get()
                     .uri(contentLocation)
                     .header("Accept", "application/fhir+json")
+                    .header("Authorization", "Bearer " + AUTH_TOKEN)
                     .exchange()
                     .expectStatus()
                     .value(status -> assertThat(status).isIn(200, 202, 400, 500)));
+  }
+
+  /** Tests that a request with an exportUrl not in allowableExportUrls returns 400. */
+  @Test
+  void rejectsExportUrlNotInAllowableExportUrls() {
+    TestDataSetup.copyTestDataToTempDir(warehouseDir);
+
+    final String uri = "http://localhost:" + port + "/fhir/$import-pnp";
+    final String requestBody =
+        """
+        {
+          "resourceType": "Parameters",
+          "parameter": [
+            {
+              "name": "exportUrl",
+              "valueUrl": "https://evil.com/fhir/$export"
+            }
+          ]
+        }
+        """;
+
+    webTestClient
+        .post()
+        .uri(uri)
+        .header("Content-Type", "application/fhir+json")
+        .header("Accept", "application/fhir+json")
+        .header("Prefer", "respond-async")
+        .header("Authorization", "Bearer " + AUTH_TOKEN)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .jsonPath("$.issue[0].diagnostics")
+        .value(diagnostics -> assertThat(diagnostics.toString()).contains("exportUrl"));
+
+    // Verify that WireMock receives zero requests to the export endpoint.
+    wireMockServer.verify(exactly(0), getRequestedFor(urlPathEqualTo("/fhir/$export")));
+  }
+
+  /**
+   * Tests that when the export manifest contains a download URL on a different origin, the job
+   * fails.
+   */
+  @Test
+  void returnsErrorWhenManifestContainsOffHostDownloadUrl() {
+    TestDataSetup.copyTestDataToTempDir(warehouseDir);
+    setupOffHostManifestStubs();
+
+    final String exportUrl = "http://localhost:" + wireMockServer.port() + "/fhir";
+    final String uri = "http://localhost:" + port + "/fhir/$import-pnp";
+    final String requestBody =
+        String.format(
+            """
+            {
+              "resourceType": "Parameters",
+              "parameter": [
+                {
+                  "name": "exportUrl",
+                  "valueUrl": "%s"
+                },
+                {
+                  "name": "exportType",
+                  "valueCode": "dynamic"
+                },
+                {
+                  "name": "saveMode",
+                  "valueCode": "overwrite"
+                }
+              ]
+            }
+            """,
+            exportUrl);
+
+    final var result =
+        webTestClient
+            .post()
+            .uri(uri)
+            .header("Content-Type", "application/fhir+json")
+            .header("Accept", "application/fhir+json")
+            .header("Prefer", "respond-async")
+            .header("Authorization", "Bearer " + AUTH_TOKEN)
+            .bodyValue(requestBody)
+            .exchange()
+            .expectStatus()
+            .isAccepted()
+            .expectHeader()
+            .exists(HttpHeaders.CONTENT_LOCATION)
+            .returnResult(String.class);
+
+    final String contentLocation =
+        result.getResponseHeaders().getFirst(HttpHeaders.CONTENT_LOCATION);
+    assertThat(contentLocation).isNotNull();
+
+    // Poll until the job fails with an error due to origin mismatch.
+    await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(2, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              final var response =
+                  webTestClient
+                      .get()
+                      .uri(contentLocation)
+                      .header("Accept", "application/fhir+json")
+                      .header("Authorization", "Bearer " + AUTH_TOKEN)
+                      .exchange()
+                      .returnResult(String.class);
+              final int status = response.getStatus().value();
+              assertThat(status).isIn(400, 500);
+              final String body =
+                  response.getResponseBodyContent() != null
+                      ? new String(response.getResponseBodyContent())
+                      : "";
+              assertThat(body).contains("Manifest download URL origin");
+            });
+
+    log.info("Off-host manifest URL correctly rejected");
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationValidatorTest.java
@@ -22,12 +22,17 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import au.csiro.pathling.async.PreAsyncValidation.PreAsyncValidationResult;
+import au.csiro.pathling.config.AuthorizationConfiguration;
+import au.csiro.pathling.config.ImportConfiguration;
+import au.csiro.pathling.config.PnpConfiguration;
+import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.errors.InvalidUserInputError;
 import au.csiro.pathling.library.io.SaveMode;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import au.csiro.pathling.util.MockUtil;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import java.time.Instant;
+import java.util.List;
 import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.InstantType;
@@ -40,6 +45,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 
 /**
  * Tests for ImportPnpOperationValidator.
@@ -54,18 +60,45 @@ class ImportPnpOperationValidatorTest {
   static class TestConfig {
 
     @Bean
-    public ImportPnpOperationValidator importPnpOperationValidator() {
-      return new ImportPnpOperationValidator();
+    @Primary
+    public ServerConfiguration serverConfiguration() {
+      final ServerConfiguration config = new ServerConfiguration();
+      final AuthorizationConfiguration auth = new AuthorizationConfiguration();
+      auth.setEnabled(false);
+      config.setAuth(auth);
+      final ImportConfiguration importConfig = new ImportConfiguration();
+      importConfig.setAllowableSources(List.of("s3://test-bucket/"));
+      config.setImport(importConfig);
+      return config;
+    }
+
+    @Bean
+    public ImportPnpOperationValidator importPnpOperationValidator(
+        final ServerConfiguration serverConfiguration) {
+      return new ImportPnpOperationValidator(serverConfiguration);
     }
   }
 
   @Autowired private ImportPnpOperationValidator validator;
+
+  @Autowired private ServerConfiguration serverConfiguration;
 
   private RequestDetails mockRequest;
 
   @BeforeEach
   void setUp() {
     mockRequest = MockUtil.mockRequest("application/fhir+json", "respond-async", false);
+    resetServerConfiguration();
+  }
+
+  /** Resets the server configuration to the default test state. */
+  private void resetServerConfiguration() {
+    final AuthorizationConfiguration auth = new AuthorizationConfiguration();
+    auth.setEnabled(false);
+    serverConfiguration.setAuth(auth);
+    final ImportConfiguration importConfig = new ImportConfiguration();
+    importConfig.setAllowableSources(List.of("s3://test-bucket/"));
+    serverConfiguration.setImport(importConfig);
   }
 
   // ========================================
@@ -111,7 +144,7 @@ class ImportPnpOperationValidatorTest {
         validator.validateParametersRequest(mockRequest, params);
 
     assertThat(result.result().exportType()).isEqualTo("dynamic"); // Default.
-    assertThat(result.result().saveMode()).isEqualTo(SaveMode.OVERWRITE); // Default.
+    assertThat(result.result().saveMode()).isEqualTo(SaveMode.MERGE); // Default.
     assertThat(result.result().importFormat()).isEqualTo(ImportFormat.NDJSON); // Default.
   }
 
@@ -601,5 +634,149 @@ class ImportPnpOperationValidatorTest {
     assertThat(request.elements()).containsExactly("id");
     assertThat(request.typeFilters()).containsExactly("Patient?active=true");
     assertThat(request.includeAssociatedData()).containsExactly("LatestProvenanceResources");
+  }
+
+  // ========================================
+  // Export URL Whitelist Tests
+  // ========================================
+
+  /** Tests that an exportUrl not matching any configured prefix is rejected. */
+  @Test
+  void rejectsExportUrlNotInAllowableExportUrls() {
+    final PnpConfiguration pnpConfig = new PnpConfiguration();
+    pnpConfig.setAllowableExportUrls(List.of("https://trusted.example.com/fhir"));
+    final ImportConfiguration importConfig = new ImportConfiguration();
+    importConfig.setAllowableSources(List.of("s3://test-bucket/"));
+    importConfig.setPnp(pnpConfig);
+    serverConfiguration.setImport(importConfig);
+
+    final Parameters params = new Parameters();
+    params
+        .addParameter()
+        .setName("exportUrl")
+        .setValue(new UrlType("https://evil.com/fhir/$export"));
+
+    assertThatCode(() -> validator.validateParametersRequest(mockRequest, params))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("exportUrl not in allowableExportUrls");
+  }
+
+  /** Tests that an exportUrl matching a configured prefix is accepted. */
+  @Test
+  void acceptsExportUrlMatchingConfiguredPrefix() {
+    final PnpConfiguration pnpConfig = new PnpConfiguration();
+    pnpConfig.setAllowableExportUrls(List.of("https://trusted.example.com/fhir"));
+    final ImportConfiguration importConfig = new ImportConfiguration();
+    importConfig.setAllowableSources(List.of("s3://test-bucket/"));
+    importConfig.setPnp(pnpConfig);
+    serverConfiguration.setImport(importConfig);
+
+    final Parameters params = new Parameters();
+    params
+        .addParameter()
+        .setName("exportUrl")
+        .setValue(new UrlType("https://trusted.example.com/fhir/$export"));
+
+    assertThatNoException()
+        .isThrownBy(() -> validator.validateParametersRequest(mockRequest, params));
+  }
+
+  /**
+   * Tests that when allowableExportUrls is empty and credentials are configured, the request is
+   * rejected.
+   */
+  @Test
+  void rejectsExportUrlWhenAllowableExportUrlsEmptyAndCredentialsConfigured() {
+    final PnpConfiguration pnpConfig = new PnpConfiguration();
+    pnpConfig.setClientId("test-client");
+    pnpConfig.setClientSecret("test-secret");
+    final ImportConfiguration importConfig = new ImportConfiguration();
+    importConfig.setAllowableSources(List.of("s3://test-bucket/"));
+    importConfig.setPnp(pnpConfig);
+    serverConfiguration.setImport(importConfig);
+
+    final Parameters params = new Parameters();
+    params
+        .addParameter()
+        .setName("exportUrl")
+        .setValue(new UrlType("https://example.org/fhir/$export"));
+
+    assertThatCode(() -> validator.validateParametersRequest(mockRequest, params))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("No trusted export URLs are configured");
+  }
+
+  // ========================================
+  // Save Mode Default Tests
+  // ========================================
+
+  /** Tests that the default saveMode is MERGE when omitted. */
+  @Test
+  void defaultsSaveModeToMerge() {
+    final Parameters params = new Parameters();
+    params
+        .addParameter()
+        .setName("exportUrl")
+        .setValue(new UrlType("https://example.org/fhir/$export"));
+
+    final PreAsyncValidationResult<ImportPnpRequest> result =
+        validator.validateParametersRequest(mockRequest, params);
+
+    assertThat(result.result().saveMode()).isEqualTo(SaveMode.MERGE);
+  }
+
+  // ========================================
+  // Authentication Interlock Tests
+  // ========================================
+
+  /**
+   * Tests that when PNP credentials are configured and auth is disabled, the request is rejected.
+   */
+  @Test
+  void rejectsImportPnpWhenAuthDisabledAndPnpCredentialsPresent() {
+    final PnpConfiguration pnpConfig = new PnpConfiguration();
+    pnpConfig.setClientId("test-client");
+    pnpConfig.setClientSecret("test-secret");
+    pnpConfig.setAllowableExportUrls(List.of("https://trusted.example.com/fhir"));
+    final ImportConfiguration importConfig = new ImportConfiguration();
+    importConfig.setAllowableSources(List.of("s3://test-bucket/"));
+    importConfig.setPnp(pnpConfig);
+    serverConfiguration.setImport(importConfig);
+    serverConfiguration.getAuth().setEnabled(false);
+
+    final Parameters params = new Parameters();
+    params
+        .addParameter()
+        .setName("exportUrl")
+        .setValue(new UrlType("https://trusted.example.com/fhir/$export"));
+
+    assertThatCode(() -> validator.validateParametersRequest(mockRequest, params))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("Authentication is required");
+  }
+
+  /**
+   * Tests that when PNP credentials are configured and auth is enabled, the request is accepted.
+   */
+  @Test
+  void acceptsImportPnpWhenAuthEnabledAndPnpCredentialsPresent() {
+    final PnpConfiguration pnpConfig = new PnpConfiguration();
+    pnpConfig.setClientId("test-client");
+    pnpConfig.setClientSecret("test-secret");
+    pnpConfig.setAllowableExportUrls(List.of("https://trusted.example.com/fhir"));
+    final ImportConfiguration importConfig = new ImportConfiguration();
+    importConfig.setAllowableSources(List.of("s3://test-bucket/"));
+    importConfig.setPnp(pnpConfig);
+    serverConfiguration.setImport(importConfig);
+    serverConfiguration.getAuth().setEnabled(true);
+
+    final Parameters params = new Parameters();
+    params
+        .addParameter()
+        .setName("exportUrl")
+        .setValue(new UrlType("https://trusted.example.com/fhir/$export"));
+
+    assertThatNoException()
+        .isThrownBy(() -> validator.validateParametersRequest(mockRequest, params));
   }
 }

--- a/server/src/test/resources/application-integration-test.yml
+++ b/server/src/test/resources/application-integration-test.yml
@@ -6,10 +6,6 @@ pathling:
       - file://
       - http://localhost
       - https://
-    pnp:
-      clientId: test-client
-      clientSecret: test-secret
-      scope: system/*.read
 spring:
   main:
     banner-mode: off

--- a/site/docs/server/configuration.md
+++ b/site/docs/server/configuration.md
@@ -44,6 +44,11 @@ Additionally, you can set any variable supported by Spring Boot, see
 These settings configure the [ping and pull import](./operations/import-pnp)
 operation, which retrieves data from external FHIR bulk export endpoints.
 
+- `pathling.import.pnp.allowableExportUrls` - (default: `[]`) A list of URL
+  prefixes which are allowable for use as export URLs within the `$import-pnp`
+  operation. When this list is non-empty, any `exportUrl` that does not start
+  with one of these prefixes is rejected. When PNP credentials are configured,
+  this list must be explicitly populated.
 - `pathling.import.pnp.clientId` - The client identifier for SMART Backend
   Services authentication.
 - `pathling.import.pnp.tokenEndpoint` - The token endpoint URL for obtaining
@@ -64,6 +69,11 @@ operation, which retrieves data from external FHIR bulk export endpoints.
   operations. This location should have sufficient space for large FHIR exports.
 - `pathling.import.pnp.fileExtension` - (default: `.ndjson`) The file extension
   to filter for when processing downloaded files.
+
+**Security note**: When PNP credentials are configured,
+`pathling.auth.enabled` must also be set to `true`. If authentication is
+disabled but PNP credentials are present, the server logs a warning at startup
+and rejects all `$import-pnp` requests.
 
 ### Export
 

--- a/site/docs/server/operations/import-pnp.md
+++ b/site/docs/server/operations/import-pnp.md
@@ -96,7 +96,7 @@ timestamp, using merge mode for incremental updates:
 | ------------- | ----------- | ------ | ------------------------------------------------------------------------------------------------------------------------------ |
 | `exportUrl`   | 1..1        | url    | The URL of the bulk export endpoint to import from. Can include query parameters (e.g., `$export?_type=Patient`).              |
 | `exportType`  | 0..1        | Coding | The type of export: `dynamic` (default) includes data as of export completion, `static` includes data as of export initiation. |
-| `mode`        | 0..1        | Coding | Controls how data is merged with existing resources. See [Save modes](#save-modes). Defaults to `overwrite`.                   |
+| `mode`        | 0..1        | Coding | Controls how data is merged with existing resources. See [Save modes](#save-modes). Defaults to `merge`.                       |
 | `inputFormat` | 0..1        | Coding | The format of source files. Defaults to `application/fhir+ndjson`. See [Supported formats](./import#supported-formats).        |
 
 ### Bulk export parameters
@@ -117,13 +117,44 @@ URL.
 
 ### Save modes
 
-| Mode        | Description                                                       |
-| ----------- | ----------------------------------------------------------------- |
-| `overwrite` | Delete and replace all existing resources of each type (default)  |
-| `merge`     | Match resources by ID; update existing resources and add new ones |
-| `append`    | Add new resources without modifying existing ones                 |
-| `ignore`    | Skip resources that already exist                                 |
-| `error`     | Fail if any resources already exist                               |
+| Mode        | Description                                                                 |
+| ----------- | --------------------------------------------------------------------------- |
+| `merge`     | Match resources by ID; update existing resources and add new ones (default) |
+| `overwrite` | Delete and replace all existing resources of each type                      |
+| `append`    | Add new resources without modifying existing ones                           |
+| `ignore`    | Skip resources that already exist                                           |
+| `error`     | Fail if any resources already exist                                         |
+
+## Security
+
+### Export URL whitelist
+
+To prevent credential leakage and server-side request forgery (SSRF), the
+`$import-pnp` operation validates the `exportUrl` against a configurable
+whitelist.
+
+- `pathling.import.pnp.allowableExportUrls` - A list of URL prefixes which are
+  allowable for use as export URLs. When this list is non-empty, any `exportUrl`
+  that does not start with one of these prefixes is rejected with a `400 Bad
+Request`.
+
+When PNP credentials are configured, this list must be explicitly configured.
+If the list is empty and credentials are present, the operation rejects all
+requests.
+
+### Authentication interlock
+
+When PNP credentials (`clientId`/`clientSecret` or `privateKeyJwk`) are
+configured, Pathling authentication (`pathling.auth.enabled`) must also be
+enabled. If authentication is disabled but PNP credentials are present, the
+server logs a warning at startup and rejects all `$import-pnp` requests.
+
+### Manifest URL validation
+
+After receiving the export manifest, Pathling validates that every download URL
+in the manifest uses the same origin (scheme + host + port) as the original
+`exportUrl`. If a manifest references a different origin, the job fails with an
+error and no bearer token is sent to the off-host URL.
 
 ## Asynchronous processing
 
@@ -200,7 +231,7 @@ PATHLING_URL = "https://pathling.example.com/fhir"
 SOURCE_EXPORT_URL = "https://source-server.example.com/fhir/$export"
 
 
-def kick_off_import(export_url, mode="overwrite", types=None, since=None):
+def kick_off_import(export_url, mode="merge", types=None, since=None):
     """Initiate a ping and pull import.
 
     Args:

--- a/site/docs/server/operations/import.md
+++ b/site/docs/server/operations/import.md
@@ -97,7 +97,7 @@ Send a request with `Content-Type: application/json` containing a JSON manifest:
 | `input`       | 1..\*       | An array of input file specifications.                                          |
 | `input.type`  | 1..1        | The FHIR resource type contained in the file.                                   |
 | `input.url`   | 1..1        | The URL where the source file can be retrieved.                                 |
-| `saveMode`    | 0..1        | The import mode. See [Import modes](#import-modes). Defaults to `overwrite`.    |
+| `saveMode`    | 0..1        | The import mode. See [Import modes](#import-modes). Defaults to `merge`.        |
 
 ### FHIR Parameters format
 
@@ -156,23 +156,23 @@ Parameters resource:
 
 #### Parameters
 
-| Name                 | Cardinality | Type   | Description                                                                  |
-| -------------------- | ----------- | ------ | ---------------------------------------------------------------------------- |
-| `inputFormat`        | 0..1        | Coding | The format of the source files. Defaults to `application/fhir+ndjson`.       |
-| `saveMode`           | 0..1        | Coding | The import mode. See [Import modes](#import-modes). Defaults to `overwrite`. |
-| `input`              | 1..\*       | -      | Contains parts describing each input file.                                   |
-| `input.resourceType` | 1..1        | Coding | The FHIR resource type contained in the file.                                |
-| `input.url`          | 1..1        | url    | The URL where the source file can be retrieved.                              |
+| Name                 | Cardinality | Type   | Description                                                              |
+| -------------------- | ----------- | ------ | ------------------------------------------------------------------------ |
+| `inputFormat`        | 0..1        | Coding | The format of the source files. Defaults to `application/fhir+ndjson`.   |
+| `saveMode`           | 0..1        | Coding | The import mode. See [Import modes](#import-modes). Defaults to `merge`. |
+| `input`              | 1..\*       | -      | Contains parts describing each input file.                               |
+| `input.resourceType` | 1..1        | Coding | The FHIR resource type contained in the file.                            |
+| `input.url`          | 1..1        | url    | The URL where the source file can be retrieved.                          |
 
 ## Import modes
 
-| Mode        | Description                                                                                                                                                    |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `overwrite` | All existing resources of the specified type are deleted and replaced with the contents of the source file. This is the default.                               |
-| `merge`     | Existing resources are matched with resources in the source file based on their ID. Existing resources are updated and new resources are added as appropriate. |
-| `append`    | Resources in the source file are added without modifying any existing resources.                                                                               |
-| `ignore`    | If the resource type already exists, the source file is ignored. Otherwise, the resources are added.                                                           |
-| `error`     | If the resource type already exists, an error is raised. Otherwise, the resources are added.                                                                   |
+| Mode        | Description                                                                                                                                                                         |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `merge`     | Existing resources are matched with resources in the source file based on their ID. Existing resources are updated and new resources are added as appropriate. This is the default. |
+| `overwrite` | All existing resources of the specified type are deleted and replaced with the contents of the source file.                                                                         |
+| `append`    | Resources in the source file are added without modifying any existing resources.                                                                                                    |
+| `ignore`    | If the resource type already exists, the source file is ignored. Otherwise, the resources are added.                                                                                |
+| `error`     | If the resource type already exists, an error is raised. Otherwise, the resources are added.                                                                                        |
 
 ## Response
 


### PR DESCRIPTION
Adds security controls to the `$import-pnp` operation to mitigate credential leakage and SSRF risks.

Changes:

- New `pathling.import.pnp.allowableExportUrls` config: when PNP credentials are configured, the export URL must match one of the configured prefixes; an empty list rejects all requests.
- Authentication interlock: if PNP credentials are configured but `pathling.auth.enabled` is `false`, the server logs a warning at startup and rejects all `$import-pnp` requests.
- Manifest URL validation: every download URL returned by the upstream export must share the same origin (scheme + host + port) as the `exportUrl`, preventing the bearer token from being sent off-host.
- Default `mode` for `$import-pnp` changed from `overwrite` to `merge`.
- Documentation updated in `site/docs/server/configuration.md` and `site/docs/server/operations/import-pnp.md`.

Test coverage added in `ImportPnpExecutorTest`, `ImportPnpOperationValidatorTest`, and `ImportPnpOperationIT`.