### PR TITLE
fix: Resolve intermittent test failures caused by shared state leaks

### DIFF
--- a/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportPnpExecutor.java
@@ -158,9 +158,12 @@ public class ImportPnpExecutor {
 
       // Execute the import using the existing ImportExecutor with custom allowable sources.
       // This bypasses the configured allowableSources validation for the staging directory,
-      // which the server downloaded and trusts. The qualified URI ensures the prefix matches
-      // whatever scheme the staging file system uses.
-      final List<String> pnpAllowableSources = List.of(tempDir.toUri().toString() + "/");
+      // which the server downloaded and trusts. Go via fs.getFileStatus() to obtain a URI in
+      // the same canonical form (with empty authority preserved on file://) that fs.listFiles
+      // produces for the downloaded files, so the UrlAllowlist string-prefix match holds:
+      // tempDir.toUri() alone yields file:/path while listed files come back as file:///path.
+      final List<String> pnpAllowableSources =
+          List.of(fs.getFileStatus(tempDir).getPath().toUri().toString() + "/");
       final ImportResponse response =
           importExecutor.execute(importRequest, jobId, pnpAllowableSources);
 

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationIT.java
@@ -701,6 +701,7 @@ class ImportPnpOperationIT {
             .header("Content-Type", "application/fhir+json")
             .header("Accept", "application/fhir+json")
             .header("Prefer", "respond-async")
+            .header("Authorization", "Bearer " + AUTH_TOKEN)
             .bodyValue(requestBody)
             .exchange()
             .expectStatus()
@@ -736,6 +737,7 @@ class ImportPnpOperationIT {
                     .get()
                     .uri(contentLocation)
                     .header("Accept", "application/fhir+json")
+                    .header("Authorization", "Bearer " + AUTH_TOKEN)
                     .exchange()
                     .expectStatus()
                     .is4xxClientError()
@@ -752,6 +754,7 @@ class ImportPnpOperationIT {
     webTestClient
         .get()
         .uri("http://localhost:" + port + "/jobs/" + jobId + "/escaped.0000.ndjson")
+        .header("Authorization", "Bearer " + AUTH_TOKEN)
         .exchange()
         .expectStatus()
         .isNotFound();

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportPnpOperationIT.java
@@ -173,6 +173,11 @@ class ImportPnpOperationIT {
 
   @AfterEach
   void cleanup() throws IOException {
+    // Clear cached Delta table state before deleting files. Otherwise the next test sees a stale
+    // DeltaLog in memory that no longer matches the on-disk warehouse rebuilt from test fixtures,
+    // and Delta refuses the import with DELTA_PATH_EXISTS.
+    pathlingContext.getSpark().catalog().clearCache();
+    org.apache.spark.sql.delta.DeltaLog.clearCache();
     FileUtils.cleanDirectory(warehouseDir.toFile());
   }
 

--- a/server/src/test/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitOAuthIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitOAuthIT.java
@@ -71,7 +71,6 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @TestPropertySource(
     properties = {
       "pathling.async.enabled=true",
-      "pathling.bulk-submit.allowable-sources[0]=http://localhost",
       // Configure submitter with OAuth credentials for symmetric (client_secret) auth.
       "pathling.bulk-submit.allowed-submitters[0].system=http://example.org/submitters",
       "pathling.bulk-submit.allowed-submitters[0].value=oauth-submitter",
@@ -118,6 +117,11 @@ class BulkSubmitOAuthIT {
     TestDataSetup.copyTestDataToTempDir(warehouseDir, "Condition");
     registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir.toAbsolutePath());
     registry.add("pathling.bulk-submit.staging-directory", stagingDir::toString);
+    // The allowable source must include the WireMock port. Bare "http://localhost" (port 80)
+    // no longer matches "http://localhost:{port}" under the URI-aware UrlAllowlist matching.
+    registry.add(
+        "pathling.bulk-submit.allowable-sources[0]",
+        () -> "http://localhost:" + wireMockServer.port());
   }
 
   @BeforeEach

--- a/server/src/test/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitOperationIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitOperationIT.java
@@ -67,7 +67,6 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @TestPropertySource(
     properties = {
       "pathling.async.enabled=true",
-      "pathling.bulk-submit.allowable-sources[0]=http://localhost",
       "pathling.bulk-submit.allowed-submitters[0].system=http://example.org/submitters",
       "pathling.bulk-submit.allowed-submitters[0].value=test-submitter"
     })
@@ -107,6 +106,11 @@ class BulkSubmitOperationIT {
     TestDataSetup.copyTestDataToTempDir(warehouseDir, "Condition");
     registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir.toAbsolutePath());
     registry.add("pathling.bulk-submit.staging-directory", stagingDir::toString);
+    // The allowable source must include the WireMock port. Bare "http://localhost" (port 80)
+    // no longer matches "http://localhost:{port}" under the URI-aware UrlAllowlist matching.
+    registry.add(
+        "pathling.bulk-submit.allowable-sources[0]",
+        () -> "http://localhost:" + wireMockServer.port());
   }
 
   @BeforeEach

--- a/server/src/test/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitProviderTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.Authentication;
@@ -79,6 +80,11 @@ class BulkSubmitProviderTest {
     final Authentication authentication = mock(Authentication.class);
     when(securityContext.getAuthentication()).thenReturn(authentication);
     SecurityContextHolder.setContext(securityContext);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
   }
 
   // ========================================

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/LibraryReferenceResolverTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/LibraryReferenceResolverTest.java
@@ -28,6 +28,7 @@ import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.errors.ResourceNotFoundError;
 import au.csiro.pathling.io.source.DataSource;
 import au.csiro.pathling.read.ReadExecutor;
+import au.csiro.pathling.test.SpringBootUnitTest;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import java.util.List;
@@ -38,21 +39,18 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Reference;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Tests for {@link LibraryReferenceResolver} covering both the relative-literal and canonical
  * reference resolution paths.
  */
-@TestInstance(Lifecycle.PER_CLASS)
+@SpringBootUnitTest
 class LibraryReferenceResolverTest {
 
   // ---------------------------------------------------------------------------
@@ -127,38 +125,17 @@ class LibraryReferenceResolverTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Canonical references — uses a real Spark session + FhirEncoders.
+  // Canonical references — uses the shared Spark session and FhirEncoders.
   // ---------------------------------------------------------------------------
 
   @Nested
-  @TestInstance(Lifecycle.PER_CLASS)
   class CanonicalReferences {
 
-    private SparkSession spark;
-    private FhirEncoders fhirEncoders;
+    @Autowired private SparkSession spark;
+    @Autowired private FhirEncoders fhirEncoders;
+
     private DataSource dataSource;
     private LibraryReferenceResolver resolver;
-
-    @BeforeAll
-    void setUpAll() {
-      spark =
-          SparkSession.builder()
-              .master("local[1]")
-              .appName("LibraryReferenceResolverTest")
-              .config("spark.driver.bindAddress", "localhost")
-              .config("spark.driver.host", "localhost")
-              .config("spark.ui.enabled", false)
-              .config("spark.sql.shuffle.partitions", 1)
-              .getOrCreate();
-      fhirEncoders = FhirEncoders.forR4().getOrCreate();
-    }
-
-    @AfterAll
-    void tearDownAll() {
-      if (spark != null) {
-        spark.stop();
-      }
-    }
 
     @BeforeEach
     void setUp() {

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamerTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamerTest.java
@@ -19,6 +19,7 @@ package au.csiro.pathling.operations.sqlquery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import au.csiro.pathling.test.SpringBootUnitTest;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.apache.spark.sql.Dataset;
@@ -27,44 +28,21 @@ import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
- * Tests for {@link SqlQueryResultStreamer} covering each output format. Uses a real local
- * SparkSession to materialise a small Dataset and a Spring {@link MockHttpServletResponse} to
- * capture written bytes and headers.
+ * Tests for {@link SqlQueryResultStreamer} covering each output format. Uses the shared Spark
+ * session to materialise a small Dataset and a Spring {@link MockHttpServletResponse} to capture
+ * written bytes and headers.
  */
-@TestInstance(Lifecycle.PER_CLASS)
+@SpringBootUnitTest
 class SqlQueryResultStreamerTest {
 
-  private SparkSession spark;
-  private SqlQueryResultStreamer streamer;
+  @Autowired private SparkSession spark;
 
-  @BeforeAll
-  void setUpAll() {
-    spark =
-        SparkSession.builder()
-            .master("local[1]")
-            .appName("SqlQueryResultStreamerTest")
-            .config("spark.driver.bindAddress", "localhost")
-            .config("spark.driver.host", "localhost")
-            .config("spark.ui.enabled", false)
-            .config("spark.sql.shuffle.partitions", 1)
-            .getOrCreate();
-    streamer = new SqlQueryResultStreamer();
-  }
-
-  @AfterAll
-  void tearDownAll() {
-    if (spark != null) {
-      spark.stop();
-    }
-  }
+  private final SqlQueryResultStreamer streamer = new SqlQueryResultStreamer();
 
   @Test
   void streamsNdjsonWithUtf8Encoding() {

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunDeltaIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunDeltaIT.java
@@ -29,6 +29,7 @@ import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -106,6 +107,7 @@ class SqlQueryRunDeltaIT {
         webTestClient
             .mutate()
             .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024))
+            .responseTimeout(Duration.ofSeconds(60))
             .build();
     jsonParser = fhirContext.newJsonParser();
   }

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
@@ -20,6 +20,7 @@ package au.csiro.pathling.operations.sqlquery;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.test.SpringBootUnitTest;
 import ca.uhn.fhir.context.FhirContext;
 import java.util.Arrays;
 import java.util.List;
@@ -35,42 +36,26 @@ import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Tests for {@link ViewRegistrationService}, with particular attention to the request-id
  * namespacing that prevents concurrent {@code $sqlquery-run} requests from clobbering one another's
  * temporary views in Spark's session-global catalog.
  */
-@TestInstance(Lifecycle.PER_CLASS)
+@SpringBootUnitTest
 class ViewRegistrationServiceTest {
 
-  private SparkSession spark;
+  @Autowired private SparkSession spark;
+  @Autowired private FhirContext fhirContext;
+
   private ViewRegistrationService service;
 
-  @BeforeAll
+  @BeforeEach
   void setUp() {
-    spark =
-        SparkSession.builder()
-            .master("local[2]")
-            .appName("ViewRegistrationServiceTest")
-            .config("spark.driver.bindAddress", "localhost")
-            .config("spark.driver.host", "localhost")
-            .config("spark.ui.enabled", false)
-            .config("spark.sql.shuffle.partitions", 1)
-            .getOrCreate();
-    service = new ViewRegistrationService(spark, FhirContext.forR4(), new ServerConfiguration());
-  }
-
-  @AfterAll
-  void tearDown() {
-    if (spark != null) {
-      spark.stop();
-    }
+    service = new ViewRegistrationService(spark, fhirContext, new ServerConfiguration());
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR groups four fixes for integration- and unit-test failures that stem from shared-state leaks and a real production bug exposed by recent refactors.

### Unit-test isolation

- Standalone Spark tests (`SqlQueryResultStreamerTest`, `ViewRegistrationServiceTest`, `LibraryReferenceResolverTest`) called `spark.stop()` in `@AfterAll`, destroying the JVM-wide `SparkContext` and causing subsequent tests to fail with `No active or default Spark session found`. Fixed by converting them to `@SpringBootUnitTest` so they share the managed Spring `SparkSession` bean and never call `stop()`.
- `BulkSubmitProviderTest` installed a Mockito mock as the active Spring `SecurityContext` in `@BeforeEach` but had no `@AfterEach` to clear it. Under JUnit 5 parallel execution the mock leaked onto adjacent `ForkJoinPool` threads, causing `SearchProviderAuthTest` to inherit the mock context and fail with `AccessDeniedError: Token not present`. Fixed by adding `@AfterEach void tearDown() { SecurityContextHolder.clearContext(); }`.

### `$import-pnp` staging allowlist (#2620)

`ImportPnpExecutor` built its staging-directory allowlist prefix with `tempDir.toUri().toString()`, which drops the empty authority on `file://` paths (yielding `file:/path`) while downloaded files come back from `fs.makeQualified` as `file:///path`. `UrlAllowlist`'s string-prefix match then rejected every downloaded file. Fixed by going through `fs.getFileStatus(tempDir).getPath()` so both sides use the same canonical URI form.

### `$import-pnp` / `$bulk-submit` integration-test fixes (#2621)

- `ImportPnpOperationIT` cleans `warehouseDir` in `@AfterEach` but leaves stale entries in Spark's catalog cache and Delta's global `DeltaLog` cache. Subsequent tests rebuild the warehouse from fixtures, but Delta's `isDeltaTable` returns false against the stale log, sending the import down `ERROR_IF_EXISTS` and failing with `DELTA_PATH_EXISTS`. Fixed by clearing both caches before deleting files.
- `testPoisonedManifestTypeFailsJobAndBlocksExfiltration` sent its requests without the `Authorization: Bearer <token>` header; the class-level auth interlock rejected them with 401 before the poisoning path executed.
- `BulkSubmitOperationIT` and `BulkSubmitOAuthIT` had `pathling.bulk-submit.allowable-sources[0]=http://localhost` in `@TestPropertySource`. The URI-aware `UrlAllowlist` resolves that prefix to effective port 80 and no longer matches the dynamic WireMock port. Moved the property into `@DynamicPropertySource` so it includes `wireMockServer.port()` at runtime.

Closes #2615.
Closes #2617.
Closes #2620.
Closes #2621.

## Test plan

- [x] Reproduced Spark failures by observing `ViewDefinitionSearchTest` and `ViewDefinitionCreateTest` errors in full suite run
- [x] Reproduced `SearchProviderAuthTest` failure with `forkCount=1`
- [x] Reproduced `ImportPnpOperationIT` failures in isolation (URL-allowlist bug) and in suite (Delta cache leak)
- [x] Full suite passes with both fixes applied (`forkCount=2`): 1481 tests, 0 failures, 0 errors
- [x] `mvn verify -Dit.test='ImportPnpOperationIT,BulkSubmitOperationIT,BulkSubmitOAuthIT'` passes: 15 tests, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)