### PR TITLE
Add command line interface

### DIFF
--- a/lib/R/pom.xml
+++ b/lib/R/pom.xml
@@ -227,6 +227,15 @@
                 <argument>install.packages("remotes", type="source")</argument>
                 <argument>-e</argument>
                 <argument>devtools::install_dev_deps(type="source")</argument>
+                <!-- Pin dbplyr to the last release before 2.6.0. dbplyr 2.6.0 is
+                     incompatible with sparklyr 1.9.4: its query-fields probe
+                     emits standard SQL (double-quoted identifiers) that the
+                     Spark parser rejects, breaking all tbl_spark operations.
+                     Run after install_dev_deps so the pin holds regardless of
+                     what the package cache restored. Remove once a sparklyr
+                     release supports dbplyr 2.6.0. -->
+                <argument>-e</argument>
+                <argument>remotes::install_version("dbplyr", version = "2.5.2", type = "source", upgrade = "never")</argument>
                 <argument>-e</argument>
                 <argument>installed.packages()[,c("Package","Version")]</argument>
                 <argument>-e</argument>

--- a/lib/python/README.md
+++ b/lib/python/README.md
@@ -22,8 +22,9 @@ pip install pathling
 
 The package ships a `pathling` console script that surfaces the library's
 functionality - data conversion, SQL on FHIR views, FHIRPath evaluation, bulk
-export, and terminology operations - through scriptable commands. It requires a
-supported Java runtime, as does the library itself.
+export, terminology operations, Python scripting (`run`), and an interactive
+console (`console`) - through scriptable commands. It requires a supported
+Java runtime, as does the library itself.
 
 The easiest way to run it is with [uv](https://docs.astral.sh/uv/):
 
@@ -42,6 +43,16 @@ view:
 ```bash
 pathling convert data/ --to parquet -o warehouse/
 pathling view data/ --view patients.json --format csv
+```
+
+The `run` and `console` commands execute Python code (a script, stdin, or
+`-c CODE`) or open an interactive IPython session, with `spark` and `pathling`
+variables already configured and in scope:
+
+```bash
+pathling run my_script.py
+pathling run -c "print(spark.version)"
+pathling console
 ```
 
 See the [command line interface documentation](https://pathling.csiro.au/docs/libraries/cli)

--- a/lib/python/README.md
+++ b/lib/python/README.md
@@ -1,5 +1,4 @@
-Python API for Pathling
-=======================
+# Python API for Pathling
 
 This is the Python API for [Pathling](https://pathling.csiro.au). It provides a
 set of tools that aid the use of FHIR terminology services and FHIR data within
@@ -16,8 +15,37 @@ Prerequisites:
 To install, run this command:
 
 ```bash
-pip install pathling  
+pip install pathling
 ```
+
+## Command line interface
+
+The package ships a `pathling` console script that surfaces the library's
+functionality - data conversion, SQL on FHIR views, FHIRPath evaluation, bulk
+export, and terminology operations - through scriptable commands. It requires a
+supported Java runtime, as does the library itself.
+
+The easiest way to run it is with [uv](https://docs.astral.sh/uv/):
+
+```bash
+# Run without installing.
+uvx pathling --version
+
+# Or install it as a tool.
+uv tool install pathling
+pathling --help
+```
+
+For example, to convert a directory of NDJSON to Parquet, or run a SQL on FHIR
+view:
+
+```bash
+pathling convert data/ --to parquet -o warehouse/
+pathling view data/ --view patients.json --format csv
+```
+
+See the [command line interface documentation](https://pathling.csiro.au/docs/libraries/cli)
+for the full list of commands and options.
 
 ## Encoders
 
@@ -109,7 +137,7 @@ display(result)
 The result of this query would look something like this:
 
 | patient_id | street                     | use  | city       | zip   |
-|------------|----------------------------|------|------------|-------|
+| ---------- | -------------------------- | ---- | ---------- | ----- |
 | 1          | 398 Kautzer Walk Suite 62  | home | Barnstable | 02675 |
 | 1          | 186 Nitzsche Forge         | work | Revere     | 02151 |
 | 2          | 1087 Quitzon Club          | home | Plymouth   | NULL  |
@@ -152,7 +180,7 @@ result.select('CODE', 'DESCRIPTION', 'VIRAL_INFECTION').show()
 Results in:
 
 | CODE      | DESCRIPTION               | VIRAL_INFECTION |
-|-----------|---------------------------|-----------------|
+| --------- | ------------------------- | --------------- |
 | 65363002  | Otitis media              | false           |
 | 16114001  | Fracture of ankle         | false           |
 | 444814009 | Viral sinusitis           | true            |
@@ -177,7 +205,7 @@ result.select('CODE', 'DESCRIPTION', 'READ_CODE').show()
 Results in:
 
 | CODE      | DESCRIPTION               | READ_CODE |
-|-----------|---------------------------|-----------|
+| --------- | ------------------------- | --------- |
 | 65363002  | Otitis media              | X00ik     |
 | 16114001  | Fracture of ankle         | S34..     |
 | 444814009 | Viral sinusitis           | XUjp0     |
@@ -213,7 +241,7 @@ result.select('CODE', 'DESCRIPTION', 'IS_ENT').show()
 Results in:
 
 | CODE      | DESCRIPTION       | IS_ENT |
-|-----------|-------------------|--------|
+| --------- | ----------------- | ------ |
 | 65363002  | Otitis media      | true   |
 | 16114001  | Fracture of ankle | false  |
 | 444814009 | Viral sinusitis   | true   |
@@ -245,7 +273,7 @@ with_displays = exploded_parents.withColumn(
 Results in:
 
 | CODE      | DESCRIPTION       | PARENT    | PARENT_DISPLAY                          |
-|-----------|-------------------|-----------|-----------------------------------------|
+| --------- | ----------------- | --------- | --------------------------------------- |
 | 65363002  | Otitis media      | 43275000  | Otitis                                  |
 | 65363002  | Otitis media      | 68996008  | Disorder of middle ear                  |
 | 16114001  | Fracture of ankle | 125603006 | Injury of ankle                         |
@@ -279,7 +307,7 @@ exploded_synonyms = synonyms.selectExpr(
 Results in:
 
 | CODE      | DESCRIPTION                          | SYNONYM                                    |
-|-----------|--------------------------------------|--------------------------------------------|
+| --------- | ------------------------------------ | ------------------------------------------ |
 | 65363002  | Otitis media                         | OM - Otitis media                          |
 | 16114001  | Fracture of ankle                    | Ankle fracture                             |
 | 16114001  | Fracture of ankle                    | Fracture of distal end of tibia and fibula |
@@ -322,8 +350,8 @@ Maven package. Once the cluster is restarted, the libraries should be available
 for import and use within all notebooks.
 
 By default, Databricks uses Java 8 within its clusters, while Pathling requires
-Java 21. To enable Java 21 support within your cluster, navigate to __Advanced
-Options > Spark > Environment Variables__ and add the following:
+Java 21. To enable Java 21 support within your cluster, navigate to **Advanced
+Options > Spark > Environment Variables** and add the following:
 
 ```bash
 JNAME=zulu21-ca-amd64

--- a/lib/python/pathling/__init__.py
+++ b/lib/python/pathling/__init__.py
@@ -79,27 +79,49 @@ _LAZY_EXPORTS = {
 
 __all__ = list(_LAZY_EXPORTS)
 
+# The package submodules that may be accessed lazily after a bare
+# ``import pathling`` (e.g. ``pathling.udfs.member_of``). This curated allow-list
+# keeps the fallback safe - unknown names still raise ``AttributeError`` - and
+# restores the pre-shim behaviour where these submodules were importable as
+# package attributes, without importing PySpark on a bare ``import pathling``.
+_LAZY_SUBMODULES = (
+    "coding",
+    "context",
+    "core",
+    "datasource",
+    "fhir",
+    "functions",
+    "udfs",
+)
+
 
 def __getattr__(name: str) -> Any:
-    """Resolves a public name by importing its submodule on first access.
+    """Resolves a public name or submodule by importing it on first access.
 
     :param name: the attribute being accessed on the ``pathling`` package.
     :return: the resolved attribute value.
-    :raises AttributeError: if the name is not a known public export.
+    :raises AttributeError: if the name is neither a known public export nor a
+            known package submodule.
     """
     module_name = _LAZY_EXPORTS.get(name)
-    if module_name is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    module = importlib.import_module(module_name)
-    value = getattr(module, name)
-    # Cache on the package so subsequent lookups bypass this hook.
-    globals()[name] = value
-    return value
+    if module_name is not None:
+        module = importlib.import_module(module_name)
+        value = getattr(module, name)
+        # Cache on the package so subsequent lookups bypass this hook.
+        globals()[name] = value
+        return value
+    if name in _LAZY_SUBMODULES:
+        submodule = importlib.import_module(f"{__name__}.{name}")
+        # Cache the submodule so subsequent lookups bypass this hook.
+        globals()[name] = submodule
+        return submodule
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def __dir__() -> list:
-    """Returns the public names of the package for introspection.
+    """Returns the public names and submodules of the package for introspection.
 
-    :return: the sorted list of public export names.
+    :return: the sorted list of public export names and lazily-available
+             submodule names.
     """
-    return sorted(__all__)
+    return sorted(set(__all__) | set(_LAZY_SUBMODULES))

--- a/lib/python/pathling/__init__.py
+++ b/lib/python/pathling/__init__.py
@@ -15,44 +15,91 @@
 # limitations under the License.
 #
 
-from .coding import Coding
-from .context import PathlingContext, StorageType
-from .core import Expression, VariableExpression
-from .datasource import DataSource, DataSources
-from .fhir import MimeType, Version
-from .functions import to_coding, to_ecl_value_set, to_snomed_coding
-from .udfs import (
-    Equivalence,
-    PropertyType,
-    designation,
-    display,
-    member_of,
-    property_of,
-    subsumed_by,
-    subsumes,
-    translate,
-)
+"""Python API for Pathling.
 
-__all__ = [
-    "PathlingContext",
-    "StorageType",
-    "MimeType",
-    "Version",
-    "Coding",
-    "member_of",
-    "translate",
-    "subsumes",
-    "subsumed_by",
-    "property_of",
-    "display",
-    "designation",
-    "PropertyType",
-    "Equivalence",
-    "to_coding",
-    "to_snomed_coding",
-    "to_ecl_value_set",
-    "Expression",
-    "VariableExpression",
-    "DataSources",
-    "DataSource",
-]
+Public names are exposed lazily (PEP 562) so that importing the ``pathling``
+package itself does not pull in PySpark and the JVM-backed submodules. The
+heavy imports happen only when a public name is first accessed, which keeps the
+command line interface's ``--help`` and ``--version`` paths fast.
+
+Author: John Grimes.
+"""
+
+# The TYPE_CHECKING imports below exist only so that type checkers and IDEs can
+# resolve the lazily-exported public names; they are intentionally unused at
+# runtime, so unused-import checks are disabled for this re-export shim.
+# ruff: noqa: F401
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .coding import Coding
+    from .context import PathlingContext, StorageType
+    from .core import Expression, VariableExpression
+    from .datasource import DataSource, DataSources
+    from .fhir import MimeType, Version
+    from .functions import to_coding, to_ecl_value_set, to_snomed_coding
+    from .udfs import (
+        Equivalence,
+        PropertyType,
+        designation,
+        display,
+        member_of,
+        property_of,
+        subsumed_by,
+        subsumes,
+        translate,
+    )
+
+# Maps each lazily-exported public name to the submodule that defines it.
+_LAZY_EXPORTS = {
+    "Coding": "pathling.coding",
+    "PathlingContext": "pathling.context",
+    "StorageType": "pathling.context",
+    "Expression": "pathling.core",
+    "VariableExpression": "pathling.core",
+    "DataSource": "pathling.datasource",
+    "DataSources": "pathling.datasource",
+    "MimeType": "pathling.fhir",
+    "Version": "pathling.fhir",
+    "to_coding": "pathling.functions",
+    "to_snomed_coding": "pathling.functions",
+    "to_ecl_value_set": "pathling.functions",
+    "member_of": "pathling.udfs",
+    "translate": "pathling.udfs",
+    "subsumes": "pathling.udfs",
+    "subsumed_by": "pathling.udfs",
+    "property_of": "pathling.udfs",
+    "display": "pathling.udfs",
+    "designation": "pathling.udfs",
+    "PropertyType": "pathling.udfs",
+    "Equivalence": "pathling.udfs",
+}
+
+__all__ = list(_LAZY_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    """Resolves a public name by importing its submodule on first access.
+
+    :param name: the attribute being accessed on the ``pathling`` package.
+    :return: the resolved attribute value.
+    :raises AttributeError: if the name is not a known public export.
+    """
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = importlib.import_module(module_name)
+    value = getattr(module, name)
+    # Cache on the package so subsequent lookups bypass this hook.
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list:
+    """Returns the public names of the package for introspection.
+
+    :return: the sorted list of public export names.
+    """
+    return sorted(__all__)

--- a/lib/python/pathling/_spark_defaults.py
+++ b/lib/python/pathling/_spark_defaults.py
@@ -1,0 +1,81 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""The single, PySpark-free source of truth for Pathling's managed Spark defaults.
+
+The managed coordinates, the Delta SQL extension, and the Delta catalog that
+every Pathling Spark session requires are defined here, built from the versions
+in :mod:`pathling._version`. Both the session builder
+(:func:`pathling.context._build_spark_session`) and the CLI merge logic
+(:mod:`pathling.cli.sparkconf`) import these values so the two cannot drift
+apart. This module deliberately imports no PySpark, so the CLI configuration
+path can reference the defaults without paying Spark's import cost.
+
+Author: John Grimes.
+"""
+
+from pathling._version import (
+    __delta_version__,
+    __java_version__,
+    __scala_version__,
+)
+
+# The Spark configuration key holding the comma-separated Maven coordinates.
+PACKAGES_KEY = "spark.jars.packages"
+
+# The Spark configuration key holding the comma-separated SQL extension classes.
+EXTENSIONS_KEY = "spark.sql.extensions"
+
+# The Spark configuration key for the session catalog implementation.
+CATALOG_KEY = "spark.sql.catalog.spark_catalog"
+
+# The managed Maven coordinate (group:artifact) for the Pathling library runtime.
+LIBRARY_RUNTIME_COORDINATE = "au.csiro.pathling:library-runtime"
+
+# The managed Maven coordinate (group:artifact) for Delta Lake, which carries the
+# Scala binary version in its artifact identifier.
+DELTA_COORDINATE = f"io.delta:delta-spark_{__scala_version__}"
+
+# The group:artifact identities of the coordinates Pathling manages, used to
+# detect a user-supplied override at a different version.
+MANAGED_COORDINATES = frozenset({LIBRARY_RUNTIME_COORDINATE, DELTA_COORDINATE})
+
+# The Delta SQL extension class that Pathling always requires.
+DELTA_EXTENSION = "io.delta.sql.DeltaSparkSessionExtension"
+
+# The Delta catalog implementation that Pathling always requires.
+DELTA_CATALOG = "org.apache.spark.sql.delta.catalog.DeltaCatalog"
+
+
+def managed_spark_defaults() -> dict:
+    """Returns the Spark configuration that Pathling always requires.
+
+    The packages string lists both managed coordinates at the versions declared
+    in :mod:`pathling._version` and retains a trailing comma, matching the
+    historical inline literal. The extension and catalog are fixed Delta class
+    names.
+
+    :return: a mapping of managed Spark configuration key to value.
+    """
+    return {
+        PACKAGES_KEY: (
+            f"{LIBRARY_RUNTIME_COORDINATE}:{__java_version__},"
+            f"{DELTA_COORDINATE}:{__delta_version__},"
+        ),
+        EXTENSIONS_KEY: DELTA_EXTENSION,
+        CATALOG_KEY: DELTA_CATALOG,
+    }

--- a/lib/python/pathling/cli/__init__.py
+++ b/lib/python/pathling/cli/__init__.py
@@ -1,0 +1,27 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Command line interface for Pathling.
+
+This subpackage exposes the Pathling Python library through a flat, verb-based
+command tree installed as the ``pathling`` console script. Modules are kept
+free of eager PySpark imports so that ``--help`` and ``--version`` remain fast;
+the Spark session is created lazily by :mod:`pathling.cli.session` only when a
+command needs it.
+
+Author: John Grimes.
+"""

--- a/lib/python/pathling/cli/config.py
+++ b/lib/python/pathling/cli/config.py
@@ -1,0 +1,408 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Configuration resolution for the Pathling command line interface.
+
+Configuration is resolved with the precedence flag > config file > built-in
+default. The config file is TOML located at
+``${XDG_CONFIG_HOME:-~/.config}/pathling/config.toml`` unless overridden with
+``--config``. Secret values for authentication may be supplied as a literal, a
+``@/path/to/file`` reference, or via an environment variable.
+
+Author: John Grimes.
+"""
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+# The library's built-in default terminology server, mirrored here so the CLI
+# can report it in error messages without starting a Spark session.
+DEFAULT_TX_SERVER = "https://tx.ontoserver.csiro.au/fhir"
+
+# The default FHIR version used when none is configured.
+DEFAULT_FHIR_VERSION = "R4"
+
+# The FHIR versions the CLI accepts.
+SUPPORTED_FHIR_VERSIONS = ("R4",)
+
+# Valid top-level keys in the config file.
+VALID_CONFIG_KEYS = frozenset(
+    {"tx-server", "fhir-version", "terminology-auth", "bulk-auth"}
+)
+
+# Valid keys within the [terminology-auth] and [bulk-auth] tables.
+VALID_AUTH_KEYS = frozenset(
+    {"client-id", "client-secret", "private-key-jwk", "token-endpoint", "scope"}
+)
+
+
+@dataclass
+class TxAuth:
+    """Terminology server authentication settings.
+
+    :param client_id: the OAuth2 client identifier.
+    :param client_secret: the resolved client secret, or None.
+    :param token_endpoint: the OAuth2 token endpoint.
+    :param scope: an optional OAuth2 scope.
+    """
+
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+    token_endpoint: Optional[str] = None
+    scope: Optional[str] = None
+
+    @property
+    def enabled(self) -> bool:
+        """Whether enough has been supplied to attempt authentication.
+
+        :return: True when a client identifier and token endpoint are present.
+        """
+        return bool(self.client_id and self.token_endpoint)
+
+
+@dataclass
+class BulkAuth:
+    """SMART backend services authentication settings for bulk export.
+
+    :param client_id: the OAuth2 client identifier.
+    :param private_key_jwk: the resolved private key JWK, or None.
+    :param client_secret: the resolved client secret, or None.
+    :param token_endpoint: the OAuth2 token endpoint.
+    :param scope: an optional OAuth2 scope.
+    """
+
+    client_id: str
+    token_endpoint: Optional[str] = None
+    private_key_jwk: Optional[str] = None
+    client_secret: Optional[str] = None
+    scope: Optional[str] = None
+
+    @property
+    def mechanism(self) -> str:
+        """A human-readable name for the credential mechanism in use.
+
+        :return: a description of the credential type for error messages.
+        """
+        if self.private_key_jwk:
+            return "a private key JWK"
+        if self.client_secret:
+            return "a client secret"
+        return "no credential"
+
+
+@dataclass
+class CliConfig:
+    """Resolved global configuration for a single invocation.
+
+    :param tx_server: the terminology server URL.
+    :param tx_auth: terminology authentication settings, or None.
+    :param fhir_version: the FHIR version code.
+    :param verbose: whether verbose logging and stack traces are enabled.
+    :param config_path: the path the config file was read from, or None.
+    """
+
+    tx_server: str = DEFAULT_TX_SERVER
+    tx_auth: Optional[TxAuth] = None
+    fhir_version: str = DEFAULT_FHIR_VERSION
+    verbose: bool = False
+    config_path: Optional[Path] = None
+
+
+def _load_toml(path: Path) -> dict:
+    """Reads and parses a TOML file using the available TOML library.
+
+    :param path: the path to the TOML file.
+    :return: the parsed contents as a dict.
+    :raises CliError: if the file cannot be parsed as TOML.
+    """
+    # Prefer the standard library on Python 3.11+, fall back to tomli.
+    try:
+        import tomllib as toml_lib
+    except ModuleNotFoundError:  # pragma: no cover - exercised on Python < 3.11.
+        import tomli as toml_lib
+
+    from pathling.cli.errors import CliError
+
+    try:
+        with open(path, "rb") as handle:
+            return toml_lib.load(handle)
+    except toml_lib.TOMLDecodeError as exc:
+        raise CliError(
+            f"Could not parse the config file at {path}: {exc}. "
+            "Check that it is valid TOML."
+        ) from exc
+
+
+def default_config_path() -> Path:
+    """Computes the default config file path, honouring ``XDG_CONFIG_HOME``.
+
+    :return: the path to the default config file location.
+    """
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "pathling" / "config.toml"
+
+
+def resolve_secret(
+    value: Optional[str],
+    env_var: Optional[str] = None,
+    env: Optional[dict] = None,
+) -> Optional[str]:
+    """Resolves a secret value from a literal, a ``@file`` reference, or an
+    environment variable.
+
+    A value beginning with ``@`` is treated as a path to a file whose stripped
+    contents are returned. When ``value`` is None and ``env_var`` is given, the
+    environment variable is consulted.
+
+    :param value: the literal value, ``@path`` reference, or None.
+    :param env_var: the name of a fallback environment variable, or None.
+    :param env: the environment mapping to read from; defaults to ``os.environ``.
+    :return: the resolved secret, or None when nothing is available.
+    :raises CliError: if a ``@file`` reference cannot be read.
+    """
+    environment = env if env is not None else os.environ
+    if value is None:
+        if env_var is not None:
+            return environment.get(env_var)
+        return None
+    if value.startswith("@"):
+        file_path = Path(value[1:])
+        from pathling.cli.errors import CliError
+
+        try:
+            return file_path.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            raise CliError(
+                f"Could not read the secret file at {file_path}: {exc}. "
+                "Check the path and permissions."
+            ) from exc
+    return value
+
+
+def load_config_file(
+    path: Path,
+    on_warning: Optional[Callable[[str], None]] = None,
+) -> dict:
+    """Loads a config file, warning about unknown keys.
+
+    :param path: the config file path.
+    :param on_warning: an optional callback invoked with each warning message;
+           defaults to writing to stderr.
+    :return: the parsed config as a dict, or an empty dict when the file is
+             absent.
+    """
+    if not path.exists():
+        return {}
+
+    warn = on_warning or (lambda message: print(message, file=sys.stderr))
+    data = _load_toml(path)
+
+    valid_keys = ", ".join(sorted(VALID_CONFIG_KEYS))
+    for key in data:
+        if key not in VALID_CONFIG_KEYS:
+            warn(
+                f"Ignoring unknown config key '{key}' in {path}. "
+                f"Valid keys are: {valid_keys}."
+            )
+    for table_name in ("terminology-auth", "bulk-auth"):
+        table = data.get(table_name)
+        if isinstance(table, dict):
+            valid_auth = ", ".join(sorted(VALID_AUTH_KEYS))
+            for key in table:
+                if key not in VALID_AUTH_KEYS:
+                    warn(
+                        f"Ignoring unknown config key '{table_name}.{key}' in "
+                        f"{path}. Valid keys are: {valid_auth}."
+                    )
+    return data
+
+
+def _resolve_tx_auth(
+    file_data: dict,
+    client_id: Optional[str],
+    client_secret: Optional[str],
+    token_endpoint: Optional[str],
+    scope: Optional[str],
+    env: Optional[dict],
+) -> Optional[TxAuth]:
+    """Merges terminology auth settings from flags and the config file.
+
+    :param file_data: the parsed config file contents.
+    :param client_id: the ``--tx-client-id`` flag value, or None.
+    :param client_secret: the ``--tx-client-secret`` flag value, or None.
+    :param token_endpoint: the ``--tx-token-endpoint`` flag value, or None.
+    :param scope: the ``--tx-scope`` flag value, or None.
+    :param env: the environment mapping for secret resolution.
+    :return: a populated :class:`TxAuth`, or None when no auth is configured.
+    """
+    table = file_data.get("terminology-auth") or {}
+    resolved_client_id = client_id or table.get("client-id")
+    resolved_token_endpoint = token_endpoint or table.get("token-endpoint")
+    resolved_scope = scope or table.get("scope")
+    resolved_secret = resolve_secret(
+        client_secret or table.get("client-secret"), None, env
+    )
+
+    if not any(
+        [resolved_client_id, resolved_token_endpoint, resolved_scope, resolved_secret]
+    ):
+        return None
+    return TxAuth(
+        client_id=resolved_client_id,
+        client_secret=resolved_secret,
+        token_endpoint=resolved_token_endpoint,
+        scope=resolved_scope,
+    )
+
+
+def resolve_bulk_auth(
+    file_bulk_auth: Optional[dict],
+    client_id: Optional[str] = None,
+    client_secret: Optional[str] = None,
+    private_key_jwk: Optional[str] = None,
+    token_endpoint: Optional[str] = None,
+    scope: Optional[str] = None,
+    env: Optional[dict] = None,
+) -> Optional[BulkAuth]:
+    """Resolves bulk export authentication from flags and the config file.
+
+    Authentication is considered configured only when a client identifier is
+    present. Secret values are resolved as a literal, a ``@file`` reference, or
+    the ``PATHLING_CLIENT_SECRET`` / ``PATHLING_PRIVATE_KEY_JWK`` environment
+    variables.
+
+    :param file_bulk_auth: the parsed ``[bulk-auth]`` table, or None.
+    :param client_id: the ``--client-id`` flag value, or None.
+    :param client_secret: the ``--client-secret`` flag value, or None.
+    :param private_key_jwk: the ``--private-key-jwk`` flag value, or None.
+    :param token_endpoint: the ``--token-endpoint`` flag value, or None.
+    :param scope: the ``--scope`` flag value, or None.
+    :param env: the environment mapping for secret resolution.
+    :return: a populated :class:`BulkAuth`, or None when no client ID is set.
+    :raises CliError: when the auth configuration is incomplete or ambiguous.
+    """
+    table = file_bulk_auth or {}
+    resolved_client_id = client_id or table.get("client-id")
+    if not resolved_client_id:
+        return None
+
+    resolved_token_endpoint = token_endpoint or table.get("token-endpoint")
+    resolved_scope = scope or table.get("scope")
+    resolved_secret = resolve_secret(
+        client_secret or table.get("client-secret"), "PATHLING_CLIENT_SECRET", env
+    )
+    resolved_jwk = resolve_secret(
+        private_key_jwk or table.get("private-key-jwk"),
+        "PATHLING_PRIVATE_KEY_JWK",
+        env,
+    )
+
+    from pathling.cli.errors import EXIT_USAGE, CliError
+
+    if not resolved_token_endpoint:
+        raise CliError(
+            "Bulk export authentication requires a token endpoint. "
+            "Add --token-endpoint, or set it in the [bulk-auth] config table.",
+            exit_code=EXIT_USAGE,
+        )
+    if resolved_secret and resolved_jwk:
+        raise CliError(
+            "Provide exactly one of --client-secret or --private-key-jwk, not both.",
+            exit_code=EXIT_USAGE,
+        )
+    if not resolved_secret and not resolved_jwk:
+        raise CliError(
+            "Bulk export authentication requires a credential. Provide one of "
+            "--client-secret or --private-key-jwk.",
+            exit_code=EXIT_USAGE,
+        )
+
+    return BulkAuth(
+        client_id=resolved_client_id,
+        token_endpoint=resolved_token_endpoint,
+        private_key_jwk=resolved_jwk,
+        client_secret=resolved_secret,
+        scope=resolved_scope,
+    )
+
+
+def resolve_config(
+    tx_server: Optional[str] = None,
+    tx_client_id: Optional[str] = None,
+    tx_client_secret: Optional[str] = None,
+    tx_token_endpoint: Optional[str] = None,
+    tx_scope: Optional[str] = None,
+    fhir_version: Optional[str] = None,
+    verbose: bool = False,
+    config_path: Optional[Path] = None,
+    env: Optional[dict] = None,
+    on_warning: Optional[Callable[[str], None]] = None,
+) -> CliConfig:
+    """Resolves global configuration from flags, the config file, and defaults.
+
+    Precedence is always flag > config file > built-in default.
+
+    :param tx_server: the ``--tx-server`` flag value, or None.
+    :param tx_client_id: the ``--tx-client-id`` flag value, or None.
+    :param tx_client_secret: the ``--tx-client-secret`` flag value, or None.
+    :param tx_token_endpoint: the ``--tx-token-endpoint`` flag value, or None.
+    :param tx_scope: the ``--tx-scope`` flag value, or None.
+    :param fhir_version: the ``--fhir-version`` flag value, or None.
+    :param verbose: the ``--verbose`` flag value.
+    :param config_path: an explicit config file path, or None for the default.
+    :param env: the environment mapping for secret resolution.
+    :param on_warning: an optional warning callback passed to the file loader.
+    :return: the resolved :class:`CliConfig`.
+    :raises CliError: if the resolved FHIR version is unsupported.
+    """
+    path = config_path or default_config_path()
+    file_data = load_config_file(path, on_warning)
+
+    resolved_tx_server = tx_server or file_data.get("tx-server") or DEFAULT_TX_SERVER
+    resolved_fhir_version = (
+        fhir_version or file_data.get("fhir-version") or DEFAULT_FHIR_VERSION
+    )
+    if resolved_fhir_version not in SUPPORTED_FHIR_VERSIONS:
+        from pathling.cli.errors import CliError
+
+        supported = ", ".join(SUPPORTED_FHIR_VERSIONS)
+        raise CliError(
+            f"Unsupported FHIR version '{resolved_fhir_version}'. "
+            f"Supported versions are: {supported}.",
+            exit_code=2,
+        )
+
+    tx_auth = _resolve_tx_auth(
+        file_data,
+        tx_client_id,
+        tx_client_secret,
+        tx_token_endpoint,
+        tx_scope,
+        env,
+    )
+
+    return CliConfig(
+        tx_server=resolved_tx_server,
+        tx_auth=tx_auth,
+        fhir_version=resolved_fhir_version,
+        verbose=verbose,
+        config_path=path if path.exists() else None,
+    )

--- a/lib/python/pathling/cli/config.py
+++ b/lib/python/pathling/cli/config.py
@@ -17,11 +17,15 @@
 
 """Configuration resolution for the Pathling command line interface.
 
-Configuration is resolved with the precedence flag > config file > built-in
-default. The config file is TOML located at
-``${XDG_CONFIG_HOME:-~/.config}/pathling/config.toml`` unless overridden with
-``--config``. Secret values for authentication may be supplied as a literal, a
-``@/path/to/file`` reference, or via an environment variable.
+A single config file is selected by the precedence explicit ``--config`` >
+project-local ``pathling.toml`` (in the current working directory) > user-level
+``${XDG_CONFIG_HOME:-~/.config}/pathling/config.toml`` > none. Files are never
+merged: keys absent from the chosen file fall back to built-in defaults, never
+to another file. The chosen file's values then resolve with the precedence flag
+> config file > built-in default. When a project-local file is discovered, a
+one-line notice naming it is emitted via the ``on_notice`` callback. Secret
+values for authentication may be supplied as a literal, a ``@/path/to/file``
+reference, or via an environment variable.
 
 Author: John Grimes.
 """
@@ -41,6 +45,11 @@ DEFAULT_FHIR_VERSION = "R4"
 
 # The FHIR versions the CLI accepts.
 SUPPORTED_FHIR_VERSIONS = ("R4",)
+
+# The name of the project-local config file discovered in the current working
+# directory, deliberately distinct from the user-level ``config.toml`` so the
+# two are never confused.
+PROJECT_CONFIG_FILENAME = "pathling.toml"
 
 # Valid top-level keys in the config file.
 VALID_CONFIG_KEYS = frozenset(
@@ -344,6 +353,34 @@ def resolve_bulk_auth(
     )
 
 
+def resolve_config_source(
+    config_path: Optional[Path],
+    cwd: Path,
+) -> tuple[Optional[Path], str]:
+    """Selects the single config file to load and reports where it came from.
+
+    Exactly one file is chosen, by the precedence explicit ``--config`` >
+    project-local ``pathling.toml`` in ``cwd`` > user-level config file > none.
+    Values are never merged across files.
+
+    :param config_path: an explicit ``--config`` path, or None.
+    :param cwd: the directory searched for a project-local ``pathling.toml``.
+    :return: a tuple of the chosen path and an origin tag, one of
+             ``"explicit"``, ``"project"``, ``"user"``, or ``"none"``. The
+             ``"none"`` case returns the (non-existent) user-level path so the
+             existing "missing file yields defaults" behaviour is preserved.
+    """
+    if config_path is not None:
+        return config_path, "explicit"
+    project_path = cwd / PROJECT_CONFIG_FILENAME
+    if project_path.exists():
+        return project_path, "project"
+    user_path = default_config_path()
+    if user_path.exists():
+        return user_path, "user"
+    return user_path, "none"
+
+
 def resolve_config(
     tx_server: Optional[str] = None,
     tx_client_id: Optional[str] = None,
@@ -353,12 +390,18 @@ def resolve_config(
     fhir_version: Optional[str] = None,
     verbose: bool = False,
     config_path: Optional[Path] = None,
+    cwd: Optional[Path] = None,
     env: Optional[dict] = None,
     on_warning: Optional[Callable[[str], None]] = None,
+    on_notice: Optional[Callable[[str], None]] = None,
 ) -> CliConfig:
     """Resolves global configuration from flags, the config file, and defaults.
 
-    Precedence is always flag > config file > built-in default.
+    A single config file is selected by the precedence explicit ``--config`` >
+    project-local ``pathling.toml`` (in ``cwd``) > user-level config file >
+    none, then its values flow through the precedence flag > config file >
+    built-in default. Files are never merged: keys absent from the chosen file
+    fall back to built-in defaults, never to another file.
 
     :param tx_server: the ``--tx-server`` flag value, or None.
     :param tx_client_id: the ``--tx-client-id`` flag value, or None.
@@ -367,14 +410,32 @@ def resolve_config(
     :param tx_scope: the ``--tx-scope`` flag value, or None.
     :param fhir_version: the ``--fhir-version`` flag value, or None.
     :param verbose: the ``--verbose`` flag value.
-    :param config_path: an explicit config file path, or None for the default.
+    :param config_path: an explicit config file path, or None for discovery.
+    :param cwd: the directory searched for a project-local ``pathling.toml``;
+           defaults to the current working directory.
     :param env: the environment mapping for secret resolution.
     :param on_warning: an optional warning callback passed to the file loader.
+    :param on_notice: an optional callback invoked with a one-line notice when a
+           project-local ``pathling.toml`` is discovered and used.
     :return: the resolved :class:`CliConfig`.
     :raises CliError: if the resolved FHIR version is unsupported.
     """
-    path = config_path or default_config_path()
+    # Exactly one file is loaded; there is no merge across config files, so any
+    # key absent from the chosen file falls back to a built-in default rather
+    # than to another file.
+    search_cwd = cwd if cwd is not None else Path.cwd()
+    path, origin = resolve_config_source(config_path, search_cwd)
     file_data = load_config_file(path, on_warning)
+
+    # Surface a project-local override so the active configuration is never a
+    # silent surprise (only when discovered, not for explicit or user-level
+    # files).
+    if origin == "project" and on_notice is not None:
+        user_path = default_config_path()
+        if user_path.exists():
+            on_notice(f"Using project config {path} (overrides {user_path}).")
+        else:
+            on_notice(f"Using project config {path}.")
 
     resolved_tx_server = tx_server or file_data.get("tx-server") or DEFAULT_TX_SERVER
     resolved_fhir_version = (

--- a/lib/python/pathling/cli/config.py
+++ b/lib/python/pathling/cli/config.py
@@ -32,7 +32,7 @@ Author: John Grimes.
 
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -53,7 +53,7 @@ PROJECT_CONFIG_FILENAME = "pathling.toml"
 
 # Valid top-level keys in the config file.
 VALID_CONFIG_KEYS = frozenset(
-    {"tx-server", "fhir-version", "terminology-auth", "bulk-auth"}
+    {"tx-server", "fhir-version", "terminology-auth", "bulk-auth", "spark"}
 )
 
 # Valid keys within the [terminology-auth] and [bulk-auth] tables.
@@ -125,6 +125,8 @@ class CliConfig:
     :param fhir_version: the FHIR version code.
     :param verbose: whether verbose logging and stack traces are enabled.
     :param config_path: the path the config file was read from, or None.
+    :param spark_conf: the resolved, validated, and merged Spark configuration
+           map to apply when a session is built; empty when nothing is set.
     """
 
     tx_server: str = DEFAULT_TX_SERVER
@@ -132,6 +134,7 @@ class CliConfig:
     fhir_version: str = DEFAULT_FHIR_VERSION
     verbose: bool = False
     config_path: Optional[Path] = None
+    spark_conf: dict = field(default_factory=dict)
 
 
 def _load_toml(path: Path) -> dict:
@@ -395,6 +398,7 @@ def resolve_config(
     tx_token_endpoint: Optional[str] = None,
     tx_scope: Optional[str] = None,
     fhir_version: Optional[str] = None,
+    spark_conf_flags: Optional[dict] = None,
     verbose: bool = False,
     config_path: Optional[Path] = None,
     cwd: Optional[Path] = None,
@@ -416,12 +420,16 @@ def resolve_config(
     :param tx_token_endpoint: the ``--tx-token-endpoint`` flag value, or None.
     :param tx_scope: the ``--tx-scope`` flag value, or None.
     :param fhir_version: the ``--fhir-version`` flag value, or None.
+    :param spark_conf_flags: the parsed ``--spark-conf`` flag map, or None; flag
+           values override the ``[spark]`` table for the same key.
     :param verbose: the ``--verbose`` flag value.
     :param config_path: an explicit config file path, or None for discovery.
     :param cwd: the directory searched for a project-local ``pathling.toml``;
            defaults to the current working directory.
     :param env: the environment mapping for secret resolution.
-    :param on_warning: an optional warning callback passed to the file loader.
+    :param on_warning: an optional warning callback passed to the file loader and
+           used to surface the managed Spark-package version-override warning;
+           defaults to writing to stderr so warnings appear even in quiet mode.
     :param on_notice: an optional callback invoked with a one-line notice when a
            project-local ``pathling.toml`` is discovered and used.
     :return: the resolved :class:`CliConfig`.
@@ -467,10 +475,23 @@ def resolve_config(
         env,
     )
 
+    # Resolve the [spark] table (combined with any --spark-conf flags, flag
+    # wins) into the effective Spark configuration, merged with Pathling's
+    # managed defaults. Any invalid key or value aborts here, before a Spark
+    # session is started; the managed-version-override warning is surfaced even
+    # in quiet mode.
+    from pathling.cli.sparkconf import merge_spark_conf, resolve_spark_conf
+
+    spark_warn = on_warning or (lambda message: print(message, file=sys.stderr))
+    spark_table = file_data.get("spark") or {}
+    resolved_spark = resolve_spark_conf(spark_table, spark_conf_flags, env)
+    spark_conf = merge_spark_conf(resolved_spark, on_warning=spark_warn)
+
     return CliConfig(
         tx_server=resolved_tx_server,
         tx_auth=tx_auth,
         fhir_version=resolved_fhir_version,
         verbose=verbose,
         config_path=path if path.exists() else None,
+        spark_conf=spark_conf,
     )

--- a/lib/python/pathling/cli/config.py
+++ b/lib/python/pathling/cli/config.py
@@ -127,6 +127,10 @@ class CliConfig:
     :param config_path: the path the config file was read from, or None.
     :param spark_conf: the resolved, validated, and merged Spark configuration
            map to apply when a session is built; empty when nothing is set.
+    :param bulk_auth_table: the parsed ``[bulk-auth]`` table from the chosen
+           config file, or None when absent. Carried so ``export`` resolves bulk
+           credentials from the already-loaded config rather than re-reading a
+           file.
     """
 
     tx_server: str = DEFAULT_TX_SERVER
@@ -135,6 +139,7 @@ class CliConfig:
     verbose: bool = False
     config_path: Optional[Path] = None
     spark_conf: dict = field(default_factory=dict)
+    bulk_auth_table: Optional[dict] = None
 
 
 def _load_toml(path: Path) -> dict:
@@ -315,14 +320,11 @@ def resolve_bulk_auth(
     :param token_endpoint: the ``--token-endpoint`` flag value, or None.
     :param scope: the ``--scope`` flag value, or None.
     :param env: the environment mapping for secret resolution.
-    :return: a populated :class:`BulkAuth`, or None when no client ID is set.
+    :return: a populated :class:`BulkAuth`, or None when no auth input is given.
     :raises CliError: when the auth configuration is incomplete or ambiguous.
     """
     table = file_bulk_auth or {}
     resolved_client_id = client_id or table.get("client-id")
-    if not resolved_client_id:
-        return None
-
     resolved_token_endpoint = token_endpoint or table.get("token-endpoint")
     resolved_scope = scope or table.get("scope")
     resolved_secret = resolve_secret(
@@ -335,6 +337,26 @@ def resolve_bulk_auth(
     )
 
     from pathling.cli.errors import EXIT_USAGE, CliError
+
+    # With no auth input at all, the export runs unauthenticated, which is valid.
+    if not any(
+        [
+            resolved_client_id,
+            resolved_token_endpoint,
+            resolved_scope,
+            resolved_secret,
+            resolved_jwk,
+        ]
+    ):
+        return None
+    # Any other auth input without a client ID is an error rather than a silent
+    # fall-through to an unauthenticated export (FR-004).
+    if not resolved_client_id:
+        raise CliError(
+            "Bulk export authentication requires a client ID. Add --client-id, "
+            "or set client-id in the [bulk-auth] config table.",
+            exit_code=EXIT_USAGE,
+        )
 
     if not resolved_token_endpoint:
         raise CliError(
@@ -440,6 +462,17 @@ def resolve_config(
     # than to another file.
     search_cwd = cwd if cwd is not None else Path.cwd()
     path, origin = resolve_config_source(config_path, search_cwd)
+
+    # An explicit --config path must exist; failing fast avoids silently falling
+    # back to another config file's credentials (FR-002).
+    if origin == "explicit" and not path.exists():
+        from pathling.cli.errors import EXIT_USAGE, CliError
+
+        raise CliError(
+            f"Config file does not exist: {path}. Check the --config path.",
+            exit_code=EXIT_USAGE,
+        )
+
     file_data = load_config_file(path, on_warning)
 
     # Surface a project-local override so the active configuration is never a
@@ -475,6 +508,17 @@ def resolve_config(
         env,
     )
 
+    # Some terminology auth input was supplied but it is insufficient to
+    # authenticate (a client ID and a token endpoint are both required); tell the
+    # user rather than silently disabling it (FR-005).
+    if tx_auth is not None and not tx_auth.enabled:
+        notify = on_warning or (lambda message: print(message, file=sys.stderr))
+        notify(
+            "Terminology authentication is incomplete and will be disabled: a "
+            "client ID and a token endpoint are both required. Provide "
+            "--tx-client-id and --tx-token-endpoint."
+        )
+
     # Resolve the [spark] table (combined with any --spark-conf flags, flag
     # wins) into the effective Spark configuration, merged with Pathling's
     # managed defaults. Any invalid key or value aborts here, before a Spark
@@ -494,4 +538,5 @@ def resolve_config(
         verbose=verbose,
         config_path=path if path.exists() else None,
         spark_conf=spark_conf,
+        bulk_auth_table=file_data.get("bulk-auth"),
     )

--- a/lib/python/pathling/cli/config.py
+++ b/lib/python/pathling/cli/config.py
@@ -139,7 +139,7 @@ def _load_toml(path: Path) -> dict:
 
     :param path: the path to the TOML file.
     :return: the parsed contents as a dict.
-    :raises CliError: if the file cannot be parsed as TOML.
+    :raises CliError: if the file cannot be read or parsed as TOML.
     """
     # Prefer the standard library on Python 3.11+, fall back to tomli.
     try:
@@ -156,6 +156,13 @@ def _load_toml(path: Path) -> dict:
         raise CliError(
             f"Could not parse the config file at {path}: {exc}. "
             "Check that it is valid TOML."
+        ) from exc
+    except OSError as exc:
+        # A directory or an unreadable file surfaces a clear, file-naming error
+        # rather than a raw OSError or a silent fallback to another config file.
+        raise CliError(
+            f"Could not read the config file at {path}: {exc}. "
+            "Check that it is a readable file."
         ) from exc
 
 

--- a/lib/python/pathling/cli/console.py
+++ b/lib/python/pathling/cli/console.py
@@ -1,0 +1,78 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""The ``pathling console`` command.
+
+Opens an interactive IPython session with ``spark`` (the Spark session) and
+``pathling`` (the configured Pathling context) bound in the user namespace,
+after a banner identifying the version and the variables in scope. IPython is
+imported inside the command body so that ``--help`` stays fast.
+
+Author: John Grimes.
+"""
+
+import platform
+
+import click
+
+from pathling._version import __version__
+from pathling.cli import session
+
+
+def build_banner() -> str:
+    """Builds the banner shown before the console's first prompt.
+
+    The banner identifies the Pathling and Python versions, lists the
+    variables in scope, and explains how to exit.
+
+    :return: the banner text.
+    """
+    return (
+        f"Pathling console (version {__version__}, "
+        f"Python {platform.python_version()})\n"
+        "Variables in scope: spark (SparkSession), pathling (PathlingContext)\n"
+        "Type exit or press Ctrl-D to leave.\n"
+    )
+
+
+@click.command(name="console")
+@click.pass_obj
+def console(obj):
+    """Open an interactive console with the Pathling environment ready.
+
+    Starts an IPython session with two variables in scope: spark (the Spark
+    session) and pathling (the configured Pathling context). Exit with
+    'exit' or Ctrl-D.
+
+    Examples:
+
+        pathling console
+
+        pathling --tx-server https://tx.example.org/fhir console
+    """
+    pc = session.create_context(obj.config, obj.console)
+
+    import IPython
+    from traitlets.config import Config
+
+    config = Config()
+    config.TerminalInteractiveShell.banner1 = build_banner()
+    IPython.start_ipython(
+        argv=[],
+        user_ns={"spark": pc.spark, "pathling": pc},
+        config=config,
+    )

--- a/lib/python/pathling/cli/console.py
+++ b/lib/python/pathling/cli/console.py
@@ -58,6 +58,10 @@ def console(obj):
     session) and pathling (the configured Pathling context). Exit with
     'exit' or Ctrl-D.
 
+    \b
+    See the Pathling Python API reference:
+    https://pathling.csiro.au/docs/python/pathling.html
+
     Examples:
 
         pathling console

--- a/lib/python/pathling/cli/convert.py
+++ b/lib/python/pathling/cli/convert.py
@@ -1,0 +1,139 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""The ``pathling convert`` command.
+
+Reads any supported FHIR data source and writes ndjson, Parquet, or Delta to an
+output path, with save-mode control and a summary of the resource types and row
+counts written.
+
+Author: John Grimes.
+"""
+
+from pathlib import Path
+
+import click
+from rich.table import Table
+
+from pathling.cli import session
+from pathling.cli.errors import EXIT_USAGE, CliError
+from pathling.cli.io import FROM_CHOICES, read_source, resolve_source
+from pathling.cli.render import check_overwrite, progress_status
+
+# The output formats convert can write.
+TO_CHOICES = ("ndjson", "parquet", "delta")
+
+# The save modes accepted on the command line.
+MODE_CHOICES = ("overwrite", "error", "append", "merge")
+
+
+@click.command(name="convert")
+@click.argument("source")
+@click.option(
+    "--from",
+    "from_format",
+    type=click.Choice(FROM_CHOICES),
+    help="Input format (auto-detected when omitted).",
+)
+@click.option(
+    "--to",
+    "to_format",
+    required=True,
+    type=click.Choice(TO_CHOICES),
+    help="Output format.",
+)
+@click.option(
+    "-o",
+    "--output",
+    "output",
+    required=True,
+    help="Output directory.",
+)
+@click.option(
+    "--mode",
+    default="error",
+    type=click.Choice(MODE_CHOICES),
+    show_default=True,
+    help="Save mode for parquet/delta output; 'merge' is delta only.",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    help="Replace an existing output path (equivalent to --mode overwrite).",
+)
+@click.pass_obj
+def convert(obj, source, from_format, to_format, output, mode, overwrite):
+    """Convert FHIR data between formats.
+
+    Examples:
+
+        pathling convert data/ --to parquet -o warehouse/
+
+        pathling convert bundles/ --from bundles --to ndjson -o out/
+    """
+    config = obj.config
+    console = obj.console
+
+    spec = resolve_source(source, from_format)
+
+    effective_mode = "overwrite" if overwrite else mode
+    if effective_mode == "merge" and to_format != "delta":
+        raise CliError(
+            "The 'merge' save mode is only valid for delta output. "
+            "Use --to delta, or choose --mode overwrite|error|append.",
+            exit_code=EXIT_USAGE,
+        )
+
+    output_path = Path(output)
+    # Error-if-exists is the default; pre-check so the message names --overwrite.
+    if effective_mode == "error":
+        check_overwrite(output_path, overwrite=False)
+
+    pc = session.create_context(config, console)
+    data_source = read_source(pc, spec)
+
+    with progress_status(
+        console, f"Writing {to_format} to {output_path}...", config.verbose
+    ):
+        sink = data_source.write
+        target = str(output_path)
+        if to_format == "ndjson":
+            sink.ndjson(target, save_mode=effective_mode)
+        elif to_format == "parquet":
+            sink.parquet(target, save_mode=effective_mode)
+        else:
+            sink.delta(target, save_mode=effective_mode)
+
+    _print_summary(console, data_source)
+
+
+def _print_summary(console, data_source) -> None:
+    """Prints a table of the resource types written and their row counts.
+
+    :param console: the stderr console to print the summary to.
+    :param data_source: the data source that was written.
+    """
+    table = Table(title="Conversion summary")
+    table.add_column("Resource type")
+    table.add_column("Rows", justify="right")
+    total = 0
+    for resource_type in sorted(data_source.resource_types()):
+        count = data_source.read(resource_type).count()
+        total += count
+        table.add_row(resource_type, str(count))
+    table.caption = f"{total} rows total"
+    console.print(table)

--- a/lib/python/pathling/cli/convert.py
+++ b/lib/python/pathling/cli/convert.py
@@ -71,12 +71,19 @@ MODE_CHOICES = ("overwrite", "error", "append", "merge")
     help="Save mode for parquet/delta output; 'merge' is delta only.",
 )
 @click.option(
+    "--type",
+    "types",
+    multiple=True,
+    help="Resource type to read from a Bundles source (repeatable). When given, "
+    "these types are used directly and driver-side discovery is skipped.",
+)
+@click.option(
     "--overwrite",
     is_flag=True,
     help="Replace an existing output path (equivalent to --mode overwrite).",
 )
 @click.pass_obj
-def convert(obj, source, from_format, to_format, output, mode, overwrite):
+def convert(obj, source, from_format, to_format, output, mode, types, overwrite):
     """Convert FHIR data between formats.
 
     Examples:
@@ -84,6 +91,8 @@ def convert(obj, source, from_format, to_format, output, mode, overwrite):
         pathling convert data/ --to parquet -o warehouse/
 
         pathling convert bundles/ --from bundles --to ndjson -o out/
+
+        pathling convert bundles/ --from bundles --type Patient --to ndjson -o out/
     """
     config = obj.config
     console = obj.console
@@ -104,7 +113,11 @@ def convert(obj, source, from_format, to_format, output, mode, overwrite):
         check_overwrite(output_path, overwrite=False)
 
     pc = session.create_context(config, console)
-    data_source = read_source(pc, spec)
+
+    # Read under the spinner so that bundle discovery (when it runs) is surfaced
+    # rather than happening silently before any feedback (FR-016).
+    with progress_status(console, "Reading source...", config.verbose):
+        data_source = read_source(pc, spec, types=list(types) or None)
 
     with progress_status(
         console, f"Writing {to_format} to {output_path}...", config.verbose
@@ -118,22 +131,24 @@ def convert(obj, source, from_format, to_format, output, mode, overwrite):
         else:
             sink.delta(target, save_mode=effective_mode)
 
-    _print_summary(console, data_source)
+    _print_summary(console, data_source, output_path)
 
 
-def _print_summary(console, data_source) -> None:
-    """Prints a table of the resource types written and their row counts.
+def _print_summary(console, data_source, output_path) -> None:
+    """Prints a table of the resource types written and the output location.
+
+    Row counts are deliberately omitted: counting each type would trigger an
+    extra full Spark job purely to print a number (FR-013).
 
     :param console: the stderr console to print the summary to.
     :param data_source: the data source that was written.
+    :param output_path: the output path the data was written to.
     """
     table = Table(title="Conversion summary")
     table.add_column("Resource type")
-    table.add_column("Rows", justify="right")
-    total = 0
     for resource_type in sorted(data_source.resource_types()):
-        count = data_source.read(resource_type).count()
-        total += count
-        table.add_row(resource_type, str(count))
-    table.caption = f"{total} rows total"
+        table.add_row(resource_type)
     console.print(table)
+    # Report the output location on its own line so a long path is not wrapped
+    # awkwardly inside the table.
+    console.print(f"Written to {output_path}")

--- a/lib/python/pathling/cli/departition.py
+++ b/lib/python/pathling/cli/departition.py
@@ -1,0 +1,145 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Departitioning of Spark directory output into a single file.
+
+Spark's distributed writers produce a directory of part files rather than a
+single file. To restore the single-file experience expected from the command
+line, this module moves the single data part file out of that directory to the
+exact path the user requested and removes the directory. The operation runs
+over the Hadoop ``FileSystem`` associated with the target path, so it works
+uniformly for local, S3, HDFS, and other Hadoop-compatible destinations,
+keeping the move on a single filesystem.
+
+Author: John Grimes.
+"""
+
+from pathlib import Path
+from typing import Union
+
+from py4j.java_gateway import is_instance_of
+
+from pathling.cli.errors import CliError
+
+
+def _filesystem(spark, reference_path: Union[str, Path]):
+    """Resolves the Hadoop ``FileSystem`` for a path, unwrapping checksums.
+
+    The filesystem is resolved from ``reference_path`` so that operations stay
+    on the one filesystem (a same-filesystem rename rather than a
+    cross-filesystem copy), whether the destination is local, S3, HDFS, or GCS.
+    On a checksummed filesystem - notably the local filesystem - the underlying
+    raw filesystem is used, so that renames neither create nor move the sibling
+    ``.crc`` checksum files that would otherwise be left beside the single-file
+    output.
+
+    :param spark: the Spark session, used to reach the JVM gateway and Hadoop
+           configuration.
+    :param reference_path: the path whose filesystem is required.
+    :return: a tuple of the (possibly raw) ``FileSystem`` and the JVM
+             ``org.apache.hadoop.fs.Path`` class.
+    """
+    path_class = spark._jvm.org.apache.hadoop.fs.Path
+    reference = path_class(str(reference_path))
+    fs = reference.getFileSystem(spark._jsc.hadoopConfiguration())
+    if is_instance_of(
+        spark._sc._gateway, fs, "org.apache.hadoop.fs.ChecksumFileSystem"
+    ):
+        fs = fs.getRawFileSystem()
+    return fs, path_class
+
+
+def remove_path(spark, path: Union[str, Path]) -> None:
+    """Removes a file or directory over its Hadoop ``FileSystem``, if it exists.
+
+    Used to clear an existing target before an overwrite and to clean up the
+    temporary departition directory. The operation is idempotent: a path that
+    does not exist is left untouched.
+
+    :param spark: the Spark session, used to reach the JVM gateway and Hadoop
+           configuration.
+    :param path: the path to remove.
+    """
+    fs, path_class = _filesystem(spark, path)
+    target = path_class(str(path))
+    if fs.exists(target):
+        fs.delete(target, True)
+
+
+def departition(
+    spark,
+    source_dir: Union[str, Path],
+    target_path: Union[str, Path],
+    part_extension: str,
+) -> None:
+    """Moves the single data part file from a Spark output directory to a path.
+
+    Lists ``source_dir`` over the Hadoop ``FileSystem`` of ``target_path``,
+    selects the data part files (those ending in ``part_extension``, ignoring
+    Spark markers such as ``_SUCCESS`` and ``.crc`` checksums), and:
+
+    - with exactly one data file, moves it to ``target_path``;
+    - with no data files (an empty result), creates an empty ``target_path``;
+    - with more than one data file, raises an error rather than choosing one.
+
+    The source directory is always removed afterwards.
+
+    :param spark: the Spark session, used to reach the JVM gateway and Hadoop
+           configuration.
+    :param source_dir: the Spark output directory to departition.
+    :param target_path: the destination path for the single data file.
+    :param part_extension: the part-file extension to select, without a leading
+           dot (e.g. ``"csv"``, ``"json"``, ``"parquet"``).
+    :raises CliError: when the source directory contains more than one data
+            file.
+    """
+    fs, path_class = _filesystem(spark, target_path)
+    source = path_class(str(source_dir))
+    target = path_class(str(target_path))
+
+    suffix = "." + part_extension
+    data_files = [
+        status.getPath()
+        for status in fs.listStatus(source)
+        if status.getPath().getName().endswith(suffix)
+    ]
+
+    if len(data_files) > 1:
+        # repartition(1) should always yield a single data file; more than one
+        # means something unexpected, so fail rather than silently pick one.
+        names = ", ".join(sorted(file.getName() for file in data_files))
+        raise CliError(
+            f"Expected a single '{part_extension}' file after departitioning "
+            f"but found more than one: {names}."
+        )
+
+    try:
+        # Ensure the target's parent exists before the move, since a Hadoop
+        # rename does not create intermediate directories.
+        parent = target.getParent()
+        if parent is not None:
+            fs.mkdirs(parent)
+
+        if not data_files:
+            # An empty result produces no data part; still write a valid, empty
+            # single file at the target path.
+            fs.create(target, True).close()
+        elif not fs.rename(data_files[0], target):
+            raise CliError(f"Failed to move the result file to {target_path}.")
+    finally:
+        # Always remove the temporary Spark output directory and its markers.
+        fs.delete(source, True)

--- a/lib/python/pathling/cli/errors.py
+++ b/lib/python/pathling/cli/errors.py
@@ -1,0 +1,144 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Error handling for the Pathling command line interface.
+
+JVM exceptions raised through Py4J carry verbose Java stack traces that are
+unhelpful at the command line. This module unwraps them to their root message
+and maps recognised categories onto concise, actionable guidance. Stack traces
+are shown only when the user passes ``--verbose``.
+
+Author: John Grimes.
+"""
+
+import re
+import traceback
+from typing import Optional
+
+# Exit code for a successful invocation.
+EXIT_SUCCESS = 0
+
+# Exit code for a runtime failure (a command failed while executing).
+EXIT_RUNTIME = 1
+
+# Exit code for a usage error (the command was invoked incorrectly).
+EXIT_USAGE = 2
+
+
+class CliError(Exception):
+    """An error with a message that is safe to show the user directly.
+
+    :param message: the human-readable error message.
+    :param exit_code: the process exit code to use; defaults to a runtime
+           failure.
+    """
+
+    def __init__(self, message: str, exit_code: int = EXIT_RUNTIME) -> None:
+        super().__init__(message)
+        self.message = message
+        self.exit_code = exit_code
+
+
+def unwrap_java_exception(exc: BaseException) -> str:
+    """Extracts the most useful single-line message from an exception.
+
+    Py4J wraps Java exceptions, whose ``str`` representation includes the full
+    stack trace. This returns the leading message line, stripping the Java
+    exception class prefix where present.
+
+    :param exc: the exception to unwrap.
+    :return: a concise message describing the underlying problem.
+    """
+    java_exception = getattr(exc, "java_exception", None)
+    if java_exception is not None:
+        get_message = getattr(java_exception, "getMessage", None)
+        message = get_message() if callable(get_message) else None
+        if not message:
+            message = str(java_exception)
+    else:
+        message = str(exc)
+
+    # Take only the first non-empty line; Java traces span many lines.
+    first_line = next((line for line in message.splitlines() if line.strip()), message)
+    # Strip a leading fully-qualified Java exception class name, e.g.
+    # "java.lang.IllegalArgumentException: actual message".
+    match = re.match(r"^(?:[\w.$]+Exception|[\w.$]+Error):\s*(.*)$", first_line)
+    if match and match.group(1):
+        return match.group(1).strip()
+    return first_line.strip()
+
+
+def _categorise(root_message: str) -> Optional[str]:
+    """Classifies a root message into a known error category.
+
+    :param root_message: the unwrapped root message.
+    :return: a category key, or None when the message is not recognised.
+    """
+    lowered = root_message.lower()
+    if "connection refused" in lowered or "failed to connect" in lowered:
+        return "connection"
+    if "unknownhost" in lowered or "unknown host" in lowered:
+        return "connection"
+    if "fhirpath" in lowered or "parse error" in lowered:
+        return "fhirpath"
+    return None
+
+
+def is_connection_error(exc: BaseException) -> bool:
+    """Determines whether an exception represents a server connection failure.
+
+    :param exc: the exception to classify.
+    :return: True when the unwrapped message looks like a connection failure.
+    """
+    return _categorise(unwrap_java_exception(exc)) == "connection"
+
+
+def friendly_message(
+    exc: BaseException,
+    verbose: bool = False,
+    server_url: Optional[str] = None,
+) -> str:
+    """Builds a friendly, actionable message for an unexpected exception.
+
+    :param exc: the exception to describe.
+    :param verbose: when True, append the full traceback.
+    :param server_url: a server URL to name in connection errors, or None.
+    :return: the message to present to the user.
+    """
+    root = unwrap_java_exception(exc)
+    category = _categorise(root)
+
+    if category == "connection" and server_url:
+        message = (
+            f"Could not reach the server at {server_url}: {root}. "
+            "Check the URL and your network connection."
+        )
+    elif category == "fhirpath":
+        message = (
+            f"The FHIRPath expression could not be evaluated: {root}. "
+            "Check the expression syntax."
+        )
+    else:
+        message = root or f"{type(exc).__name__}"
+        if not verbose:
+            message = f"{message} Re-run with --verbose for the full stack trace."
+
+    if verbose:
+        # Use the three-argument form for Python 3.9 compatibility.
+        trace = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        message = message + "\n\n" + trace
+    return message

--- a/lib/python/pathling/cli/errors.py
+++ b/lib/python/pathling/cli/errors.py
@@ -38,6 +38,25 @@ EXIT_RUNTIME = 1
 # Exit code for a usage error (the command was invoked incorrectly).
 EXIT_USAGE = 2
 
+# Signals that an unwrapped root message describes an authentication failure
+# rather than a connection, timeout, or server-side problem. The SMART
+# backend-services setup surfaces "Failed to retrieve SMART configuration" when
+# the token endpoint or credential is wrong, so that phrasing is included
+# alongside the standard OAuth2 rejection codes.
+_AUTH_PATTERN = re.compile(
+    r"\b401\b"
+    r"|\bunauthorized\b"
+    r"|invalid_client|invalid_grant|invalid_scope|unauthorized_client"
+    r"|smart configuration"
+    r"|smart auth"
+    r"|access[ _]token"
+    r"|token endpoint"
+    r"|authentication (?:failed|error)"
+    r"|failed to authenticate"
+    r"|credential",
+    re.IGNORECASE,
+)
+
 
 class CliError(Exception):
     """An error with a message that is safe to show the user directly.
@@ -93,7 +112,11 @@ def _categorise(root_message: str) -> Optional[str]:
         return "connection"
     if "unknownhost" in lowered or "unknown host" in lowered:
         return "connection"
-    if "fhirpath" in lowered or "parse error" in lowered:
+    if _AUTH_PATTERN.search(root_message):
+        return "auth"
+    # Require a FHIRPath-specific signal rather than the bare substring "parse
+    # error", which can appear in unrelated parse failures (FR-012).
+    if "fhirpath" in lowered:
         return "fhirpath"
     return None
 
@@ -105,6 +128,21 @@ def is_connection_error(exc: BaseException) -> bool:
     :return: True when the unwrapped message looks like a connection failure.
     """
     return _categorise(unwrap_java_exception(exc)) == "connection"
+
+
+def is_auth_error(exc: BaseException) -> bool:
+    """Determines whether an exception represents an authentication failure.
+
+    Used to decide whether an export failure should be reported as an
+    authentication problem; connection, timeout, and server-side errors that
+    happen to occur while authentication is configured must not be misdiagnosed
+    as bad credentials.
+
+    :param exc: the exception to classify.
+    :return: True when the unwrapped message looks like an authentication
+             failure.
+    """
+    return _categorise(unwrap_java_exception(exc)) == "auth"
 
 
 def friendly_message(

--- a/lib/python/pathling/cli/export.py
+++ b/lib/python/pathling/cli/export.py
@@ -1,0 +1,247 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""The ``pathling export`` command.
+
+Performs a FHIR Bulk Data export (system, group, or patient level) with the
+library's filters and SMART backend services authentication, downloading
+ndjson to the output directory and reporting a summary of files and resource
+counts.
+
+Author: John Grimes.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import click
+from rich.table import Table
+
+from pathling.cli import session
+from pathling.cli.config import default_config_path, load_config_file, resolve_bulk_auth
+from pathling.cli.errors import EXIT_USAGE, CliError, unwrap_java_exception
+from pathling.cli.render import check_overwrite, progress_status
+
+
+def _parse_since(since):
+    """Parses a ``--since`` ISO 8601 timestamp with a timezone offset.
+
+    :param since: the raw ``--since`` value, or None.
+    :return: a timezone-aware datetime, or None when not given.
+    :raises CliError: when the value is not ISO 8601 with a timezone.
+    """
+    if since is None:
+        return None
+    # Python 3.9's fromisoformat does not accept the 'Z' UTC suffix.
+    normalised = since[:-1] + "+00:00" if since.endswith("Z") else since
+    try:
+        parsed = datetime.fromisoformat(normalised)
+    except ValueError as exc:
+        raise CliError(
+            f"Could not parse --since value '{since}': {exc}. Use an ISO 8601 "
+            "timestamp with a timezone, e.g. 2024-01-01T00:00:00Z.",
+            exit_code=EXIT_USAGE,
+        ) from exc
+    if parsed.tzinfo is None:
+        raise CliError(
+            f"The --since value '{since}' has no timezone. Use an ISO 8601 "
+            "timestamp with a timezone, e.g. 2024-01-01T00:00:00+10:00.",
+            exit_code=EXIT_USAGE,
+        )
+    return parsed
+
+
+def _build_auth_config(bulk_auth) -> dict:
+    """Builds the library's auth config dict from resolved bulk auth.
+
+    :param bulk_auth: the resolved :class:`BulkAuth`.
+    :return: the auth config dict accepted by the bulk export client.
+    """
+    auth_config = {
+        "enabled": True,
+        "use_smart": True,
+        "client_id": bulk_auth.client_id,
+        "token_endpoint": bulk_auth.token_endpoint,
+    }
+    if bulk_auth.private_key_jwk:
+        auth_config["private_key_jwk"] = bulk_auth.private_key_jwk
+    if bulk_auth.client_secret:
+        auth_config["client_secret"] = bulk_auth.client_secret
+    if bulk_auth.scope:
+        auth_config["scope"] = bulk_auth.scope
+    return auth_config
+
+
+@click.command(name="export")
+@click.argument("endpoint")
+@click.option("-o", "--output", "output", required=True, help="Output directory.")
+@click.option("--group", "group", help="Group ID for a group-level export.")
+@click.option(
+    "--patient",
+    "patients",
+    multiple=True,
+    help="Patient reference for a patient-level export (repeatable).",
+)
+@click.option(
+    "--type", "types", multiple=True, help="Resource type to include (repeatable)."
+)
+@click.option(
+    "--elements", "elements", multiple=True, help="Element to include (repeatable)."
+)
+@click.option(
+    "--type-filter", "type_filters", multiple=True, help="Type filter (repeatable)."
+)
+@click.option(
+    "--include-associated-data",
+    "include_associated_data",
+    multiple=True,
+    help="Associated data to include (repeatable).",
+)
+@click.option(
+    "--since", "since", help="Only include resources modified since (ISO 8601)."
+)
+@click.option("--timeout", "timeout", type=int, help="Timeout in seconds.")
+@click.option(
+    "--max-downloads",
+    "max_downloads",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Maximum concurrent downloads.",
+)
+@click.option("--client-id", "client_id", help="SMART auth client ID.")
+@click.option("--token-endpoint", "token_endpoint", help="SMART auth token endpoint.")
+@click.option("--scope", "scope", help="SMART auth scope.")
+@click.option(
+    "--private-key-jwk",
+    "private_key_jwk",
+    help="SMART auth private key JWK (literal, @file, or env).",
+)
+@click.option(
+    "--client-secret",
+    "client_secret",
+    help="SMART auth client secret (literal, @file, or env).",
+)
+@click.option("--overwrite", is_flag=True, help="Replace an existing output directory.")
+@click.pass_obj
+def export(
+    obj,
+    endpoint,
+    output,
+    group,
+    patients,
+    types,
+    elements,
+    type_filters,
+    include_associated_data,
+    since,
+    timeout,
+    max_downloads,
+    client_id,
+    token_endpoint,
+    scope,
+    private_key_jwk,
+    client_secret,
+    overwrite,
+):
+    """Bulk export data from a FHIR server.
+
+    Examples:
+
+        pathling export https://server/fhir -o out/ --type Patient
+
+        pathling export https://server/fhir -o out/ --group 123
+    """
+    config = obj.config
+    console = obj.console
+
+    if group and patients:
+        raise CliError(
+            "--group and --patient are mutually exclusive. Choose a group-level "
+            "or a patient-level export, not both.",
+            exit_code=EXIT_USAGE,
+        )
+
+    output_path = Path(output)
+    check_overwrite(output_path, overwrite)
+    since_dt = _parse_since(since)
+
+    file_data = load_config_file(config.config_path or default_config_path())
+    bulk_auth = resolve_bulk_auth(
+        file_data.get("bulk-auth"),
+        client_id=client_id,
+        client_secret=client_secret,
+        private_key_jwk=private_key_jwk,
+        token_endpoint=token_endpoint,
+        scope=scope,
+    )
+    auth_config = _build_auth_config(bulk_auth) if bulk_auth else None
+
+    pc = session.create_context(config, console)
+
+    with progress_status(
+        console,
+        f"Exporting from {endpoint} (kick-off, polling, download)...",
+        config.verbose,
+    ):
+        try:
+            data_source = pc.read.bulk(
+                fhir_endpoint_url=endpoint,
+                output_dir=str(output_path),
+                overwrite=True,
+                group_id=group or None,
+                patients=list(patients) or None,
+                since=since_dt,
+                types=list(types) or None,
+                elements=list(elements) or None,
+                include_associated_data=list(include_associated_data) or None,
+                type_filters=list(type_filters) or None,
+                timeout=timeout,
+                max_concurrent_downloads=max_downloads,
+                auth_config=auth_config,
+            )
+        except Exception as exc:  # noqa: BLE001 - re-raised as a friendly error.
+            if bulk_auth is not None:
+                raise CliError(
+                    f"Authentication failed using {bulk_auth.mechanism} against "
+                    f"{bulk_auth.token_endpoint}: {unwrap_java_exception(exc)}. "
+                    "Check the client ID, credential, and token endpoint."
+                ) from exc
+            raise
+
+    _print_summary(console, data_source, output_path)
+
+
+def _print_summary(console, data_source, output_path) -> None:
+    """Prints a summary of the files written and resource counts.
+
+    :param console: the stderr console.
+    :param data_source: the ndjson data source for the exported files.
+    :param output_path: the output directory the files were written to.
+    """
+    table = Table(title="Export summary")
+    table.add_column("Resource type")
+    table.add_column("Rows", justify="right")
+    total = 0
+    for resource_type in sorted(data_source.resource_types()):
+        count = data_source.read(resource_type).count()
+        total += count
+        table.add_row(resource_type, str(count))
+
+    files = sorted(p.name for p in output_path.glob("*.ndjson"))
+    table.caption = f"{len(files)} files, {total} rows downloaded to {output_path}"
+    console.print(table)

--- a/lib/python/pathling/cli/export.py
+++ b/lib/python/pathling/cli/export.py
@@ -32,8 +32,13 @@ import click
 from rich.table import Table
 
 from pathling.cli import session
-from pathling.cli.config import default_config_path, load_config_file, resolve_bulk_auth
-from pathling.cli.errors import EXIT_USAGE, CliError, unwrap_java_exception
+from pathling.cli.config import resolve_bulk_auth
+from pathling.cli.errors import (
+    EXIT_USAGE,
+    CliError,
+    is_auth_error,
+    unwrap_java_exception,
+)
 from pathling.cli.render import check_overwrite, progress_status
 
 
@@ -180,9 +185,8 @@ def export(
     check_overwrite(output_path, overwrite)
     since_dt = _parse_since(since)
 
-    file_data = load_config_file(config.config_path or default_config_path())
     bulk_auth = resolve_bulk_auth(
-        file_data.get("bulk-auth"),
+        config.bulk_auth_table,
         client_id=client_id,
         client_secret=client_secret,
         private_key_jwk=private_key_jwk,
@@ -215,7 +219,11 @@ def export(
                 auth_config=auth_config,
             )
         except Exception as exc:  # noqa: BLE001 - re-raised as a friendly error.
-            if bulk_auth is not None:
+            # Only claim an authentication failure when the error genuinely looks
+            # like one; otherwise surface the unwrapped root cause so a server
+            # outage, timeout, or HTTP 500 is not misdiagnosed as bad
+            # credentials (FR-001).
+            if bulk_auth is not None and is_auth_error(exc):
                 raise CliError(
                     f"Authentication failed using {bulk_auth.mechanism} against "
                     f"{bulk_auth.token_endpoint}: {unwrap_java_exception(exc)}. "
@@ -227,7 +235,10 @@ def export(
 
 
 def _print_summary(console, data_source, output_path) -> None:
-    """Prints a summary of the files written and resource counts.
+    """Prints a summary of the resource types, file count, and output path.
+
+    Row counts are deliberately omitted: counting each type would trigger an
+    extra full Spark job purely to print a number (FR-013).
 
     :param console: the stderr console.
     :param data_source: the ndjson data source for the exported files.
@@ -235,13 +246,11 @@ def _print_summary(console, data_source, output_path) -> None:
     """
     table = Table(title="Export summary")
     table.add_column("Resource type")
-    table.add_column("Rows", justify="right")
-    total = 0
     for resource_type in sorted(data_source.resource_types()):
-        count = data_source.read(resource_type).count()
-        total += count
-        table.add_row(resource_type, str(count))
-
-    files = sorted(p.name for p in output_path.glob("*.ndjson"))
-    table.caption = f"{len(files)} files, {total} rows downloaded to {output_path}"
+        table.add_row(resource_type)
     console.print(table)
+
+    # Report the file count and output location on their own line so a long path
+    # is not wrapped awkwardly inside the table.
+    files = sorted(p.name for p in output_path.glob("*.ndjson"))
+    console.print(f"{len(files)} files downloaded to {output_path}")

--- a/lib/python/pathling/cli/fhirpath.py
+++ b/lib/python/pathling/cli/fhirpath.py
@@ -99,6 +99,7 @@ def fhirpath(
     output,
     limit,
     overwrite,
+    departition,
 ):
     """Evaluate a FHIRPath expression against FHIR data.
 
@@ -112,7 +113,7 @@ def fhirpath(
     console = obj.console
 
     spec = resolve_source(source, from_format, allow_resource=True)
-    output_spec = resolve_output(output, output_format, limit, overwrite)
+    output_spec = resolve_output(output, output_format, limit, overwrite, departition)
     parsed_variables = _parse_variables(variables)
 
     # --context and --var only apply to single-resource evaluation; reject them

--- a/lib/python/pathling/cli/fhirpath.py
+++ b/lib/python/pathling/cli/fhirpath.py
@@ -103,6 +103,10 @@ def fhirpath(
 ):
     """Evaluate a FHIRPath expression against FHIR data.
 
+    \b
+    See the FHIRPath documentation:
+    https://pathling.csiro.au/docs/fhirpath
+
     Examples:
 
         pathling fhirpath data/ -t Patient -e 'name.family'

--- a/lib/python/pathling/cli/fhirpath.py
+++ b/lib/python/pathling/cli/fhirpath.py
@@ -18,9 +18,9 @@
 """The ``pathling fhirpath`` command.
 
 Evaluates a FHIRPath expression against either a whole data source (one row of
-``id`` and ``result`` per resource) or a single FHIR resource JSON file (the
-typed result values). Supports context expressions, named variables, and a FHIR
-search ``--filter`` in data source mode.
+``id`` and ``result`` per resource) or a single FHIR resource JSON file (one
+``type`` and ``result`` row per result item). Supports context expressions,
+named variables, and a FHIR search ``--filter`` in data source mode.
 
 Author: John Grimes.
 """
@@ -230,11 +230,12 @@ def _run_single_resource(
             for item in result["results"]
         ]
         # An explicit schema is required so that an empty result still has the
-        # expected columns rather than failing schema inference.
+        # expected columns rather than failing schema inference. The payload
+        # column is named "result" to match data source mode.
         schema = StructType(
             [
                 StructField("type", StringType(), True),
-                StructField("value", StringType(), True),
+                StructField("result", StringType(), True),
             ]
         )
         result_df = pc.spark.createDataFrame(rows, schema)

--- a/lib/python/pathling/cli/fhirpath.py
+++ b/lib/python/pathling/cli/fhirpath.py
@@ -1,0 +1,260 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""The ``pathling fhirpath`` command.
+
+Evaluates a FHIRPath expression against either a whole data source (one row of
+``id`` and ``result`` per resource) or a single FHIR resource JSON file (the
+typed result values). Supports context expressions, named variables, and a FHIR
+search ``--filter`` in data source mode.
+
+Author: John Grimes.
+"""
+
+import click
+
+from pathling.cli import session
+from pathling.cli.errors import EXIT_USAGE, CliError
+from pathling.cli.io import (
+    FROM_CHOICES,
+    SourceFormat,
+    read_single_resource,
+    read_source,
+    resolve_source,
+)
+from pathling.cli.render import (
+    OutputFormat,
+    progress_status,
+    resolve_output,
+    write_output,
+)
+
+
+def _parse_variables(var_specs) -> dict:
+    """Parses repeated ``name=value`` variable specifications.
+
+    :param var_specs: the raw ``--var`` values.
+    :return: a dict of variable names to string values.
+    :raises CliError: when a specification is not in ``name=value`` form.
+    """
+    variables = {}
+    for spec in var_specs:
+        if "=" not in spec:
+            raise CliError(
+                f"Invalid --var '{spec}'. Use --var name=value.",
+                exit_code=EXIT_USAGE,
+            )
+        name, value = spec.split("=", 1)
+        variables[name] = value
+    return variables
+
+
+@click.command(name="fhirpath")
+@click.argument("source")
+@click.option(
+    "--from",
+    "from_format",
+    type=click.Choice(FROM_CHOICES),
+    help="Input format (auto-detected when omitted).",
+)
+@click.option(
+    "-e", "--expression", "expression", required=True, help="FHIRPath expression."
+)
+@click.option(
+    "-t", "--type", "resource_type", help="Subject resource type (data source mode)."
+)
+@click.option("--context", "context_expression", help="Optional context expression.")
+@click.option(
+    "--var", "variables", multiple=True, help="Named variable, name=value (repeatable)."
+)
+@click.option(
+    "--filter", "filter_expr", help="FHIR search expression (data source mode)."
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(
+        [
+            OutputFormat.TABLE,
+            OutputFormat.CSV,
+            OutputFormat.JSON,
+            OutputFormat.NDJSON,
+            OutputFormat.PARQUET,
+            OutputFormat.DELTA,
+        ]
+    ),
+    help="Output format (default: table; inferred from -o extension).",
+)
+@click.option("-o", "--output", "output", help="Write results to this path.")
+@click.option(
+    "--limit", default=1000, show_default=True, help="Row cap for table output."
+)
+@click.option("--overwrite", is_flag=True, help="Replace an existing output path.")
+@click.pass_obj
+def fhirpath(
+    obj,
+    source,
+    from_format,
+    expression,
+    resource_type,
+    context_expression,
+    variables,
+    filter_expr,
+    output_format,
+    output,
+    limit,
+    overwrite,
+):
+    """Evaluate a FHIRPath expression against FHIR data.
+
+    Examples:
+
+        pathling fhirpath data/ -t Patient -e 'name.family'
+
+        pathling fhirpath patient.json -e 'name.given.first()'
+    """
+    config = obj.config
+    console = obj.console
+
+    spec = resolve_source(source, from_format, allow_resource=True)
+    output_spec = resolve_output(output, output_format, limit, overwrite)
+    parsed_variables = _parse_variables(variables)
+
+    # --context and --var only apply to single-resource evaluation; reject them
+    # in data source mode rather than silently ignoring them (and before any
+    # Spark session is started).
+    if spec.format != SourceFormat.RESOURCE and (
+        context_expression or parsed_variables
+    ):
+        raise CliError(
+            "--context and --var are only supported in single-resource mode "
+            "(when SOURCE is a single FHIR resource JSON file).",
+            exit_code=EXIT_USAGE,
+        )
+
+    pc = session.create_context(config, console)
+
+    if spec.format == SourceFormat.RESOURCE:
+        _run_single_resource(
+            pc,
+            spec,
+            expression,
+            resource_type,
+            context_expression,
+            parsed_variables,
+            output_spec,
+            console,
+            config.verbose,
+        )
+    else:
+        _run_data_source(
+            pc,
+            spec,
+            expression,
+            resource_type,
+            filter_expr,
+            output_spec,
+            console,
+            config.verbose,
+        )
+
+
+def _run_data_source(
+    pc, spec, expression, resource_type, filter_expr, output_spec, console, verbose
+) -> None:
+    """Evaluates an expression over every resource in a data source.
+
+    :param pc: the Pathling context.
+    :param spec: the resolved data source spec.
+    :param expression: the FHIRPath expression.
+    :param resource_type: the subject resource type; required here.
+    :param filter_expr: an optional FHIR search filter, or None.
+    :param output_spec: the resolved output spec.
+    :param console: the stderr console.
+    :param verbose: whether verbose mode is active.
+    :raises CliError: when the resource type is missing.
+    """
+    if not resource_type:
+        raise CliError(
+            "Data source mode requires the subject resource type. "
+            "Add -t/--type, e.g. -t Patient.",
+            exit_code=EXIT_USAGE,
+        )
+
+    data_source = read_source(pc, spec)
+    resources = data_source.read(resource_type)
+    if filter_expr:
+        resources = resources.filter(pc.search_to_column(resource_type, filter_expr))
+
+    with progress_status(console, "Evaluating FHIRPath...", verbose):
+        result_column = pc.fhirpath_to_column(resource_type, expression)
+        result = resources.select(
+            resources["id"].alias("id"), result_column.cast("string").alias("result")
+        )
+        write_output(result, output_spec, console)
+
+
+def _run_single_resource(
+    pc,
+    spec,
+    expression,
+    resource_type,
+    context_expression,
+    variables,
+    output_spec,
+    console,
+    verbose,
+) -> None:
+    """Evaluates an expression against a single FHIR resource file.
+
+    :param pc: the Pathling context.
+    :param spec: the resolved resource spec.
+    :param expression: the FHIRPath expression.
+    :param resource_type: an optional resource type override, or None.
+    :param context_expression: an optional context expression, or None.
+    :param variables: the parsed named variables.
+    :param output_spec: the resolved output spec.
+    :param console: the stderr console.
+    :param verbose: whether verbose mode is active.
+    """
+    detected_type, resource_json = read_single_resource(spec.path)
+    effective_type = resource_type or detected_type
+
+    with progress_status(console, "Evaluating FHIRPath...", verbose):
+        result = pc.evaluate_fhirpath(
+            effective_type,
+            resource_json,
+            expression,
+            context_expression=context_expression,
+            variables=variables or None,
+        )
+        from pyspark.sql.types import StringType, StructField, StructType
+
+        rows = [
+            (item["type"], None if item["value"] is None else str(item["value"]))
+            for item in result["results"]
+        ]
+        # An explicit schema is required so that an empty result still has the
+        # expected columns rather than failing schema inference.
+        schema = StructType(
+            [
+                StructField("type", StringType(), True),
+                StructField("value", StringType(), True),
+            ]
+        )
+        result_df = pc.spark.createDataFrame(rows, schema)
+        write_output(result_df, output_spec, console)

--- a/lib/python/pathling/cli/fhirpath.py
+++ b/lib/python/pathling/cli/fhirpath.py
@@ -181,7 +181,9 @@ def _run_data_source(
             exit_code=EXIT_USAGE,
         )
 
-    data_source = read_source(pc, spec)
+    # The subject resource type is already known, so pass it to the Bundles
+    # reader to avoid a redundant driver-side discovery pass (FR-015).
+    data_source = read_source(pc, spec, types=[resource_type])
     resources = data_source.read(resource_type)
     if filter_expr:
         resources = resources.filter(pc.search_to_column(resource_type, filter_expr))

--- a/lib/python/pathling/cli/fhirpath.py
+++ b/lib/python/pathling/cli/fhirpath.py
@@ -37,7 +37,7 @@ from pathling.cli.io import (
     resolve_source,
 )
 from pathling.cli.render import (
-    OutputFormat,
+    output_options,
     progress_status,
     resolve_output,
     write_output,
@@ -84,26 +84,7 @@ def _parse_variables(var_specs) -> dict:
 @click.option(
     "--filter", "filter_expr", help="FHIR search expression (data source mode)."
 )
-@click.option(
-    "--format",
-    "output_format",
-    type=click.Choice(
-        [
-            OutputFormat.TABLE,
-            OutputFormat.CSV,
-            OutputFormat.JSON,
-            OutputFormat.NDJSON,
-            OutputFormat.PARQUET,
-            OutputFormat.DELTA,
-        ]
-    ),
-    help="Output format (default: table; inferred from -o extension).",
-)
-@click.option("-o", "--output", "output", help="Write results to this path.")
-@click.option(
-    "--limit", default=1000, show_default=True, help="Row cap for table output."
-)
-@click.option("--overwrite", is_flag=True, help="Replace an existing output path.")
+@output_options
 @click.pass_obj
 def fhirpath(
     obj,

--- a/lib/python/pathling/cli/io.py
+++ b/lib/python/pathling/cli/io.py
@@ -26,11 +26,20 @@ Author: John Grimes.
 """
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
 from pathling.cli.errors import EXIT_USAGE, CliError
+
+# The number of leading characters of a candidate file inspected during format
+# detection. A FHIR resource names its ``resourceType`` near the start of the
+# object, so this is enough to recognise a Bundle without parsing the whole file.
+_DETECTION_PREFIX_CHARS = 4096
+
+# Matches a FHIR Bundle's ``resourceType`` declaration within the leading prefix.
+_BUNDLE_JSON_MARKER = re.compile(r'"resourceType"\s*:\s*"Bundle"')
 
 
 class SourceFormat:
@@ -68,18 +77,20 @@ class SourceSpec:
 def _looks_like_bundle(path: Path) -> bool:
     """Determines whether a JSON or XML file appears to contain a FHIR Bundle.
 
+    Only a leading prefix of the file is read; a full parse is unnecessary to
+    recognise a Bundle and wasteful for large files (FR-014).
+
     :param path: the file to inspect.
-    :return: True when the file's first resource is a Bundle.
+    :return: True when the file's leading prefix declares a Bundle resource.
     """
     try:
-        if path.suffix == ".xml":
-            head = path.read_text(encoding="utf-8", errors="ignore")[:512]
-            return "<Bundle" in head
-        with open(path, "r", encoding="utf-8") as handle:
-            data = json.load(handle)
-        return isinstance(data, dict) and data.get("resourceType") == "Bundle"
-    except (OSError, ValueError):
+        with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+            head = handle.read(_DETECTION_PREFIX_CHARS)
+    except OSError:
         return False
+    if path.suffix == ".xml":
+        return "<Bundle" in head
+    return _BUNDLE_JSON_MARKER.search(head) is not None
 
 
 def _describe_directory(path: Path) -> str:
@@ -223,11 +234,15 @@ def read_single_resource(path: Path) -> tuple:
     return resource_type, text
 
 
-def read_source(pc, spec: SourceSpec):
+def read_source(pc, spec: SourceSpec, types: Optional[List[str]] = None):
     """Reads a :class:`SourceSpec` into a Pathling ``DataSource``.
 
     :param pc: the :class:`PathlingContext` to read with.
     :param spec: the resolved source specification.
+    :param types: the resource types to read from a Bundles source. When
+           provided (non-empty), these are used directly and the driver-side
+           discovery pass is skipped; when None or empty, discovery enumerates
+           the types. Ignored for non-Bundles formats (FR-015).
     :return: a Pathling ``DataSource`` for the input.
     :raises CliError: when the format is not a data source format.
     """
@@ -235,8 +250,10 @@ def read_source(pc, spec: SourceSpec):
     if spec.format == SourceFormat.NDJSON:
         return pc.read.ndjson(path)
     if spec.format == SourceFormat.BUNDLES:
-        types = discover_bundle_resource_types(spec.path)
-        return pc.read.bundles(path, types)
+        resource_types = (
+            list(types) if types else discover_bundle_resource_types(spec.path)
+        )
+        return pc.read.bundles(path, resource_types)
     if spec.format == SourceFormat.PARQUET:
         return pc.read.parquet(path)
     if spec.format == SourceFormat.DELTA:

--- a/lib/python/pathling/cli/io.py
+++ b/lib/python/pathling/cli/io.py
@@ -1,0 +1,246 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Data source detection and reading for the Pathling command line interface.
+
+Format is auto-detected from the contents of the input path, with an explicit
+``--from`` override. Detection and validation run before any Spark session is
+started so that obvious mistakes (a missing or empty path, an ambiguous
+directory) fail quickly with an actionable message.
+
+Author: John Grimes.
+"""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from pathling.cli.errors import EXIT_USAGE, CliError
+
+
+class SourceFormat:
+    """The recognised data source formats."""
+
+    NDJSON = "ndjson"
+    BUNDLES = "bundles"
+    PARQUET = "parquet"
+    DELTA = "delta"
+    # A single FHIR resource JSON file, used only by the ``fhirpath`` command.
+    RESOURCE = "resource"
+
+
+# The formats that may be supplied via ``--from`` (RESOURCE is auto-only).
+FROM_CHOICES = (
+    SourceFormat.NDJSON,
+    SourceFormat.BUNDLES,
+    SourceFormat.PARQUET,
+    SourceFormat.DELTA,
+)
+
+
+@dataclass
+class SourceSpec:
+    """A resolved data source input.
+
+    :param path: the input path; verified to exist.
+    :param format: one of the :class:`SourceFormat` values.
+    """
+
+    path: Path
+    format: str
+
+
+def _looks_like_bundle(path: Path) -> bool:
+    """Determines whether a JSON or XML file appears to contain a FHIR Bundle.
+
+    :param path: the file to inspect.
+    :return: True when the file's first resource is a Bundle.
+    """
+    try:
+        if path.suffix == ".xml":
+            head = path.read_text(encoding="utf-8", errors="ignore")[:512]
+            return "<Bundle" in head
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        return isinstance(data, dict) and data.get("resourceType") == "Bundle"
+    except (OSError, ValueError):
+        return False
+
+
+def _describe_directory(path: Path) -> str:
+    """Summarises the contents of a directory for an error message.
+
+    :param path: the directory to describe.
+    :return: a comma-separated list of the entry names, capped for brevity.
+    """
+    names = sorted(entry.name for entry in path.iterdir())
+    if len(names) > 10:
+        names = names[:10] + ["..."]
+    return ", ".join(names) if names else "(empty)"
+
+
+def detect_format(path: Path, allow_resource: bool = False) -> str:
+    """Auto-detects the format of a data source path.
+
+    :param path: the input path.
+    :param allow_resource: when True, a single JSON file is treated as a single
+           FHIR resource rather than rejected.
+    :return: the detected :class:`SourceFormat` value.
+    :raises CliError: when the path is missing or empty, or the format cannot
+            be determined unambiguously.
+    """
+    if not path.exists():
+        raise CliError(
+            f"Input path does not exist: {path}. "
+            "Check the path relative to your working directory.",
+            exit_code=EXIT_USAGE,
+        )
+
+    if path.is_file():
+        if allow_resource and path.suffix == ".json":
+            return SourceFormat.RESOURCE
+        raise CliError(
+            f"Input path is a file: {path}. Data source commands expect a "
+            "directory of FHIR data; pass a directory or specify --from.",
+            exit_code=EXIT_USAGE,
+        )
+
+    entries = list(path.iterdir())
+    if not entries:
+        raise CliError(f"Input directory is empty: {path}.", exit_code=EXIT_USAGE)
+
+    parquet_tables = [entry for entry in entries if entry.name.endswith(".parquet")]
+    if parquet_tables:
+        if any((table / "_delta_log").exists() for table in parquet_tables):
+            return SourceFormat.DELTA
+        return SourceFormat.PARQUET
+
+    if any(entry.suffix in (".ndjson", ".jsonl") for entry in entries):
+        return SourceFormat.NDJSON
+
+    json_xml = [entry for entry in entries if entry.suffix in (".json", ".xml")]
+    if json_xml:
+        if _looks_like_bundle(sorted(json_xml)[0]):
+            return SourceFormat.BUNDLES
+
+    raise CliError(
+        f"Could not determine the format of {path}. Found: "
+        f"{_describe_directory(path)}. "
+        "Specify the format with --from ndjson|bundles|parquet|delta.",
+        exit_code=EXIT_USAGE,
+    )
+
+
+def resolve_source(
+    path_str: str,
+    from_format: Optional[str] = None,
+    allow_resource: bool = False,
+) -> SourceSpec:
+    """Resolves a source path and format, validating before Spark startup.
+
+    :param path_str: the positional source path.
+    :param from_format: an explicit ``--from`` override, or None to auto-detect.
+    :param allow_resource: whether a single resource JSON file is permitted.
+    :return: the resolved :class:`SourceSpec`.
+    :raises CliError: when the path is invalid or the format cannot be resolved.
+    """
+    path = Path(path_str)
+    if from_format is not None:
+        if not path.exists():
+            raise CliError(
+                f"Input path does not exist: {path}. "
+                "Check the path relative to your working directory.",
+                exit_code=EXIT_USAGE,
+            )
+        return SourceSpec(path=path, format=from_format)
+    return SourceSpec(path=path, format=detect_format(path, allow_resource))
+
+
+def discover_bundle_resource_types(path: Path) -> List[str]:
+    """Discovers the distinct resource types contained in a directory of
+    FHIR Bundles.
+
+    :param path: the directory of bundle JSON files.
+    :return: a sorted list of distinct resource type codes found in the bundle
+             entries.
+    :raises CliError: when no resource types can be found.
+    """
+    types = set()
+    for entry in sorted(path.iterdir()):
+        if entry.suffix != ".json":
+            continue
+        try:
+            with open(entry, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, ValueError):
+            continue
+        for bundle_entry in data.get("entry", []) or []:
+            resource = bundle_entry.get("resource") or {}
+            resource_type = resource.get("resourceType")
+            if resource_type:
+                types.add(resource_type)
+    if not types:
+        raise CliError(
+            f"No FHIR resources were found in the bundles at {path}. "
+            "Check that the directory contains FHIR Bundle JSON files."
+        )
+    return sorted(types)
+
+
+def read_single_resource(path: Path) -> tuple:
+    """Reads a single FHIR resource JSON file.
+
+    :param path: the path to the resource file.
+    :return: a tuple of (resource_type, resource_json_string).
+    :raises CliError: when the file cannot be read or has no resource type.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+        data = json.loads(text)
+    except (OSError, ValueError) as exc:
+        raise CliError(f"Could not read the FHIR resource at {path}: {exc}.") from exc
+    resource_type = data.get("resourceType")
+    if not resource_type:
+        raise CliError(
+            f"The file {path} does not contain a 'resourceType' and is not a "
+            "FHIR resource."
+        )
+    return resource_type, text
+
+
+def read_source(pc, spec: SourceSpec):
+    """Reads a :class:`SourceSpec` into a Pathling ``DataSource``.
+
+    :param pc: the :class:`PathlingContext` to read with.
+    :param spec: the resolved source specification.
+    :return: a Pathling ``DataSource`` for the input.
+    :raises CliError: when the format is not a data source format.
+    """
+    path = str(spec.path)
+    if spec.format == SourceFormat.NDJSON:
+        return pc.read.ndjson(path)
+    if spec.format == SourceFormat.BUNDLES:
+        types = discover_bundle_resource_types(spec.path)
+        return pc.read.bundles(path, types)
+    if spec.format == SourceFormat.PARQUET:
+        return pc.read.parquet(path)
+    if spec.format == SourceFormat.DELTA:
+        return pc.read.delta(path)
+    raise CliError(
+        f"Cannot read '{spec.format}' as a data source.", exit_code=EXIT_USAGE
+    )

--- a/lib/python/pathling/cli/main.py
+++ b/lib/python/pathling/cli/main.py
@@ -44,6 +44,7 @@ from pathling.cli import view as view_module
 from pathling.cli.config import CliConfig, resolve_config
 from pathling.cli.errors import EXIT_RUNTIME, CliError, friendly_message
 from pathling.cli.render import stderr_console
+from pathling.cli.sparkconf import parse_spark_conf_flags
 
 
 @dataclass
@@ -119,6 +120,14 @@ class PathlingCli(click.Group):
     "--fhir-version", help="FHIR version (config key: fhir-version; default R4)."
 )
 @click.option(
+    "--spark-conf",
+    "spark_conf",
+    metavar="KEY=VALUE",
+    multiple=True,
+    help="Set a Spark configuration property "
+    "(repeatable; overrides the [spark] config table).",
+)
+@click.option(
     "--config",
     "config_path",
     type=click.Path(path_type=Path),
@@ -139,6 +148,7 @@ def cli(
     tx_token_endpoint,
     tx_scope,
     fhir_version,
+    spark_conf,
     config_path,
     verbose,
 ):
@@ -159,6 +169,7 @@ def cli(
         tx_token_endpoint=tx_token_endpoint,
         tx_scope=tx_scope,
         fhir_version=fhir_version,
+        spark_conf_flags=parse_spark_conf_flags(spark_conf),
         verbose=verbose,
         config_path=config_path,
         on_warning=lambda message: console.print(message, style="yellow"),

--- a/lib/python/pathling/cli/main.py
+++ b/lib/python/pathling/cli/main.py
@@ -34,9 +34,11 @@ import click
 from rich.console import Console
 
 from pathling._version import __version__
+from pathling.cli import console as console_module
 from pathling.cli import convert as convert_module
 from pathling.cli import export as export_module
 from pathling.cli import fhirpath as fhirpath_module
+from pathling.cli import run as run_module
 from pathling.cli import terminology as terminology_module
 from pathling.cli import view as view_module
 from pathling.cli.config import CliConfig, resolve_config
@@ -143,8 +145,9 @@ def cli(
     """Pathling: a command line interface for FHIR analytics.
 
     Run a SQL on FHIR view, evaluate FHIRPath, convert FHIR data between
-    formats, bulk export from a FHIR server, or run terminology operations
-    over a dataset of codes. Configuration may be set with global flags or a
+    formats, bulk export from a FHIR server, run terminology operations
+    over a dataset of codes, or script and explore interactively with the
+    run and console commands. Configuration may be set with global flags or a
     TOML config file at $XDG_CONFIG_HOME/pathling/config.toml (flags take
     precedence).
     """
@@ -168,6 +171,10 @@ cli.add_command(convert_module.convert)
 cli.add_command(view_module.view)
 cli.add_command(fhirpath_module.fhirpath)
 cli.add_command(export_module.export)
+
+# Register the scripting commands.
+cli.add_command(run_module.run)
+cli.add_command(console_module.console)
 
 # Register the terminology commands.
 for _terminology_command in terminology_module.TERMINOLOGY_COMMANDS:

--- a/lib/python/pathling/cli/main.py
+++ b/lib/python/pathling/cli/main.py
@@ -1,0 +1,178 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""The root command group for the Pathling command line interface.
+
+This module defines the global options, resolves configuration, registers every
+subcommand, and installs a single central error handler that turns exceptions
+(including unwrapped JVM exceptions) into concise messages with appropriate exit
+codes. Heavy imports (PySpark, the JVM-backed library) are deferred to command
+execution so that ``--help`` and ``--version`` stay fast.
+
+Author: John Grimes.
+"""
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+from pathling._version import __version__
+from pathling.cli import convert as convert_module
+from pathling.cli import export as export_module
+from pathling.cli import fhirpath as fhirpath_module
+from pathling.cli import terminology as terminology_module
+from pathling.cli import view as view_module
+from pathling.cli.config import CliConfig, resolve_config
+from pathling.cli.errors import EXIT_RUNTIME, CliError, friendly_message
+from pathling.cli.render import stderr_console
+
+
+@dataclass
+class CliContext:
+    """The object carried on the Click context for every command.
+
+    :param config: the resolved global configuration.
+    :param console: the stderr console for progress and error output.
+    """
+
+    config: CliConfig
+    console: Console
+
+
+def _console_from(ctx: click.Context) -> Console:
+    """Returns the stderr console from the context, or a fresh one.
+
+    :param ctx: the Click context.
+    :return: a console for writing error output.
+    """
+    if isinstance(ctx.obj, CliContext):
+        return ctx.obj.console
+    return stderr_console()
+
+
+def _verbose_from(ctx: click.Context) -> bool:
+    """Returns whether verbose mode is active for the context.
+
+    :param ctx: the Click context.
+    :return: True when verbose output was requested.
+    """
+    return isinstance(ctx.obj, CliContext) and ctx.obj.config.verbose
+
+
+class PathlingCli(click.Group):
+    """The root group with centralised error handling and exit codes."""
+
+    def invoke(self, ctx: click.Context):
+        """Invokes a command, mapping errors to friendly messages and codes.
+
+        :param ctx: the Click context.
+        :return: the command's return value on success.
+        """
+        try:
+            return super().invoke(ctx)
+        except click.exceptions.Exit:
+            # Normal exits from eager options such as --help and --version
+            # carry their own exit code; let them propagate untouched.
+            raise
+        except (KeyboardInterrupt, click.exceptions.Abort):
+            _console_from(ctx).print("\nAborted.", style="yellow")
+            sys.exit(EXIT_RUNTIME)
+        except click.ClickException:
+            # Let Click render usage errors (exit code 2) itself.
+            raise
+        except CliError as exc:
+            _console_from(ctx).print(exc.message, style="red")
+            sys.exit(exc.exit_code)
+        except Exception as exc:  # noqa: BLE001 - the central runtime handler.
+            message = friendly_message(exc, verbose=_verbose_from(ctx))
+            _console_from(ctx).print(message, style="red")
+            sys.exit(EXIT_RUNTIME)
+
+
+@click.group(cls=PathlingCli, context_settings={"help_option_names": ["-h", "--help"]})
+@click.version_option(version=__version__, prog_name="pathling")
+@click.option("--tx-server", help="Terminology server URL (config key: tx-server).")
+@click.option("--tx-client-id", help="Terminology auth client ID.")
+@click.option("--tx-client-secret", help="Terminology auth client secret.")
+@click.option("--tx-token-endpoint", help="Terminology auth token endpoint.")
+@click.option("--tx-scope", help="Terminology auth scope.")
+@click.option(
+    "--fhir-version", help="FHIR version (config key: fhir-version; default R4)."
+)
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(path_type=Path),
+    help="Path to the TOML config file "
+    "(default: $XDG_CONFIG_HOME/pathling/config.toml).",
+)
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Enable Spark/JVM logging and full stack traces on error.",
+)
+@click.pass_context
+def cli(
+    ctx: click.Context,
+    tx_server,
+    tx_client_id,
+    tx_client_secret,
+    tx_token_endpoint,
+    tx_scope,
+    fhir_version,
+    config_path,
+    verbose,
+):
+    """Pathling: a command line interface for FHIR analytics.
+
+    Run a SQL on FHIR view, evaluate FHIRPath, convert FHIR data between
+    formats, bulk export from a FHIR server, or run terminology operations
+    over a dataset of codes. Configuration may be set with global flags or a
+    TOML config file at $XDG_CONFIG_HOME/pathling/config.toml (flags take
+    precedence).
+    """
+    console = stderr_console()
+    config = resolve_config(
+        tx_server=tx_server,
+        tx_client_id=tx_client_id,
+        tx_client_secret=tx_client_secret,
+        tx_token_endpoint=tx_token_endpoint,
+        tx_scope=tx_scope,
+        fhir_version=fhir_version,
+        verbose=verbose,
+        config_path=config_path,
+        on_warning=lambda message: console.print(message, style="yellow"),
+    )
+    ctx.obj = CliContext(config=config, console=console)
+
+
+# Register the data commands.
+cli.add_command(convert_module.convert)
+cli.add_command(view_module.view)
+cli.add_command(fhirpath_module.fhirpath)
+cli.add_command(export_module.export)
+
+# Register the terminology commands.
+for _terminology_command in terminology_module.TERMINOLOGY_COMMANDS:
+    cli.add_command(_terminology_command)
+
+
+if __name__ == "__main__":
+    cli()

--- a/lib/python/pathling/cli/main.py
+++ b/lib/python/pathling/cli/main.py
@@ -29,6 +29,7 @@ Author: John Grimes.
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 import click
 from rich.console import Console
@@ -79,6 +80,21 @@ def _verbose_from(ctx: click.Context) -> bool:
     return isinstance(ctx.obj, CliContext) and ctx.obj.config.verbose
 
 
+def _server_url_from(ctx: click.Context) -> Optional[str]:
+    """Returns the configured terminology server URL for the context, or None.
+
+    Threaded into the friendly error message so a connection failure from
+    convert/view/fhirpath names the server it could not reach (FR-011). The
+    terminology commands enrich their own connection errors, so this only
+    affects the generic ``Exception`` path used by the other commands.
+
+    :param ctx: the Click context.
+    :return: the configured terminology server URL, or None when no context is
+             present.
+    """
+    return ctx.obj.config.tx_server if isinstance(ctx.obj, CliContext) else None
+
+
 class PathlingCli(click.Group):
     """The root group with centralised error handling and exit codes."""
 
@@ -104,7 +120,11 @@ class PathlingCli(click.Group):
             _console_from(ctx).print(exc.message, style="red")
             sys.exit(exc.exit_code)
         except Exception as exc:  # noqa: BLE001 - the central runtime handler.
-            message = friendly_message(exc, verbose=_verbose_from(ctx))
+            message = friendly_message(
+                exc,
+                verbose=_verbose_from(ctx),
+                server_url=_server_url_from(ctx),
+            )
             _console_from(ctx).print(message, style="red")
             sys.exit(EXIT_RUNTIME)
 

--- a/lib/python/pathling/cli/main.py
+++ b/lib/python/pathling/cli/main.py
@@ -162,6 +162,7 @@ def cli(
         verbose=verbose,
         config_path=config_path,
         on_warning=lambda message: console.print(message, style="yellow"),
+        on_notice=lambda message: console.print(message, style="dim"),
     )
     ctx.obj = CliContext(config=config, console=console)
 

--- a/lib/python/pathling/cli/render.py
+++ b/lib/python/pathling/cli/render.py
@@ -44,7 +44,7 @@ from pathling.cli.departition import departition, remove_path
 from pathling.cli.errors import EXIT_USAGE, CliError
 
 # The default cap on rows collected for stdout table rendering.
-DEFAULT_LIMIT = 1000
+DEFAULT_LIMIT = 50
 
 
 class OutputFormat:

--- a/lib/python/pathling/cli/render.py
+++ b/lib/python/pathling/cli/render.py
@@ -341,7 +341,8 @@ def write_output(df, spec: OutputSpec, console: Console) -> None:
 
     For stdout, the table format is capped at ``spec.limit`` rows; other
     formats stream the full result. File output is written as a single file for
-    CSV/JSON/NDJSON/Parquet and as a Delta table directory for Delta.
+    CSV/JSON/NDJSON/Parquet (Parquet via Arrow to preserve column types) and as
+    a Delta table directory for Delta.
 
     :param df: the result Spark DataFrame.
     :param spec: the resolved output specification.
@@ -369,6 +370,16 @@ def write_output(df, spec: OutputSpec, console: Console) -> None:
 def _write_file(df, spec: OutputSpec) -> int:
     """Writes a result DataFrame to a file in the resolved format.
 
+    Parquet is collected to an Arrow table and written directly, which
+    preserves column types faithfully (in particular nested struct and array
+    columns, which a pandas round-trip degrades to anonymous lists, and
+    nullable integers, which pandas coerces to floating point). CSV, JSON, and
+    NDJSON are collected via pandas and written with its text serialisers. In
+    every case the output is a single file rather than a directory of Spark
+    part files, and the row count is taken from the materialised result to
+    avoid a second query execution (which would re-run terminology UDFs against
+    the server).
+
     :param df: the result Spark DataFrame.
     :param spec: the resolved output specification with a non-None path.
     :return: the number of rows written.
@@ -381,10 +392,13 @@ def _write_file(df, spec: OutputSpec) -> int:
         writer.save(str(path))
         return df.count()
 
-    # Single-file formats are materialised on the driver via pandas so the
-    # output is a single file rather than a directory of Spark part files. The
-    # row count is taken from the materialised frame to avoid a second query
-    # execution (which would re-run terminology UDFs against the server).
+    if spec.format == OutputFormat.PARQUET:
+        import pyarrow.parquet as pq
+
+        table = df.toArrow()
+        pq.write_table(table, str(path))
+        return table.num_rows
+
     pdf = df.toPandas()
     if spec.format == OutputFormat.CSV:
         pdf.to_csv(path, index=False)
@@ -392,6 +406,4 @@ def _write_file(df, spec: OutputSpec) -> int:
         pdf.to_json(path, orient="records", indent=2)
     elif spec.format == OutputFormat.NDJSON:
         pdf.to_json(path, orient="records", lines=True)
-    elif spec.format == OutputFormat.PARQUET:
-        pdf.to_parquet(path, index=False)
     return len(pdf)

--- a/lib/python/pathling/cli/render.py
+++ b/lib/python/pathling/cli/render.py
@@ -57,14 +57,6 @@ class OutputFormat:
     DELTA = "delta"
 
 
-# Formats that may be written to a file with ``-o``.
-FILE_FORMATS = (
-    OutputFormat.CSV,
-    OutputFormat.NDJSON,
-    OutputFormat.PARQUET,
-    OutputFormat.DELTA,
-)
-
 # Formats that require ``-o`` because they cannot render to stdout.
 PATH_REQUIRED_FORMATS = (OutputFormat.PARQUET, OutputFormat.DELTA)
 

--- a/lib/python/pathling/cli/render.py
+++ b/lib/python/pathling/cli/render.py
@@ -34,6 +34,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Sequence
 
+import click
 from rich.console import Console
 from rich.table import Table
 
@@ -65,6 +66,53 @@ FILE_FORMATS = (
 
 # Formats that require ``-o`` because they cannot render to stdout.
 PATH_REQUIRED_FORMATS = (OutputFormat.PARQUET, OutputFormat.DELTA)
+
+# The complete set of output formats accepted by the ``--format`` option, shared
+# by every command that produces tabular output.
+OUTPUT_FORMAT_CHOICE = click.Choice(
+    [
+        OutputFormat.TABLE,
+        OutputFormat.CSV,
+        OutputFormat.JSON,
+        OutputFormat.NDJSON,
+        OutputFormat.PARQUET,
+        OutputFormat.DELTA,
+    ]
+)
+
+
+def output_options(func):
+    """Applies the shared ``--format``/``-o``/``--limit``/``--overwrite`` options.
+
+    These four options form the common output surface of every command that
+    emits a result DataFrame, and are resolved together by
+    :func:`resolve_output` and consumed by :func:`write_output`.
+
+    :param func: the command callback to decorate.
+    :return: the decorated callback.
+    """
+    options = [
+        click.option(
+            "--format",
+            "output_format",
+            type=OUTPUT_FORMAT_CHOICE,
+            help="Output format (default: table; inferred from -o extension).",
+        ),
+        click.option("-o", "--output", "output", help="Write results to this path."),
+        click.option(
+            "--limit",
+            default=DEFAULT_LIMIT,
+            show_default=True,
+            help="Row cap for table output.",
+        ),
+        click.option(
+            "--overwrite", is_flag=True, help="Replace an existing output path."
+        ),
+    ]
+    for option in reversed(options):
+        func = option(func)
+    return func
+
 
 # Maps file extensions to output formats for inference.
 _EXTENSION_FORMATS = {

--- a/lib/python/pathling/cli/render.py
+++ b/lib/python/pathling/cli/render.py
@@ -17,11 +17,12 @@
 
 """Output rendering and progress reporting for the command line interface.
 
-Tabular results render to a human-readable table by default, with CSV, JSON,
-and NDJSON alternatives for piping, and file output (including Parquet and
-Delta) via ``-o``. Data is written to stdout; progress, status, and the
-row-count confirmation for file output go to stderr so that piped output stays
-clean.
+Tabular results render to a human-readable table by default, with CSV and
+NDJSON alternatives for piping, and file output (CSV, NDJSON, Parquet, and
+Delta) via ``-o``. File output is produced by Spark's native writers and, by
+default, departitioned to a single file at the requested path. Data is written
+to stdout; progress, status, and the write confirmation go to stderr so that
+piped output stays clean.
 
 Author: John Grimes.
 """
@@ -29,6 +30,7 @@ Author: John Grimes.
 import csv
 import io
 import json
+import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -38,6 +40,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from pathling.cli.departition import departition, remove_path
 from pathling.cli.errors import EXIT_USAGE, CliError
 
 # The default cap on rows collected for stdout table rendering.
@@ -49,7 +52,6 @@ class OutputFormat:
 
     TABLE = "table"
     CSV = "csv"
-    JSON = "json"
     NDJSON = "ndjson"
     PARQUET = "parquet"
     DELTA = "delta"
@@ -58,7 +60,6 @@ class OutputFormat:
 # Formats that may be written to a file with ``-o``.
 FILE_FORMATS = (
     OutputFormat.CSV,
-    OutputFormat.JSON,
     OutputFormat.NDJSON,
     OutputFormat.PARQUET,
     OutputFormat.DELTA,
@@ -67,13 +68,21 @@ FILE_FORMATS = (
 # Formats that require ``-o`` because they cannot render to stdout.
 PATH_REQUIRED_FORMATS = (OutputFormat.PARQUET, OutputFormat.DELTA)
 
+# Maps each departitioned file format to the extension Spark gives its part
+# files, used to select the single data file from the temporary output
+# directory.
+_PART_EXTENSIONS = {
+    OutputFormat.CSV: "csv",
+    OutputFormat.NDJSON: "json",
+    OutputFormat.PARQUET: "parquet",
+}
+
 # The complete set of output formats accepted by the ``--format`` option, shared
 # by every command that produces tabular output.
 OUTPUT_FORMAT_CHOICE = click.Choice(
     [
         OutputFormat.TABLE,
         OutputFormat.CSV,
-        OutputFormat.JSON,
         OutputFormat.NDJSON,
         OutputFormat.PARQUET,
         OutputFormat.DELTA,
@@ -82,11 +91,12 @@ OUTPUT_FORMAT_CHOICE = click.Choice(
 
 
 def output_options(func):
-    """Applies the shared ``--format``/``-o``/``--limit``/``--overwrite`` options.
+    """Applies the shared output options to a command callback.
 
-    These four options form the common output surface of every command that
-    emits a result DataFrame, and are resolved together by
-    :func:`resolve_output` and consumed by :func:`write_output`.
+    These options form the common output surface of every command that emits a
+    result DataFrame - ``--format``, ``-o``/``--output``, ``--limit``,
+    ``--overwrite``, and ``--departition/--no-departition`` - and are resolved
+    together by :func:`resolve_output` and consumed by :func:`write_output`.
 
     :param func: the command callback to decorate.
     :return: the decorated callback.
@@ -108,6 +118,14 @@ def output_options(func):
         click.option(
             "--overwrite", is_flag=True, help="Replace an existing output path."
         ),
+        click.option(
+            "--departition/--no-departition",
+            "departition",
+            default=True,
+            show_default=True,
+            help="Write file output as a single file (or a Spark directory of "
+            "part files).",
+        ),
     ]
     for option in reversed(options):
         func = option(func)
@@ -117,7 +135,6 @@ def output_options(func):
 # Maps file extensions to output formats for inference.
 _EXTENSION_FORMATS = {
     ".csv": OutputFormat.CSV,
-    ".json": OutputFormat.JSON,
     ".ndjson": OutputFormat.NDJSON,
     ".jsonl": OutputFormat.NDJSON,
     ".parquet": OutputFormat.PARQUET,
@@ -132,12 +149,15 @@ class OutputSpec:
     :param format: one of the :class:`OutputFormat` values.
     :param limit: the row cap for stdout table rendering.
     :param overwrite: whether an existing output path may be replaced.
+    :param departition: whether file output is departitioned to a single file
+           (the default) rather than left as a Spark directory of part files.
     """
 
     path: Optional[Path]
     format: str
     limit: int = DEFAULT_LIMIT
     overwrite: bool = False
+    departition: bool = True
 
 
 def infer_format_from_extension(path: Path) -> Optional[str]:
@@ -154,6 +174,7 @@ def resolve_output(
     format_flag: Optional[str],
     limit: int = DEFAULT_LIMIT,
     overwrite: bool = False,
+    departition: bool = True,
 ) -> OutputSpec:
     """Resolves and validates output options.
 
@@ -161,6 +182,7 @@ def resolve_output(
     :param format_flag: the ``--format`` value, or None to default/infer.
     :param limit: the stdout table row cap.
     :param overwrite: whether replacing an existing output path is allowed.
+    :param departition: whether file output is departitioned to a single file.
     :return: the resolved :class:`OutputSpec`.
     :raises CliError: when the combination of options is invalid.
     """
@@ -169,11 +191,19 @@ def resolve_output(
     if format_flag is not None:
         fmt = format_flag
     elif path is not None:
+        if path.suffix.lower() == ".json":
+            # The JSON-array format has been removed; point the user at NDJSON
+            # rather than silently treating a .json file as newline-delimited.
+            raise CliError(
+                "The JSON-array output format has been removed. Use --format "
+                "ndjson, or a .ndjson filename, for newline-delimited JSON.",
+                exit_code=EXIT_USAGE,
+            )
         inferred = infer_format_from_extension(path)
         if inferred is None:
             raise CliError(
                 f"Could not infer an output format from '{path}'. "
-                "Use --format csv|json|ndjson|parquet|delta.",
+                "Use --format csv|ndjson|parquet|delta.",
                 exit_code=EXIT_USAGE,
             )
         fmt = inferred
@@ -183,7 +213,7 @@ def resolve_output(
     if fmt == OutputFormat.TABLE and path is not None:
         raise CliError(
             "The table format cannot be written to a file. Use --format "
-            "csv|json|ndjson|parquet|delta with -o, or drop -o for a table.",
+            "csv|ndjson|parquet|delta with -o, or drop -o for a table.",
             exit_code=EXIT_USAGE,
         )
     if fmt in PATH_REQUIRED_FORMATS and path is None:
@@ -192,7 +222,13 @@ def resolve_output(
             exit_code=EXIT_USAGE,
         )
 
-    return OutputSpec(path=path, format=fmt, limit=limit, overwrite=overwrite)
+    return OutputSpec(
+        path=path,
+        format=fmt,
+        limit=limit,
+        overwrite=overwrite,
+        departition=departition,
+    )
 
 
 def check_overwrite(path: Path, overwrite: bool) -> None:
@@ -262,16 +298,6 @@ def _records(columns: Sequence[str], rows: Sequence[Sequence]) -> List[dict]:
     return [dict(zip(columns, row)) for row in rows]
 
 
-def render_json(columns: Sequence[str], rows: Sequence[Sequence]) -> str:
-    """Renders rows as a JSON array of objects.
-
-    :param columns: the column names.
-    :param rows: the row values.
-    :return: the JSON text.
-    """
-    return json.dumps(_records(columns, rows), default=str, indent=2)
-
-
 def render_ndjson(columns: Sequence[str], rows: Sequence[Sequence]) -> str:
     """Renders rows as newline-delimited JSON objects.
 
@@ -289,7 +315,7 @@ def render_rows(columns: Sequence[str], rows: Sequence[Sequence], fmt: str) -> s
 
     :param columns: the column names.
     :param rows: the row values.
-    :param fmt: one of table, csv, json, or ndjson.
+    :param fmt: one of table, csv, or ndjson.
     :return: the rendered text.
     :raises CliError: when the format cannot render to stdout.
     """
@@ -297,8 +323,6 @@ def render_rows(columns: Sequence[str], rows: Sequence[Sequence], fmt: str) -> s
         return render_table(columns, rows)
     if fmt == OutputFormat.CSV:
         return render_csv(columns, rows)
-    if fmt == OutputFormat.JSON:
-        return render_json(columns, rows)
     if fmt == OutputFormat.NDJSON:
         return render_ndjson(columns, rows)
     raise CliError(
@@ -340,9 +364,9 @@ def write_output(df, spec: OutputSpec, console: Console) -> None:
     """Writes a result DataFrame to stdout or a file per the output spec.
 
     For stdout, the table format is capped at ``spec.limit`` rows; other
-    formats stream the full result. File output is written as a single file for
-    CSV/JSON/NDJSON/Parquet (Parquet via Arrow to preserve column types) and as
-    a Delta table directory for Delta.
+    formats stream the full result. File output is produced by Spark's native
+    writers (see :func:`_write_file`) and confirmed with a single stderr line
+    naming the format and path.
 
     :param df: the result Spark DataFrame.
     :param spec: the resolved output specification.
@@ -363,47 +387,78 @@ def write_output(df, spec: OutputSpec, console: Console) -> None:
         return
 
     check_overwrite(spec.path, spec.overwrite)
-    count = _write_file(df, spec)
-    console.print(f"Wrote {count} rows to {spec.path}.")
+    _write_file(df, spec)
+    console.print(f"Wrote {spec.format} output to {spec.path}.")
 
 
-def _write_file(df, spec: OutputSpec) -> int:
-    """Writes a result DataFrame to a file in the resolved format.
+def _write_file(df, spec: OutputSpec) -> None:
+    """Writes a result DataFrame to a file using Spark's native writers.
 
-    Parquet is collected to an Arrow table and written directly, which
-    preserves column types faithfully (in particular nested struct and array
-    columns, which a pandas round-trip degrades to anonymous lists, and
-    nullable integers, which pandas coerces to floating point). CSV, JSON, and
-    NDJSON are collected via pandas and written with its text serialisers. In
-    every case the output is a single file rather than a directory of Spark
-    part files, and the row count is taken from the materialised result to
-    avoid a second query execution (which would re-run terminology UDFs against
-    the server).
+    CSV, NDJSON, and Parquet are written by Spark rather than collected onto
+    the driver, so a result larger than driver memory can be written. By
+    default the output is departitioned to a single file: the frame is
+    repartitioned to one partition, written to a uniquely named temporary
+    directory beside the target (on the same filesystem, so the final move is a
+    rename), and the single data part file is moved to the target path before
+    the temporary directory is removed. Delta is always written as a Spark
+    table directory and is never departitioned.
+
+    No row count is reported: a Spark write returns none, and obtaining one
+    would require collecting the result or re-executing the query (re-running
+    terminology UDFs against the server).
 
     :param df: the result Spark DataFrame.
     :param spec: the resolved output specification with a non-None path.
-    :return: the number of rows written.
+    :raises CliError: when departitioning finds more than one data part file.
     """
     path = spec.path
+    spark = df.sparkSession
+
     if spec.format == OutputFormat.DELTA:
         writer = df.write.format("delta")
         if spec.overwrite:
             writer = writer.mode("overwrite")
         writer.save(str(path))
-        return df.count()
+        return
 
-    if spec.format == OutputFormat.PARQUET:
-        import pyarrow.parquet as pq
+    # Replace any existing target up front when overwriting, so a directory
+    # write or a departition move into place finds a clear path (Delta handles
+    # its own overwrite above).
+    if spec.overwrite:
+        remove_path(spark, path)
 
-        table = df.toArrow()
-        pq.write_table(table, str(path))
-        return table.num_rows
+    if not spec.departition:
+        # Leave Spark's native directory of part files at the target, written
+        # with full parallelism (no repartition to a single partition).
+        _write_spark_directory(df, spec.format, path)
+        return
 
-    pdf = df.toPandas()
-    if spec.format == OutputFormat.CSV:
-        pdf.to_csv(path, index=False)
-    elif spec.format == OutputFormat.JSON:
-        pdf.to_json(path, orient="records", indent=2)
-    elif spec.format == OutputFormat.NDJSON:
-        pdf.to_json(path, orient="records", lines=True)
-    return len(pdf)
+    part_extension = _PART_EXTENSIONS[spec.format]
+    # A uniquely named, hidden sibling of the target keeps the temporary output
+    # on the same filesystem so departitioning moves rather than copies.
+    temp_dir = path.parent / f".{path.name}.departition-{uuid.uuid4().hex}"
+    try:
+        _write_spark_directory(df.repartition(1), spec.format, temp_dir)
+        departition(spark, temp_dir, path, part_extension)
+    finally:
+        # Always remove the temporary directory, including on a write failure.
+        remove_path(spark, temp_dir)
+
+
+def _write_spark_directory(frame, fmt: str, target_dir) -> None:
+    """Writes a frame to a Spark directory of part files in the given format.
+
+    :param frame: the Spark DataFrame to write (already repartitioned as
+           required by the caller).
+    :param fmt: the file format - CSV, NDJSON, or Parquet.
+    :param target_dir: the directory Spark writes its part files into.
+    """
+    writer = frame.write.mode("overwrite")
+    if fmt == OutputFormat.CSV:
+        writer.option("header", "true").csv(str(target_dir))
+    elif fmt == OutputFormat.NDJSON:
+        # Retain null-valued fields so every record carries the same keys,
+        # matching the prior driver-side behaviour.
+        writer.option("ignoreNullFields", "false").json(str(target_dir))
+    else:
+        writer.parquet(str(target_dir))

--- a/lib/python/pathling/cli/render.py
+++ b/lib/python/pathling/cli/render.py
@@ -1,0 +1,349 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Output rendering and progress reporting for the command line interface.
+
+Tabular results render to a human-readable table by default, with CSV, JSON,
+and NDJSON alternatives for piping, and file output (including Parquet and
+Delta) via ``-o``. Data is written to stdout; progress, status, and the
+row-count confirmation for file output go to stderr so that piped output stays
+clean.
+
+Author: John Grimes.
+"""
+
+import csv
+import io
+import json
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+from rich.console import Console
+from rich.table import Table
+
+from pathling.cli.errors import EXIT_USAGE, CliError
+
+# The default cap on rows collected for stdout table rendering.
+DEFAULT_LIMIT = 1000
+
+
+class OutputFormat:
+    """The recognised output formats."""
+
+    TABLE = "table"
+    CSV = "csv"
+    JSON = "json"
+    NDJSON = "ndjson"
+    PARQUET = "parquet"
+    DELTA = "delta"
+
+
+# Formats that may be written to a file with ``-o``.
+FILE_FORMATS = (
+    OutputFormat.CSV,
+    OutputFormat.JSON,
+    OutputFormat.NDJSON,
+    OutputFormat.PARQUET,
+    OutputFormat.DELTA,
+)
+
+# Formats that require ``-o`` because they cannot render to stdout.
+PATH_REQUIRED_FORMATS = (OutputFormat.PARQUET, OutputFormat.DELTA)
+
+# Maps file extensions to output formats for inference.
+_EXTENSION_FORMATS = {
+    ".csv": OutputFormat.CSV,
+    ".json": OutputFormat.JSON,
+    ".ndjson": OutputFormat.NDJSON,
+    ".jsonl": OutputFormat.NDJSON,
+    ".parquet": OutputFormat.PARQUET,
+}
+
+
+@dataclass
+class OutputSpec:
+    """Describes where and how results leave the CLI.
+
+    :param path: the output path, or None to write to stdout.
+    :param format: one of the :class:`OutputFormat` values.
+    :param limit: the row cap for stdout table rendering.
+    :param overwrite: whether an existing output path may be replaced.
+    """
+
+    path: Optional[Path]
+    format: str
+    limit: int = DEFAULT_LIMIT
+    overwrite: bool = False
+
+
+def infer_format_from_extension(path: Path) -> Optional[str]:
+    """Infers an output format from a file extension.
+
+    :param path: the output path.
+    :return: the inferred format, or None when the extension is unrecognised.
+    """
+    return _EXTENSION_FORMATS.get(path.suffix.lower())
+
+
+def resolve_output(
+    output_path: Optional[str],
+    format_flag: Optional[str],
+    limit: int = DEFAULT_LIMIT,
+    overwrite: bool = False,
+) -> OutputSpec:
+    """Resolves and validates output options.
+
+    :param output_path: the ``-o`` path, or None for stdout.
+    :param format_flag: the ``--format`` value, or None to default/infer.
+    :param limit: the stdout table row cap.
+    :param overwrite: whether replacing an existing output path is allowed.
+    :return: the resolved :class:`OutputSpec`.
+    :raises CliError: when the combination of options is invalid.
+    """
+    path = Path(output_path) if output_path else None
+
+    if format_flag is not None:
+        fmt = format_flag
+    elif path is not None:
+        inferred = infer_format_from_extension(path)
+        if inferred is None:
+            raise CliError(
+                f"Could not infer an output format from '{path}'. "
+                "Use --format csv|json|ndjson|parquet|delta.",
+                exit_code=EXIT_USAGE,
+            )
+        fmt = inferred
+    else:
+        fmt = OutputFormat.TABLE
+
+    if fmt == OutputFormat.TABLE and path is not None:
+        raise CliError(
+            "The table format cannot be written to a file. Use --format "
+            "csv|json|ndjson|parquet|delta with -o, or drop -o for a table.",
+            exit_code=EXIT_USAGE,
+        )
+    if fmt in PATH_REQUIRED_FORMATS and path is None:
+        raise CliError(
+            f"The {fmt} format requires an output path. Add -o <path>.",
+            exit_code=EXIT_USAGE,
+        )
+
+    return OutputSpec(path=path, format=fmt, limit=limit, overwrite=overwrite)
+
+
+def check_overwrite(path: Path, overwrite: bool) -> None:
+    """Fails when an output path already exists and overwrite was not requested.
+
+    :param path: the output path to check.
+    :param overwrite: whether overwriting is permitted.
+    :raises CliError: when the path exists and overwrite is False.
+    """
+    if path.exists() and not overwrite:
+        raise CliError(
+            f"Output path already exists: {path}. Pass --overwrite to replace it."
+        )
+
+
+def _cell(value: object) -> str:
+    """Formats a value as a table cell string.
+
+    :param value: the cell value.
+    :return: an empty string for None, otherwise the string form.
+    """
+    return "" if value is None else str(value)
+
+
+def render_table(columns: Sequence[str], rows: Sequence[Sequence]) -> str:
+    """Renders rows as a human-readable table with a row-count caption.
+
+    :param columns: the column names.
+    :param rows: the row values.
+    :return: the rendered table as a string.
+    """
+    table = Table(caption=f"{len(rows)} rows", caption_justify="left")
+    for column in columns:
+        table.add_column(str(column))
+    for row in rows:
+        table.add_row(*[_cell(value) for value in row])
+    buffer = io.StringIO()
+    # Disable markup and highlighting so that data values containing square
+    # brackets (e.g. Spark error codes or array-like strings) render verbatim
+    # rather than being interpreted as Rich markup.
+    Console(file=buffer, width=120, markup=False, highlight=False).print(table)
+    return buffer.getvalue()
+
+
+def render_csv(columns: Sequence[str], rows: Sequence[Sequence]) -> str:
+    """Renders rows as CSV with a header line.
+
+    :param columns: the column names.
+    :param rows: the row values.
+    :return: the CSV text.
+    """
+    buffer = io.StringIO()
+    writer = csv.writer(buffer, lineterminator="\n")
+    writer.writerow(list(columns))
+    for row in rows:
+        writer.writerow(["" if value is None else value for value in row])
+    return buffer.getvalue()
+
+
+def _records(columns: Sequence[str], rows: Sequence[Sequence]) -> List[dict]:
+    """Builds a list of column-keyed dicts from rows.
+
+    :param columns: the column names.
+    :param rows: the row values.
+    :return: a list of record dicts preserving column order.
+    """
+    return [dict(zip(columns, row)) for row in rows]
+
+
+def render_json(columns: Sequence[str], rows: Sequence[Sequence]) -> str:
+    """Renders rows as a JSON array of objects.
+
+    :param columns: the column names.
+    :param rows: the row values.
+    :return: the JSON text.
+    """
+    return json.dumps(_records(columns, rows), default=str, indent=2)
+
+
+def render_ndjson(columns: Sequence[str], rows: Sequence[Sequence]) -> str:
+    """Renders rows as newline-delimited JSON objects.
+
+    :param columns: the column names.
+    :param rows: the row values.
+    :return: the NDJSON text.
+    """
+    return "\n".join(
+        json.dumps(record, default=str) for record in _records(columns, rows)
+    )
+
+
+def render_rows(columns: Sequence[str], rows: Sequence[Sequence], fmt: str) -> str:
+    """Renders rows in the requested stdout format.
+
+    :param columns: the column names.
+    :param rows: the row values.
+    :param fmt: one of table, csv, json, or ndjson.
+    :return: the rendered text.
+    :raises CliError: when the format cannot render to stdout.
+    """
+    if fmt == OutputFormat.TABLE:
+        return render_table(columns, rows)
+    if fmt == OutputFormat.CSV:
+        return render_csv(columns, rows)
+    if fmt == OutputFormat.JSON:
+        return render_json(columns, rows)
+    if fmt == OutputFormat.NDJSON:
+        return render_ndjson(columns, rows)
+    raise CliError(
+        f"The {fmt} format cannot be rendered to stdout.", exit_code=EXIT_USAGE
+    )
+
+
+def stderr_console() -> Console:
+    """Creates a Rich console that writes to stderr.
+
+    Markup and highlighting are disabled so that arbitrary message text - error
+    messages, file paths, and JVM error codes that may contain square brackets -
+    is printed verbatim and never misinterpreted as Rich markup (which would
+    otherwise raise a ``MarkupError``).
+
+    :return: a console bound to stderr for progress and status messages.
+    """
+    return Console(stderr=True, markup=False, highlight=False)
+
+
+@contextmanager
+def progress_status(console: Console, message: str, verbose: bool = False):
+    """Shows a status spinner on stderr for a long-running stage.
+
+    :param console: the stderr console.
+    :param message: the status message to display.
+    :param verbose: when True, print a plain line instead of a spinner so that
+           it does not interfere with verbose log output.
+    """
+    if verbose:
+        console.print(message)
+        yield
+        return
+    with console.status(message):
+        yield
+
+
+def write_output(df, spec: OutputSpec, console: Console) -> None:
+    """Writes a result DataFrame to stdout or a file per the output spec.
+
+    For stdout, the table format is capped at ``spec.limit`` rows; other
+    formats stream the full result. File output is written as a single file for
+    CSV/JSON/NDJSON/Parquet and as a Delta table directory for Delta.
+
+    :param df: the result Spark DataFrame.
+    :param spec: the resolved output specification.
+    :param console: the stderr console for the confirmation message.
+    :raises CliError: when the output path exists without ``--overwrite``.
+    """
+    columns = list(df.columns)
+
+    if spec.path is None:
+        if spec.format == OutputFormat.TABLE:
+            rows = [list(row) for row in df.limit(spec.limit).collect()]
+        else:
+            rows = [list(row) for row in df.collect()]
+        text = render_rows(columns, rows, spec.format)
+        # Strip any trailing newline so print's own newline does not introduce
+        # a spurious blank line (which would parse as an empty CSV row).
+        print(text.rstrip("\n"))
+        return
+
+    check_overwrite(spec.path, spec.overwrite)
+    count = _write_file(df, spec)
+    console.print(f"Wrote {count} rows to {spec.path}.")
+
+
+def _write_file(df, spec: OutputSpec) -> int:
+    """Writes a result DataFrame to a file in the resolved format.
+
+    :param df: the result Spark DataFrame.
+    :param spec: the resolved output specification with a non-None path.
+    :return: the number of rows written.
+    """
+    path = spec.path
+    if spec.format == OutputFormat.DELTA:
+        writer = df.write.format("delta")
+        if spec.overwrite:
+            writer = writer.mode("overwrite")
+        writer.save(str(path))
+        return df.count()
+
+    # Single-file formats are materialised on the driver via pandas so the
+    # output is a single file rather than a directory of Spark part files. The
+    # row count is taken from the materialised frame to avoid a second query
+    # execution (which would re-run terminology UDFs against the server).
+    pdf = df.toPandas()
+    if spec.format == OutputFormat.CSV:
+        pdf.to_csv(path, index=False)
+    elif spec.format == OutputFormat.JSON:
+        pdf.to_json(path, orient="records", indent=2)
+    elif spec.format == OutputFormat.NDJSON:
+        pdf.to_json(path, orient="records", lines=True)
+    elif spec.format == OutputFormat.PARQUET:
+        pdf.to_parquet(path, index=False)
+    return len(pdf)

--- a/lib/python/pathling/cli/resources/quiet-log4j2.properties
+++ b/lib/python/pathling/cli/resources/quiet-log4j2.properties
@@ -1,0 +1,7 @@
+rootLogger.level = off
+appender.console.type = Console
+appender.console.name = console
+appender.console.target = SYSTEM_ERR
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss} %p %c{1}: %m%n
+rootLogger.appenderRef.console.ref = console

--- a/lib/python/pathling/cli/run.py
+++ b/lib/python/pathling/cli/run.py
@@ -1,0 +1,255 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""The ``pathling run`` command.
+
+Executes user-supplied Python code - from a script file, standard input, or an
+inline ``-c`` option - with ``spark`` (the Spark session) and ``pathling`` (the
+configured Pathling context) bound in the code's global scope, reproducing
+Python interpreter script semantics (``sys.argv``, ``__main__``, ``__file__``,
+``sys.path``, traceback fidelity, and ``SystemExit`` propagation).
+
+Author: John Grimes.
+"""
+
+import os
+import sys
+import traceback
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import click
+
+from pathling.cli import session
+from pathling.cli.errors import EXIT_RUNTIME
+
+# The context key under which the raw command arguments are recorded.
+_RAW_ARGS_KEY = "pathling.run.raw_args"
+
+
+@dataclass
+class CodeSource:
+    """A resolved source of program text for execution.
+
+    :param text: the program source code.
+    :param filename: the filename to compile under, which appears in
+           tracebacks and syntax errors (the script path, ``<stdin>``, or
+           ``<string>``).
+    :param argv0: the value for ``sys.argv[0]``, following Python interpreter
+           conventions (the script path, ``-``, or ``-c``).
+    :param path_entry: the entry to prepend to ``sys.path`` (the script's
+           directory for files, ``""`` for stdin and inline code).
+    :param file_attr: the value for ``__file__`` in the program's globals, or
+           None to leave it unset (stdin and inline code).
+    """
+
+    text: str
+    filename: str
+    argv0: str
+    path_entry: str
+    file_attr: Optional[str]
+
+
+class RunCommand(click.Command):
+    """A command that records its raw argument list before parsing.
+
+    The raw arguments are needed to distinguish ``run script.py -c CODE``
+    (a usage error: two code sources) from ``run -c CODE a b`` (inline code
+    with trailing arguments), which parse to the same option values.
+    """
+
+    def parse_args(self, ctx, args):
+        """Stores the raw arguments on the context, then parses as normal.
+
+        :param ctx: the Click context.
+        :param args: the raw argument list for this command.
+        :return: the remaining arguments after parsing.
+        """
+        ctx.meta[_RAW_ARGS_KEY] = list(args)
+        return super().parse_args(ctx, args)
+
+
+def _positional_precedes_code_flag(raw_args) -> bool:
+    """Determines whether a positional argument appears before ``-c``.
+
+    A positional (a script path or ``-``) before the inline-code flag means
+    the user supplied two code sources, which is a usage error. A positional
+    after the flag is simply an argument to the inline program.
+
+    :param raw_args: the raw argument list as typed on the command line.
+    :return: True when a script positional precedes the ``-c`` flag.
+    """
+    for token in raw_args:
+        if token == "-c" or token == "--code" or token.startswith("--code="):
+            return False
+        if token == "--":
+            return False
+        if token == "-" or not token.startswith("-"):
+            return True
+    return False
+
+
+def _resolve_source(ctx, script, code, args) -> Tuple[CodeSource, list]:
+    """Validates the code-source rules and reads the program text.
+
+    Exactly one source is required: a script path, ``-`` (stdin), or
+    ``-c CODE``. All validation happens here, before the Spark session is
+    started.
+
+    :param ctx: the Click context.
+    :param script: the script positional, or None.
+    :param code: the ``-c`` option value, or None.
+    :param args: the trailing arguments tuple.
+    :return: the resolved :class:`CodeSource` and the program's argument list
+             (``sys.argv[1:]``).
+    :raises click.UsageError: when the code-source rules are violated or the
+            script file cannot be read.
+    """
+    if code is not None:
+        if _positional_precedes_code_flag(ctx.meta.get(_RAW_ARGS_KEY, [])):
+            raise click.UsageError(
+                "Cannot use both a script and -c; supply exactly one code source."
+            )
+        # Any positional that Click captured belongs to the program's argv.
+        trailing = ([script] if script is not None else []) + list(args)
+        return (
+            CodeSource(
+                text=code,
+                filename="<string>",
+                argv0="-c",
+                path_entry="",
+                file_attr=None,
+            ),
+            trailing,
+        )
+
+    if script is None:
+        raise click.UsageError(
+            "Supply a code source: a script path, '-' for stdin, or -c CODE."
+        )
+
+    if script == "-":
+        return (
+            CodeSource(
+                text=sys.stdin.read(),
+                filename="<stdin>",
+                argv0="-",
+                path_entry="",
+                file_attr=None,
+            ),
+            list(args),
+        )
+
+    try:
+        with open(script, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError as exc:
+        raise click.UsageError(f"Cannot read script '{script}': {exc}") from exc
+    return (
+        CodeSource(
+            text=text,
+            filename=script,
+            argv0=script,
+            path_entry=os.path.dirname(os.path.abspath(script)),
+            file_attr=script,
+        ),
+        list(args),
+    )
+
+
+def _execute(source: CodeSource, program_args, namespace) -> None:
+    """Compiles and executes the program with interpreter semantics.
+
+    ``sys.argv`` and ``sys.path`` are set for the duration of execution and
+    restored afterwards. Uncaught exceptions print a standard traceback with
+    the CLI's own frames removed and exit 1; ``SystemExit`` propagates
+    untouched so its status becomes the process exit code.
+
+    :param source: the resolved code source.
+    :param program_args: the program's arguments (``sys.argv[1:]``).
+    :param namespace: the extra globals to bind (``spark`` and ``pathling``).
+    """
+    try:
+        code_object = compile(source.text, source.filename, "exec")
+    except SyntaxError as exc:
+        # Pass no traceback: the interpreter prints only the error excerpt and
+        # the SyntaxError line for a syntax error, with no traceback header or
+        # frames.
+        traceback.print_exception(type(exc), exc, None, file=sys.stderr)
+        # Flush explicitly: the stream may be block-buffered (for example the
+        # capture stream used by Click's test runner) and the process exits
+        # immediately after.
+        sys.stderr.flush()
+        sys.exit(EXIT_RUNTIME)
+
+    program_globals = {"__name__": "__main__", **namespace}
+    if source.file_attr is not None:
+        program_globals["__file__"] = source.file_attr
+
+    saved_argv = sys.argv
+    saved_path = list(sys.path)
+    sys.argv = [source.argv0] + list(program_args)
+    sys.path.insert(0, source.path_entry)
+    try:
+        exec(code_object, program_globals)
+    except Exception as exc:
+        # Drop the CLI's own frame (this function's exec call) so the
+        # traceback starts at the user's code, exactly as the interpreter
+        # would print it.
+        tb = exc.__traceback__.tb_next if exc.__traceback__ else None
+        traceback.print_exception(type(exc), exc, tb, file=sys.stderr)
+        # See the flush comment in the syntax-error path above.
+        sys.stderr.flush()
+        sys.exit(EXIT_RUNTIME)
+    finally:
+        sys.argv = saved_argv
+        sys.path[:] = saved_path
+
+
+@click.command(
+    name="run",
+    cls=RunCommand,
+    context_settings={"ignore_unknown_options": True},
+)
+@click.argument("script", required=False)
+@click.option("-c", "--code", "code", help="Inline Python code to execute.")
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+@click.pass_context
+def run(ctx, script, code, args):
+    """Run Python code with the Pathling environment ready.
+
+    Executes a script file (or '-' for standard input, or inline code via
+    -c) with two variables already in scope: spark (the Spark session) and
+    pathling (the configured Pathling context). Trailing arguments are
+    passed to the code as sys.argv, following Python interpreter
+    conventions.
+
+    Examples:
+
+        pathling run script.py input.ndjson out/
+
+        pathling run -c "print(spark.version)"
+
+        cat job.py | pathling run -
+    """
+    source, program_args = _resolve_source(ctx, script, code, args)
+
+    obj = ctx.obj
+    pc = session.create_context(obj.config, obj.console)
+    namespace = {"spark": pc.spark, "pathling": pc}
+
+    _execute(source, program_args, namespace)

--- a/lib/python/pathling/cli/run.py
+++ b/lib/python/pathling/cli/run.py
@@ -238,6 +238,10 @@ def run(ctx, script, code, args):
     passed to the code as sys.argv, following Python interpreter
     conventions.
 
+    \b
+    See the Pathling Python API reference:
+    https://pathling.csiro.au/docs/python/pathling.html
+
     Examples:
 
         pathling run script.py input.ndjson out/

--- a/lib/python/pathling/cli/run.py
+++ b/lib/python/pathling/cli/run.py
@@ -242,13 +242,17 @@ def run(ctx, script, code, args):
     See the Pathling Python API reference:
     https://pathling.csiro.au/docs/python/pathling.html
 
-    Examples:
+    Example - project a tabular view of patients, then summarise it with
+    SQL. Save this as summary.py and run "pathling run summary.py":
 
-        pathling run script.py input.ndjson out/
-
-        pathling run -c "print(spark.version)"
-
-        cat job.py | pathling run -
+    \b
+        patients = pathling.read.ndjson("data").view(
+            "Patient",
+            select=[{"column": [{"path": "gender", "name": "gender"}]}],
+        )
+        patients.createOrReplaceTempView("patient")
+        spark.sql("SELECT gender, count(*) AS count "
+                  "FROM patient GROUP BY gender").show()
     """
     source, program_args = _resolve_source(ctx, script, code, args)
 

--- a/lib/python/pathling/cli/session.py
+++ b/lib/python/pathling/cli/session.py
@@ -67,16 +67,14 @@ def _write_quiet_log4j2() -> str:
 def _build_quiet_spark(config: CliConfig):
     """Builds a Spark session with logging suppressed before JVM launch.
 
+    The Pathling and Delta package configuration is shared with
+    :func:`pathling.context._build_spark_session`; this function only adds the
+    CLI-specific quiet-logging options on top.
+
     :param config: the resolved CLI configuration.
     :return: a configured :class:`SparkSession`.
     """
-    from pyspark.sql import SparkSession
-
-    from pathling._version import (
-        __delta_version__,
-        __java_version__,
-        __scala_version__,
-    )
+    from pathling.context import _build_spark_session
 
     # Pin Spark's Python workers to the interpreter running the CLI. Without
     # this, Spark launches workers using whatever ``python3`` is first on the
@@ -84,25 +82,14 @@ def _build_quiet_spark(config: CliConfig):
     # PYTHON_VERSION_MISMATCH error on any operation that uses Python workers.
     os.environ.setdefault("PYSPARK_PYTHON", sys.executable)
 
-    builder = (
-        SparkSession.builder.config(
-            "spark.jars.packages",
-            f"au.csiro.pathling:library-runtime:{__java_version__},"
-            f"io.delta:delta-spark_{__scala_version__}:{__delta_version__},",
-        )
-        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-        .config(
-            "spark.sql.catalog.spark_catalog",
-            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
-        )
-    )
+    extra_configs = {}
     if not config.verbose:
         log4j2_path = _write_quiet_log4j2()
-        builder = builder.config(
-            "spark.driver.extraJavaOptions",
-            f"-Dlog4j2.configurationFile=file:{log4j2_path}",
-        ).config("spark.ui.showConsoleProgress", "false")
-    return builder.getOrCreate()
+        extra_configs["spark.driver.extraJavaOptions"] = (
+            f"-Dlog4j2.configurationFile=file:{log4j2_path}"
+        )
+        extra_configs["spark.ui.showConsoleProgress"] = "false"
+    return _build_spark_session(extra_configs)
 
 
 def _create_pathling_context(config: CliConfig):

--- a/lib/python/pathling/cli/session.py
+++ b/lib/python/pathling/cli/session.py
@@ -19,16 +19,18 @@
 
 The Spark session is created only when a command actually needs it, behind a
 status spinner on stderr. Spark and JVM logging is suppressed by default by
-pointing the driver JVM at a generated log4j2 configuration before launch, and
+pointing the driver JVM at a packaged log4j2 configuration before launch, and
 lowering the log level once the context exists; ``--verbose`` leaves logging at
 its defaults.
 
 Author: John Grimes.
 """
 
+import atexit
 import os
 import sys
-import tempfile
+from contextlib import ExitStack
+from importlib.resources import as_file, files
 from typing import Optional
 
 from rich.console import Console
@@ -36,32 +38,33 @@ from rich.console import Console
 from pathling.cli.config import CliConfig
 from pathling.cli.render import progress_status, stderr_console
 
-# A log4j2 configuration that silences Spark and JVM logging. It is written to a
-# temporary file and supplied to the driver JVM before launch so that startup
-# noise, and task-failure stack traces, are suppressed (the CLI surfaces its own
-# concise error message instead). The level is raised again by ``--verbose``.
-_QUIET_LOG4J2 = """\
-rootLogger.level = off
-appender.console.type = Console
-appender.console.name = console
-appender.console.target = SYSTEM_ERR
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} %p %c{1}: %m%n
-rootLogger.appenderRef.console.ref = console
-"""
+# The packaged log4j2 configuration that silences Spark and JVM logging. It is
+# supplied to the driver JVM before launch so that startup noise, and
+# task-failure stack traces, are suppressed (the CLI surfaces its own concise
+# error message instead). The level is raised again by ``--verbose``.
+_QUIET_LOG4J2_RESOURCE = "quiet-log4j2.properties"
+
+# Keeps the materialised packaged resource path valid for the process lifetime.
+# For a directory-installed wheel the resource is a real file and needs no
+# cleanup; for a zipped install it is a temporary extraction removed when the
+# stack closes at interpreter exit. Either way no per-run temporary file is left
+# behind, unlike the previous NamedTemporaryFile approach (FR-017).
+_RESOURCE_STACK = ExitStack()
+atexit.register(_RESOURCE_STACK.close)
 
 
-def _write_quiet_log4j2() -> str:
-    """Writes the quiet log4j2 configuration to a temporary file.
+def quiet_log4j2_path() -> str:
+    """Resolves a filesystem path to the packaged quiet log4j2 configuration.
 
-    :return: the path to the written configuration file.
+    The configuration ships as static package data, so no per-run temporary file
+    is created. The materialised path is kept valid for the process lifetime so
+    the driver JVM can read it during and after session start.
+
+    :return: the filesystem path to the quiet log4j2 properties file.
     """
-    handle = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".properties", prefix="pathling-cli-log4j2-", delete=False
-    )
-    handle.write(_QUIET_LOG4J2)
-    handle.close()
-    return handle.name
+    resource = files("pathling.cli").joinpath("resources", _QUIET_LOG4J2_RESOURCE)
+    path = _RESOURCE_STACK.enter_context(as_file(resource))
+    return str(path)
 
 
 def _build_quiet_spark(config: CliConfig):
@@ -92,7 +95,7 @@ def _build_quiet_spark(config: CliConfig):
         "spark.sql.execution.arrow.pyspark.enabled": "true",
     }
     if not config.verbose:
-        log4j2_path = _write_quiet_log4j2()
+        log4j2_path = quiet_log4j2_path()
         extra_configs["spark.driver.extraJavaOptions"] = (
             f"-Dlog4j2.configurationFile=file:{log4j2_path}"
         )

--- a/lib/python/pathling/cli/session.py
+++ b/lib/python/pathling/cli/session.py
@@ -1,0 +1,171 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Lazy Spark session and Pathling context creation for the CLI.
+
+The Spark session is created only when a command actually needs it, behind a
+status spinner on stderr. Spark and JVM logging is suppressed by default by
+pointing the driver JVM at a generated log4j2 configuration before launch, and
+lowering the log level once the context exists; ``--verbose`` leaves logging at
+its defaults.
+
+Author: John Grimes.
+"""
+
+import os
+import sys
+import tempfile
+from typing import Optional
+
+from rich.console import Console
+
+from pathling.cli.config import CliConfig
+from pathling.cli.render import progress_status, stderr_console
+
+# A log4j2 configuration that silences Spark and JVM logging. It is written to a
+# temporary file and supplied to the driver JVM before launch so that startup
+# noise, and task-failure stack traces, are suppressed (the CLI surfaces its own
+# concise error message instead). The level is raised again by ``--verbose``.
+_QUIET_LOG4J2 = """\
+rootLogger.level = off
+appender.console.type = Console
+appender.console.name = console
+appender.console.target = SYSTEM_ERR
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss} %p %c{1}: %m%n
+rootLogger.appenderRef.console.ref = console
+"""
+
+
+def _write_quiet_log4j2() -> str:
+    """Writes the quiet log4j2 configuration to a temporary file.
+
+    :return: the path to the written configuration file.
+    """
+    handle = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".properties", prefix="pathling-cli-log4j2-", delete=False
+    )
+    handle.write(_QUIET_LOG4J2)
+    handle.close()
+    return handle.name
+
+
+def _build_quiet_spark(config: CliConfig):
+    """Builds a Spark session with logging suppressed before JVM launch.
+
+    :param config: the resolved CLI configuration.
+    :return: a configured :class:`SparkSession`.
+    """
+    from pyspark.sql import SparkSession
+
+    from pathling._version import (
+        __delta_version__,
+        __java_version__,
+        __scala_version__,
+    )
+
+    # Pin Spark's Python workers to the interpreter running the CLI. Without
+    # this, Spark launches workers using whatever ``python3`` is first on the
+    # PATH, which may be a different minor version from the driver and causes a
+    # PYTHON_VERSION_MISMATCH error on any operation that uses Python workers.
+    os.environ.setdefault("PYSPARK_PYTHON", sys.executable)
+
+    builder = (
+        SparkSession.builder.config(
+            "spark.jars.packages",
+            f"au.csiro.pathling:library-runtime:{__java_version__},"
+            f"io.delta:delta-spark_{__scala_version__}:{__delta_version__},",
+        )
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+    )
+    if not config.verbose:
+        log4j2_path = _write_quiet_log4j2()
+        builder = builder.config(
+            "spark.driver.extraJavaOptions",
+            f"-Dlog4j2.configurationFile=file:{log4j2_path}",
+        ).config("spark.ui.showConsoleProgress", "false")
+    return builder.getOrCreate()
+
+
+def _create_pathling_context(config: CliConfig):
+    """Builds the Spark session and Pathling context from the configuration.
+
+    :param config: the resolved CLI configuration.
+    :return: a configured :class:`PathlingContext`.
+    """
+    from pathling import PathlingContext
+
+    spark = _build_quiet_spark(config)
+    if not config.verbose:
+        # In local mode the driver JVM is launched before builder-level Java
+        # options apply, so log suppression relies on lowering the level here.
+        # OFF (rather than ERROR) also hides task-failure stack traces, which
+        # the CLI surfaces as its own concise message.
+        spark.sparkContext.setLogLevel("OFF")
+
+    auth = config.tx_auth
+    return PathlingContext.create(
+        spark,
+        terminology_server_url=config.tx_server,
+        enable_auth=bool(auth and auth.enabled),
+        token_endpoint=auth.token_endpoint if auth else None,
+        client_id=auth.client_id if auth else None,
+        client_secret=auth.client_secret if auth else None,
+        scope=auth.scope if auth else None,
+    )
+
+
+def create_context(config: CliConfig, console: Optional[Console] = None):
+    """Creates a :class:`PathlingContext` configured from the CLI settings.
+
+    In the default (non-verbose) mode the JVM launcher's startup banner and Ivy
+    dependency-resolution report - which Spark prints to file descriptor 2
+    before any log configuration can take effect in local mode - are swallowed
+    by redirecting that descriptor for the duration of session creation, while
+    the status spinner is routed to a preserved copy of the real stderr so that
+    progress remains visible.
+
+    :param config: the resolved CLI configuration.
+    :param console: the stderr console for the status spinner; created when
+           None.
+    :return: a configured :class:`PathlingContext`.
+    """
+    console = console or stderr_console()
+
+    if config.verbose:
+        with progress_status(console, "Starting Spark session...", True):
+            return _create_pathling_context(config)
+
+    # Preserve the real stderr for the spinner, then point fd 2 at /dev/null so
+    # the launcher's banner is discarded during session creation.
+    saved_fd = os.dup(2)
+    devnull_fd = os.open(os.devnull, os.O_WRONLY)
+    spinner_stream = os.fdopen(os.dup(saved_fd), "w")
+    spinner_console = Console(file=spinner_stream, markup=False, highlight=False)
+    try:
+        os.dup2(devnull_fd, 2)
+        with progress_status(spinner_console, "Starting Spark session...", False):
+            return _create_pathling_context(config)
+    finally:
+        os.dup2(saved_fd, 2)
+        os.close(saved_fd)
+        os.close(devnull_fd)
+        spinner_stream.close()

--- a/lib/python/pathling/cli/session.py
+++ b/lib/python/pathling/cli/session.py
@@ -83,10 +83,11 @@ def _build_quiet_spark(config: CliConfig):
     os.environ.setdefault("PYSPARK_PYTHON", sys.executable)
 
     extra_configs = {
-        # Enable Arrow-based columnar transfer so that materialising query
-        # results on the driver (see render._write_file, and toPandas in the
-        # interactive console) collects via Arrow record batches rather than
-        # pickling rows one at a time. Set before the user overlay below so an
+        # Enable Arrow-based columnar transfer so that any ``toPandas`` call in
+        # the interactive console collects via Arrow record batches rather than
+        # pickling rows one at a time. File output no longer collects to the
+        # driver - Spark writes it directly - so this setting now serves only
+        # the interactive console. Set before the user overlay below so an
         # explicit --spark-conf value still wins.
         "spark.sql.execution.arrow.pyspark.enabled": "true",
     }

--- a/lib/python/pathling/cli/session.py
+++ b/lib/python/pathling/cli/session.py
@@ -89,6 +89,11 @@ def _build_quiet_spark(config: CliConfig):
             f"-Dlog4j2.configurationFile=file:{log4j2_path}"
         )
         extra_configs["spark.ui.showConsoleProgress"] = "false"
+    # Overlay the user-supplied Spark configuration last so that a user value
+    # wins over the CLI's quiet-logging options for the same key (FR-012). A
+    # user-set spark.driver.extraJavaOptions therefore replaces the quiet
+    # log4j2 option, leaving Spark logging at its defaults.
+    extra_configs.update(config.spark_conf)
     return _build_spark_session(extra_configs)
 
 

--- a/lib/python/pathling/cli/session.py
+++ b/lib/python/pathling/cli/session.py
@@ -82,7 +82,14 @@ def _build_quiet_spark(config: CliConfig):
     # PYTHON_VERSION_MISMATCH error on any operation that uses Python workers.
     os.environ.setdefault("PYSPARK_PYTHON", sys.executable)
 
-    extra_configs = {}
+    extra_configs = {
+        # Enable Arrow-based columnar transfer so that materialising query
+        # results on the driver (see render._write_file, and toPandas in the
+        # interactive console) collects via Arrow record batches rather than
+        # pickling rows one at a time. Set before the user overlay below so an
+        # explicit --spark-conf value still wins.
+        "spark.sql.execution.arrow.pyspark.enabled": "true",
+    }
     if not config.verbose:
         log4j2_path = _write_quiet_log4j2()
         extra_configs["spark.driver.extraJavaOptions"] = (

--- a/lib/python/pathling/cli/sparkconf.py
+++ b/lib/python/pathling/cli/sparkconf.py
@@ -1,0 +1,269 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Parsing, validation, coercion, and merge for user-supplied Spark settings.
+
+This module holds the pure logic that turns ``[spark]`` config-table entries and
+``--spark-conf KEY=VALUE`` flags into the effective Spark configuration applied
+when a session is built. Keys must begin with ``spark.``; scalar values are
+coerced to the string form Spark expects; values support the existing
+``@file``/environment secret resolution. The three managed keys
+(``spark.jars.packages``, ``spark.sql.extensions``,
+``spark.sql.catalog.spark_catalog``) are merged with item-level protection
+against Pathling's managed defaults so the library keeps working while user
+additions take effect. None of this requires PySpark, so it runs before any
+Spark session starts.
+
+Author: John Grimes.
+"""
+
+from typing import Callable, Optional
+
+from pathling._spark_defaults import (
+    CATALOG_KEY,
+    EXTENSIONS_KEY,
+    MANAGED_COORDINATES,
+    PACKAGES_KEY,
+    managed_spark_defaults,
+)
+from pathling.cli.errors import EXIT_USAGE, CliError
+
+
+def parse_spark_conf_flags(flags) -> dict:
+    """Parses repeatable ``--spark-conf KEY=VALUE`` flags into a mapping.
+
+    Each flag is split on the first ``=`` only, so a value may itself contain
+    ``=`` (for example a JVM option). When the same key appears more than once,
+    the last occurrence wins.
+
+    :param flags: an iterable of raw ``KEY=VALUE`` flag strings.
+    :return: a mapping of key to value, with later duplicates overriding earlier.
+    :raises CliError: if a flag is not of the form ``KEY=VALUE`` (exit code 2).
+    """
+    result = {}
+    for flag in flags or ():
+        if "=" not in flag:
+            raise CliError(
+                f"Invalid --spark-conf value '{flag}'. Expected the form KEY=VALUE.",
+                exit_code=EXIT_USAGE,
+            )
+        key, value = flag.split("=", 1)
+        result[key] = value
+    return result
+
+
+def validate_and_coerce(key: str, value) -> str:
+    """Validates a Spark configuration key and coerces its value to a string.
+
+    The key must begin with ``spark.``. Scalar values (string, integer, float,
+    boolean) are coerced to the string form Spark expects, with booleans
+    rendered as ``true``/``false``. Any other value type (a TOML array or table)
+    is rejected.
+
+    :param key: the Spark configuration key.
+    :param value: the raw value from the config table or a flag.
+    :return: the value coerced to a string.
+    :raises CliError: if the key is not prefixed ``spark.`` or the value is not
+            a scalar (exit code 2).
+    """
+    if not key.startswith("spark."):
+        raise CliError(
+            f"Invalid Spark configuration key '{key}'. "
+            "Spark configuration keys must begin with 'spark.'.",
+            exit_code=EXIT_USAGE,
+        )
+    # ``bool`` is a subclass of ``int``, so it must be checked first to render
+    # as ``true``/``false`` rather than ``1``/``0``.
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float, str)):
+        return str(value)
+    raise CliError(
+        f"Invalid value for Spark configuration key '{key}'. "
+        "Only scalar values (string, integer, float, boolean) are allowed.",
+        exit_code=EXIT_USAGE,
+    )
+
+
+def resolve_spark_conf(
+    file_table: Optional[dict],
+    flag_map: Optional[dict],
+    env: Optional[dict] = None,
+) -> dict:
+    """Combines, validates, coerces, and secret-resolves the user Spark map.
+
+    The flag map overrides the file table per key. Each entry's key and value
+    are then validated and coerced, and string values are passed through the
+    existing secret resolver so a ``@file`` reference is read from disk.
+
+    :param file_table: the parsed ``[spark]`` table, or None.
+    :param flag_map: the parsed ``--spark-conf`` flag map, or None.
+    :param env: the environment mapping for secret resolution.
+    :return: the validated, coerced, and resolved user Spark map.
+    :raises CliError: if a key or value is invalid, or a ``@file`` reference
+            cannot be read.
+    """
+    # The secret resolver is imported lazily to avoid a circular import with the
+    # config module, which depends on this module.
+    from pathling.cli.config import resolve_secret
+
+    combined = {}
+    combined.update(file_table or {})
+    # Flag values win over the file table for the same key.
+    combined.update(flag_map or {})
+
+    resolved = {}
+    for key, raw in combined.items():
+        coerced = validate_and_coerce(key, raw)
+        resolved[key] = resolve_secret(coerced, None, env)
+    return resolved
+
+
+def _split_list(value: str) -> list:
+    """Splits a comma-separated Spark list value, dropping empty entries.
+
+    :param value: a comma-separated string such as a packages or extensions list.
+    :return: the non-empty, stripped items in order.
+    """
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _group_artifact(coordinate: str) -> str:
+    """Returns the ``group:artifact`` identity of a Maven coordinate.
+
+    :param coordinate: a ``group:artifact:version`` Maven coordinate.
+    :return: the ``group:artifact`` prefix used to detect a version override.
+    """
+    return ":".join(coordinate.split(":")[:2])
+
+
+def _merge_packages(
+    user_value: str,
+    on_warning: Optional[Callable[[str], None]],
+) -> str:
+    """Unions user package coordinates with the managed defaults.
+
+    Managed coordinates appear first. A user coordinate whose ``group:artifact``
+    is new is appended. A user coordinate that matches a managed
+    ``group:artifact`` at a different version replaces the managed entry and, for
+    a Pathling-managed coordinate, emits a single warning naming it.
+
+    :param user_value: the user's comma-separated ``spark.jars.packages`` value.
+    :param on_warning: a callback for the managed-version-override warning, or
+           None to suppress it.
+    :return: the merged, deduplicated comma-separated packages string.
+    """
+    result = []
+    # Map each ``group:artifact`` to its index in ``result`` for deduplication.
+    index_of = {}
+
+    def add(coordinate: str) -> None:
+        identity = _group_artifact(coordinate)
+        if identity not in index_of:
+            index_of[identity] = len(result)
+            result.append(coordinate)
+            return
+        existing = result[index_of[identity]]
+        if existing == coordinate:
+            return
+        # A different version of an already-present coordinate: the user wins.
+        result[index_of[identity]] = coordinate
+        if identity in MANAGED_COORDINATES and on_warning is not None:
+            on_warning(
+                f"The Spark configuration overrides the managed package "
+                f"'{identity}' with '{coordinate}'. This non-default version "
+                "may not be supported."
+            )
+
+    for coordinate in _split_list(managed_spark_defaults()[PACKAGES_KEY]):
+        add(coordinate)
+    for coordinate in _split_list(user_value):
+        add(coordinate)
+    return ",".join(result)
+
+
+def _merge_extensions(user_value: str) -> str:
+    """Unions user SQL extension classes with the managed defaults.
+
+    The Delta extension (listed in the managed defaults) is always retained and
+    appears first; user extensions are appended, deduplicated.
+
+    :param user_value: the user's comma-separated ``spark.sql.extensions`` value.
+    :return: the merged, deduplicated comma-separated extensions string.
+    """
+    result = []
+    seen = set()
+    managed = _split_list(managed_spark_defaults()[EXTENSIONS_KEY])
+    for extension in managed + _split_list(user_value):
+        if extension not in seen:
+            seen.add(extension)
+            result.append(extension)
+    return ",".join(result)
+
+
+def _merge_catalog(user_value: str, key: str) -> Optional[str]:
+    """Validates the session catalog against the managed Delta catalog.
+
+    :param user_value: the user's ``spark.sql.catalog.spark_catalog`` value.
+    :param key: the configuration key, for the error message.
+    :return: None when the value equals the managed Delta catalog (a no-op the
+             builder already applies); the function never returns another value.
+    :raises CliError: if the value differs from the managed Delta catalog (exit
+            code 2).
+    """
+    managed = managed_spark_defaults()[CATALOG_KEY]
+    if user_value == managed:
+        return None
+    raise CliError(
+        f"The Spark configuration key '{key}' is managed by Pathling and must be "
+        f"'{managed}'. Remove it or set it to the Delta catalog.",
+        exit_code=EXIT_USAGE,
+    )
+
+
+def merge_spark_conf(
+    user_map: dict,
+    on_warning: Optional[Callable[[str], None]] = None,
+) -> dict:
+    """Merges the user Spark map with Pathling's managed defaults.
+
+    Plain keys pass through unchanged. The managed list keys
+    (``spark.jars.packages``, ``spark.sql.extensions``) are unioned with the
+    managed defaults and deduplicated. ``spark.sql.catalog.spark_catalog`` is
+    dropped when it equals the managed Delta catalog and is an error otherwise.
+    Only keys the user actually set appear in the result; keys they did not touch
+    are left to the session builder's managed defaults.
+
+    :param user_map: the validated, coerced, and resolved user Spark map.
+    :param on_warning: a callback for the managed-version-override warning, or
+           None to suppress it.
+    :return: the effective Spark configuration to apply on top of the defaults.
+    :raises CliError: if the session catalog is set to a non-Delta value.
+    """
+    result = {}
+    for key, value in user_map.items():
+        if key == PACKAGES_KEY:
+            result[key] = _merge_packages(value, on_warning)
+        elif key == EXTENSIONS_KEY:
+            result[key] = _merge_extensions(value)
+        elif key == CATALOG_KEY:
+            merged = _merge_catalog(value, key)
+            if merged is not None:
+                result[key] = merged
+        else:
+            result[key] = value
+    return result

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -165,7 +165,16 @@ def _validate_coding_source(dataset, system, system_column):
 
 
 def _execute(
-    obj, dataset, system, system_column, output_format, output, limit, overwrite, build
+    obj,
+    dataset,
+    system,
+    system_column,
+    output_format,
+    output,
+    limit,
+    overwrite,
+    departition,
+    build,
 ):
     """Runs a terminology operation and emits the augmented dataset.
 
@@ -177,6 +186,7 @@ def _execute(
     :param output: the ``-o`` path, or None.
     :param limit: the table row cap.
     :param overwrite: whether to replace an existing output path.
+    :param departition: whether file output is departitioned to a single file.
     :param build: a callback ``(pc, df) -> result_df`` performing the operation.
     :raises CliError: for validation and unreachable-server failures.
     """
@@ -185,7 +195,7 @@ def _execute(
 
     # Validate cheap inputs before paying the Spark cold start.
     _validate_coding_source(dataset, system, system_column)
-    output_spec = resolve_output(output, output_format, limit, overwrite)
+    output_spec = resolve_output(output, output_format, limit, overwrite, departition)
     pc = session.create_context(config, console)
     df = _read_dataset(pc, dataset)
 
@@ -226,6 +236,7 @@ def member_of(
     output,
     limit,
     overwrite,
+    departition,
     value_set,
 ):
     """Test codes for membership of a value set.
@@ -253,6 +264,7 @@ def member_of(
         output,
         limit,
         overwrite,
+        departition,
         build,
     )
 
@@ -280,6 +292,7 @@ def translate(
     output,
     limit,
     overwrite,
+    departition,
     concept_map,
     reverse,
     equivalences,
@@ -324,6 +337,7 @@ def translate(
         output,
         limit,
         overwrite,
+        departition,
         build,
     )
 
@@ -370,6 +384,7 @@ def _run_subsumption(
     output,
     limit,
     overwrite,
+    departition,
     other_code_column,
     other_system,
     other_system_column,
@@ -389,6 +404,7 @@ def _run_subsumption(
     :param output: the output path, or None.
     :param limit: the table row cap.
     :param overwrite: whether to replace an existing output path.
+    :param departition: whether file output is departitioned to a single file.
     :param other_code_column: the right code column.
     :param other_system: the right fixed system URI, or None.
     :param other_system_column: the right per-row system column, or None.
@@ -418,6 +434,7 @@ def _run_subsumption(
         output,
         limit,
         overwrite,
+        departition,
         build,
     )
 
@@ -438,6 +455,7 @@ def subsumes(
     output,
     limit,
     overwrite,
+    departition,
     other_code_column,
     other_system,
     other_system_column,
@@ -463,6 +481,7 @@ def subsumes(
         output,
         limit,
         overwrite,
+        departition,
         other_code_column,
         other_system,
         other_system_column,
@@ -485,6 +504,7 @@ def subsumed_by(
     output,
     limit,
     overwrite,
+    departition,
     other_code_column,
     other_system,
     other_system_column,
@@ -510,6 +530,7 @@ def subsumed_by(
         output,
         limit,
         overwrite,
+        departition,
         other_code_column,
         other_system,
         other_system_column,
@@ -535,6 +556,7 @@ def display(
     output,
     limit,
     overwrite,
+    departition,
     accept_language,
 ):
     """Look up display names for codes.
@@ -561,6 +583,7 @@ def display(
         output,
         limit,
         overwrite,
+        departition,
         build,
     )
 
@@ -592,6 +615,7 @@ def property_of(
     output,
     limit,
     overwrite,
+    departition,
     property_code,
     property_type,
     accept_language,
@@ -624,6 +648,7 @@ def property_of(
         output,
         limit,
         overwrite,
+        departition,
         build,
     )
 
@@ -648,6 +673,7 @@ def designation(
     output,
     limit,
     overwrite,
+    departition,
     use,
     language,
 ):
@@ -686,6 +712,7 @@ def designation(
         output,
         limit,
         overwrite,
+        departition,
         build,
     )
 

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -114,27 +114,51 @@ def _validate_columns(df, required, dataset):
         )
 
 
-def _coding_column(code_column, system, system_column, version):
-    """Builds a Coding struct column from a code column and a system source.
+def _coding_column(code_column, system, system_column, version, *, code=None):
+    """Builds a Coding struct column from a code source and a system source.
 
-    :param code_column: the code column name.
+    :param code_column: the per-row code column name, used when ``code`` is None.
     :param system: a fixed system URI, or None.
     :param system_column: a per-row system column name, or None.
     :param version: an optional code system version.
+    :param code: a fixed literal code applied to every row, or None to read the
+           code per row from ``code_column``. This mirrors the fixed-versus-column
+           handling of the system part.
     :return: a Spark Column containing a Coding struct.
     :raises CliError: when the system source is missing or ambiguous.
     """
     from pyspark.sql.functions import col, lit, struct
 
     system_col = lit(system) if system else col(system_column)
+    code_col = lit(code) if code is not None else col(code_column)
     return struct(
         lit(None).alias("id"),
         system_col.alias("system"),
         lit(version).alias("version"),
-        col(code_column).alias("code"),
+        code_col.alias("code"),
         lit(None).alias("display"),
         lit(None).alias("userSelected"),
     )
+
+
+def _require_exactly_one(first, first_name, second, second_name, neither_message):
+    """Validates that exactly one of a pair of options is provided.
+
+    :param first: the first option's value, falsey when the option is absent.
+    :param first_name: the first option's flag name, used in the error message.
+    :param second: the second option's value, falsey when the option is absent.
+    :param second_name: the second option's flag name, used in the error message.
+    :param neither_message: the error message to raise when neither is provided;
+           it should name both options so the user knows the valid choices.
+    :raises CliError: with EXIT_USAGE when both or neither option is provided.
+    """
+    if first and second:
+        raise CliError(
+            f"{first_name} and {second_name} are mutually exclusive. Provide one.",
+            exit_code=EXIT_USAGE,
+        )
+    if not first and not second:
+        raise CliError(neither_message, exit_code=EXIT_USAGE)
 
 
 def _validate_coding_source(dataset, system, system_column):
@@ -151,17 +175,13 @@ def _validate_coding_source(dataset, system, system_column):
             f"Dataset does not exist: {dataset}. Check the path.",
             exit_code=EXIT_USAGE,
         )
-    if system and system_column:
-        raise CliError(
-            "--system and --system-column are mutually exclusive. Provide one.",
-            exit_code=EXIT_USAGE,
-        )
-    if not system and not system_column:
-        raise CliError(
-            "A code system is required. Provide --system <uri> or "
-            "--system-column <name>.",
-            exit_code=EXIT_USAGE,
-        )
+    _require_exactly_one(
+        system,
+        "--system",
+        system_column,
+        "--system-column",
+        "A code system is required. Provide --system <uri> or --system-column <name>.",
+    )
 
 
 def _execute(
@@ -353,9 +373,13 @@ def _second_coding_options(func):
     """
     options = [
         click.option(
+            "--other-code",
+            "other_code",
+            help="Fixed target code applied to every row.",
+        ),
+        click.option(
             "--other-code-column",
             "other_code_column",
-            required=True,
             help="Second code column.",
         ),
         click.option("--other-system", "other_system", help="Second fixed system URI."),
@@ -385,6 +409,7 @@ def _run_subsumption(
     limit,
     overwrite,
     departition,
+    other_code,
     other_code_column,
     other_system,
     other_system_column,
@@ -404,11 +429,32 @@ def _run_subsumption(
     :param output: the output path, or None.
     :param limit: the table row cap.
     :param overwrite: whether to replace an existing output path.
-    :param departition: whether file output is departitioned to a single file.
-    :param other_code_column: the right code column.
+    :param other_code: a fixed target code applied to every row, or None.
+    :param other_code_column: the right code column, or None when a fixed target
+           code is supplied.
     :param other_system: the right fixed system URI, or None.
     :param other_system_column: the right per-row system column, or None.
+    :raises CliError: when the target code or system options are absent or
+            mutually exclusive.
     """
+    # Validate the target options before paying the Spark cold start.
+    _require_exactly_one(
+        other_code,
+        "--other-code",
+        other_code_column,
+        "--other-code-column",
+        "A target code is required. Provide --other-code <code> or "
+        "--other-code-column <name>.",
+    )
+    _require_exactly_one(
+        other_system,
+        "--other-system",
+        other_system_column,
+        "--other-system-column",
+        "A target system is required. Provide --other-system <uri> or "
+        "--other-system-column <name>.",
+    )
+
     name = result_column or default_name
 
     def build(pc, df):
@@ -421,7 +467,11 @@ def _run_subsumption(
         )
         left = _coding_column(code_column, system, system_column, system_version)
         right = _coding_column(
-            other_code_column, other_system, other_system_column, system_version
+            other_code_column,
+            other_system,
+            other_system_column,
+            system_version,
+            code=other_code,
         )
         return df.withColumn(name, getattr(udfs, operation)(left, right))
 
@@ -456,16 +506,23 @@ def subsumes(
     limit,
     overwrite,
     departition,
+    other_code,
     other_code_column,
     other_system,
     other_system_column,
 ):
-    """Test subsumption between two code columns.
+    """Test subsumption against another code column or a fixed target coding.
 
-    Example:
+    Compare a column of codes against either a second code column or a single
+    fixed target coding supplied with ``--other-code``.
+
+    Examples:
 
         pathling subsumes codes.csv --code-column a --system http://snomed.info/sct \\
             --other-code-column b --other-system http://snomed.info/sct
+
+        pathling subsumes codes.csv --code-column code --system http://snomed.info/sct \\
+            --other-code 73211009 --other-system http://snomed.info/sct
     """
     _run_subsumption(
         obj,
@@ -482,6 +539,7 @@ def subsumes(
         limit,
         overwrite,
         departition,
+        other_code,
         other_code_column,
         other_system,
         other_system_column,
@@ -505,16 +563,23 @@ def subsumed_by(
     limit,
     overwrite,
     departition,
+    other_code,
     other_code_column,
     other_system,
     other_system_column,
 ):
-    """Test reverse subsumption between two code columns.
+    """Test reverse subsumption against another code column or a fixed target.
 
-    Example:
+    Compare a column of codes against either a second code column or a single
+    fixed target coding supplied with ``--other-code``.
+
+    Examples:
 
         pathling subsumed-by codes.csv --code-column a --system http://snomed.info/sct \\
             --other-code-column b --other-system http://snomed.info/sct
+
+        pathling subsumed-by codes.csv --code-column code --system http://snomed.info/sct \\
+            --other-code 73211009 --other-system http://snomed.info/sct
     """
     _run_subsumption(
         obj,
@@ -531,6 +596,7 @@ def subsumed_by(
         limit,
         overwrite,
         departition,
+        other_code,
         other_code_column,
         other_system,
         other_system_column,

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -104,6 +104,11 @@ def _validate_columns(df, required, dataset):
     :param dataset: the dataset path for the error message.
     :raises CliError: when any required column is missing.
     """
+    # This check is inherently late: validating a column name requires the
+    # dataset schema, which is only available after the Spark session has read
+    # the source. Cheaper inputs (the dataset path and the system options) are
+    # already validated before the Spark cold start; the column check is as early
+    # as it can be without a bespoke per-format schema pre-read (FR-019).
     missing = [name for name in required if name and name not in df.columns]
     if missing:
         available = ", ".join(df.columns)
@@ -114,9 +119,15 @@ def _validate_columns(df, required, dataset):
         )
 
 
-def _coding_column(code_column, system, system_column, version, *, code=None):
+def _coding_column(pc, code_column, system, system_column, version, *, code=None):
     """Builds a Coding struct column from a code source and a system source.
 
+    The struct's field names and order are derived from the library's own Coding
+    builder rather than hand-listed, so the CLI cannot drift from the library
+    Coding schema (FR-018). Fields other than the code, system, and version are
+    set to null, exactly as the library does for codings built from columns.
+
+    :param pc: the Pathling context, used to resolve the library Coding schema.
     :param code_column: the per-row code column name, used when ``code`` is None.
     :param system: a fixed system URI, or None.
     :param system_column: a per-row system column name, or None.
@@ -129,16 +140,23 @@ def _coding_column(code_column, system, system_column, version, *, code=None):
     """
     from pyspark.sql.functions import col, lit, struct
 
+    from pathling.functions import to_coding
+
+    # Resolve the canonical Coding field names and order from the library's own
+    # builder; analysing the schema does not trigger a Spark job.
+    reference = to_coding(lit(None), "")
+    field_names = (
+        pc.spark.range(1).select(reference.alias("c")).schema["c"].dataType.fieldNames()
+    )
+
     system_col = lit(system) if system else col(system_column)
     code_col = lit(code) if code is not None else col(code_column)
-    return struct(
-        lit(None).alias("id"),
-        system_col.alias("system"),
-        lit(version).alias("version"),
-        code_col.alias("code"),
-        lit(None).alias("display"),
-        lit(None).alias("userSelected"),
-    )
+    overrides = {
+        "system": system_col,
+        "version": lit(version),
+        "code": code_col,
+    }
+    return struct(*[overrides.get(name, lit(None)).alias(name) for name in field_names])
 
 
 def _require_exactly_one(first, first_name, second, second_name, neither_message):
@@ -272,7 +290,7 @@ def member_of(
         from pathling import udfs
 
         _validate_columns(df, [code_column, system_column], dataset)
-        coding = _coding_column(code_column, system, system_column, system_version)
+        coding = _coding_column(pc, code_column, system, system_column, system_version)
         return df.withColumn(name, udfs.member_of(coding, value_set))
 
     _execute(
@@ -334,7 +352,7 @@ def translate(
         from pathling import udfs
 
         _validate_columns(df, [code_column, system_column], dataset)
-        coding = _coding_column(code_column, system, system_column, system_version)
+        coding = _coding_column(pc, code_column, system, system_column, system_version)
         translation = udfs.translate(
             coding,
             concept_map,
@@ -465,8 +483,9 @@ def _run_subsumption(
             [code_column, system_column, other_code_column, other_system_column],
             dataset,
         )
-        left = _coding_column(code_column, system, system_column, system_version)
+        left = _coding_column(pc, code_column, system, system_column, system_version)
         right = _coding_column(
+            pc,
             other_code_column,
             other_system,
             other_system_column,
@@ -637,7 +656,7 @@ def display(
         from pathling import udfs
 
         _validate_columns(df, [code_column, system_column], dataset)
-        coding = _coding_column(code_column, system, system_column, system_version)
+        coding = _coding_column(pc, code_column, system, system_column, system_version)
         return df.withColumn(name, udfs.display(coding, accept_language))
 
     _execute(
@@ -699,7 +718,7 @@ def property_of(
         from pathling import udfs
 
         _validate_columns(df, [code_column, system_column], dataset)
-        coding = _coding_column(code_column, system, system_column, system_version)
+        coding = _coding_column(pc, code_column, system, system_column, system_version)
         return df.withColumn(
             name,
             udfs.property_of(coding, property_code, property_type, accept_language),
@@ -757,7 +776,7 @@ def designation(
         from pathling.coding import Coding
 
         _validate_columns(df, [code_column, system_column], dataset)
-        coding = _coding_column(code_column, system, system_column, system_version)
+        coding = _coding_column(pc, code_column, system, system_column, system_version)
         use_coding = None
         if use:
             if "|" not in use:

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -1,0 +1,723 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""The Pathling terminology commands.
+
+Each command reads a tabular dataset (CSV or Parquet), builds codings from a
+named code column plus either a fixed system URI or a per-row system column,
+calls the corresponding library terminology function, appends the result
+column(s), and emits the augmented dataset per the shared output options.
+
+Author: John Grimes.
+"""
+
+from pathlib import Path
+
+import click
+
+from pathling.cli import session
+from pathling.cli.errors import (
+    EXIT_USAGE,
+    CliError,
+    is_connection_error,
+    unwrap_java_exception,
+)
+from pathling.cli.render import (
+    OutputFormat,
+    progress_status,
+    resolve_output,
+    write_output,
+)
+
+# The output formats the terminology commands support.
+_FORMAT_CHOICE = click.Choice(
+    [
+        OutputFormat.TABLE,
+        OutputFormat.CSV,
+        OutputFormat.JSON,
+        OutputFormat.NDJSON,
+        OutputFormat.PARQUET,
+        OutputFormat.DELTA,
+    ]
+)
+
+
+def _common_options(func):
+    """Applies the dataset argument, coding options, and output options.
+
+    :param func: the command callback to decorate.
+    :return: the decorated callback.
+    """
+    options = [
+        click.argument("dataset"),
+        click.option(
+            "--code-column", "code_column", required=True, help="Code column name."
+        ),
+        click.option("--system", "system", help="Fixed code system URI."),
+        click.option(
+            "--system-column", "system_column", help="Per-row system column name."
+        ),
+        click.option(
+            "--coding-version", "coding_version", help="Optional coding version."
+        ),
+        click.option(
+            "--result-column", "result_column", help="Override the result column name."
+        ),
+        click.option(
+            "--format", "output_format", type=_FORMAT_CHOICE, help="Output format."
+        ),
+        click.option("-o", "--output", "output", help="Write results to this path."),
+        click.option(
+            "--limit", default=1000, show_default=True, help="Row cap for table output."
+        ),
+        click.option(
+            "--overwrite", is_flag=True, help="Replace an existing output path."
+        ),
+    ]
+    for option in reversed(options):
+        func = option(func)
+    return func
+
+
+def _read_dataset(pc, dataset):
+    """Reads a CSV or Parquet dataset into a Spark DataFrame.
+
+    :param pc: the Pathling context.
+    :param dataset: the path to the dataset file.
+    :return: the loaded DataFrame.
+    :raises CliError: when the path is missing or the type is unsupported.
+    """
+    path = Path(dataset)
+    if not path.exists():
+        raise CliError(
+            f"Dataset does not exist: {path}. Check the path.", exit_code=EXIT_USAGE
+        )
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return pc.spark.read.csv(str(path), header=True, inferSchema=False)
+    if suffix == ".parquet":
+        return pc.spark.read.parquet(str(path))
+    raise CliError(
+        f"Unsupported dataset type '{suffix}'. Use a .csv or .parquet file.",
+        exit_code=EXIT_USAGE,
+    )
+
+
+def _validate_columns(df, required, dataset):
+    """Validates that the named columns exist, listing the actual columns.
+
+    :param df: the dataset DataFrame.
+    :param required: the column names that must be present.
+    :param dataset: the dataset path for the error message.
+    :raises CliError: when any required column is missing.
+    """
+    missing = [name for name in required if name and name not in df.columns]
+    if missing:
+        available = ", ".join(df.columns)
+        raise CliError(
+            f"Column(s) not found in {dataset}: {', '.join(missing)}. "
+            f"Available columns: {available}.",
+            exit_code=EXIT_USAGE,
+        )
+
+
+def _coding_column(code_column, system, system_column, version):
+    """Builds a Coding struct column from a code column and a system source.
+
+    :param code_column: the code column name.
+    :param system: a fixed system URI, or None.
+    :param system_column: a per-row system column name, or None.
+    :param version: an optional coding version.
+    :return: a Spark Column containing a Coding struct.
+    :raises CliError: when the system source is missing or ambiguous.
+    """
+    from pyspark.sql.functions import col, lit, struct
+
+    system_col = lit(system) if system else col(system_column)
+    return struct(
+        lit(None).alias("id"),
+        system_col.alias("system"),
+        lit(version).alias("version"),
+        col(code_column).alias("code"),
+        lit(None).alias("display"),
+        lit(None).alias("userSelected"),
+    )
+
+
+def _validate_coding_source(dataset, system, system_column):
+    """Validates the dataset path and code system options before Spark starts.
+
+    :param dataset: the dataset path.
+    :param system: a fixed system URI, or None.
+    :param system_column: a per-row system column name, or None.
+    :raises CliError: when the dataset is missing or the system options are
+            absent or mutually exclusive.
+    """
+    if not Path(dataset).exists():
+        raise CliError(
+            f"Dataset does not exist: {dataset}. Check the path.",
+            exit_code=EXIT_USAGE,
+        )
+    if system and system_column:
+        raise CliError(
+            "--system and --system-column are mutually exclusive. Provide one.",
+            exit_code=EXIT_USAGE,
+        )
+    if not system and not system_column:
+        raise CliError(
+            "A code system is required. Provide --system <uri> or "
+            "--system-column <name>.",
+            exit_code=EXIT_USAGE,
+        )
+
+
+def _execute(
+    obj, dataset, system, system_column, output_format, output, limit, overwrite, build
+):
+    """Runs a terminology operation and emits the augmented dataset.
+
+    :param obj: the CLI context object.
+    :param dataset: the dataset path.
+    :param system: a fixed system URI, or None.
+    :param system_column: a per-row system column name, or None.
+    :param output_format: the ``--format`` value, or None.
+    :param output: the ``-o`` path, or None.
+    :param limit: the table row cap.
+    :param overwrite: whether to replace an existing output path.
+    :param build: a callback ``(pc, df) -> result_df`` performing the operation.
+    :raises CliError: for validation and unreachable-server failures.
+    """
+    config = obj.config
+    console = obj.console
+
+    # Validate cheap inputs before paying the Spark cold start.
+    _validate_coding_source(dataset, system, system_column)
+    output_spec = resolve_output(output, output_format, limit, overwrite)
+    pc = session.create_context(config, console)
+    df = _read_dataset(pc, dataset)
+
+    try:
+        with progress_status(
+            console, "Running terminology operation...", config.verbose
+        ):
+            result_df = build(pc, df)
+            write_output(result_df, output_spec, console)
+    except CliError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - enrich connection failures.
+        if is_connection_error(exc):
+            raise CliError(
+                f"Could not reach the terminology server at {config.tx_server}: "
+                f"{unwrap_java_exception(exc)}. Set the server with --tx-server "
+                "<url> or the 'tx-server' config key."
+            ) from exc
+        raise
+
+
+# ========== member-of ==========
+
+
+@click.command(name="member-of")
+@_common_options
+@click.option("--value-set", "value_set", required=True, help="Value set URI.")
+@click.pass_obj
+def member_of(
+    obj,
+    dataset,
+    code_column,
+    system,
+    system_column,
+    coding_version,
+    result_column,
+    output_format,
+    output,
+    limit,
+    overwrite,
+    value_set,
+):
+    """Test codes for membership of a value set.
+
+    Example:
+
+        pathling member-of codes.csv --code-column code \\
+            --system http://snomed.info/sct --value-set <uri>
+    """
+    name = result_column or "member_of"
+
+    def build(pc, df):
+        from pathling import udfs
+
+        _validate_columns(df, [code_column, system_column], dataset)
+        coding = _coding_column(code_column, system, system_column, coding_version)
+        return df.withColumn(name, udfs.member_of(coding, value_set))
+
+    _execute(
+        obj,
+        dataset,
+        system,
+        system_column,
+        output_format,
+        output,
+        limit,
+        overwrite,
+        build,
+    )
+
+
+# ========== translate ==========
+
+
+@click.command(name="translate")
+@_common_options
+@click.option("--concept-map", "concept_map", required=True, help="Concept map URI.")
+@click.option("--reverse", is_flag=True, help="Reverse the translation direction.")
+@click.option(
+    "--equivalence", "equivalences", multiple=True, help="Equivalence (repeatable)."
+)
+@click.pass_obj
+def translate(
+    obj,
+    dataset,
+    code_column,
+    system,
+    system_column,
+    coding_version,
+    result_column,
+    output_format,
+    output,
+    limit,
+    overwrite,
+    concept_map,
+    reverse,
+    equivalences,
+):
+    """Translate codes using a concept map.
+
+    Example:
+
+        pathling translate codes.csv --code-column code \\
+            --system http://snomed.info/sct --concept-map <uri> --reverse
+    """
+    base = result_column or "translated"
+    system_name = f"{base}_system"
+    code_name = f"{base}_code"
+
+    def build(pc, df):
+        from pyspark.sql.functions import col, explode_outer
+
+        from pathling import udfs
+
+        _validate_columns(df, [code_column, system_column], dataset)
+        coding = _coding_column(code_column, system, system_column, coding_version)
+        translation = udfs.translate(
+            coding,
+            concept_map,
+            reverse=reverse,
+            equivalences=list(equivalences) or None,
+        )
+        with_translation = df.withColumn("_translation", explode_outer(translation))
+        return with_translation.select(
+            *df.columns,
+            col("_translation.system").alias(system_name),
+            col("_translation.code").alias(code_name),
+        )
+
+    _execute(
+        obj,
+        dataset,
+        system,
+        system_column,
+        output_format,
+        output,
+        limit,
+        overwrite,
+        build,
+    )
+
+
+# ========== subsumes / subsumed-by ==========
+
+
+def _second_coding_options(func):
+    """Adds the second coding options used by subsumes and subsumed-by.
+
+    :param func: the command callback to decorate.
+    :return: the decorated callback.
+    """
+    options = [
+        click.option(
+            "--other-code-column",
+            "other_code_column",
+            required=True,
+            help="Second code column.",
+        ),
+        click.option("--other-system", "other_system", help="Second fixed system URI."),
+        click.option(
+            "--other-system-column",
+            "other_system_column",
+            help="Second per-row system column.",
+        ),
+    ]
+    for option in reversed(options):
+        func = option(func)
+    return func
+
+
+def _run_subsumption(
+    obj,
+    operation,
+    default_name,
+    dataset,
+    code_column,
+    system,
+    system_column,
+    coding_version,
+    result_column,
+    output_format,
+    output,
+    limit,
+    overwrite,
+    other_code_column,
+    other_system,
+    other_system_column,
+):
+    """Shared implementation for subsumes and subsumed-by.
+
+    :param obj: the CLI context object.
+    :param operation: the udf attribute name (``subsumes`` or ``subsumed_by``).
+    :param default_name: the default result column name.
+    :param dataset: the dataset path.
+    :param code_column: the left code column.
+    :param system: the left fixed system URI, or None.
+    :param system_column: the left per-row system column, or None.
+    :param coding_version: the optional coding version.
+    :param result_column: the result column override, or None.
+    :param output_format: the output format, or None.
+    :param output: the output path, or None.
+    :param limit: the table row cap.
+    :param overwrite: whether to replace an existing output path.
+    :param other_code_column: the right code column.
+    :param other_system: the right fixed system URI, or None.
+    :param other_system_column: the right per-row system column, or None.
+    """
+    name = result_column or default_name
+
+    def build(pc, df):
+        from pathling import udfs
+
+        _validate_columns(
+            df,
+            [code_column, system_column, other_code_column, other_system_column],
+            dataset,
+        )
+        left = _coding_column(code_column, system, system_column, coding_version)
+        right = _coding_column(
+            other_code_column, other_system, other_system_column, coding_version
+        )
+        return df.withColumn(name, getattr(udfs, operation)(left, right))
+
+    _execute(
+        obj,
+        dataset,
+        system,
+        system_column,
+        output_format,
+        output,
+        limit,
+        overwrite,
+        build,
+    )
+
+
+@click.command(name="subsumes")
+@_common_options
+@_second_coding_options
+@click.pass_obj
+def subsumes(
+    obj,
+    dataset,
+    code_column,
+    system,
+    system_column,
+    coding_version,
+    result_column,
+    output_format,
+    output,
+    limit,
+    overwrite,
+    other_code_column,
+    other_system,
+    other_system_column,
+):
+    """Test subsumption between two code columns.
+
+    Example:
+
+        pathling subsumes codes.csv --code-column a --system http://snomed.info/sct \\
+            --other-code-column b --other-system http://snomed.info/sct
+    """
+    _run_subsumption(
+        obj,
+        "subsumes",
+        "subsumes",
+        dataset,
+        code_column,
+        system,
+        system_column,
+        coding_version,
+        result_column,
+        output_format,
+        output,
+        limit,
+        overwrite,
+        other_code_column,
+        other_system,
+        other_system_column,
+    )
+
+
+@click.command(name="subsumed-by")
+@_common_options
+@_second_coding_options
+@click.pass_obj
+def subsumed_by(
+    obj,
+    dataset,
+    code_column,
+    system,
+    system_column,
+    coding_version,
+    result_column,
+    output_format,
+    output,
+    limit,
+    overwrite,
+    other_code_column,
+    other_system,
+    other_system_column,
+):
+    """Test reverse subsumption between two code columns.
+
+    Example:
+
+        pathling subsumed-by codes.csv --code-column a --system http://snomed.info/sct \\
+            --other-code-column b --other-system http://snomed.info/sct
+    """
+    _run_subsumption(
+        obj,
+        "subsumed_by",
+        "subsumed_by",
+        dataset,
+        code_column,
+        system,
+        system_column,
+        coding_version,
+        result_column,
+        output_format,
+        output,
+        limit,
+        overwrite,
+        other_code_column,
+        other_system,
+        other_system_column,
+    )
+
+
+# ========== display ==========
+
+
+@click.command(name="display")
+@_common_options
+@click.option("--accept-language", "accept_language", help="Preferred language(s).")
+@click.pass_obj
+def display(
+    obj,
+    dataset,
+    code_column,
+    system,
+    system_column,
+    coding_version,
+    result_column,
+    output_format,
+    output,
+    limit,
+    overwrite,
+    accept_language,
+):
+    """Look up display names for codes.
+
+    Example:
+
+        pathling display codes.csv --code-column code --system http://loinc.org
+    """
+    name = result_column or "display"
+
+    def build(pc, df):
+        from pathling import udfs
+
+        _validate_columns(df, [code_column, system_column], dataset)
+        coding = _coding_column(code_column, system, system_column, coding_version)
+        return df.withColumn(name, udfs.display(coding, accept_language))
+
+    _execute(
+        obj,
+        dataset,
+        system,
+        system_column,
+        output_format,
+        output,
+        limit,
+        overwrite,
+        build,
+    )
+
+
+# ========== property-of ==========
+
+
+@click.command(name="property-of")
+@_common_options
+@click.option("--property", "property_code", required=True, help="Property code.")
+@click.option(
+    "--property-type",
+    "property_type",
+    default="string",
+    show_default=True,
+    help="Property type.",
+)
+@click.option("--accept-language", "accept_language", help="Preferred language(s).")
+@click.pass_obj
+def property_of(
+    obj,
+    dataset,
+    code_column,
+    system,
+    system_column,
+    coding_version,
+    result_column,
+    output_format,
+    output,
+    limit,
+    overwrite,
+    property_code,
+    property_type,
+    accept_language,
+):
+    """Look up properties for codes.
+
+    Example:
+
+        pathling property-of codes.csv --code-column code \\
+            --system http://snomed.info/sct --property parent --property-type code
+    """
+    name = result_column or "property"
+
+    def build(pc, df):
+        from pathling import udfs
+
+        _validate_columns(df, [code_column, system_column], dataset)
+        coding = _coding_column(code_column, system, system_column, coding_version)
+        return df.withColumn(
+            name,
+            udfs.property_of(coding, property_code, property_type, accept_language),
+        )
+
+    _execute(
+        obj,
+        dataset,
+        system,
+        system_column,
+        output_format,
+        output,
+        limit,
+        overwrite,
+        build,
+    )
+
+
+# ========== designation ==========
+
+
+@click.command(name="designation")
+@_common_options
+@click.option("--use", "use", help="Designation use as 'system|code'.")
+@click.option("--language", "language", help="Designation language.")
+@click.pass_obj
+def designation(
+    obj,
+    dataset,
+    code_column,
+    system,
+    system_column,
+    coding_version,
+    result_column,
+    output_format,
+    output,
+    limit,
+    overwrite,
+    use,
+    language,
+):
+    """Look up designations for codes.
+
+    Example:
+
+        pathling designation codes.csv --code-column code \\
+            --system http://snomed.info/sct --language en
+    """
+    name = result_column or "designation"
+
+    def build(pc, df):
+        from pathling import udfs
+        from pathling.coding import Coding
+
+        _validate_columns(df, [code_column, system_column], dataset)
+        coding = _coding_column(code_column, system, system_column, coding_version)
+        use_coding = None
+        if use:
+            if "|" not in use:
+                raise CliError(
+                    f"Invalid --use '{use}'. Use the form 'system|code'.",
+                    exit_code=EXIT_USAGE,
+                )
+            use_system, use_code = use.split("|", 1)
+            use_coding = Coding(use_system, use_code)
+        return df.withColumn(name, udfs.designation(coding, use_coding, language))
+
+    _execute(
+        obj,
+        dataset,
+        system,
+        system_column,
+        output_format,
+        output,
+        limit,
+        overwrite,
+        build,
+    )
+
+
+# All terminology commands, in display order.
+TERMINOLOGY_COMMANDS = (
+    member_of,
+    translate,
+    subsumes,
+    subsumed_by,
+    display,
+    property_of,
+    designation,
+)

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -37,22 +37,10 @@ from pathling.cli.errors import (
     unwrap_java_exception,
 )
 from pathling.cli.render import (
-    OutputFormat,
+    output_options,
     progress_status,
     resolve_output,
     write_output,
-)
-
-# The output formats the terminology commands support.
-_FORMAT_CHOICE = click.Choice(
-    [
-        OutputFormat.TABLE,
-        OutputFormat.CSV,
-        OutputFormat.JSON,
-        OutputFormat.NDJSON,
-        OutputFormat.PARQUET,
-        OutputFormat.DELTA,
-    ]
 )
 
 
@@ -62,6 +50,7 @@ def _common_options(func):
     :param func: the command callback to decorate.
     :return: the decorated callback.
     """
+    func = output_options(func)
     options = [
         click.argument("dataset"),
         click.option(
@@ -76,16 +65,6 @@ def _common_options(func):
         ),
         click.option(
             "--result-column", "result_column", help="Override the result column name."
-        ),
-        click.option(
-            "--format", "output_format", type=_FORMAT_CHOICE, help="Output format."
-        ),
-        click.option("-o", "--output", "output", help="Write results to this path."),
-        click.option(
-            "--limit", default=1000, show_default=True, help="Row cap for table output."
-        ),
-        click.option(
-            "--overwrite", is_flag=True, help="Replace an existing output path."
         ),
     ]
     for option in reversed(options):

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -61,7 +61,7 @@ def _common_options(func):
             "--system-column", "system_column", help="Per-row system column name."
         ),
         click.option(
-            "--coding-version", "coding_version", help="Optional coding version."
+            "--system-version", "system_version", help="Optional code system version."
         ),
         click.option(
             "--result-column", "result_column", help="Override the result column name."
@@ -120,7 +120,7 @@ def _coding_column(code_column, system, system_column, version):
     :param code_column: the code column name.
     :param system: a fixed system URI, or None.
     :param system_column: a per-row system column name, or None.
-    :param version: an optional coding version.
+    :param version: an optional code system version.
     :return: a Spark Column containing a Coding struct.
     :raises CliError: when the system source is missing or ambiguous.
     """
@@ -230,7 +230,7 @@ def member_of(
     code_column,
     system,
     system_column,
-    coding_version,
+    system_version,
     result_column,
     output_format,
     output,
@@ -252,7 +252,7 @@ def member_of(
         from pathling import udfs
 
         _validate_columns(df, [code_column, system_column], dataset)
-        coding = _coding_column(code_column, system, system_column, coding_version)
+        coding = _coding_column(code_column, system, system_column, system_version)
         return df.withColumn(name, udfs.member_of(coding, value_set))
 
     _execute(
@@ -286,7 +286,7 @@ def translate(
     code_column,
     system,
     system_column,
-    coding_version,
+    system_version,
     result_column,
     output_format,
     output,
@@ -314,7 +314,7 @@ def translate(
         from pathling import udfs
 
         _validate_columns(df, [code_column, system_column], dataset)
-        coding = _coding_column(code_column, system, system_column, coding_version)
+        coding = _coding_column(code_column, system, system_column, system_version)
         translation = udfs.translate(
             coding,
             concept_map,
@@ -378,7 +378,7 @@ def _run_subsumption(
     code_column,
     system,
     system_column,
-    coding_version,
+    system_version,
     result_column,
     output_format,
     output,
@@ -398,7 +398,7 @@ def _run_subsumption(
     :param code_column: the left code column.
     :param system: the left fixed system URI, or None.
     :param system_column: the left per-row system column, or None.
-    :param coding_version: the optional coding version.
+    :param system_version: the optional code system version.
     :param result_column: the result column override, or None.
     :param output_format: the output format, or None.
     :param output: the output path, or None.
@@ -419,9 +419,9 @@ def _run_subsumption(
             [code_column, system_column, other_code_column, other_system_column],
             dataset,
         )
-        left = _coding_column(code_column, system, system_column, coding_version)
+        left = _coding_column(code_column, system, system_column, system_version)
         right = _coding_column(
-            other_code_column, other_system, other_system_column, coding_version
+            other_code_column, other_system, other_system_column, system_version
         )
         return df.withColumn(name, getattr(udfs, operation)(left, right))
 
@@ -449,7 +449,7 @@ def subsumes(
     code_column,
     system,
     system_column,
-    coding_version,
+    system_version,
     result_column,
     output_format,
     output,
@@ -475,7 +475,7 @@ def subsumes(
         code_column,
         system,
         system_column,
-        coding_version,
+        system_version,
         result_column,
         output_format,
         output,
@@ -498,7 +498,7 @@ def subsumed_by(
     code_column,
     system,
     system_column,
-    coding_version,
+    system_version,
     result_column,
     output_format,
     output,
@@ -524,7 +524,7 @@ def subsumed_by(
         code_column,
         system,
         system_column,
-        coding_version,
+        system_version,
         result_column,
         output_format,
         output,
@@ -550,7 +550,7 @@ def display(
     code_column,
     system,
     system_column,
-    coding_version,
+    system_version,
     result_column,
     output_format,
     output,
@@ -571,7 +571,7 @@ def display(
         from pathling import udfs
 
         _validate_columns(df, [code_column, system_column], dataset)
-        coding = _coding_column(code_column, system, system_column, coding_version)
+        coding = _coding_column(code_column, system, system_column, system_version)
         return df.withColumn(name, udfs.display(coding, accept_language))
 
     _execute(
@@ -609,7 +609,7 @@ def property_of(
     code_column,
     system,
     system_column,
-    coding_version,
+    system_version,
     result_column,
     output_format,
     output,
@@ -633,7 +633,7 @@ def property_of(
         from pathling import udfs
 
         _validate_columns(df, [code_column, system_column], dataset)
-        coding = _coding_column(code_column, system, system_column, coding_version)
+        coding = _coding_column(code_column, system, system_column, system_version)
         return df.withColumn(
             name,
             udfs.property_of(coding, property_code, property_type, accept_language),
@@ -667,7 +667,7 @@ def designation(
     code_column,
     system,
     system_column,
-    coding_version,
+    system_version,
     result_column,
     output_format,
     output,
@@ -691,7 +691,7 @@ def designation(
         from pathling.coding import Coding
 
         _validate_columns(df, [code_column, system_column], dataset)
-        coding = _coding_column(code_column, system, system_column, coding_version)
+        coding = _coding_column(code_column, system, system_column, system_version)
         use_coding = None
         if use:
             if "|" not in use:

--- a/lib/python/pathling/cli/view.py
+++ b/lib/python/pathling/cli/view.py
@@ -118,6 +118,10 @@ def view(
 ):
     """Run a SQL on FHIR ViewDefinition against a data source.
 
+    \b
+    See the ViewDefinition specification:
+    https://sql-on-fhir.org/ig/StructureDefinition-ViewDefinition.html
+
     Examples:
 
         pathling view data/ --view patients.json

--- a/lib/python/pathling/cli/view.py
+++ b/lib/python/pathling/cli/view.py
@@ -114,6 +114,7 @@ def view(
     output,
     limit,
     overwrite,
+    departition,
 ):
     """Run a SQL on FHIR ViewDefinition against a data source.
 
@@ -130,7 +131,7 @@ def view(
 
     spec = resolve_source(source, from_format)
     view_text, resource_type = _load_view(view_path, view_json)
-    output_spec = resolve_output(output, output_format, limit, overwrite)
+    output_spec = resolve_output(output, output_format, limit, overwrite, departition)
 
     pc = session.create_context(config, console)
     data_source = read_source(pc, spec)

--- a/lib/python/pathling/cli/view.py
+++ b/lib/python/pathling/cli/view.py
@@ -33,7 +33,7 @@ from pathling.cli import session
 from pathling.cli.errors import EXIT_USAGE, CliError
 from pathling.cli.io import FROM_CHOICES, read_source, resolve_source
 from pathling.cli.render import (
-    OutputFormat,
+    output_options,
     progress_status,
     resolve_output,
     write_output,
@@ -101,26 +101,7 @@ def _load_view(view_path, view_json) -> tuple:
 @click.option(
     "--filter", "filter_expr", help="FHIR search expression to restrict rows."
 )
-@click.option(
-    "--format",
-    "output_format",
-    type=click.Choice(
-        [
-            OutputFormat.TABLE,
-            OutputFormat.CSV,
-            OutputFormat.JSON,
-            OutputFormat.NDJSON,
-            OutputFormat.PARQUET,
-            OutputFormat.DELTA,
-        ]
-    ),
-    help="Output format (default: table; inferred from -o extension).",
-)
-@click.option("-o", "--output", "output", help="Write results to this path.")
-@click.option(
-    "--limit", default=1000, show_default=True, help="Row cap for table output."
-)
-@click.option("--overwrite", is_flag=True, help="Replace an existing output path.")
+@output_options
 @click.pass_obj
 def view(
     obj,

--- a/lib/python/pathling/cli/view.py
+++ b/lib/python/pathling/cli/view.py
@@ -138,7 +138,9 @@ def view(
     output_spec = resolve_output(output, output_format, limit, overwrite, departition)
 
     pc = session.create_context(config, console)
-    data_source = read_source(pc, spec)
+    # The view already knows its single subject resource type, so pass it to the
+    # Bundles reader to avoid a redundant driver-side discovery pass (FR-015).
+    data_source = read_source(pc, spec, types=[resource_type])
 
     if filter_expr:
         resources = data_source.read(resource_type)

--- a/lib/python/pathling/cli/view.py
+++ b/lib/python/pathling/cli/view.py
@@ -1,0 +1,165 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""The ``pathling view`` command.
+
+Executes a SQL on FHIR ViewDefinition (a JSON file or inline string) against a
+data source and emits the tabular result in the requested format, optionally
+restricting the resources processed with a FHIR search ``--filter``.
+
+Author: John Grimes.
+"""
+
+import json
+from pathlib import Path
+
+import click
+
+from pathling.cli import session
+from pathling.cli.errors import EXIT_USAGE, CliError
+from pathling.cli.io import FROM_CHOICES, read_source, resolve_source
+from pathling.cli.render import (
+    OutputFormat,
+    progress_status,
+    resolve_output,
+    write_output,
+)
+
+
+def _load_view(view_path, view_json) -> tuple:
+    """Loads and minimally validates a ViewDefinition.
+
+    :param view_path: the ``--view`` file path, or None.
+    :param view_json: the ``--view-json`` inline string, or None.
+    :return: a tuple of (view_json_string, resource_type).
+    :raises CliError: when neither or both sources are given, or the JSON is
+            malformed or missing a resource.
+    """
+    if view_path and view_json:
+        raise CliError(
+            "Provide either --view or --view-json, not both.", exit_code=EXIT_USAGE
+        )
+    if not view_path and not view_json:
+        raise CliError(
+            "A ViewDefinition is required. Pass --view <path> or --view-json '<json>'.",
+            exit_code=EXIT_USAGE,
+        )
+
+    if view_path:
+        path = Path(view_path)
+        if not path.exists():
+            raise CliError(
+                f"ViewDefinition file does not exist: {path}.", exit_code=EXIT_USAGE
+            )
+        text = path.read_text(encoding="utf-8")
+        origin = str(path)
+    else:
+        text = view_json
+        origin = "the inline --view-json value"
+
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise CliError(
+            f"The ViewDefinition in {origin} is not valid JSON: {exc}. "
+            "Check for a missing comma, brace, or quote near that position."
+        ) from exc
+
+    resource_type = parsed.get("resource")
+    if not resource_type:
+        raise CliError(
+            f"The ViewDefinition in {origin} has no 'resource'. A view must name "
+            'the resource it is based on, e.g. {"resource": "Patient", ...}.'
+        )
+    return text, resource_type
+
+
+@click.command(name="view")
+@click.argument("source")
+@click.option(
+    "--from",
+    "from_format",
+    type=click.Choice(FROM_CHOICES),
+    help="Input format (auto-detected when omitted).",
+)
+@click.option("--view", "view_path", help="Path to a ViewDefinition JSON file.")
+@click.option("--view-json", "view_json", help="Inline ViewDefinition JSON string.")
+@click.option(
+    "--filter", "filter_expr", help="FHIR search expression to restrict rows."
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(
+        [
+            OutputFormat.TABLE,
+            OutputFormat.CSV,
+            OutputFormat.JSON,
+            OutputFormat.NDJSON,
+            OutputFormat.PARQUET,
+            OutputFormat.DELTA,
+        ]
+    ),
+    help="Output format (default: table; inferred from -o extension).",
+)
+@click.option("-o", "--output", "output", help="Write results to this path.")
+@click.option(
+    "--limit", default=1000, show_default=True, help="Row cap for table output."
+)
+@click.option("--overwrite", is_flag=True, help="Replace an existing output path.")
+@click.pass_obj
+def view(
+    obj,
+    source,
+    from_format,
+    view_path,
+    view_json,
+    filter_expr,
+    output_format,
+    output,
+    limit,
+    overwrite,
+):
+    """Run a SQL on FHIR ViewDefinition against a data source.
+
+    Examples:
+
+        pathling view data/ --view patients.json
+
+        pathling view data/ --view patients.json --format csv
+
+        pathling view data/ --view-json '{"resource":"Patient",...}' -o out.parquet
+    """
+    config = obj.config
+    console = obj.console
+
+    spec = resolve_source(source, from_format)
+    view_text, resource_type = _load_view(view_path, view_json)
+    output_spec = resolve_output(output, output_format, limit, overwrite)
+
+    pc = session.create_context(config, console)
+    data_source = read_source(pc, spec)
+
+    if filter_expr:
+        resources = data_source.read(resource_type)
+        filter_column = pc.search_to_column(resource_type, filter_expr)
+        filtered = resources.filter(filter_column)
+        data_source = pc.read.datasets({resource_type: filtered})
+
+    with progress_status(console, "Running view...", config.verbose):
+        result = data_source.view(json=view_text)
+        write_output(result, output_spec, console)

--- a/lib/python/pathling/context.py
+++ b/lib/python/pathling/context.py
@@ -15,6 +15,11 @@
 # limitations under the License.
 #
 
+"""Pathling context and Spark session construction for the Python API.
+
+Author: John Grimes.
+"""
+
 # noinspection PyPackageRequirements
 
 from typing import TYPE_CHECKING, Optional, Sequence
@@ -22,11 +27,7 @@ from typing import TYPE_CHECKING, Optional, Sequence
 from py4j.java_gateway import JavaObject
 from pyspark.sql import Column, DataFrame, SparkSession
 
-from pathling._version import (
-    __delta_version__,
-    __java_version__,
-    __scala_version__,
-)
+from pathling._spark_defaults import managed_spark_defaults
 from pathling.fhir import MimeType
 
 if TYPE_CHECKING:
@@ -61,28 +62,23 @@ def _convert_typed_values(jtyped_values) -> list:
 def _build_spark_session(extra_configs: Optional[dict] = None) -> SparkSession:
     """Builds a Spark session configured with the Pathling and Delta packages.
 
-    This is the single source of truth for the package coordinates, Delta SQL
-    extension, and Delta catalog configuration that Pathling requires. Callers
-    that need to bring their own session (for example to set driver JVM options
-    before launch) supply those via ``extra_configs`` rather than re-declaring
-    the package configuration.
+    The managed package coordinates, Delta SQL extension, and Delta catalog are
+    sourced from :func:`pathling._spark_defaults.managed_spark_defaults`, the
+    single source of truth shared with the CLI merge logic. Callers that need to
+    bring their own session (for example to set driver JVM options before launch)
+    supply those via ``extra_configs`` rather than re-declaring the package
+    configuration; a caller entry overrides the matching default for that key.
 
     :param extra_configs: optional additional Spark configuration entries to set
            on the builder before the session is created.
     :return: a configured :class:`SparkSession`.
     """
-    builder = (
-        SparkSession.builder.config(
-            "spark.jars.packages",
-            f"au.csiro.pathling:library-runtime:{__java_version__},"
-            f"io.delta:delta-spark_{__scala_version__}:{__delta_version__},",
-        )
-        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-        .config(
-            "spark.sql.catalog.spark_catalog",
-            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
-        )
-    )
+    builder = SparkSession.builder
+    # Apply Pathling's managed defaults first, then any caller-supplied entries,
+    # so that a caller value (for example a quiet-logging option) overrides the
+    # corresponding default for the same key.
+    for key, value in managed_spark_defaults().items():
+        builder = builder.config(key, value)
     for key, value in (extra_configs or {}).items():
         builder = builder.config(key, value)
     return builder.getOrCreate()

--- a/lib/python/pathling/context.py
+++ b/lib/python/pathling/context.py
@@ -58,6 +58,36 @@ def _convert_typed_values(jtyped_values) -> list:
     return results
 
 
+def _build_spark_session(extra_configs: Optional[dict] = None) -> SparkSession:
+    """Builds a Spark session configured with the Pathling and Delta packages.
+
+    This is the single source of truth for the package coordinates, Delta SQL
+    extension, and Delta catalog configuration that Pathling requires. Callers
+    that need to bring their own session (for example to set driver JVM options
+    before launch) supply those via ``extra_configs`` rather than re-declaring
+    the package configuration.
+
+    :param extra_configs: optional additional Spark configuration entries to set
+           on the builder before the session is created.
+    :return: a configured :class:`SparkSession`.
+    """
+    builder = (
+        SparkSession.builder.config(
+            "spark.jars.packages",
+            f"au.csiro.pathling:library-runtime:{__java_version__},"
+            f"io.delta:delta-spark_{__scala_version__}:{__delta_version__},",
+        )
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+    )
+    for key, value in (extra_configs or {}).items():
+        builder = builder.config(key, value)
+    return builder.getOrCreate()
+
+
 class StorageType:
     MEMORY: str = "memory"
     DISK: str = "disk"
@@ -214,30 +244,15 @@ class PathlingContext:
         """
 
         def _new_spark_session():
-            spark_builder = (
-                SparkSession.builder.config(
-                    "spark.jars.packages",
-                    f"au.csiro.pathling:library-runtime:{__java_version__},"
-                    f"io.delta:delta-spark_{__scala_version__}:{__delta_version__},",
-                )
-                .config(
-                    "spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension"
-                )
-                .config(
-                    "spark.sql.catalog.spark_catalog",
-                    "org.apache.spark.sql.delta.catalog.DeltaCatalog",
-                )
-            )
-
-            # Add remote debugging configuration if enabled
+            extra_configs = {}
+            # Add remote debugging configuration if enabled.
             if enable_remote_debugging:
                 suspend_option = "y" if debug_suspend else "n"
-                debug_options = f"-agentlib:jdwp=transport=dt_socket,server=y,suspend={suspend_option},address={debug_port}"
-                spark_builder = spark_builder.config(
-                    "spark.driver.extraJavaOptions", debug_options
+                extra_configs["spark.driver.extraJavaOptions"] = (
+                    f"-agentlib:jdwp=transport=dt_socket,server=y,"
+                    f"suspend={suspend_option},address={debug_port}"
                 )
-
-            return spark_builder.getOrCreate()
+            return _build_spark_session(extra_configs)
 
         spark = spark or SparkSession.getActiveSession() or _new_spark_session()
         jvm = spark._jvm

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -38,10 +38,16 @@ classifiers = [
 dependencies = [
     "pyspark>=4.0.0,<4.1.0",
     "deprecated>=1.2.13",
+    "click>=8.1.7",
+    "rich>=13.7.0",
+    "tomli>=2.0.1; python_version < \"3.11\"",
 ]
 
 [project.urls]
 Homepage = "https://github.com/aehrc/pathling"
+
+[project.scripts]
+pathling = "pathling.cli.main:cli"
 
 [dependency-groups]
 dev = [

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -73,6 +73,7 @@ pattern = '__version__="(?P<version>[^"]+)"'
 packages = ["pathling"]
 artifacts = [
     "target/dependency/*.jar",
+    "pathling/cli/resources/*.properties",
 ]
 
 [tool.hatch.build.targets.wheel.shared-data]

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "deprecated>=1.2.13",
     "click>=8.1.7",
     "rich>=13.7.0",
+    "ipython>=8.18.1",
     "tomli>=2.0.1; python_version < \"3.11\"",
 ]
 
@@ -54,7 +55,6 @@ dev = [
     "Sphinx>=1.6,<8",
     "sphinx-rtd-theme==1.2.2",
     "pytest==8.2.0",
-    "ipython==8.10.0",
     "wheel==0.46.3",
     "twine==6.2.0",
     "build==1.2.1",

--- a/lib/python/tests/cli/__init__.py
+++ b/lib/python/tests/cli/__init__.py
@@ -1,0 +1,21 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for the Pathling command line interface.
+
+Author: John Grimes.
+"""

--- a/lib/python/tests/cli/conftest.py
+++ b/lib/python/tests/cli/conftest.py
@@ -26,8 +26,28 @@ shared mock-backed context instead of starting a fresh Spark session.
 Author: John Grimes.
 """
 
+import inspect
+
 from click.testing import CliRunner
 from pytest import fixture
+
+
+def make_cli_runner(runner_cls=CliRunner):
+    """Builds a Click ``CliRunner``, keeping stdout and stderr separate where
+    supported.
+
+    Click 8.2 removed the ``mix_stderr`` parameter from ``CliRunner.__init__``.
+    This passes ``mix_stderr=False`` only when the constructor still accepts it,
+    so the fixture builds on Click 8.1 (Python 3.9) and 8.2+ (Python 3.10+).
+
+    :param runner_cls: the runner class to construct; overridable so the
+           feature-detection branches can be tested without a particular Click
+           version installed. Defaults to :class:`click.testing.CliRunner`.
+    :return: a constructed runner instance.
+    """
+    if "mix_stderr" in inspect.signature(runner_cls.__init__).parameters:
+        return runner_cls(mix_stderr=False)
+    return runner_cls()
 
 
 @fixture
@@ -36,7 +56,7 @@ def runner():
 
     :return: a configured :class:`CliRunner`.
     """
-    return CliRunner(mix_stderr=False)
+    return make_cli_runner()
 
 
 @fixture

--- a/lib/python/tests/cli/conftest.py
+++ b/lib/python/tests/cli/conftest.py
@@ -1,0 +1,60 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Shared fixtures for the command line interface tests.
+
+The session-scoped Spark/``PathlingContext`` fixture (``pathling_ctx``), the
+mock server fixture (``mock_server``), and the test data directory fixture
+(``test_data_dir``) are inherited from the parent ``tests/conftest.py``. This
+module adds a Click ``CliRunner`` and a helper that makes commands use the
+shared mock-backed context instead of starting a fresh Spark session.
+
+Author: John Grimes.
+"""
+
+from click.testing import CliRunner
+from pytest import fixture
+
+
+@fixture
+def runner():
+    """Provides a Click ``CliRunner`` with stdout and stderr kept separate.
+
+    :return: a configured :class:`CliRunner`.
+    """
+    return CliRunner(mix_stderr=False)
+
+
+@fixture
+def patched_context(monkeypatch, pathling_ctx):
+    """Makes commands reuse the shared mock-backed ``PathlingContext``.
+
+    Commands call ``session.create_context`` to obtain a context; this fixture
+    replaces that with a factory returning the session-scoped ``pathling_ctx``,
+    which is wired to the JVM mock terminology service, so terminology commands
+    run without a live server and without paying a per-test Spark cold start.
+
+    :param monkeypatch: the pytest monkeypatch fixture.
+    :param pathling_ctx: the shared Pathling context fixture.
+    :return: the shared :class:`PathlingContext`.
+    """
+
+    def _factory(config, console=None):
+        return pathling_ctx
+
+    monkeypatch.setattr("pathling.cli.session.create_context", _factory)
+    return pathling_ctx

--- a/lib/python/tests/cli/test_config.py
+++ b/lib/python/tests/cli/test_config.py
@@ -33,6 +33,7 @@ from pathling.cli.config import (
     CliConfig,
     default_config_path,
     load_config_file,
+    resolve_bulk_auth,
     resolve_config,
     resolve_config_source,
     resolve_secret,
@@ -55,6 +56,21 @@ def _write_named(directory: Path, name: str, contents: str) -> Path:
     return path
 
 
+def _isolated_defaults(monkeypatch, tmp_path: Path) -> dict:
+    """Returns resolve_config kwargs that yield built-in defaults with no file.
+
+    Isolates user-level discovery (via XDG, writing no user file) and points the
+    project search at an empty directory, so configuration resolves to the
+    built-in defaults without an explicit ``--config`` path. This replaces the
+    former idiom of passing a non-existent ``--config`` path, which is now a
+    usage error (FR-002).
+    """
+    _user_config(monkeypatch, tmp_path)
+    empty = tmp_path / "empty-cwd"
+    empty.mkdir()
+    return {"cwd": empty}
+
+
 def _user_config(monkeypatch, tmp_path: Path) -> Path:
     """Isolates user-level config discovery and returns the user config path.
 
@@ -73,15 +89,127 @@ def _user_config(monkeypatch, tmp_path: Path) -> Path:
 # ========== Defaults ==========
 
 
-def test_defaults_when_no_flags_or_file(tmp_path):
+def test_defaults_when_no_flags_or_file(tmp_path, monkeypatch):
     """With no flags and no file, built-in defaults are used."""
-    config = resolve_config(config_path=tmp_path / "missing.toml")
+    config = resolve_config(**_isolated_defaults(monkeypatch, tmp_path))
 
     assert config.tx_server == DEFAULT_TX_SERVER
     assert config.fhir_version == DEFAULT_FHIR_VERSION
     assert config.tx_auth is None
     assert config.verbose is False
     assert config.config_path is None
+    assert config.bulk_auth_table is None
+
+
+# ========== Explicit config existence, bulk-auth table, partial tx auth (US1) ==========
+
+
+def test_explicit_missing_config_is_usage_error(tmp_path):
+    """An explicit --config path that does not exist is a usage error naming it.
+
+    The command must not silently fall back to another config file's
+    credentials (FR-002).
+    """
+    missing = tmp_path / "does-not-exist.toml"
+
+    with pytest.raises(CliError) as exc_info:
+        resolve_config(config_path=missing)
+
+    assert exc_info.value.exit_code == 2
+    assert str(missing) in exc_info.value.message
+
+
+def test_cliconfig_carries_bulk_auth_table_and_loaded_path(tmp_path):
+    """CliConfig carries the parsed [bulk-auth] table and the file loaded.
+
+    This lets ``export`` resolve credentials from the already-resolved config
+    rather than re-reading a config file path (FR-003).
+    """
+    path = _write_config(
+        tmp_path,
+        "[bulk-auth]\n"
+        'client-id = "bulk-client"\n'
+        'token-endpoint = "https://auth/token"\n'
+        'client-secret = "shh"\n',
+    )
+
+    config = resolve_config(config_path=path)
+
+    assert config.config_path == path
+    assert config.bulk_auth_table == {
+        "client-id": "bulk-client",
+        "token-endpoint": "https://auth/token",
+        "client-secret": "shh",
+    }
+
+
+def test_bulk_auth_table_absent_is_none(tmp_path):
+    """A config file with no [bulk-auth] table yields a None bulk_auth_table."""
+    path = _write_config(tmp_path, 'tx-server = "https://a/fhir"\n')
+
+    config = resolve_config(config_path=path)
+
+    assert config.bulk_auth_table is None
+
+
+def test_resolve_bulk_auth_no_input_returns_none():
+    """With no auth input at all, resolution returns None (unauthenticated)."""
+    assert resolve_bulk_auth(None) is None
+    assert resolve_bulk_auth({}) is None
+
+
+def test_resolve_bulk_auth_input_without_client_id_errors():
+    """Auth input present but no client ID is a usage error, not a silent skip.
+
+    Covers both the flag path and the [bulk-auth] table path (FR-004).
+    """
+    with pytest.raises(CliError) as flag_error:
+        resolve_bulk_auth(
+            None, token_endpoint="https://auth/token", client_secret="shh"
+        )
+    assert flag_error.value.exit_code == 2
+    assert "client id" in flag_error.value.message.lower()
+
+    table = {"token-endpoint": "https://auth/token", "client-secret": "shh"}
+    with pytest.raises(CliError) as table_error:
+        resolve_bulk_auth(table)
+    assert table_error.value.exit_code == 2
+
+
+def test_partial_terminology_auth_warns(tmp_path):
+    """Partial terminology auth (insufficient to authenticate) warns the user.
+
+    Supplying only a client ID is not enough to authenticate (a token endpoint
+    is also required); the user is told rather than having it silently disabled
+    (FR-005).
+    """
+    path = _write_config(tmp_path, 'tx-server = "https://a/fhir"\n')
+    warnings = []
+
+    config = resolve_config(
+        tx_client_id="only-client", config_path=path, on_warning=warnings.append
+    )
+
+    # The auth is not enabled, and the user was warned about why.
+    assert config.tx_auth is not None and config.tx_auth.enabled is False
+    assert any(
+        "terminolog" in message.lower() and "auth" in message.lower()
+        for message in warnings
+    )
+
+
+def test_complete_terminology_auth_does_not_warn(tmp_path):
+    """A complete terminology auth configuration produces no partial-auth warning."""
+    path = _write_config(
+        tmp_path,
+        '[terminology-auth]\nclient-id = "c"\ntoken-endpoint = "https://auth/token"\n',
+    )
+    warnings = []
+
+    config = resolve_config(config_path=path, on_warning=warnings.append)
+
+    assert config.tx_auth.enabled is True
+    assert not any("incomplete" in message.lower() for message in warnings)
 
 
 # ========== Precedence ==========
@@ -113,10 +241,10 @@ def test_fhir_version_precedence(tmp_path):
     assert resolve_config(fhir_version="R4", config_path=path).fhir_version == "R4"
 
 
-def test_unsupported_fhir_version_is_usage_error(tmp_path):
+def test_unsupported_fhir_version_is_usage_error(tmp_path, monkeypatch):
     """An unsupported FHIR version is rejected as a usage error."""
     with pytest.raises(CliError) as exc_info:
-        resolve_config(fhir_version="R3", config_path=tmp_path / "missing.toml")
+        resolve_config(fhir_version="R3", **_isolated_defaults(monkeypatch, tmp_path))
 
     assert exc_info.value.exit_code == 2
     assert "R3" in exc_info.value.message
@@ -596,25 +724,27 @@ def test_spark_flag_overrides_file_value(tmp_path):
     assert config.spark_conf["spark.executor.memory"] == "4g"
 
 
-def test_spark_flag_repeated_last_wins(tmp_path):
+def test_spark_flag_repeated_last_wins(tmp_path, monkeypatch):
     """A repeated flag for the same key resolves to the last occurrence."""
     flags = parse_spark_conf_flags(
         ["spark.executor.memory=2g", "spark.executor.memory=4g"]
     )
 
     config = resolve_config(
-        config_path=tmp_path / "missing.toml", spark_conf_flags=flags
+        spark_conf_flags=flags, **_isolated_defaults(monkeypatch, tmp_path)
     )
 
     assert config.spark_conf["spark.executor.memory"] == "4g"
 
 
-def test_spark_flag_non_spark_key_is_error(tmp_path):
+def test_spark_flag_non_spark_key_is_error(tmp_path, monkeypatch):
     """A non-spark. key supplied via flag aborts with a CliError."""
     flags = {"executor.memory": "4g"}
 
     with pytest.raises(CliError) as exc_info:
-        resolve_config(config_path=tmp_path / "missing.toml", spark_conf_flags=flags)
+        resolve_config(
+            spark_conf_flags=flags, **_isolated_defaults(monkeypatch, tmp_path)
+        )
 
     assert exc_info.value.exit_code == 2
     assert "executor.memory" in exc_info.value.message

--- a/lib/python/tests/cli/test_config.py
+++ b/lib/python/tests/cli/test_config.py
@@ -30,6 +30,7 @@ import pytest
 from pathling.cli.config import (
     DEFAULT_FHIR_VERSION,
     DEFAULT_TX_SERVER,
+    CliConfig,
     default_config_path,
     load_config_file,
     resolve_config,
@@ -37,6 +38,7 @@ from pathling.cli.config import (
     resolve_secret,
 )
 from pathling.cli.errors import CliError
+from pathling.cli.sparkconf import parse_spark_conf_flags
 
 
 def _write_config(tmp_path: Path, contents: str) -> Path:
@@ -509,3 +511,110 @@ def test_unreadable_config_file_errors(tmp_path):
     finally:
         # Restore permissions so the temp file can be cleaned up.
         os.chmod(path, 0o644)
+
+
+# ========== Spark configuration: field and valid key (Foundational) ==========
+
+
+def test_cliconfig_has_empty_spark_conf_by_default():
+    """CliConfig exposes a spark_conf field defaulting to an empty dict."""
+    config = CliConfig()
+
+    assert config.spark_conf == {}
+    # Each instance must get its own dict, never a shared mutable default.
+    other = CliConfig()
+    config.spark_conf["spark.x"] = "1"
+    assert other.spark_conf == {}
+
+
+def test_spark_table_is_a_valid_top_level_key(tmp_path):
+    """A [spark] table produces no unknown-key warning (spark is valid)."""
+    path = _write_config(tmp_path, '[spark]\n"spark.sql.shuffle.partitions" = 16\n')
+    warnings = []
+
+    load_config_file(path, on_warning=warnings.append)
+
+    assert not any(
+        "spark" in message and "unknown" in message.lower() for message in warnings
+    )
+
+
+# ========== Spark configuration: [spark] table resolution (US1) ==========
+
+
+def test_spark_table_resolved_into_spark_conf(tmp_path):
+    """A [spark] table is coerced and stored on CliConfig.spark_conf."""
+    path = _write_config(
+        tmp_path,
+        "[spark]\n"
+        '"spark.sql.shuffle.partitions" = 16\n'
+        '"spark.sql.adaptive.enabled" = true\n',
+    )
+
+    config = resolve_config(config_path=path)
+
+    # Plain keys pass through the merge as coerced strings.
+    assert config.spark_conf["spark.sql.shuffle.partitions"] == "16"
+    assert config.spark_conf["spark.sql.adaptive.enabled"] == "true"
+
+
+def test_spark_table_resolves_file_secret(tmp_path):
+    """A @file value in the [spark] table is resolved from the file."""
+    secret_file = tmp_path / "s3-key"
+    secret_file.write_text("the-key\n", encoding="utf-8")
+    path = _write_config(
+        tmp_path,
+        f'[spark]\n"spark.hadoop.fs.s3a.secret.key" = "@{secret_file}"\n',
+    )
+
+    config = resolve_config(config_path=path)
+
+    assert config.spark_conf["spark.hadoop.fs.s3a.secret.key"] == "the-key"
+
+
+def test_spark_table_invalid_key_is_usage_error(tmp_path):
+    """A non-spark. key in the [spark] table aborts with exit code 2."""
+    path = _write_config(tmp_path, '[spark]\n"executor.memory" = "4g"\n')
+
+    with pytest.raises(CliError) as exc_info:
+        resolve_config(config_path=path)
+
+    assert exc_info.value.exit_code == 2
+    assert "executor.memory" in exc_info.value.message
+
+
+# ========== Spark configuration: --spark-conf flag precedence (US2) ==========
+
+
+def test_spark_flag_overrides_file_value(tmp_path):
+    """A --spark-conf flag value overrides the [spark] table for the same key."""
+    path = _write_config(tmp_path, '[spark]\n"spark.executor.memory" = "2g"\n')
+    flags = parse_spark_conf_flags(["spark.executor.memory=4g"])
+
+    config = resolve_config(config_path=path, spark_conf_flags=flags)
+
+    assert config.spark_conf["spark.executor.memory"] == "4g"
+
+
+def test_spark_flag_repeated_last_wins(tmp_path):
+    """A repeated flag for the same key resolves to the last occurrence."""
+    flags = parse_spark_conf_flags(
+        ["spark.executor.memory=2g", "spark.executor.memory=4g"]
+    )
+
+    config = resolve_config(
+        config_path=tmp_path / "missing.toml", spark_conf_flags=flags
+    )
+
+    assert config.spark_conf["spark.executor.memory"] == "4g"
+
+
+def test_spark_flag_non_spark_key_is_error(tmp_path):
+    """A non-spark. key supplied via flag aborts with a CliError."""
+    flags = {"executor.memory": "4g"}
+
+    with pytest.raises(CliError) as exc_info:
+        resolve_config(config_path=tmp_path / "missing.toml", spark_conf_flags=flags)
+
+    assert exc_info.value.exit_code == 2
+    assert "executor.memory" in exc_info.value.message

--- a/lib/python/tests/cli/test_config.py
+++ b/lib/python/tests/cli/test_config.py
@@ -1,0 +1,212 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for configuration loading and precedence.
+
+These tests exercise the pure configuration logic without starting Spark.
+
+Author: John Grimes.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from pathling.cli.config import (
+    DEFAULT_FHIR_VERSION,
+    DEFAULT_TX_SERVER,
+    default_config_path,
+    load_config_file,
+    resolve_config,
+    resolve_secret,
+)
+from pathling.cli.errors import CliError
+
+
+def _write_config(tmp_path: Path, contents: str) -> Path:
+    """Writes a config file and returns its path."""
+    path = tmp_path / "config.toml"
+    path.write_text(contents, encoding="utf-8")
+    return path
+
+
+# ========== Defaults ==========
+
+
+def test_defaults_when_no_flags_or_file(tmp_path):
+    """With no flags and no file, built-in defaults are used."""
+    config = resolve_config(config_path=tmp_path / "missing.toml")
+
+    assert config.tx_server == DEFAULT_TX_SERVER
+    assert config.fhir_version == DEFAULT_FHIR_VERSION
+    assert config.tx_auth is None
+    assert config.verbose is False
+    assert config.config_path is None
+
+
+# ========== Precedence ==========
+
+
+def test_file_overrides_default(tmp_path):
+    """A value in the config file overrides the built-in default."""
+    path = _write_config(tmp_path, 'tx-server = "https://file.example/fhir"\n')
+
+    config = resolve_config(config_path=path)
+
+    assert config.tx_server == "https://file.example/fhir"
+    assert config.config_path == path
+
+
+def test_flag_overrides_file(tmp_path):
+    """A command-line flag overrides the config file."""
+    path = _write_config(tmp_path, 'tx-server = "https://file.example/fhir"\n')
+
+    config = resolve_config(tx_server="https://flag.example/fhir", config_path=path)
+
+    assert config.tx_server == "https://flag.example/fhir"
+
+
+def test_fhir_version_precedence(tmp_path):
+    """The FHIR version follows flag > file > default."""
+    path = _write_config(tmp_path, 'fhir-version = "R4"\n')
+    assert resolve_config(config_path=path).fhir_version == "R4"
+    assert resolve_config(fhir_version="R4", config_path=path).fhir_version == "R4"
+
+
+def test_unsupported_fhir_version_is_usage_error(tmp_path):
+    """An unsupported FHIR version is rejected as a usage error."""
+    with pytest.raises(CliError) as exc_info:
+        resolve_config(fhir_version="R3", config_path=tmp_path / "missing.toml")
+
+    assert exc_info.value.exit_code == 2
+    assert "R3" in exc_info.value.message
+
+
+# ========== XDG path resolution ==========
+
+
+def test_default_config_path_honours_xdg(monkeypatch):
+    """The default config path honours XDG_CONFIG_HOME when set."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/custom/xdg")
+
+    assert default_config_path() == Path("/custom/xdg/pathling/config.toml")
+
+
+def test_default_config_path_falls_back_to_home(monkeypatch):
+    """The default config path falls back to ~/.config when XDG is unset."""
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: Path("/home/tester")))
+
+    assert default_config_path() == Path("/home/tester/.config/pathling/config.toml")
+
+
+# ========== Unknown key warnings ==========
+
+
+def test_unknown_top_level_key_warns(tmp_path):
+    """An unknown top-level config key produces a warning naming the key."""
+    path = _write_config(tmp_path, 'unknown-key = "x"\ntx-server = "https://a/fhir"\n')
+    warnings = []
+
+    load_config_file(path, on_warning=warnings.append)
+
+    assert any("unknown-key" in message for message in warnings)
+    assert any("Valid keys" in message for message in warnings)
+
+
+def test_unknown_auth_key_warns(tmp_path):
+    """An unknown key within an auth table produces a qualified warning."""
+    path = _write_config(tmp_path, '[terminology-auth]\nbogus = 1\nclient-id = "abc"\n')
+    warnings = []
+
+    load_config_file(path, on_warning=warnings.append)
+
+    assert any("terminology-auth.bogus" in message for message in warnings)
+
+
+# ========== Terminology auth table ==========
+
+
+def test_terminology_auth_table(tmp_path):
+    """The [terminology-auth] table is resolved into TxAuth."""
+    path = _write_config(
+        tmp_path,
+        'tx-server = "https://tx/fhir"\n\n'
+        "[terminology-auth]\n"
+        'client-id = "my-client"\n'
+        'client-secret = "shh"\n'
+        'token-endpoint = "https://auth/token"\n'
+        'scope = "system/*.read"\n',
+    )
+
+    config = resolve_config(config_path=path)
+
+    assert config.tx_auth is not None
+    assert config.tx_auth.client_id == "my-client"
+    assert config.tx_auth.client_secret == "shh"
+    assert config.tx_auth.token_endpoint == "https://auth/token"
+    assert config.tx_auth.scope == "system/*.read"
+    assert config.tx_auth.enabled is True
+
+
+def test_auth_flag_overrides_file_secret(tmp_path):
+    """An auth flag overrides the corresponding config file value."""
+    path = _write_config(
+        tmp_path,
+        "[terminology-auth]\n"
+        'client-id = "file-client"\n'
+        'token-endpoint = "https://auth/token"\n',
+    )
+
+    config = resolve_config(tx_client_id="flag-client", config_path=path)
+
+    assert config.tx_auth.client_id == "flag-client"
+
+
+# ========== Secret resolution ==========
+
+
+def test_resolve_secret_literal():
+    """A literal secret is returned unchanged."""
+    assert resolve_secret("literal-secret") == "literal-secret"
+
+
+def test_resolve_secret_from_file(tmp_path):
+    """A @file reference reads and strips the file contents."""
+    secret_file = tmp_path / "secret.txt"
+    secret_file.write_text("  file-secret\n", encoding="utf-8")
+
+    assert resolve_secret(f"@{secret_file}") == "file-secret"
+
+
+def test_resolve_secret_missing_file_errors(tmp_path):
+    """A @file reference to a missing file is an error."""
+    with pytest.raises(CliError):
+        resolve_secret(f"@{tmp_path / 'nope.txt'}")
+
+
+def test_resolve_secret_from_env():
+    """A None value falls back to the named environment variable."""
+    assert (
+        resolve_secret(None, "MY_SECRET", env={"MY_SECRET": "env-secret"})
+        == "env-secret"
+    )
+
+
+def test_resolve_secret_none_without_env():
+    """A None value with no env var yields None."""
+    assert resolve_secret(None, "MISSING", env={}) is None

--- a/lib/python/tests/cli/test_config.py
+++ b/lib/python/tests/cli/test_config.py
@@ -22,6 +22,7 @@ These tests exercise the pure configuration logic without starting Spark.
 Author: John Grimes.
 """
 
+import os
 from pathlib import Path
 
 import pytest
@@ -470,3 +471,41 @@ def test_no_notice_for_user_none_and_explicit_origins(tmp_path, monkeypatch):
     explicit_notices = []
     resolve_config(config_path=explicit, cwd=project, on_notice=explicit_notices.append)
     assert explicit_notices == []
+
+
+# ========== Config file read errors ==========
+
+
+def test_project_config_that_is_a_directory_errors(tmp_path, monkeypatch):
+    """A project pathling.toml that is a directory raises a clear CliError
+    naming it, rather than silently falling back to the user-level file."""
+    # A user-level file exists, so a silent fallback would be observable.
+    user_path = _user_config(monkeypatch, tmp_path)
+    user_path.write_text('tx-server = "https://user.example/fhir"\n', encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir()
+    # Create the project config path as a directory rather than a file.
+    (project / "pathling.toml").mkdir()
+
+    with pytest.raises(CliError) as exc_info:
+        resolve_config(cwd=project)
+
+    assert str(project / "pathling.toml") in exc_info.value.message
+
+
+def test_unreadable_config_file_errors(tmp_path):
+    """An unreadable config file raises a clear CliError naming it."""
+    path = _write_config(tmp_path, 'tx-server = "https://a/fhir"\n')
+    os.chmod(path, 0o000)
+    # Skip when the file remains readable (for example when running as root).
+    if os.access(path, os.R_OK):
+        os.chmod(path, 0o644)
+        pytest.skip("cannot make the file unreadable as the current user")
+
+    try:
+        with pytest.raises(CliError) as exc_info:
+            resolve_config(config_path=path)
+        assert str(path) in exc_info.value.message
+    finally:
+        # Restore permissions so the temp file can be cleaned up.
+        os.chmod(path, 0o644)

--- a/lib/python/tests/cli/test_config.py
+++ b/lib/python/tests/cli/test_config.py
@@ -32,6 +32,7 @@ from pathling.cli.config import (
     default_config_path,
     load_config_file,
     resolve_config,
+    resolve_config_source,
     resolve_secret,
 )
 from pathling.cli.errors import CliError
@@ -42,6 +43,28 @@ def _write_config(tmp_path: Path, contents: str) -> Path:
     path = tmp_path / "config.toml"
     path.write_text(contents, encoding="utf-8")
     return path
+
+
+def _write_named(directory: Path, name: str, contents: str) -> Path:
+    """Writes a named config file into a directory and returns its path."""
+    path = directory / name
+    path.write_text(contents, encoding="utf-8")
+    return path
+
+
+def _user_config(monkeypatch, tmp_path: Path) -> Path:
+    """Isolates user-level config discovery and returns the user config path.
+
+    Points ``XDG_CONFIG_HOME`` at a directory under ``tmp_path`` so that
+    ``default_config_path()`` never resolves to the real user file. The parent
+    directory is created; the file itself is not, so callers control whether a
+    user-level config exists by writing to the returned path.
+    """
+    xdg = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    user_path = xdg / "pathling" / "config.toml"
+    user_path.parent.mkdir(parents=True, exist_ok=True)
+    return user_path
 
 
 # ========== Defaults ==========
@@ -210,3 +233,240 @@ def test_resolve_secret_from_env():
 def test_resolve_secret_none_without_env():
     """A None value with no env var yields None."""
     assert resolve_secret(None, "MISSING", env={}) is None
+
+
+# ========== Project-local config: override (US1) ==========
+
+
+def test_project_config_overrides_user_config(tmp_path, monkeypatch):
+    """A project-local pathling.toml overrides the user-level config value."""
+    # Arrange: a user-level config sets server A, a project file sets server B.
+    user_path = _user_config(monkeypatch, tmp_path)
+    user_path.write_text('tx-server = "https://user.example/fhir"\n', encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir()
+    project_file = _write_named(
+        project, "pathling.toml", 'tx-server = "https://project.example/fhir"\n'
+    )
+
+    # Act.
+    config = resolve_config(cwd=project)
+
+    # Assert: the project value wins and the chosen path is the project file.
+    assert config.tx_server == "https://project.example/fhir"
+    assert config.config_path == project_file
+
+
+def test_user_config_used_when_no_project_file(tmp_path, monkeypatch):
+    """With no project pathling.toml, the user-level config is used."""
+    user_path = _user_config(monkeypatch, tmp_path)
+    user_path.write_text('tx-server = "https://user.example/fhir"\n', encoding="utf-8")
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    config = resolve_config(cwd=empty)
+
+    assert config.tx_server == "https://user.example/fhir"
+    assert config.config_path == user_path
+
+
+def test_flag_overrides_project_config(tmp_path, monkeypatch):
+    """A --tx-server flag overrides a project-local pathling.toml value."""
+    _user_config(monkeypatch, tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_named(
+        project, "pathling.toml", 'tx-server = "https://project.example/fhir"\n'
+    )
+
+    config = resolve_config(tx_server="https://flag.example/fhir", cwd=project)
+
+    assert config.tx_server == "https://flag.example/fhir"
+
+
+def test_explicit_config_ignores_project_file(tmp_path, monkeypatch):
+    """An explicit config_path is used and the project pathling.toml ignored."""
+    _user_config(monkeypatch, tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_named(
+        project, "pathling.toml", 'tx-server = "https://project.example/fhir"\n'
+    )
+    explicit = _write_named(
+        project, "explicit.toml", 'tx-server = "https://explicit.example/fhir"\n'
+    )
+
+    config = resolve_config(config_path=explicit, cwd=project)
+
+    assert config.tx_server == "https://explicit.example/fhir"
+    assert config.config_path == explicit
+
+
+def test_resolve_config_source_origins(tmp_path, monkeypatch):
+    """resolve_config_source returns the right path and origin per precedence."""
+    user_path = _user_config(monkeypatch, tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    # Explicit wins regardless of any project or user file.
+    explicit = tmp_path / "explicit.toml"
+    assert resolve_config_source(explicit, project) == (explicit, "explicit")
+
+    # The project-local file is chosen when present and no explicit path is given.
+    project_file = _write_named(project, "pathling.toml", "")
+    assert resolve_config_source(None, project) == (project_file, "project")
+
+    # The user-level file is chosen when it exists and no project file is present.
+    user_path.write_text("", encoding="utf-8")
+    assert resolve_config_source(None, empty) == (user_path, "user")
+
+    # Origin "none" returns the (missing) user path so defaults apply.
+    user_path.unlink()
+    assert resolve_config_source(None, empty) == (user_path, "none")
+
+
+def test_project_config_parse_error_names_file(tmp_path, monkeypatch):
+    """A malformed project pathling.toml raises CliError naming that file."""
+    _user_config(monkeypatch, tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    bad = _write_named(project, "pathling.toml", "this is not = = valid toml\n")
+
+    with pytest.raises(CliError) as exc_info:
+        resolve_config(cwd=project)
+
+    assert str(bad) in exc_info.value.message
+
+
+def test_project_config_unknown_key_warns_naming_file(tmp_path, monkeypatch):
+    """An unknown key in the project file warns, naming that file."""
+    _user_config(monkeypatch, tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    bad = _write_named(project, "pathling.toml", 'unknown-key = "x"\n')
+    warnings = []
+
+    resolve_config(cwd=project, on_warning=warnings.append)
+
+    assert any("unknown-key" in message and str(bad) in message for message in warnings)
+
+
+# ========== Project-local config: no merge (US2) ==========
+
+
+def test_omitted_project_key_falls_back_to_default_not_user(tmp_path, monkeypatch):
+    """A key omitted from the project file resolves to the built-in default,
+    never to the user-level value (FR-003, no silent merge).
+
+    The terminology server is used as the distinguishing key because its
+    built-in default differs from a value the user can set. The FHIR version
+    cannot demonstrate this on its own, as the only supported version equals
+    its default.
+    """
+    # Arrange: the user-level file sets tx-server (server A) and fhir-version.
+    user_path = _user_config(monkeypatch, tmp_path)
+    user_path.write_text(
+        'tx-server = "https://user.example/fhir"\nfhir-version = "R4"\n',
+        encoding="utf-8",
+    )
+    project = tmp_path / "project"
+    project.mkdir()
+    # The project file sets only fhir-version, deliberately omitting tx-server.
+    _write_named(project, "pathling.toml", 'fhir-version = "R4"\n')
+
+    config = resolve_config(cwd=project)
+
+    # The omitted tx-server falls back to the default, not the user value A.
+    assert config.tx_server == DEFAULT_TX_SERVER
+    assert config.fhir_version == DEFAULT_FHIR_VERSION
+
+
+def test_user_auth_table_does_not_leak_into_project(tmp_path, monkeypatch):
+    """A user-level [terminology-auth] table does not apply when the project
+    file defines no auth table."""
+    user_path = _user_config(monkeypatch, tmp_path)
+    user_path.write_text(
+        "[terminology-auth]\n"
+        'client-id = "user-client"\n'
+        'token-endpoint = "https://user-auth/token"\n',
+        encoding="utf-8",
+    )
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_named(
+        project, "pathling.toml", 'tx-server = "https://project.example/fhir"\n'
+    )
+
+    config = resolve_config(cwd=project)
+
+    assert config.tx_auth is None
+
+
+# ========== Project-local config: notice (US3) ==========
+
+
+def test_notice_for_project_file_with_user_file(tmp_path, monkeypatch):
+    """A discovered project file emits one notice naming it and the overridden
+    user-level file."""
+    user_path = _user_config(monkeypatch, tmp_path)
+    user_path.write_text('tx-server = "https://user.example/fhir"\n', encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir()
+    project_file = _write_named(
+        project, "pathling.toml", 'tx-server = "https://project.example/fhir"\n'
+    )
+    notices = []
+
+    resolve_config(cwd=project, on_notice=notices.append)
+
+    assert notices == [f"Using project config {project_file} (overrides {user_path})."]
+
+
+def test_notice_omits_overrides_without_user_file(tmp_path, monkeypatch):
+    """The notice omits the overrides clause when no user-level file exists."""
+    # Isolate XDG but write no user-level file.
+    _user_config(monkeypatch, tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    project_file = _write_named(
+        project, "pathling.toml", 'tx-server = "https://project.example/fhir"\n'
+    )
+    notices = []
+
+    resolve_config(cwd=project, on_notice=notices.append)
+
+    assert notices == [f"Using project config {project_file}."]
+
+
+def test_no_notice_for_user_none_and_explicit_origins(tmp_path, monkeypatch):
+    """No notice is emitted for the user, none, and explicit origins."""
+    user_path = _user_config(monkeypatch, tmp_path)
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    # User origin: a user-level file exists, no project file present.
+    user_path.write_text('tx-server = "https://user.example/fhir"\n', encoding="utf-8")
+    user_notices = []
+    resolve_config(cwd=empty, on_notice=user_notices.append)
+    assert user_notices == []
+
+    # None origin: neither a user-level nor a project file exists.
+    user_path.unlink()
+    none_notices = []
+    resolve_config(cwd=empty, on_notice=none_notices.append)
+    assert none_notices == []
+
+    # Explicit origin: an explicit path is given, the project file is ignored.
+    project = tmp_path / "project"
+    project.mkdir()
+    explicit = _write_named(
+        project, "explicit.toml", 'tx-server = "https://explicit.example/fhir"\n'
+    )
+    _write_named(
+        project, "pathling.toml", 'tx-server = "https://project.example/fhir"\n'
+    )
+    explicit_notices = []
+    resolve_config(config_path=explicit, cwd=project, on_notice=explicit_notices.append)
+    assert explicit_notices == []

--- a/lib/python/tests/cli/test_console.py
+++ b/lib/python/tests/cli/test_console.py
@@ -1,0 +1,95 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for the ``pathling console`` command.
+
+The banner builder is unit tested as a plain function; the IPython embedding is
+tested with ``IPython.start_ipython`` monkeypatched, asserting the namespace,
+configuration, and eager startup order. Real REPL behaviour is verified by
+manual demonstration per the feature quickstart.
+
+Author: John Grimes.
+"""
+
+import IPython
+
+from pathling._version import __version__
+from pathling.cli.console import build_banner
+from pathling.cli.main import cli
+
+# ========== Banner builder ==========
+
+
+def test_banner_contains_version_variables_and_exit_hint():
+    """The banner names the version, both variables, and how to exit."""
+    banner = build_banner()
+
+    assert __version__ in banner
+    assert "spark" in banner
+    assert "pathling" in banner
+    assert "exit" in banner.lower()
+
+
+# ========== IPython embedding ==========
+
+
+def test_console_starts_ipython_with_namespace(runner, patched_context, monkeypatch):
+    """The console passes argv=[], the exact namespace, and the banner."""
+    captured = {}
+
+    def fake_start_ipython(argv=None, user_ns=None, config=None, **kwargs):
+        captured["argv"] = argv
+        captured["user_ns"] = user_ns
+        captured["config"] = config
+
+    monkeypatch.setattr(IPython, "start_ipython", fake_start_ipython)
+
+    result = runner.invoke(cli, ["console"])
+
+    # A clean return from IPython exits 0.
+    assert result.exit_code == 0, result.stderr
+    # IPython must not consume the process's own argv.
+    assert captured["argv"] == []
+    # The namespace contains exactly spark and pathling, correctly bound.
+    assert captured["user_ns"] == {
+        "spark": patched_context.spark,
+        "pathling": patched_context,
+    }
+    # The configuration carries the banner.
+    assert captured["config"].TerminalInteractiveShell.banner1 == build_banner()
+
+
+def test_console_creates_context_before_starting_ipython(
+    runner, pathling_ctx, monkeypatch
+):
+    """The environment is created eagerly, before the REPL starts."""
+    calls = []
+
+    def factory(config, console=None):
+        calls.append("create_context")
+        return pathling_ctx
+
+    def fake_start_ipython(argv=None, user_ns=None, config=None, **kwargs):
+        calls.append("start_ipython")
+
+    monkeypatch.setattr("pathling.cli.session.create_context", factory)
+    monkeypatch.setattr(IPython, "start_ipython", fake_start_ipython)
+
+    result = runner.invoke(cli, ["console"])
+
+    assert result.exit_code == 0, result.stderr
+    assert calls == ["create_context", "start_ipython"]

--- a/lib/python/tests/cli/test_convert.py
+++ b/lib/python/tests/cli/test_convert.py
@@ -23,14 +23,78 @@ Spark fixture, exercising format conversions, save modes, and error paths.
 Author: John Grimes.
 """
 
+import io as _io
 import os
 import shutil
+from contextlib import contextmanager
+from pathlib import Path
 
 from pytest import fixture
+from rich.console import Console
 
 from pathling.cli.main import cli
 
 PATIENT_COUNT = 9
+
+
+class _FakeSink:
+    """A no-op write sink capturing nothing; the write path is exercised
+    elsewhere."""
+
+    def ndjson(self, target, save_mode=None):
+        pass
+
+    def parquet(self, target, save_mode=None):
+        pass
+
+    def delta(self, target, save_mode=None):
+        pass
+
+
+class _FakeDataSource:
+    """A stand-in data source for convert without Spark.
+
+    ``read`` raises so any per-type ``count()`` in the summary is caught.
+    """
+
+    def __init__(self, resource_types):
+        self._resource_types = resource_types
+        self.write = _FakeSink()
+
+    def resource_types(self):
+        return self._resource_types
+
+    def read(self, resource_type):
+        raise AssertionError("the summary must not read per-type counts")
+
+
+class _FakeReader:
+    """Records the resource types passed to ``bundles``."""
+
+    def __init__(self, resource_types):
+        self._resource_types = resource_types
+        self.bundles_types = None
+
+    def bundles(self, path, types):
+        self.bundles_types = types
+        return _FakeDataSource(self._resource_types)
+
+
+class _FakePc:
+    """A minimal context exposing a recording ``read`` reader."""
+
+    def __init__(self, resource_types):
+        self.read = _FakeReader(resource_types)
+
+
+def _bundles_dir(tmp_path):
+    """Creates a minimal directory of FHIR Bundle JSON for convert tests."""
+    bundles = tmp_path / "bundles"
+    bundles.mkdir()
+    (bundles / "b.json").write_text(
+        '{"resourceType":"Bundle","type":"collection","entry":[]}', encoding="utf-8"
+    )
+    return bundles
 
 
 @fixture(scope="module")
@@ -70,9 +134,128 @@ def test_ndjson_to_parquet_with_summary(
     # A Patient parquet table is written under the output directory.
     written = sorted(entry.name for entry in out.iterdir())
     assert any(name.startswith("Patient") for name in written), written
-    # The summary names the resource types and counts (on stderr).
+    # The summary names the resource types written, but no longer triggers a
+    # per-type row count (FR-013). The output path is also reported, but is not
+    # asserted here as Rich wraps the long temp path across lines in the narrow
+    # test console; the path is covered by test_summary_does_not_count_per_type.
     assert "Patient" in result.stderr
-    assert str(PATIENT_COUNT) in result.stderr
+    assert "Condition" in result.stderr
+
+
+# ========== Summary, --type, and discovery (US5, no Spark) ==========
+
+
+def test_summary_does_not_count_per_type():
+    """The conversion summary lists resource types without a per-type count.
+
+    The fake data source raises from ``read`` so any ``read().count()`` in the
+    summary would fail the test (FR-013).
+    """
+    from pathling.cli.convert import _print_summary
+
+    buffer = _io.StringIO()
+    console = Console(file=buffer, width=200, highlight=False)
+
+    _print_summary(console, _FakeDataSource(["Condition", "Patient"]), Path("/out"))
+
+    rendered = buffer.getvalue()
+    assert "Patient" in rendered
+    assert "Condition" in rendered
+    assert "/out" in rendered
+
+
+def test_convert_type_passes_through_and_skips_discovery(runner, monkeypatch, tmp_path):
+    """`--type` is used directly and skips driver-side discovery (FR-015)."""
+    import pathling.cli.io as io_module
+
+    discovery_calls = []
+    monkeypatch.setattr(
+        io_module,
+        "discover_bundle_resource_types",
+        lambda path: discovery_calls.append(path) or ["unused"],
+    )
+    pc = _FakePc(["Patient", "Condition"])
+    monkeypatch.setattr(
+        "pathling.cli.session.create_context", lambda config, console=None: pc
+    )
+
+    bundles = _bundles_dir(tmp_path)
+    out = tmp_path / "out"
+
+    result = runner.invoke(
+        cli,
+        [
+            "convert",
+            str(bundles),
+            "--from",
+            "bundles",
+            "--to",
+            "ndjson",
+            "-o",
+            str(out),
+            "--type",
+            "Patient",
+            "--type",
+            "Condition",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert discovery_calls == []
+    assert pc.read.bundles_types == ["Patient", "Condition"]
+
+
+def test_convert_discovery_runs_under_spinner(runner, monkeypatch, tmp_path):
+    """Without `--type`, bundle discovery runs under the progress spinner rather
+    than silently before it (FR-016)."""
+    import pathling.cli.convert as convert_module
+    import pathling.cli.io as io_module
+
+    active = []
+    snapshot = {}
+
+    @contextmanager
+    def fake_progress(console, message, verbose):
+        active.append(message)
+        try:
+            yield
+        finally:
+            active.pop()
+
+    monkeypatch.setattr(convert_module, "progress_status", fake_progress)
+
+    def fake_discover(path):
+        # Record the active spinner messages at the moment discovery runs.
+        snapshot["active"] = list(active)
+        return ["Patient"]
+
+    monkeypatch.setattr(io_module, "discover_bundle_resource_types", fake_discover)
+
+    pc = _FakePc(["Patient"])
+    monkeypatch.setattr(
+        "pathling.cli.session.create_context", lambda config, console=None: pc
+    )
+
+    bundles = _bundles_dir(tmp_path)
+    out = tmp_path / "out"
+
+    result = runner.invoke(
+        cli,
+        [
+            "convert",
+            str(bundles),
+            "--from",
+            "bundles",
+            "--to",
+            "ndjson",
+            "-o",
+            str(out),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    # Discovery ran while at least one progress spinner was active.
+    assert snapshot["active"]
 
 
 # ========== Round trip ==========

--- a/lib/python/tests/cli/test_convert.py
+++ b/lib/python/tests/cli/test_convert.py
@@ -1,0 +1,222 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Integration tests for the ``pathling convert`` command.
+
+These tests drive the command through Click's ``CliRunner`` against the shared
+Spark fixture, exercising format conversions, save modes, and error paths.
+
+Author: John Grimes.
+"""
+
+import os
+import shutil
+
+from pytest import fixture
+
+from pathling.cli.main import cli
+
+PATIENT_COUNT = 9
+
+
+@fixture(scope="module")
+def ndjson_input(test_data_dir, tmp_path_factory):
+    """A clean ndjson input directory with just Patient and Condition."""
+    source = os.path.join(test_data_dir, "ndjson")
+    target = tmp_path_factory.mktemp("convert-input")
+    for name in ("Patient.ndjson", "Condition.ndjson"):
+        shutil.copy(os.path.join(source, name), target / name)
+    return target
+
+
+def _count_ndjson_lines(directory, resource_type):
+    """Counts the JSON lines written for a resource type in a directory."""
+    total = 0
+    for entry in directory.iterdir():
+        if entry.name.startswith(resource_type) and entry.suffix == ".ndjson":
+            with open(entry) as handle:
+                total += sum(1 for line in handle if line.strip())
+    return total
+
+
+# ========== ndjson to parquet ==========
+
+
+def test_ndjson_to_parquet_with_summary(
+    runner, patched_context, ndjson_input, tmp_path
+):
+    """Converting ndjson to Parquet writes tables and prints a summary."""
+    out = tmp_path / "warehouse"
+
+    result = runner.invoke(
+        cli, ["convert", str(ndjson_input), "--to", "parquet", "-o", str(out)]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    # A Patient parquet table is written under the output directory.
+    written = sorted(entry.name for entry in out.iterdir())
+    assert any(name.startswith("Patient") for name in written), written
+    # The summary names the resource types and counts (on stderr).
+    assert "Patient" in result.stderr
+    assert str(PATIENT_COUNT) in result.stderr
+
+
+# ========== Round trip ==========
+
+
+def test_parquet_to_ndjson_round_trip(runner, patched_context, ndjson_input, tmp_path):
+    """A parquet round trip preserves the Patient resource count."""
+    warehouse = tmp_path / "warehouse"
+    roundtrip = tmp_path / "roundtrip"
+
+    first = runner.invoke(
+        cli, ["convert", str(ndjson_input), "--to", "parquet", "-o", str(warehouse)]
+    )
+    assert first.exit_code == 0, first.stderr
+
+    second = runner.invoke(
+        cli, ["convert", str(warehouse), "--to", "ndjson", "-o", str(roundtrip)]
+    )
+    assert second.exit_code == 0, second.stderr
+    assert _count_ndjson_lines(roundtrip, "Patient") == PATIENT_COUNT
+
+
+# ========== Bundles input ==========
+
+
+def test_bundles_input(runner, patched_context, test_data_dir, tmp_path):
+    """Bundles input is auto-detected and converted to ndjson."""
+    bundles = os.path.join(test_data_dir, "bundles")
+    out = tmp_path / "from-bundles"
+
+    result = runner.invoke(
+        cli, ["convert", bundles, "--from", "bundles", "--to", "ndjson", "-o", str(out)]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert _count_ndjson_lines(out, "Patient") > 0
+
+
+# ========== Delta output and merge ==========
+
+
+def test_delta_output_and_merge(runner, patched_context, ndjson_input, tmp_path):
+    """Delta output is written and can be re-written with --mode merge."""
+    out = tmp_path / "delta-warehouse"
+
+    first = runner.invoke(
+        cli, ["convert", str(ndjson_input), "--to", "delta", "-o", str(out)]
+    )
+    assert first.exit_code == 0, first.stderr
+    assert (out / "Patient.parquet" / "_delta_log").exists()
+
+    merged = runner.invoke(
+        cli,
+        [
+            "convert",
+            str(ndjson_input),
+            "--to",
+            "delta",
+            "-o",
+            str(out),
+            "--mode",
+            "merge",
+        ],
+    )
+    assert merged.exit_code == 0, merged.stderr
+
+
+# ========== Error paths ==========
+
+
+def test_existing_output_without_overwrite_fails(
+    runner, patched_context, ndjson_input, tmp_path
+):
+    """Writing to an existing path without --overwrite fails showing the flag."""
+    out = tmp_path / "warehouse"
+    out.mkdir()
+
+    result = runner.invoke(
+        cli, ["convert", str(ndjson_input), "--to", "parquet", "-o", str(out)]
+    )
+
+    assert result.exit_code == 1
+    assert "--overwrite" in result.stderr
+
+
+def test_existing_output_with_overwrite_succeeds(
+    runner, patched_context, ndjson_input, tmp_path
+):
+    """Passing --overwrite allows replacing an existing output path."""
+    out = tmp_path / "warehouse"
+
+    first = runner.invoke(
+        cli, ["convert", str(ndjson_input), "--to", "parquet", "-o", str(out)]
+    )
+    assert first.exit_code == 0, first.stderr
+
+    again = runner.invoke(
+        cli,
+        [
+            "convert",
+            str(ndjson_input),
+            "--to",
+            "parquet",
+            "-o",
+            str(out),
+            "--overwrite",
+        ],
+    )
+    assert again.exit_code == 0, again.stderr
+
+
+def test_merge_mode_validation_for_non_delta(
+    runner, patched_context, ndjson_input, tmp_path
+):
+    """The merge save mode is rejected for non-delta output as a usage error."""
+    out = tmp_path / "warehouse"
+
+    result = runner.invoke(
+        cli,
+        [
+            "convert",
+            str(ndjson_input),
+            "--to",
+            "parquet",
+            "-o",
+            str(out),
+            "--mode",
+            "merge",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "merge" in result.stderr.lower()
+
+
+def test_ambiguous_format_error(runner, patched_context, tmp_path):
+    """An undetectable input directory fails with guidance to use --from."""
+    ambiguous = tmp_path / "mixed"
+    ambiguous.mkdir()
+    (ambiguous / "mystery.dat").write_text("???")
+
+    result = runner.invoke(
+        cli, ["convert", str(ambiguous), "--to", "ndjson", "-o", str(tmp_path / "out")]
+    )
+
+    assert result.exit_code == 2
+    assert "--from" in result.stderr

--- a/lib/python/tests/cli/test_departition.py
+++ b/lib/python/tests/cli/test_departition.py
@@ -1,0 +1,184 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for the departition helper.
+
+These exercise :func:`pathling.cli.departition.departition` against locally
+constructed directories that mimic Spark's part-file output (data parts plus
+``_SUCCESS`` and ``.crc`` markers). A Spark session is required only to reach
+the JVM gateway and Hadoop configuration, so the shared session fixture is
+reused; no DataFrame is written.
+
+Author: John Grimes.
+"""
+
+from pathlib import Path
+
+import pytest
+from pytest import fixture
+
+from pathling.cli.departition import departition
+from pathling.cli.errors import CliError
+
+
+@fixture(scope="module")
+def spark(pathling_ctx):
+    """Provides the Spark session from the shared Pathling context.
+
+    :param pathling_ctx: the shared Pathling context fixture.
+    :return: the underlying Spark session.
+    """
+    return pathling_ctx.spark
+
+
+def _make_output_dir(
+    directory: Path, part_files: dict, *, markers: bool = True
+) -> Path:
+    """Builds a directory mimicking Spark's part-file output.
+
+    :param directory: the directory to create and populate.
+    :param part_files: a mapping of part file name to its text content.
+    :param markers: when True, add ``_SUCCESS`` and ``.crc`` checksum markers.
+    :return: the populated directory.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    for name, content in part_files.items():
+        (directory / name).write_text(content)
+        if markers:
+            # Spark's local filesystem writes a hidden ".<name>.crc" checksum.
+            (directory / f".{name}.crc").write_text("crc")
+    if markers:
+        (directory / "_SUCCESS").write_text("")
+        (directory / "._SUCCESS.crc").write_text("crc")
+    return directory
+
+
+# ========== Single data file ==========
+
+
+def test_single_part_file_moved_to_exact_target(spark, tmp_path):
+    """A single part file is moved verbatim to the exact target path."""
+    source = _make_output_dir(
+        tmp_path / "_tmp", {"part-00000-abc-c000.csv": "id,name\n1,Smith\n"}
+    )
+    target = tmp_path / "out.csv"
+
+    departition(spark, source, target, "csv")
+
+    assert target.is_file()
+    assert target.read_text() == "id,name\n1,Smith\n"
+
+
+def test_source_directory_removed_after_departition(spark, tmp_path):
+    """The source directory is deleted once the data file has been moved."""
+    source = _make_output_dir(tmp_path / "_tmp", {"part-00000-abc-c000.csv": "data\n"})
+    target = tmp_path / "out.csv"
+
+    departition(spark, source, target, "csv")
+
+    assert not source.exists()
+
+
+# ========== Markers ==========
+
+
+def test_markers_ignored_and_removed(spark, tmp_path):
+    """``_SUCCESS`` and ``.crc`` markers are never picked and are removed."""
+    source = _make_output_dir(
+        tmp_path / "_tmp",
+        {"part-00000-abc-c000.csv": "real\n"},
+        markers=True,
+    )
+    target = tmp_path / "out.csv"
+
+    departition(spark, source, target, "csv")
+
+    # The target holds the data part, not a marker, and the source (with all
+    # its markers) is gone.
+    assert target.read_text() == "real\n"
+    assert not source.exists()
+
+
+# ========== More than one data file ==========
+
+
+def test_multiple_data_files_raises_clear_error(spark, tmp_path):
+    """More than one data part file is an error rather than a silent choice."""
+    source = _make_output_dir(
+        tmp_path / "_tmp",
+        {
+            "part-00000-abc-c000.csv": "a\n",
+            "part-00001-abc-c000.csv": "b\n",
+        },
+    )
+    target = tmp_path / "out.csv"
+
+    with pytest.raises(CliError) as exc_info:
+        departition(spark, source, target, "csv")
+
+    # The message names the problem so the user understands why it failed.
+    assert "more than one" in exc_info.value.message.lower()
+
+
+# ========== Empty result (zero data files) ==========
+
+
+def test_zero_data_files_produces_empty_target(spark, tmp_path):
+    """An empty result (no data part) yields an empty single target file."""
+    # Only markers, no data part file - as Spark produces for the text formats
+    # when there are no rows.
+    source = _make_output_dir(tmp_path / "_tmp", {}, markers=True)
+    target = tmp_path / "out.csv"
+
+    departition(spark, source, target, "csv")
+
+    assert target.is_file()
+    assert target.read_text() == ""
+    assert not source.exists()
+
+
+# ========== Extensions ==========
+
+
+@pytest.mark.parametrize("extension", ["csv", "json", "parquet"])
+def test_works_for_each_part_extension(spark, tmp_path, extension):
+    """The helper selects the data file by the writer's part extension."""
+    source = _make_output_dir(
+        tmp_path / "_tmp",
+        {f"part-00000-abc-c000.{extension}": "payload"},
+    )
+    target = tmp_path / f"out.{extension}"
+
+    departition(spark, source, target, extension)
+
+    assert target.read_text() == "payload"
+
+
+# ========== Nested target directory ==========
+
+
+def test_nested_target_directory_is_created(spark, tmp_path):
+    """A target under a non-existent parent directory is created as needed."""
+    source = _make_output_dir(
+        tmp_path / "_tmp", {"part-00000-abc-c000.csv": "nested\n"}
+    )
+    target = tmp_path / "deeply" / "nested" / "out.csv"
+
+    departition(spark, source, target, "csv")
+
+    assert target.is_file()
+    assert target.read_text() == "nested\n"

--- a/lib/python/tests/cli/test_entry_point.py
+++ b/lib/python/tests/cli/test_entry_point.py
@@ -1,0 +1,122 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Subprocess smoke test of the installed ``pathling`` console script.
+
+This proves the packaging contract: the entry point declared in pyproject.toml
+resolves to a working command that runs quickly without starting Spark.
+
+Author: John Grimes.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from pathling._version import __version__
+
+# The console script is installed alongside the active interpreter.
+ENTRY_POINT = Path(sys.executable).parent / "pathling"
+
+
+@pytest.mark.skipif(
+    not ENTRY_POINT.exists(), reason="pathling console script is not installed"
+)
+def test_entry_point_version_is_fast():
+    """`pathling --version` runs via the real console script, fast and green."""
+    result = subprocess.run(
+        [str(ENTRY_POINT), "--version"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert __version__ in result.stdout
+
+
+@pytest.mark.skipif(
+    not ENTRY_POINT.exists(), reason="pathling console script is not installed"
+)
+def test_entry_point_help_lists_commands():
+    """`pathling --help` runs via the console script and lists the commands."""
+    result = subprocess.run(
+        [str(ENTRY_POINT), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    for command in ("convert", "view", "fhirpath", "export", "member-of"):
+        assert command in result.stdout
+
+
+@pytest.mark.skipif(
+    not ENTRY_POINT.exists(), reason="pathling console script is not installed"
+)
+def test_real_invocation_output_is_clean():
+    """A real (non-mocked) command produces clean stdout and silent stderr.
+
+    This exercises the actual Spark session creation path and asserts the
+    end-to-end guarantees: data only on stdout (SC-007), and no Spark/JVM/Ivy
+    log noise or stack traces on stderr by default (FR-004).
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        resource = Path(tmp) / "patient.json"
+        resource.write_text(
+            json.dumps(
+                {
+                    "resourceType": "Patient",
+                    "id": "x",
+                    "name": [{"given": ["John"], "family": "Smith"}],
+                }
+            )
+        )
+        result = subprocess.run(
+            [
+                str(ENTRY_POINT),
+                "fhirpath",
+                str(resource),
+                "-e",
+                "name.given.first()",
+                "--format",
+                "csv",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+    assert result.returncode == 0, result.stderr
+    # Data is on stdout, and only the data.
+    assert "John" in result.stdout
+    assert "INFO" not in result.stdout and "WARN" not in result.stdout
+    # No Spark/JVM/Ivy log noise or stack traces on stderr by default.
+    for noise in (
+        "Setting default log level",
+        "resolving dependencies",
+        "Using incubator modules",
+        "\tat org.apache",
+        "Traceback",
+    ):
+        assert noise not in result.stderr, result.stderr

--- a/lib/python/tests/cli/test_errors.py
+++ b/lib/python/tests/cli/test_errors.py
@@ -25,7 +25,9 @@ from pathling.cli.errors import (
     EXIT_SUCCESS,
     EXIT_USAGE,
     CliError,
+    _categorise,
     friendly_message,
+    is_auth_error,
     unwrap_java_exception,
 )
 
@@ -136,3 +138,55 @@ def test_verbose_includes_stack_trace():
 
     assert "Traceback" in verbose
     assert "Traceback" not in quiet
+
+
+# ========== Authentication error classification (US1) ==========
+
+
+def test_is_auth_error_true_for_auth_messages():
+    """Genuine authentication failures are classified as auth errors."""
+    auth_messages = [
+        "HTTP 401 Unauthorized",
+        "invalid_client",
+        # The real SMART backend-services setup failure surfaces this message.
+        "Failed to retrieve SMART configuration",
+        "Authentication failed: bad credential",
+    ]
+    for message in auth_messages:
+        assert is_auth_error(RuntimeError(message)), message
+
+
+def test_is_auth_error_false_for_non_auth_messages():
+    """Connection, timeout, and server-error failures are not auth errors."""
+    non_auth_messages = [
+        "Connection refused",
+        "Read timed out",
+        "HTTP 500 Internal Server Error",
+        "Server returned status 503 Service Unavailable",
+    ]
+    for message in non_auth_messages:
+        assert not is_auth_error(RuntimeError(message)), message
+
+
+# ========== Connection message and FHIRPath categorisation (US4) ==========
+
+
+def test_connection_error_with_server_url_uses_reach_phrasing():
+    """A connection error with a server URL produces the 'could not reach'
+    message naming the configured server (FR-011)."""
+    exc = RuntimeError("Connection refused")
+
+    message = friendly_message(exc, server_url="https://tx.example/fhir")
+
+    assert "Could not reach the server at https://tx.example/fhir" in message
+
+
+def test_bare_parse_error_not_categorised_as_fhirpath():
+    """A generic 'parse error' that is not a FHIRPath failure is not labelled as
+    a FHIRPath error (FR-012)."""
+    assert _categorise("JSON parse error at line 2") != "fhirpath"
+
+
+def test_genuine_fhirpath_error_still_categorised():
+    """A message naming FHIRPath is still categorised as a FHIRPath error."""
+    assert _categorise("FHIRPath parse error at position 3") == "fhirpath"

--- a/lib/python/tests/cli/test_errors.py
+++ b/lib/python/tests/cli/test_errors.py
@@ -1,0 +1,138 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for exception unwrapping, message mapping, and exit codes.
+
+Author: John Grimes.
+"""
+
+from pathling.cli.errors import (
+    EXIT_RUNTIME,
+    EXIT_SUCCESS,
+    EXIT_USAGE,
+    CliError,
+    friendly_message,
+    unwrap_java_exception,
+)
+
+
+class _FakeJavaException:
+    """A stand-in for a Py4J Java exception exposing getMessage()."""
+
+    def __init__(self, message):
+        self._message = message
+
+    def getMessage(self):  # noqa: N802 - mirrors the Java method name.
+        return self._message
+
+
+class _FakePy4JError(Exception):
+    """A stand-in for py4j.protocol.Py4JJavaError carrying a java_exception."""
+
+    def __init__(self, str_value, java_exception):
+        super().__init__(str_value)
+        self._str_value = str_value
+        self.java_exception = java_exception
+
+    def __str__(self):
+        return self._str_value
+
+
+# ========== Exit codes ==========
+
+
+def test_exit_codes():
+    """The exit code constants follow the contract (0/1/2)."""
+    assert EXIT_SUCCESS == 0
+    assert EXIT_RUNTIME == 1
+    assert EXIT_USAGE == 2
+
+
+def test_cli_error_default_exit_code():
+    """A CliError defaults to the runtime failure exit code."""
+    assert CliError("boom").exit_code == EXIT_RUNTIME
+    assert CliError("bad usage", exit_code=EXIT_USAGE).exit_code == EXIT_USAGE
+
+
+# ========== Java exception unwrapping ==========
+
+
+def test_unwrap_uses_java_get_message():
+    """A wrapped Java exception is unwrapped to its getMessage() value."""
+    stack_trace = (
+        "py4j.protocol.Py4JJavaError: An error occurred\n"
+        "\tat au.csiro.pathling.Foo.bar(Foo.java:42)\n"
+        "\tat ...\n"
+    )
+    exc = _FakePy4JError(stack_trace, _FakeJavaException("The real cause"))
+
+    assert unwrap_java_exception(exc) == "The real cause"
+
+
+def test_unwrap_strips_java_class_prefix():
+    """A leading Java exception class name is stripped from the message."""
+    exc = _FakeJavaException("java.lang.IllegalArgumentException: bad input here")
+    # Wrap so the function sees it via java_exception.
+    wrapper = _FakePy4JError("ignored", exc)
+
+    assert unwrap_java_exception(wrapper) == "bad input here"
+
+
+def test_unwrap_plain_exception():
+    """A plain Python exception is unwrapped to its message."""
+    assert unwrap_java_exception(ValueError("plain message")) == "plain message"
+
+
+# ========== Friendly message mapping ==========
+
+
+def test_connection_error_names_server():
+    """A connection error names the server URL and suggests a check."""
+    exc = RuntimeError("Connection refused")
+
+    message = friendly_message(exc, server_url="https://tx.example/fhir")
+
+    assert "https://tx.example/fhir" in message
+    assert "Connection refused" in message
+
+
+def test_fhirpath_error_is_categorised():
+    """A FHIRPath parse error is mapped to expression guidance."""
+    exc = RuntimeError("FHIRPath parse error at position 3")
+
+    message = friendly_message(exc)
+
+    assert "expression" in message.lower()
+
+
+def test_unknown_error_hints_verbose():
+    """An unrecognised error hints at --verbose when not verbose."""
+    message = friendly_message(RuntimeError("something odd"), verbose=False)
+
+    assert "--verbose" in message
+
+
+def test_verbose_includes_stack_trace():
+    """Verbose mode appends the full traceback, non-verbose does not."""
+    try:
+        raise ValueError("kaboom")
+    except ValueError as exc:
+        verbose = friendly_message(exc, verbose=True)
+        quiet = friendly_message(exc, verbose=False)
+
+    assert "Traceback" in verbose
+    assert "Traceback" not in quiet

--- a/lib/python/tests/cli/test_export.py
+++ b/lib/python/tests/cli/test_export.py
@@ -23,14 +23,213 @@ the library test suite. Authentication resolution is unit tested without Spark.
 Author: John Grimes.
 """
 
+import io as _io
 import os
 
 import pytest
 from flask import Response, request
+from rich.console import Console
 
 from pathling.cli.config import resolve_bulk_auth
 from pathling.cli.errors import CliError
 from pathling.cli.main import cli
+
+
+class _FakeReadable:
+    """A stand-in dataset exposing the row ``count`` the summary may read."""
+
+    def count(self):
+        return 1
+
+
+class _FakeDataSource:
+    """A stand-in bulk data source for summary printing without Spark."""
+
+    def resource_types(self):
+        return ["Patient"]
+
+    def read(self, resource_type):
+        return _FakeReadable()
+
+
+class _FakeReader:
+    """A stand-in ``pc.read`` whose ``bulk`` delegates to a supplied callback."""
+
+    def __init__(self, on_bulk):
+        self._on_bulk = on_bulk
+
+    def bulk(self, **kwargs):
+        return self._on_bulk(kwargs)
+
+
+class _FakePc:
+    """A minimal stand-in :class:`PathlingContext` for the export command."""
+
+    def __init__(self, on_bulk):
+        self.read = _FakeReader(on_bulk)
+
+
+def _patch_bulk(monkeypatch, on_bulk):
+    """Routes ``export`` at a fake context whose ``read.bulk`` runs ``on_bulk``.
+
+    :param monkeypatch: the pytest monkeypatch fixture.
+    :param on_bulk: a callback ``(kwargs) -> data_source`` (may raise).
+    :return: the fake context.
+    """
+    pc = _FakePc(on_bulk)
+    monkeypatch.setattr(
+        "pathling.cli.session.create_context", lambda config, console=None: pc
+    )
+    return pc
+
+
+# ========== Failure classification (US1, no Spark) ==========
+
+
+def test_non_auth_failure_reports_root_cause(runner, monkeypatch, tmp_path):
+    """A non-auth failure under configured auth reports the root cause and does
+    not claim authentication failed (FR-001)."""
+
+    def boom(_kwargs):
+        raise RuntimeError("HTTP 500 Internal Server Error during download")
+
+    _patch_bulk(monkeypatch, boom)
+    out = tmp_path / "export"
+
+    result = runner.invoke(
+        cli,
+        [
+            "export",
+            "https://server/fhir",
+            "-o",
+            str(out),
+            "--client-id",
+            "c",
+            "--token-endpoint",
+            "https://auth/token",
+            "--client-secret",
+            "shh",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "500" in result.stderr
+    assert "authentication failed" not in result.stderr.lower()
+
+
+def test_auth_failure_reports_auth_message(runner, monkeypatch, tmp_path):
+    """A genuine auth failure names the mechanism and token endpoint (FR-001)."""
+
+    def boom(_kwargs):
+        # The real SMART backend-services setup failure surfaces this message.
+        raise RuntimeError("Failed to retrieve SMART configuration")
+
+    _patch_bulk(monkeypatch, boom)
+    out = tmp_path / "export"
+
+    result = runner.invoke(
+        cli,
+        [
+            "export",
+            "https://server/fhir",
+            "-o",
+            str(out),
+            "--client-id",
+            "c",
+            "--token-endpoint",
+            "https://auth/token",
+            "--client-secret",
+            "shh",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "authentication failed" in result.stderr.lower()
+    assert "https://auth/token" in result.stderr
+    assert "a client secret" in result.stderr
+
+
+def test_export_resolves_bulk_auth_from_resolved_config(runner, monkeypatch, tmp_path):
+    """Export resolves bulk auth from the resolved config's [bulk-auth] table,
+    not by re-reading a config file path (FR-003)."""
+    captured = {}
+
+    def spy_resolve(file_bulk_auth, **_kwargs):
+        captured["table"] = file_bulk_auth
+        return None
+
+    monkeypatch.setattr("pathling.cli.export.resolve_bulk_auth", spy_resolve)
+
+    # Export must resolve from the already-parsed config, never re-read a file.
+    def _fail_if_reread(*_args, **_kwargs):
+        raise AssertionError("export must not re-read a config file")
+
+    monkeypatch.setattr(
+        "pathling.cli.export.load_config_file", _fail_if_reread, raising=False
+    )
+
+    def ok_bulk(kwargs):
+        captured["auth_config"] = kwargs.get("auth_config")
+        return _FakeDataSource()
+
+    _patch_bulk(monkeypatch, ok_bulk)
+
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        "[bulk-auth]\n"
+        'client-id = "table-client"\n'
+        'token-endpoint = "https://auth/token"\n'
+        'client-secret = "shh"\n',
+        encoding="utf-8",
+    )
+    out = tmp_path / "export"
+
+    result = runner.invoke(
+        cli,
+        ["--config", str(config_file), "export", "https://server/fhir", "-o", str(out)],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    # The table passed to resolution is the resolved config's [bulk-auth] table.
+    assert captured["table"] == {
+        "client-id": "table-client",
+        "token-endpoint": "https://auth/token",
+        "client-secret": "shh",
+    }
+    # No auth was configured by the spy, so the export ran unauthenticated.
+    assert captured["auth_config"] is None
+
+
+class _SummaryFakeDataSource:
+    """A data source whose ``read`` raises, to catch any per-type count."""
+
+    def resource_types(self):
+        return ["Condition", "Patient"]
+
+    def read(self, resource_type):
+        raise AssertionError("the summary must not read per-type counts")
+
+
+def test_export_summary_reports_files_types_path_without_count(tmp_path):
+    """The export summary reports the file count, resource types, and output
+    path without a per-type row count (FR-013)."""
+    from pathling.cli.export import _print_summary
+
+    out = tmp_path / "export"
+    out.mkdir()
+    (out / "Patient.0000.ndjson").write_text("{}\n", encoding="utf-8")
+    (out / "Condition.0000.ndjson").write_text("{}\n", encoding="utf-8")
+
+    buffer = _io.StringIO()
+    console = Console(file=buffer, width=200, highlight=False)
+
+    _print_summary(console, _SummaryFakeDataSource(), out)
+
+    rendered = buffer.getvalue()
+    assert "Patient" in rendered
+    assert "Condition" in rendered
+    assert "2 files" in rendered
+    assert str(out) in rendered
 
 
 @pytest.fixture

--- a/lib/python/tests/cli/test_export.py
+++ b/lib/python/tests/cli/test_export.py
@@ -1,0 +1,264 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Integration and unit tests for the ``pathling export`` command.
+
+The export integration tests run against the same mock bulk data server used by
+the library test suite. Authentication resolution is unit tested without Spark.
+
+Author: John Grimes.
+"""
+
+import os
+
+import pytest
+from flask import Response, request
+
+from pathling.cli.config import resolve_bulk_auth
+from pathling.cli.errors import CliError
+from pathling.cli.main import cli
+
+
+@pytest.fixture
+def bulk_server(mock_server, test_data_dir):
+    """A mock bulk data server serving Patient and Condition ndjson."""
+    ndjson_dir = os.path.join(test_data_dir, "ndjson")
+    captured = {}
+
+    @mock_server.route("/fhir/$export", methods=["GET"])
+    def export_route():
+        captured["args"] = dict(request.args)
+        resp = Response(status=202)
+        resp.headers["content-location"] = mock_server.url("/pool")
+        return resp
+
+    @mock_server.route("/pool", methods=["GET"])
+    def pool():
+        return dict(
+            transactionTime="1970-01-01T00:00:00.000Z",
+            output=[
+                dict(type=rt, url=mock_server.url(f"/download/{rt}"), count=1)
+                for rt in ("Patient", "Condition")
+            ],
+        )
+
+    @mock_server.route("/download/<resource>", methods=["GET"])
+    def download(resource):
+        with open(os.path.join(ndjson_dir, f"{resource}.ndjson")) as handle:
+            return handle.read()
+
+    mock_server.captured = captured
+    return mock_server
+
+
+# ========== System-level export ==========
+
+
+def test_system_export_with_summary(runner, patched_context, bulk_server, tmp_path):
+    """A system-level export downloads files and prints a summary."""
+    out = tmp_path / "export"
+
+    with bulk_server.run():
+        result = runner.invoke(
+            cli, ["export", bulk_server.url("/fhir"), "-o", str(out)]
+        )
+
+    assert result.exit_code == 0, result.stderr
+    assert any(out.glob("Patient*.ndjson"))
+    assert "Patient" in result.stderr
+
+
+def test_type_and_since_passed_through(runner, patched_context, bulk_server, tmp_path):
+    """The --type and --since options are sent on the export request."""
+    out = tmp_path / "export"
+
+    with bulk_server.run():
+        result = runner.invoke(
+            cli,
+            [
+                "export",
+                bulk_server.url("/fhir"),
+                "-o",
+                str(out),
+                "--type",
+                "Patient",
+                "--since",
+                "2020-01-01T00:00:00Z",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stderr
+    args = bulk_server.captured["args"]
+    assert "Patient" in args.get("_type", "")
+    assert "_since" in args
+
+
+# ========== Error paths ==========
+
+
+def test_group_and_patient_mutually_exclusive(runner, patched_context, tmp_path):
+    """--group and --patient together is a usage error naming both flags."""
+    result = runner.invoke(
+        cli,
+        [
+            "export",
+            "http://localhost:9/fhir",
+            "-o",
+            str(tmp_path / "out"),
+            "--group",
+            "123",
+            "--patient",
+            "Patient/1",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "--group" in result.stderr and "--patient" in result.stderr
+
+
+def test_since_parse_error(runner, patched_context, tmp_path):
+    """An unparseable --since shows the expected ISO 8601 form."""
+    result = runner.invoke(
+        cli,
+        [
+            "export",
+            "http://localhost:9/fhir",
+            "-o",
+            str(tmp_path / "out"),
+            "--since",
+            "yesterday",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "ISO 8601" in result.stderr
+
+
+def test_existing_output_without_overwrite(runner, patched_context, tmp_path):
+    """An existing output directory without --overwrite fails showing the flag."""
+    out = tmp_path / "export"
+    out.mkdir()
+
+    result = runner.invoke(cli, ["export", "http://localhost:9/fhir", "-o", str(out)])
+
+    assert result.exit_code == 1
+    assert "--overwrite" in result.stderr
+
+
+def test_auth_failure_names_mechanism(runner, patched_context, bulk_server, tmp_path):
+    """An authentication failure names the credential mechanism attempted."""
+    out = tmp_path / "export"
+
+    @bulk_server.route("/token", methods=["POST"])
+    def token():
+        return Response(status=401)
+
+    with bulk_server.run():
+        result = runner.invoke(
+            cli,
+            [
+                "export",
+                bulk_server.url("/fhir"),
+                "-o",
+                str(out),
+                "--client-id",
+                "my-client",
+                "--token-endpoint",
+                bulk_server.url("/token"),
+                "--client-secret",
+                "shh",
+            ],
+        )
+
+    assert result.exit_code == 1
+    assert (
+        "authenticat" in result.stderr.lower()
+        or "client secret" in result.stderr.lower()
+    )
+
+
+# ========== Auth resolution (no Spark) ==========
+
+
+def test_resolve_bulk_auth_secret_from_file(tmp_path):
+    """A client secret @file reference is read for bulk auth."""
+    secret_file = tmp_path / "secret.txt"
+    secret_file.write_text("file-secret\n")
+
+    auth = resolve_bulk_auth(
+        None,
+        client_id="c",
+        token_endpoint="https://auth/token",
+        client_secret=f"@{secret_file}",
+    )
+
+    assert auth.client_secret == "file-secret"
+    assert auth.mechanism == "a client secret"
+
+
+def test_resolve_bulk_auth_secret_from_env():
+    """A client secret falls back to the environment variable."""
+    auth = resolve_bulk_auth(
+        None,
+        client_id="c",
+        token_endpoint="https://auth/token",
+        env={"PATHLING_CLIENT_SECRET": "env-secret"},
+    )
+
+    assert auth.client_secret == "env-secret"
+
+
+def test_resolve_bulk_auth_requires_token_endpoint():
+    """Bulk auth without a token endpoint is a usage error."""
+    with pytest.raises(CliError) as exc_info:
+        resolve_bulk_auth(None, client_id="c", client_secret="shh")
+
+    assert exc_info.value.exit_code == 2
+    assert "token endpoint" in exc_info.value.message.lower()
+
+
+def test_resolve_bulk_auth_exactly_one_credential():
+    """Providing both a secret and a JWK is a usage error."""
+    with pytest.raises(CliError) as exc_info:
+        resolve_bulk_auth(
+            None,
+            client_id="c",
+            token_endpoint="https://auth/token",
+            client_secret="shh",
+            private_key_jwk="{...}",
+        )
+
+    assert exc_info.value.exit_code == 2
+
+
+def test_resolve_bulk_auth_none_without_client_id():
+    """No client ID means no authentication is configured."""
+    assert resolve_bulk_auth(None) is None
+
+
+def test_resolve_bulk_auth_from_config_table():
+    """Bulk auth is resolved from the [bulk-auth] config table."""
+    table = {
+        "client-id": "table-client",
+        "token-endpoint": "https://auth/token",
+        "client-secret": "table-secret",
+    }
+
+    auth = resolve_bulk_auth(table)
+
+    assert auth.client_id == "table-client"
+    assert auth.client_secret == "table-secret"

--- a/lib/python/tests/cli/test_fhirpath.py
+++ b/lib/python/tests/cli/test_fhirpath.py
@@ -123,9 +123,11 @@ def test_single_resource_mode(runner, patched_context, patient_file):
 
     assert result.exit_code == 0, result.stderr
     rows = list(csv.reader(io.StringIO(result.stdout)))
-    assert rows[0] == ["type", "value"]
-    values = [row[1] for row in rows[1:]]
-    assert "John" in values
+    # The payload column is named "result" in both modes; single-resource mode
+    # pairs it with the result item "type" rather than a resource "id".
+    assert rows[0] == ["type", "result"]
+    results = [row[1] for row in rows[1:]]
+    assert "John" in results
 
 
 def test_single_resource_context_and_vars(runner, patched_context, patient_file):

--- a/lib/python/tests/cli/test_fhirpath.py
+++ b/lib/python/tests/cli/test_fhirpath.py
@@ -208,3 +208,99 @@ def test_context_rejected_in_data_source_mode(runner, patched_context, ndjson_so
 
     assert result.exit_code == 2
     assert "single-resource" in result.stderr.lower()
+
+
+# ========== Bundles read uses the -t/--type resource type, no discovery (US5) ==========
+
+
+class _FakeColumn:
+    """A column stand-in returning itself for the chained calls used here."""
+
+    def alias(self, _name):
+        return self
+
+    def cast(self, _type):
+        return self
+
+
+class _FakeResultDF:
+    """A minimal result frame for stdout table rendering without Spark."""
+
+    columns = ["id", "result"]
+
+    def limit(self, _n):
+        return self
+
+    def collect(self):
+        return []
+
+
+class _FakeResources:
+    """Stands in for the resources frame read for a resource type."""
+
+    def __getitem__(self, _key):
+        return _FakeColumn()
+
+    def select(self, *_cols):
+        return _FakeResultDF()
+
+
+class _FakeFhirpathSource:
+    """A data source whose ``read`` returns a fake resources frame."""
+
+    def read(self, _resource_type):
+        return _FakeResources()
+
+
+def test_fhirpath_bundles_uses_type_argument(runner, monkeypatch, tmp_path):
+    """fhirpath data-source mode over a Bundles source reads using the -t/--type
+    resource type and runs no discovery pass (FR-015)."""
+    import pathling.cli.io as io_module
+
+    discovery_calls = []
+    monkeypatch.setattr(
+        io_module,
+        "discover_bundle_resource_types",
+        lambda path: discovery_calls.append(path) or ["WRONG"],
+    )
+
+    captured = {}
+
+    class _Reader:
+        def bundles(self, path, types):
+            captured["types"] = types
+            return _FakeFhirpathSource()
+
+    class _Pc:
+        read = _Reader()
+
+        def fhirpath_to_column(self, _resource_type, _expression):
+            return _FakeColumn()
+
+    monkeypatch.setattr(
+        "pathling.cli.session.create_context", lambda config, console=None: _Pc()
+    )
+
+    bundles = tmp_path / "bundles"
+    bundles.mkdir()
+    (bundles / "b.json").write_text(
+        '{"resourceType":"Bundle","entry":[]}', encoding="utf-8"
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "fhirpath",
+            str(bundles),
+            "--from",
+            "bundles",
+            "-t",
+            "Patient",
+            "-e",
+            "name.family",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert discovery_calls == []
+    assert captured["types"] == ["Patient"]

--- a/lib/python/tests/cli/test_fhirpath.py
+++ b/lib/python/tests/cli/test_fhirpath.py
@@ -1,0 +1,208 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Integration tests for the ``pathling fhirpath`` command.
+
+Author: John Grimes.
+"""
+
+import csv
+import io
+import json
+import os
+
+from pytest import fixture
+
+from pathling.cli.main import cli
+
+PATIENT_JSON = {
+    "resourceType": "Patient",
+    "id": "example",
+    "active": True,
+    "name": [
+        {"use": "official", "family": "Smith", "given": ["John", "James"]},
+        {"use": "nickname", "family": "Smith", "given": ["Johnny"]},
+    ],
+}
+
+
+@fixture(scope="module")
+def ndjson_source(test_data_dir):
+    """The shared ndjson test data directory."""
+    return os.path.join(test_data_dir, "ndjson")
+
+
+@fixture
+def patient_file(tmp_path):
+    """Writes a single Patient resource file and returns its path."""
+    path = tmp_path / "patient.json"
+    path.write_text(json.dumps(PATIENT_JSON), encoding="utf-8")
+    return path
+
+
+# ========== Data source mode ==========
+
+
+def test_data_source_mode(runner, patched_context, ndjson_source):
+    """Data source mode prints a table of resource IDs and results."""
+    result = runner.invoke(
+        cli,
+        [
+            "fhirpath",
+            ndjson_source,
+            "-t",
+            "Patient",
+            "-e",
+            "name.first().family",
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = list(csv.reader(io.StringIO(result.stdout)))
+    assert rows[0] == ["id", "result"]
+    # One row per patient (nine in the fixture).
+    assert len(rows) == 10
+
+
+def test_data_source_mode_requires_type(runner, patched_context, ndjson_source):
+    """Omitting -t in data source mode is a usage error."""
+    result = runner.invoke(cli, ["fhirpath", ndjson_source, "-e", "name.family"])
+
+    assert result.exit_code == 2
+    assert "-t" in result.stderr or "type" in result.stderr.lower()
+
+
+def test_data_source_filter(runner, patched_context, ndjson_source):
+    """A --filter restricts the resources evaluated."""
+    result = runner.invoke(
+        cli,
+        [
+            "fhirpath",
+            ndjson_source,
+            "-t",
+            "Patient",
+            "-e",
+            "name.first().family",
+            "--filter",
+            "family=Krajcik437",
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = list(csv.reader(io.StringIO(result.stdout)))
+    assert 1 < len(rows) < 10
+
+
+# ========== Single resource mode ==========
+
+
+def test_single_resource_mode(runner, patched_context, patient_file):
+    """Single-resource mode returns typed result values."""
+    result = runner.invoke(
+        cli,
+        ["fhirpath", str(patient_file), "-e", "name.given.first()", "--format", "csv"],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = list(csv.reader(io.StringIO(result.stdout)))
+    assert rows[0] == ["type", "value"]
+    values = [row[1] for row in rows[1:]]
+    assert "John" in values
+
+
+def test_single_resource_context_and_vars(runner, patched_context, patient_file):
+    """A context expression and named variables are honoured."""
+    result = runner.invoke(
+        cli,
+        [
+            "fhirpath",
+            str(patient_file),
+            "-e",
+            "%greeting",
+            "--var",
+            "greeting=hello",
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert "hello" in result.stdout
+
+    contextual = runner.invoke(
+        cli,
+        [
+            "fhirpath",
+            str(patient_file),
+            "-e",
+            "given",
+            "--context",
+            "name",
+            "--format",
+            "csv",
+        ],
+    )
+    assert contextual.exit_code == 0, contextual.stderr
+    assert "John" in contextual.stdout
+
+
+# ========== Error handling ==========
+
+
+def test_invalid_expression(runner, patched_context, ndjson_source):
+    """An invalid expression yields a clear message, exit 1, no stack trace."""
+    result = runner.invoke(
+        cli, ["fhirpath", ndjson_source, "-t", "Patient", "-e", "name.bogus("]
+    )
+
+    assert result.exit_code == 1
+    assert result.stderr.strip() != ""
+    assert "Traceback" not in result.stderr
+    assert "\tat " not in result.stderr
+
+
+def test_invalid_var_is_usage_error(runner, patched_context, patient_file):
+    """A malformed --var is a usage error."""
+    result = runner.invoke(
+        cli, ["fhirpath", str(patient_file), "-e", "active", "--var", "noequals"]
+    )
+
+    assert result.exit_code == 2
+
+
+def test_context_rejected_in_data_source_mode(runner, patched_context, ndjson_source):
+    """--context is rejected in data source mode rather than silently ignored."""
+    result = runner.invoke(
+        cli,
+        [
+            "fhirpath",
+            ndjson_source,
+            "-t",
+            "Patient",
+            "-e",
+            "name.family",
+            "--context",
+            "name",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "single-resource" in result.stderr.lower()

--- a/lib/python/tests/cli/test_help.py
+++ b/lib/python/tests/cli/test_help.py
@@ -84,6 +84,23 @@ def test_console_help_mentions_variables(runner):
     assert "exit" in result.output.lower()
 
 
+@pytest.mark.parametrize(
+    ("command_name", "url"),
+    [
+        ("run", "https://pathling.csiro.au/docs/python/pathling.html"),
+        ("console", "https://pathling.csiro.au/docs/python/pathling.html"),
+        ("view", "https://sql-on-fhir.org/ig/StructureDefinition-ViewDefinition.html"),
+        ("fhirpath", "https://pathling.csiro.au/docs/fhirpath"),
+    ],
+)
+def test_help_links_to_reference_docs(runner, command_name, url):
+    """Each command's help points to its relevant reference documentation."""
+    result = runner.invoke(cli, [command_name, "--help"])
+
+    assert result.exit_code == 0
+    assert url in result.output
+
+
 def test_root_help_describes_config_file(runner):
     """The root help describes the config file location and the --config flag."""
     result = runner.invoke(cli, ["--help"])

--- a/lib/python/tests/cli/test_help.py
+++ b/lib/python/tests/cli/test_help.py
@@ -30,8 +30,8 @@ from pathling.cli.main import cli
 COMMAND_NAMES = sorted(cli.commands.keys())
 
 
-def test_all_eleven_commands_registered():
-    """The eleven commands from the contract are all registered."""
+def test_all_commands_registered():
+    """The commands from the contracts are all registered."""
     assert COMMAND_NAMES == sorted(
         [
             "convert",
@@ -45,6 +45,8 @@ def test_all_eleven_commands_registered():
             "display",
             "property-of",
             "designation",
+            "run",
+            "console",
         ]
     )
 
@@ -58,6 +60,28 @@ def test_command_help_has_example(runner, command_name):
     assert "example" in result.output.lower()
     # The example always invokes the tool by name.
     assert "pathling" in result.output
+
+
+def test_run_help_mentions_sources_and_arguments(runner):
+    """`run --help` documents the code sources and argument passing."""
+    result = runner.invoke(cli, ["run", "--help"])
+
+    assert result.exit_code == 0
+    assert "SCRIPT" in result.output
+    assert "-c" in result.output
+    assert "spark" in result.output
+    assert "pathling" in result.output
+    assert "sys.argv" in result.output
+
+
+def test_console_help_mentions_variables(runner):
+    """`console --help` documents the in-scope variables and how to exit."""
+    result = runner.invoke(cli, ["console", "--help"])
+
+    assert result.exit_code == 0
+    assert "spark" in result.output
+    assert "pathling" in result.output
+    assert "exit" in result.output.lower()
 
 
 def test_root_help_describes_config_file(runner):

--- a/lib/python/tests/cli/test_help.py
+++ b/lib/python/tests/cli/test_help.py
@@ -1,0 +1,69 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests that every command's --help is documented per the CLI contract.
+
+The CLI contract (contracts/cli.md) requires every command to be documented
+with at least one usage example, and the root help to describe the config file.
+
+Author: John Grimes.
+"""
+
+import pytest
+
+from pathling.cli.main import cli
+
+COMMAND_NAMES = sorted(cli.commands.keys())
+
+
+def test_all_eleven_commands_registered():
+    """The eleven commands from the contract are all registered."""
+    assert COMMAND_NAMES == sorted(
+        [
+            "convert",
+            "view",
+            "fhirpath",
+            "export",
+            "member-of",
+            "translate",
+            "subsumes",
+            "subsumed-by",
+            "display",
+            "property-of",
+            "designation",
+        ]
+    )
+
+
+@pytest.mark.parametrize("command_name", COMMAND_NAMES)
+def test_command_help_has_example(runner, command_name):
+    """Each command's --help includes at least one usage example."""
+    result = runner.invoke(cli, [command_name, "--help"])
+
+    assert result.exit_code == 0
+    assert "example" in result.output.lower()
+    # The example always invokes the tool by name.
+    assert "pathling" in result.output
+
+
+def test_root_help_describes_config_file(runner):
+    """The root help describes the config file location and the --config flag."""
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "config.toml" in result.output
+    assert "--config" in result.output

--- a/lib/python/tests/cli/test_io.py
+++ b/lib/python/tests/cli/test_io.py
@@ -1,0 +1,243 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for data source format auto-detection.
+
+Detection runs before Spark starts, so these tests build small fixture
+directories and assert the detected format and the error paths.
+
+Author: John Grimes.
+"""
+
+import json
+
+import pytest
+
+from pathling.cli.errors import CliError
+from pathling.cli.io import (
+    SourceFormat,
+    SourceSpec,
+    detect_format,
+    discover_bundle_resource_types,
+    read_single_resource,
+    read_source,
+    resolve_source,
+)
+
+
+def _bundle(resource_types):
+    """Builds a minimal FHIR Bundle dict containing the given resource types."""
+    return {
+        "resourceType": "Bundle",
+        "type": "collection",
+        "entry": [
+            {"resource": {"resourceType": rt, "id": "x"}} for rt in resource_types
+        ],
+    }
+
+
+# ========== Directory detection ==========
+
+
+def test_detects_ndjson(tmp_path):
+    """A directory of .ndjson files is detected as ndjson."""
+    (tmp_path / "Patient.ndjson").write_text('{"resourceType":"Patient"}\n')
+
+    assert detect_format(tmp_path) == SourceFormat.NDJSON
+
+
+def test_detects_ndjson_ignoring_other_files(tmp_path):
+    """Stray non-FHIR files do not prevent ndjson detection."""
+    (tmp_path / "Patient.ndjson").write_text('{"resourceType":"Patient"}\n')
+    (tmp_path / "notes.txt").write_text("ignore me")
+
+    assert detect_format(tmp_path) == SourceFormat.NDJSON
+
+
+def test_detects_parquet(tmp_path):
+    """A directory of *.parquet tables without a delta log is parquet."""
+    table = tmp_path / "Patient.parquet"
+    table.mkdir()
+    (table / "part-00000.snappy.parquet").write_bytes(b"PAR1")
+
+    assert detect_format(tmp_path) == SourceFormat.PARQUET
+
+
+def test_detects_delta_by_delta_log(tmp_path):
+    """A *.parquet table containing a _delta_log directory is delta."""
+    table = tmp_path / "Patient.parquet"
+    (table / "_delta_log").mkdir(parents=True)
+    (table / "part-00000.snappy.parquet").write_bytes(b"PAR1")
+
+    assert detect_format(tmp_path) == SourceFormat.DELTA
+
+
+def test_detects_bundles(tmp_path):
+    """A directory of JSON Bundle files is detected as bundles."""
+    (tmp_path / "bundle1.json").write_text(json.dumps(_bundle(["Patient"])))
+
+    assert detect_format(tmp_path) == SourceFormat.BUNDLES
+
+
+# ========== Single resource detection ==========
+
+
+def test_detects_single_resource_when_allowed(tmp_path):
+    """A single JSON resource file is detected as a resource when allowed."""
+    resource = tmp_path / "patient.json"
+    resource.write_text('{"resourceType":"Patient","id":"x"}')
+
+    assert detect_format(resource, allow_resource=True) == SourceFormat.RESOURCE
+
+
+def test_single_file_rejected_when_not_allowed(tmp_path):
+    """A single file is rejected as a data source when resource mode is off."""
+    resource = tmp_path / "patient.json"
+    resource.write_text('{"resourceType":"Patient"}')
+
+    with pytest.raises(CliError):
+        detect_format(resource, allow_resource=False)
+
+
+# ========== Error paths ==========
+
+
+def test_missing_path_errors_before_spark(tmp_path):
+    """A missing path fails with a usage error naming the path."""
+    missing = tmp_path / "does-not-exist"
+
+    with pytest.raises(CliError) as exc_info:
+        detect_format(missing)
+
+    assert exc_info.value.exit_code == 2
+    assert str(missing) in exc_info.value.message
+
+
+def test_empty_directory_errors(tmp_path):
+    """An empty directory fails with a usage error."""
+    with pytest.raises(CliError) as exc_info:
+        detect_format(tmp_path)
+
+    assert exc_info.value.exit_code == 2
+    assert "empty" in exc_info.value.message.lower()
+
+
+def test_ambiguous_directory_lists_contents(tmp_path):
+    """An undetectable directory lists what was found and shows --from."""
+    (tmp_path / "mystery.dat").write_text("???")
+    (tmp_path / "other.bin").write_text("???")
+
+    with pytest.raises(CliError) as exc_info:
+        detect_format(tmp_path)
+
+    message = exc_info.value.message
+    assert "mystery.dat" in message
+    assert "--from" in message
+
+
+# ========== resolve_source ==========
+
+
+def test_resolve_source_with_explicit_from(tmp_path):
+    """An explicit --from skips detection but still checks existence."""
+    (tmp_path / "Patient.ndjson").write_text('{"resourceType":"Patient"}\n')
+
+    spec = resolve_source(str(tmp_path), from_format=SourceFormat.PARQUET)
+
+    assert spec.format == SourceFormat.PARQUET
+    assert spec.path == tmp_path
+
+
+def test_resolve_source_missing_with_from_errors(tmp_path):
+    """An explicit --from with a missing path is still a usage error."""
+    with pytest.raises(CliError) as exc_info:
+        resolve_source(str(tmp_path / "missing"), from_format=SourceFormat.NDJSON)
+
+    assert exc_info.value.exit_code == 2
+
+
+# ========== Bundle resource type discovery ==========
+
+
+def test_discover_bundle_resource_types(tmp_path):
+    """Distinct resource types across bundle entries are discovered."""
+    (tmp_path / "a.json").write_text(json.dumps(_bundle(["Patient", "Condition"])))
+    (tmp_path / "b.json").write_text(json.dumps(_bundle(["Patient", "Observation"])))
+
+    assert discover_bundle_resource_types(tmp_path) == [
+        "Condition",
+        "Observation",
+        "Patient",
+    ]
+
+
+def test_discover_bundle_resource_types_empty_errors(tmp_path):
+    """A directory with no bundle resources is an error."""
+    (tmp_path / "empty.json").write_text(json.dumps(_bundle([])))
+
+    with pytest.raises(CliError):
+        discover_bundle_resource_types(tmp_path)
+
+
+# ========== Single resource reading ==========
+
+
+def test_read_single_resource(tmp_path):
+    """A single resource file yields its type and raw JSON."""
+    resource = tmp_path / "patient.json"
+    resource.write_text('{"resourceType":"Patient","id":"x"}')
+
+    resource_type, text = read_single_resource(resource)
+
+    assert resource_type == "Patient"
+    assert "Patient" in text
+
+
+def test_read_single_resource_without_type_errors(tmp_path):
+    """A JSON file lacking resourceType is an error."""
+    resource = tmp_path / "notaresource.json"
+    resource.write_text('{"foo":"bar"}')
+
+    with pytest.raises(CliError):
+        read_single_resource(resource)
+
+
+# ========== Additional edge cases ==========
+
+
+def test_detects_xml_bundles(tmp_path):
+    """A directory of XML Bundle files is detected as bundles."""
+    (tmp_path / "bundle.xml").write_text('<?xml version="1.0"?><Bundle xmlns="x"/>')
+
+    assert detect_format(tmp_path) == SourceFormat.BUNDLES
+
+
+def test_ambiguous_directory_truncates_long_listing(tmp_path):
+    """An ambiguous directory with many files truncates its listing."""
+    for index in range(15):
+        (tmp_path / f"file{index:02d}.dat").write_text("x")
+
+    with pytest.raises(CliError) as exc_info:
+        detect_format(tmp_path)
+
+    assert "..." in exc_info.value.message
+
+
+def test_read_source_rejects_resource_format():
+    """read_source rejects the single-resource format as a data source."""
+    with pytest.raises(CliError):
+        read_source(None, SourceSpec(path=None, format=SourceFormat.RESOURCE))

--- a/lib/python/tests/cli/test_io.py
+++ b/lib/python/tests/cli/test_io.py
@@ -27,10 +27,12 @@ import json
 
 import pytest
 
+import pathling.cli.io as io_module
 from pathling.cli.errors import CliError
 from pathling.cli.io import (
     SourceFormat,
     SourceSpec,
+    _looks_like_bundle,
     detect_format,
     discover_bundle_resource_types,
     read_single_resource,
@@ -241,3 +243,123 @@ def test_read_source_rejects_resource_format():
     """read_source rejects the single-resource format as a data source."""
     with pytest.raises(CliError):
         read_source(None, SourceSpec(path=None, format=SourceFormat.RESOURCE))
+
+
+# ========== Prefix-based bundle detection (US5) ==========
+
+
+def test_looks_like_bundle_uses_leading_prefix(tmp_path):
+    """Bundle detection decides from a leading prefix, not a full parse.
+
+    The file is a valid Bundle in its prefix but invalid JSON after it; a full
+    ``json.load`` would fail, so a True result proves only the prefix was read
+    (FR-014).
+    """
+    path = tmp_path / "big.json"
+    path.write_text(
+        '{"resourceType": "Bundle", "type": "collection", "entry": [ this is '
+        "not valid json after the prefix",
+        encoding="utf-8",
+    )
+
+    assert _looks_like_bundle(path) is True
+
+
+def test_looks_like_bundle_false_for_non_bundle(tmp_path):
+    """A non-Bundle resource file is not detected as a Bundle."""
+    path = tmp_path / "patient.json"
+    path.write_text('{"resourceType": "Patient", "id": "x"}', encoding="utf-8")
+
+    assert _looks_like_bundle(path) is False
+
+
+# ========== read_source resource-type passthrough (US5) ==========
+
+
+class _RecordingReader:
+    """Records the arguments passed to ``bundles``."""
+
+    def __init__(self):
+        self.bundles_args = None
+
+    def bundles(self, path, types):
+        self.bundles_args = (path, types)
+        return "data-source"
+
+
+class _RecordingPc:
+    """A minimal context exposing a recording ``read`` reader."""
+
+    def __init__(self):
+        self.read = _RecordingReader()
+
+
+def test_read_source_with_types_skips_discovery(tmp_path, monkeypatch):
+    """An explicit ``types`` argument is used directly and skips discovery
+    (FR-015)."""
+    calls = []
+    monkeypatch.setattr(
+        io_module,
+        "discover_bundle_resource_types",
+        lambda path: calls.append(path) or ["should-not-be-used"],
+    )
+    pc = _RecordingPc()
+    spec = SourceSpec(path=tmp_path, format=SourceFormat.BUNDLES)
+
+    result = read_source(pc, spec, types=["Patient", "Condition"])
+
+    assert result == "data-source"
+    assert calls == []
+    assert pc.read.bundles_args == (str(tmp_path), ["Patient", "Condition"])
+
+
+def test_read_source_types_inert_for_non_bundles(tmp_path, monkeypatch):
+    """An explicit ``types`` argument has no effect on a non-Bundles source.
+
+    Covers the spec edge case that ``convert --type`` must not change behaviour
+    for ndjson/parquet/delta inputs.
+    """
+    calls = []
+    monkeypatch.setattr(
+        io_module,
+        "discover_bundle_resource_types",
+        lambda path: calls.append(path) or ["should-not-be-used"],
+    )
+
+    class _NdjsonReader:
+        def __init__(self):
+            self.ndjson_path = None
+
+        def ndjson(self, path):
+            self.ndjson_path = path
+            return "ndjson-data-source"
+
+    class _Pc:
+        read = _NdjsonReader()
+
+    pc = _Pc()
+    spec = SourceSpec(path=tmp_path, format=SourceFormat.NDJSON)
+
+    result = read_source(pc, spec, types=["Patient", "Condition"])
+
+    assert result == "ndjson-data-source"
+    assert pc.read.ndjson_path == str(tmp_path)
+    # Discovery is never consulted for a non-Bundles source.
+    assert calls == []
+
+
+def test_read_source_without_types_runs_discovery(tmp_path, monkeypatch):
+    """With no explicit types, discovery runs to enumerate the bundle types."""
+    calls = []
+    monkeypatch.setattr(
+        io_module,
+        "discover_bundle_resource_types",
+        lambda path: calls.append(path) or ["Patient"],
+    )
+    pc = _RecordingPc()
+    spec = SourceSpec(path=tmp_path, format=SourceFormat.BUNDLES)
+
+    read_source(pc, spec)
+
+    assert calls == [tmp_path]
+    assert pc.read.bundles_args == (str(tmp_path), ["Patient"])

--- a/lib/python/tests/cli/test_main.py
+++ b/lib/python/tests/cli/test_main.py
@@ -1,0 +1,97 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for the root command: version, help, and deferred heavy imports.
+
+Author: John Grimes.
+"""
+
+import subprocess
+import sys
+
+from pathling._version import __version__
+from pathling.cli.main import cli
+
+ALL_COMMANDS = [
+    "convert",
+    "view",
+    "fhirpath",
+    "export",
+    "member-of",
+    "translate",
+    "subsumes",
+    "subsumed-by",
+    "display",
+    "property-of",
+    "designation",
+]
+
+
+# ========== Version ==========
+
+
+def test_version_prints_package_version(runner):
+    """`pathling --version` prints the package version and exits 0."""
+    result = runner.invoke(cli, ["--version"])
+
+    assert result.exit_code == 0
+    assert __version__ in result.output
+
+
+# ========== Help ==========
+
+
+def test_help_lists_all_commands(runner):
+    """`pathling --help` documents every command."""
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    for command in ALL_COMMANDS:
+        assert command in result.output
+
+
+def test_help_mentions_config_file(runner):
+    """The root help describes the config file location."""
+    result = runner.invoke(cli, ["--help"])
+
+    assert "config" in result.output.lower()
+
+
+# ========== Deferred imports ==========
+
+
+def test_importing_main_does_not_import_pyspark():
+    """Importing pathling.cli.main must not import pyspark.
+
+    This is checked in a fresh subprocess because the test process has already
+    imported pyspark via the shared Spark fixture.
+    """
+    code = (
+        "import sys\n"
+        "import pathling.cli.main\n"
+        "assert 'pyspark' not in sys.modules, "
+        "'pyspark was imported by pathling.cli.main'\n"
+        "print('ok')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout

--- a/lib/python/tests/cli/test_main.py
+++ b/lib/python/tests/cli/test_main.py
@@ -38,6 +38,8 @@ ALL_COMMANDS = [
     "display",
     "property-of",
     "designation",
+    "run",
+    "console",
 ]
 
 
@@ -74,17 +76,19 @@ def test_help_mentions_config_file(runner):
 # ========== Deferred imports ==========
 
 
-def test_importing_main_does_not_import_pyspark():
-    """Importing pathling.cli.main must not import pyspark.
+def test_importing_main_does_not_import_heavy_modules():
+    """Importing pathling.cli.main must import neither pyspark nor IPython.
 
     This is checked in a fresh subprocess because the test process has already
-    imported pyspark via the shared Spark fixture.
+    imported the heavy modules via the shared fixtures.
     """
     code = (
         "import sys\n"
         "import pathling.cli.main\n"
         "assert 'pyspark' not in sys.modules, "
         "'pyspark was imported by pathling.cli.main'\n"
+        "assert 'IPython' not in sys.modules, "
+        "'IPython was imported by pathling.cli.main'\n"
         "print('ok')\n"
     )
     result = subprocess.run(

--- a/lib/python/tests/cli/test_main.py
+++ b/lib/python/tests/cli/test_main.py
@@ -107,3 +107,50 @@ def test_importing_main_does_not_import_heavy_modules():
 
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout
+
+
+# ========== Central error handler threads the server URL (US4) ==========
+
+
+def test_central_handler_passes_tx_server_as_server_url(runner, monkeypatch, tmp_path):
+    """The central handler passes the configured tx_server to friendly_message
+    so connection failures from convert/view/fhirpath name the server (FR-011).
+    """
+    captured = {}
+
+    def fake_friendly(exc, verbose=False, server_url=None):
+        captured["server_url"] = server_url
+        return "rendered"
+
+    monkeypatch.setattr("pathling.cli.main.friendly_message", fake_friendly)
+
+    # Fail inside the command, past configuration resolution, with a generic
+    # exception so the central ``except Exception`` branch is exercised.
+    def boom(config, console=None):
+        raise RuntimeError("Connection refused")
+
+    monkeypatch.setattr("pathling.cli.session.create_context", boom)
+
+    source = tmp_path / "data"
+    source.mkdir()
+    (source / "Patient.ndjson").write_text(
+        '{"resourceType":"Patient"}\n', encoding="utf-8"
+    )
+    out = tmp_path / "out"
+
+    result = runner.invoke(
+        cli,
+        [
+            "--tx-server",
+            "https://tx.example/fhir",
+            "convert",
+            str(source),
+            "--to",
+            "ndjson",
+            "-o",
+            str(out),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert captured["server_url"] == "https://tx.example/fhir"

--- a/lib/python/tests/cli/test_main.py
+++ b/lib/python/tests/cli/test_main.py
@@ -73,6 +73,14 @@ def test_help_mentions_config_file(runner):
     assert "config" in result.output.lower()
 
 
+def test_help_lists_spark_conf_option(runner):
+    """The root group exposes a repeatable --spark-conf option in its help."""
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "--spark-conf" in result.output
+
+
 # ========== Deferred imports ==========
 
 

--- a/lib/python/tests/cli/test_render.py
+++ b/lib/python/tests/cli/test_render.py
@@ -1,0 +1,194 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for output rendering and output option resolution.
+
+The pure rendering and validation logic is tested without Spark.
+
+Author: John Grimes.
+"""
+
+import csv
+import io
+import json
+
+import pytest
+
+from pathling.cli.errors import CliError
+from pathling.cli.render import (
+    OutputFormat,
+    check_overwrite,
+    infer_format_from_extension,
+    render_csv,
+    render_json,
+    render_ndjson,
+    render_table,
+    resolve_output,
+)
+
+COLUMNS = ["id", "family"]
+ROWS = [["1", "Smith"], ["2", None]]
+
+
+# ========== Table ==========
+
+
+def test_table_includes_values_and_row_count():
+    """The table renders values and a row-count caption."""
+    output = render_table(COLUMNS, ROWS)
+
+    assert "Smith" in output
+    assert "2 rows" in output
+
+
+def test_table_empty_indicates_zero_rows():
+    """An empty result renders an explicit '0 rows' indication."""
+    output = render_table(COLUMNS, [])
+
+    assert "0 rows" in output
+
+
+def test_table_renders_square_brackets_verbatim():
+    """Cell values containing square brackets are not treated as Rich markup."""
+    # A value like a Spark error code would crash a markup-enabled renderer.
+    output = render_table(["v"], [["[FAILED_EXECUTE_UDF] detail"]])
+
+    assert "[FAILED_EXECUTE_UDF]" in output
+
+
+# ========== CSV ==========
+
+
+def test_csv_has_header_and_rows():
+    """CSV output includes a header row and parses back to the input rows."""
+    output = render_csv(COLUMNS, ROWS)
+
+    parsed = list(csv.reader(io.StringIO(output)))
+    assert parsed[0] == COLUMNS
+    assert parsed[1] == ["1", "Smith"]
+    # None is rendered as an empty field.
+    assert parsed[2] == ["2", ""]
+
+
+# ========== JSON ==========
+
+
+def test_json_is_array_of_objects():
+    """JSON output is a valid array of column-keyed objects."""
+    output = render_json(COLUMNS, ROWS)
+
+    parsed = json.loads(output)
+    assert parsed == [
+        {"id": "1", "family": "Smith"},
+        {"id": "2", "family": None},
+    ]
+
+
+# ========== NDJSON ==========
+
+
+def test_ndjson_is_one_object_per_line():
+    """NDJSON output is one JSON object per line."""
+    output = render_ndjson(COLUMNS, ROWS)
+
+    lines = output.splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == {"id": "1", "family": "Smith"}
+
+
+# ========== Format inference ==========
+
+
+def test_infer_format_from_extension():
+    """Output format is inferred from the file extension."""
+    from pathlib import Path
+
+    assert infer_format_from_extension(Path("out.csv")) == OutputFormat.CSV
+    assert infer_format_from_extension(Path("out.json")) == OutputFormat.JSON
+    assert infer_format_from_extension(Path("out.ndjson")) == OutputFormat.NDJSON
+    assert infer_format_from_extension(Path("out.parquet")) == OutputFormat.PARQUET
+    assert infer_format_from_extension(Path("out.unknown")) is None
+
+
+def test_resolve_output_infers_from_path():
+    """An output path with a known extension resolves its format."""
+    spec = resolve_output("results.csv", None)
+
+    assert spec.format == OutputFormat.CSV
+    assert str(spec.path) == "results.csv"
+
+
+def test_resolve_output_default_is_table():
+    """With no path and no flag, the default format is a table."""
+    spec = resolve_output(None, None)
+
+    assert spec.format == OutputFormat.TABLE
+    assert spec.path is None
+
+
+# ========== Validation errors ==========
+
+
+def test_table_with_output_path_is_error():
+    """Requesting the table format with -o is a usage error."""
+    with pytest.raises(CliError) as exc_info:
+        resolve_output("out.txt", OutputFormat.TABLE)
+
+    assert exc_info.value.exit_code == 2
+
+
+def test_parquet_without_output_path_is_error():
+    """Requesting parquet without -o is a usage error."""
+    with pytest.raises(CliError) as exc_info:
+        resolve_output(None, OutputFormat.PARQUET)
+
+    assert exc_info.value.exit_code == 2
+
+
+def test_unknown_extension_without_format_is_error():
+    """An unknown -o extension without --format is a usage error."""
+    with pytest.raises(CliError) as exc_info:
+        resolve_output("out.weird", None)
+
+    assert exc_info.value.exit_code == 2
+
+
+# ========== Overwrite handling ==========
+
+
+def test_check_overwrite_existing_without_flag_errors(tmp_path):
+    """An existing output path without --overwrite is an error showing the flag."""
+    existing = tmp_path / "out.csv"
+    existing.write_text("data")
+
+    with pytest.raises(CliError) as exc_info:
+        check_overwrite(existing, overwrite=False)
+
+    assert "--overwrite" in exc_info.value.message
+
+
+def test_check_overwrite_existing_with_flag_ok(tmp_path):
+    """An existing output path with --overwrite is allowed."""
+    existing = tmp_path / "out.csv"
+    existing.write_text("data")
+
+    check_overwrite(existing, overwrite=True)
+
+
+def test_check_overwrite_missing_ok(tmp_path):
+    """A non-existent output path passes the overwrite check."""
+    check_overwrite(tmp_path / "new.csv", overwrite=False)

--- a/lib/python/tests/cli/test_render.py
+++ b/lib/python/tests/cli/test_render.py
@@ -33,9 +33,10 @@ from pathling.cli.render import (
     OutputFormat,
     check_overwrite,
     infer_format_from_extension,
+    output_options,
     render_csv,
-    render_json,
     render_ndjson,
+    render_rows,
     render_table,
     resolve_output,
 )
@@ -84,20 +85,6 @@ def test_csv_has_header_and_rows():
     assert parsed[2] == ["2", ""]
 
 
-# ========== JSON ==========
-
-
-def test_json_is_array_of_objects():
-    """JSON output is a valid array of column-keyed objects."""
-    output = render_json(COLUMNS, ROWS)
-
-    parsed = json.loads(output)
-    assert parsed == [
-        {"id": "1", "family": "Smith"},
-        {"id": "2", "family": None},
-    ]
-
-
 # ========== NDJSON ==========
 
 
@@ -110,6 +97,40 @@ def test_ndjson_is_one_object_per_line():
     assert json.loads(lines[0]) == {"id": "1", "family": "Smith"}
 
 
+# ========== JSON-array format removal (T015) ==========
+
+
+def test_format_json_is_not_an_accepted_choice():
+    """The removed json format is rejected as an invalid --format choice."""
+    import click
+    from click.testing import CliRunner
+
+    @click.command()
+    @output_options
+    def cmd(**kwargs):
+        pass
+
+    result = CliRunner().invoke(cmd, ["--format", "json", "-o", "out.txt"])
+
+    assert result.exit_code != 0
+    assert "is not one of" in result.output
+
+
+def test_json_output_path_errors_with_ndjson_suggestion():
+    """A .json output path raises a usage error pointing at NDJSON."""
+    with pytest.raises(CliError) as exc_info:
+        resolve_output("out.json", None)
+
+    assert exc_info.value.exit_code == 2
+    assert "ndjson" in exc_info.value.message.lower()
+
+
+def test_json_is_not_a_stdout_format():
+    """The json format can no longer be rendered to stdout."""
+    with pytest.raises(CliError):
+        render_rows(COLUMNS, ROWS, "json")
+
+
 # ========== Format inference ==========
 
 
@@ -118,8 +139,10 @@ def test_infer_format_from_extension():
     from pathlib import Path
 
     assert infer_format_from_extension(Path("out.csv")) == OutputFormat.CSV
-    assert infer_format_from_extension(Path("out.json")) == OutputFormat.JSON
+    # The json-array format is removed, so a .json extension is not inferred.
+    assert infer_format_from_extension(Path("out.json")) is None
     assert infer_format_from_extension(Path("out.ndjson")) == OutputFormat.NDJSON
+    assert infer_format_from_extension(Path("out.jsonl")) == OutputFormat.NDJSON
     assert infer_format_from_extension(Path("out.parquet")) == OutputFormat.PARQUET
     assert infer_format_from_extension(Path("out.unknown")) is None
 
@@ -165,6 +188,38 @@ def test_unknown_extension_without_format_is_error():
         resolve_output("out.weird", None)
 
     assert exc_info.value.exit_code == 2
+
+
+# ========== Departition resolution ==========
+
+
+def test_resolve_output_departition_defaults_true():
+    """Departitioning is on by default in the resolved spec."""
+    spec = resolve_output("out.csv", None)
+
+    assert spec.departition is True
+
+
+def test_resolve_output_no_departition_resolves_false():
+    """--no-departition resolves to a spec with departitioning disabled."""
+    spec = resolve_output("out.csv", None, departition=False)
+
+    assert spec.departition is False
+
+
+def test_departition_flag_appears_in_command_help():
+    """The --departition/--no-departition flag is offered in command help."""
+    import click
+    from click.testing import CliRunner
+
+    @click.command()
+    @output_options
+    def cmd(**kwargs):
+        pass
+
+    result = CliRunner().invoke(cmd, ["--help"])
+
+    assert "--no-departition" in result.output
 
 
 # ========== Overwrite handling ==========

--- a/lib/python/tests/cli/test_run.py
+++ b/lib/python/tests/cli/test_run.py
@@ -1,0 +1,333 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for the ``pathling run`` command.
+
+These tests drive the command through Click's ``CliRunner`` against the shared
+Spark fixture, asserting Python-interpreter parity: namespace binding, script
+semantics (``__name__``, ``__file__``, ``sys.path``), argument passing,
+traceback fidelity, and exit codes.
+
+Author: John Grimes.
+"""
+
+import sys
+
+from pytest import fixture
+
+from pathling.cli.main import cli
+
+
+@fixture
+def forbidden_context(monkeypatch):
+    """Fails the test if any command attempts to start the environment.
+
+    Used by usage-error tests to prove that validation happens before the
+    (expensive) session startup.
+
+    :param monkeypatch: the pytest monkeypatch fixture.
+    """
+
+    def _fail(config, console=None):
+        raise AssertionError("create_context must not be called for usage errors")
+
+    monkeypatch.setattr("pathling.cli.session.create_context", _fail)
+
+
+def _write_script(tmp_path, body, name="script.py"):
+    """Writes a script body to a file under tmp_path and returns its path.
+
+    :param tmp_path: the test's temporary directory.
+    :param body: the Python source for the script.
+    :param name: the file name for the script.
+    :return: the path to the written script as a string.
+    """
+    path = tmp_path / name
+    path.write_text(body)
+    return str(path)
+
+
+# ========== Namespace binding ==========
+
+
+def test_spark_and_pathling_are_bound(runner, patched_context, tmp_path):
+    """The script sees the context's Spark session and the context itself."""
+    script = _write_script(
+        tmp_path,
+        "print(id(spark))\nprint(id(pathling))\n",
+    )
+
+    result = runner.invoke(cli, ["run", script])
+
+    assert result.exit_code == 0, result.stderr
+    lines = result.stdout.splitlines()
+    assert lines[0] == str(id(patched_context.spark))
+    assert lines[1] == str(id(patched_context))
+
+
+def test_stdout_passes_through_unmodified(runner, patched_context, tmp_path):
+    """The script's stdout appears on the CLI's stdout unmodified."""
+    script = _write_script(tmp_path, "print('hello from user code')\n")
+
+    result = runner.invoke(cli, ["run", script])
+
+    assert result.exit_code == 0, result.stderr
+    assert "hello from user code\n" in result.stdout
+
+
+# ========== Interpreter script semantics ==========
+
+
+def test_main_module_semantics(runner, patched_context, tmp_path):
+    """The script runs as __main__ with __file__ set to the script path."""
+    script = _write_script(
+        tmp_path,
+        "print(__name__)\nprint(__file__)\n",
+    )
+
+    result = runner.invoke(cli, ["run", script])
+
+    assert result.exit_code == 0, result.stderr
+    lines = result.stdout.splitlines()
+    assert lines[0] == "__main__"
+    assert lines[1] == script
+
+
+def test_script_directory_is_on_sys_path(runner, patched_context, tmp_path):
+    """sys.path[0] is the script's directory during execution."""
+    script = _write_script(tmp_path, "import sys\nprint(sys.path[0])\n")
+
+    result = runner.invoke(cli, ["run", script])
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout.splitlines()[0] == str(tmp_path)
+
+
+def test_sibling_module_import(runner, patched_context, tmp_path):
+    """A script can import a module that sits next to it."""
+    (tmp_path / "sibling.py").write_text("VALUE = 'from sibling'\n")
+    script = _write_script(tmp_path, "import sibling\nprint(sibling.VALUE)\n")
+
+    result = runner.invoke(cli, ["run", script])
+
+    assert result.exit_code == 0, result.stderr
+    assert "from sibling" in result.stdout
+
+
+# ========== Error handling and exit codes ==========
+
+
+def test_uncaught_exception_prints_clean_traceback(runner, patched_context, tmp_path):
+    """An uncaught exception prints a standard traceback and exits 1."""
+    script = _write_script(
+        tmp_path,
+        "def boom():\n    raise ValueError('user error')\nboom()\n",
+    )
+
+    result = runner.invoke(cli, ["run", script])
+
+    assert result.exit_code == 1
+    assert "Traceback (most recent call last)" in result.stderr
+    assert "ValueError: user error" in result.stderr
+    # The traceback names the user's script file, not CLI internals.
+    assert script in result.stderr
+    assert "cli/run.py" not in result.stderr
+    assert "click" not in result.stderr
+
+
+def test_syntax_error_names_script_and_exits_1(runner, patched_context, tmp_path):
+    """A syntax error names the script file and exits 1."""
+    script = _write_script(tmp_path, "def broken(\n")
+
+    result = runner.invoke(cli, ["run", script])
+
+    assert result.exit_code == 1
+    assert "SyntaxError" in result.stderr
+    assert script in result.stderr
+    # The interpreter prints no traceback header or frames for a syntax
+    # error, so neither may the CLI.
+    assert "Traceback (most recent call last)" not in result.stderr
+    assert "cli/run.py" not in result.stderr
+
+
+def test_sys_exit_code_propagates_without_traceback(runner, patched_context, tmp_path):
+    """sys.exit(3) exits with code 3 and prints no traceback."""
+    script = _write_script(tmp_path, "import sys\nsys.exit(3)\n")
+
+    result = runner.invoke(cli, ["run", script])
+
+    assert result.exit_code == 3
+    assert "Traceback" not in result.stderr
+    assert "Traceback" not in result.stdout
+
+
+def test_sys_exit_message_prints_and_exits_1(runner, patched_context, tmp_path):
+    """sys.exit('msg') prints the message and exits 1."""
+    script = _write_script(tmp_path, "import sys\nsys.exit('the exit message')\n")
+
+    result = runner.invoke(cli, ["run", script])
+
+    assert result.exit_code == 1
+    assert "the exit message" in result.output + result.stderr
+    assert "Traceback" not in result.stderr
+
+
+# ========== Inline code and stdin sources ==========
+
+
+def test_inline_code_executes_with_namespace(runner, patched_context):
+    """-c code executes with both variables bound."""
+    result = runner.invoke(cli, ["run", "-c", "print(id(spark)); print(id(pathling))"])
+
+    assert result.exit_code == 0, result.stderr
+    lines = result.stdout.splitlines()
+    assert lines[0] == str(id(patched_context.spark))
+    assert lines[1] == str(id(patched_context))
+
+
+def test_inline_code_traceback_names_string(runner, patched_context):
+    """An exception in -c code names <string> in the traceback."""
+    result = runner.invoke(cli, ["run", "-c", "raise ValueError('inline')"])
+
+    assert result.exit_code == 1
+    assert '"<string>"' in result.stderr
+    assert "ValueError: inline" in result.stderr
+
+
+def test_inline_syntax_error_names_string(runner, patched_context):
+    """A syntax error in -c code names <string>."""
+    result = runner.invoke(cli, ["run", "-c", "def broken("])
+
+    assert result.exit_code == 1
+    assert "SyntaxError" in result.stderr
+    assert '"<string>"' in result.stderr
+    # The interpreter prints no traceback header or frames for a syntax
+    # error, so neither may the CLI.
+    assert "Traceback (most recent call last)" not in result.stderr
+    assert "cli/run.py" not in result.stderr
+
+
+def test_stdin_code_executes_with_namespace(runner, patched_context):
+    """Code piped on stdin via '-' executes with both variables bound."""
+    result = runner.invoke(cli, ["run", "-"], input="print(type(pathling).__name__)\n")
+
+    assert result.exit_code == 0, result.stderr
+    assert "PathlingContext" in result.stdout
+
+
+def test_stdin_traceback_names_stdin(runner, patched_context):
+    """An exception in stdin code names <stdin> in the traceback."""
+    result = runner.invoke(cli, ["run", "-"], input="raise ValueError('piped')\n")
+
+    assert result.exit_code == 1
+    assert '"<stdin>"' in result.stderr
+    assert "ValueError: piped" in result.stderr
+
+
+def test_inline_and_stdin_sys_path_zero_is_empty(runner, patched_context):
+    """sys.path[0] is '' (the working directory) for -c and stdin code."""
+    inline = runner.invoke(cli, ["run", "-c", "import sys; print(repr(sys.path[0]))"])
+    piped = runner.invoke(
+        cli, ["run", "-"], input="import sys\nprint(repr(sys.path[0]))\n"
+    )
+
+    assert inline.exit_code == 0, inline.stderr
+    assert inline.stdout.splitlines()[0] == "''"
+    assert piped.exit_code == 0, piped.stderr
+    assert piped.stdout.splitlines()[0] == "''"
+
+
+# ========== Usage errors before session start ==========
+
+
+def test_script_and_inline_code_is_usage_error(runner, forbidden_context, tmp_path):
+    """Supplying both a script and -c is a usage error before session start."""
+    script = _write_script(tmp_path, "print('never runs')\n")
+
+    result = runner.invoke(cli, ["run", script, "-c", "print(1)"])
+
+    assert result.exit_code == 2
+    assert "-c" in result.stderr
+
+
+def test_no_source_is_usage_error(runner, forbidden_context):
+    """Supplying no code source is a usage error before session start."""
+    result = runner.invoke(cli, ["run"])
+
+    assert result.exit_code == 2
+
+
+# ========== Argument passing (interpreter parity) ==========
+
+ARGV_PROGRAM = "import sys\nprint(sys.argv)\n"
+
+
+def test_script_argv_follows_interpreter_convention(runner, patched_context, tmp_path):
+    """For `run script.py a b`, user code sees ['script.py', 'a', 'b']."""
+    script = _write_script(tmp_path, ARGV_PROGRAM)
+
+    result = runner.invoke(cli, ["run", script, "a", "b"])
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout.splitlines()[0] == str([script, "a", "b"])
+
+
+def test_inline_code_argv_follows_interpreter_convention(runner, patched_context):
+    """For `run -c CODE a b`, user code sees ['-c', 'a', 'b']."""
+    result = runner.invoke(cli, ["run", "-c", ARGV_PROGRAM, "a", "b"])
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout.splitlines()[0] == str(["-c", "a", "b"])
+
+
+def test_stdin_argv_follows_interpreter_convention(runner, patched_context):
+    """For `run - a b`, user code sees ['-', 'a', 'b']."""
+    result = runner.invoke(cli, ["run", "-", "a", "b"], input=ARGV_PROGRAM)
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout.splitlines()[0] == str(["-", "a", "b"])
+
+
+def test_dash_prefixed_arguments_pass_through(runner, patched_context, tmp_path):
+    """Dash-prefixed trailing arguments reach the script unparsed."""
+    script = _write_script(tmp_path, ARGV_PROGRAM)
+
+    result = runner.invoke(cli, ["run", script, "--input", "a.ndjson", "out/"])
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout.splitlines()[0] == str([script, "--input", "a.ndjson", "out/"])
+
+
+def test_sys_argv_is_restored_after_command(runner, patched_context, tmp_path):
+    """The process's original sys.argv is restored after the command returns."""
+    script = _write_script(tmp_path, "print('ok')\n")
+    original_argv = list(sys.argv)
+
+    result = runner.invoke(cli, ["run", script, "a", "b"])
+
+    assert result.exit_code == 0, result.stderr
+    assert sys.argv == original_argv
+
+
+def test_missing_script_is_usage_error_without_session(
+    runner, forbidden_context, tmp_path
+):
+    """A missing script path is a usage error that never starts the session."""
+    result = runner.invoke(cli, ["run", str(tmp_path / "missing.py")])
+
+    assert result.exit_code == 2
+    assert "missing.py" in result.stderr

--- a/lib/python/tests/cli/test_runner_fixture.py
+++ b/lib/python/tests/cli/test_runner_fixture.py
@@ -1,0 +1,71 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for the portable Click runner builder (US3 / FR-010).
+
+Click 8.2 removed the ``mix_stderr`` parameter from ``CliRunner.__init__``. The
+extracted ``make_cli_runner`` helper must construct a runner on either Click
+version, passing ``mix_stderr=False`` only where the parameter is accepted, so
+the suite collects and runs on Python 3.9 (Click 8.1) and 3.10+ (Click 8.2+).
+
+Author: John Grimes.
+"""
+
+from click.testing import CliRunner
+
+from tests.cli.conftest import make_cli_runner
+
+
+class _RunnerWithMixStderr:
+    """A stand-in whose constructor accepts ``mix_stderr`` (Click 8.1 shape)."""
+
+    def __init__(self, mix_stderr=True):
+        self.mix_stderr = mix_stderr
+
+
+class _RunnerWithoutMixStderr:
+    """A stand-in whose constructor omits ``mix_stderr`` (Click 8.2 shape)."""
+
+    def __init__(self):
+        # A distinctive sentinel proves the parameter was never supplied.
+        self.mix_stderr = "unset"
+
+
+def test_default_builds_real_cli_runner():
+    """With no override, the helper builds a genuine Click ``CliRunner``."""
+    runner = make_cli_runner()
+
+    assert isinstance(runner, CliRunner)
+
+
+def test_passes_mix_stderr_false_when_supported():
+    """When the constructor accepts ``mix_stderr``, it is passed as False."""
+    runner = make_cli_runner(_RunnerWithMixStderr)
+
+    assert runner.mix_stderr is False
+
+
+def test_omits_mix_stderr_when_not_supported():
+    """When the constructor lacks ``mix_stderr``, it is constructed without it.
+
+    A constructor that does not accept the parameter would raise ``TypeError``
+    if the helper passed it; reaching the sentinel proves it was omitted.
+    """
+    runner = make_cli_runner(_RunnerWithoutMixStderr)
+
+    assert isinstance(runner, _RunnerWithoutMixStderr)
+    assert runner.mix_stderr == "unset"

--- a/lib/python/tests/cli/test_session.py
+++ b/lib/python/tests/cli/test_session.py
@@ -17,12 +17,34 @@
 
 """Unit tests for the Spark session helpers that do not require Spark.
 
+The session-build tests mock :func:`pathling.context._build_spark_session` so
+that the configuration assembled by ``_build_quiet_spark`` can be captured
+without starting Spark.
+
 Author: John Grimes.
 """
 
 from pathlib import Path
 
-from pathling.cli.session import _write_quiet_log4j2
+import pathling.context as context_module
+from pathling.cli.config import CliConfig
+from pathling.cli.session import _build_quiet_spark, _write_quiet_log4j2
+
+
+def _capture_build(monkeypatch) -> dict:
+    """Replaces the session builder with a stub that captures its configuration.
+
+    :param monkeypatch: the pytest monkeypatch fixture.
+    :return: a dict populated with the ``extra_configs`` passed to the builder.
+    """
+    captured = {}
+
+    def fake_build(extra_configs=None):
+        captured.update(extra_configs or {})
+        return "session"
+
+    monkeypatch.setattr(context_module, "_build_spark_session", fake_build)
+    return captured
 
 
 def test_quiet_log4j2_file_is_written():
@@ -33,3 +55,46 @@ def test_quiet_log4j2_file_is_written():
     contents = path.read_text(encoding="utf-8")
     assert "rootLogger.level = off" in contents
     assert "SYSTEM_ERR" in contents
+
+
+def test_build_quiet_spark_passes_spark_conf(monkeypatch):
+    """User Spark settings reach the session builder."""
+    captured = _capture_build(monkeypatch)
+    config = CliConfig(verbose=True, spark_conf={"spark.sql.shuffle.partitions": "16"})
+
+    result = _build_quiet_spark(config)
+
+    assert result == "session"
+    assert captured["spark.sql.shuffle.partitions"] == "16"
+
+
+def test_build_quiet_spark_user_wins_over_quiet_java_options(monkeypatch):
+    """A user-set spark.driver.extraJavaOptions overrides the quiet default."""
+    captured = _capture_build(monkeypatch)
+    config = CliConfig(
+        verbose=False,
+        spark_conf={"spark.driver.extraJavaOptions": "-Dcustom=1"},
+    )
+
+    _build_quiet_spark(config)
+
+    # The user value wins over the CLI's quiet-logging option for the same key.
+    assert captured["spark.driver.extraJavaOptions"] == "-Dcustom=1"
+    # The quiet console-progress option the user did not set still applies.
+    assert captured["spark.ui.showConsoleProgress"] == "false"
+
+
+def test_build_quiet_spark_empty_conf_keeps_quiet_defaults(monkeypatch):
+    """An empty spark_conf leaves the quiet-mode behaviour unchanged."""
+    captured = _capture_build(monkeypatch)
+    config = CliConfig(verbose=False, spark_conf={})
+
+    _build_quiet_spark(config)
+
+    assert captured["spark.ui.showConsoleProgress"] == "false"
+    assert "log4j2.configurationFile" in captured["spark.driver.extraJavaOptions"]
+    # Only the two quiet-logging options are present.
+    assert set(captured) == {
+        "spark.driver.extraJavaOptions",
+        "spark.ui.showConsoleProgress",
+    }

--- a/lib/python/tests/cli/test_session.py
+++ b/lib/python/tests/cli/test_session.py
@@ -1,0 +1,35 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for the Spark session helpers that do not require Spark.
+
+Author: John Grimes.
+"""
+
+from pathlib import Path
+
+from pathling.cli.session import _write_quiet_log4j2
+
+
+def test_quiet_log4j2_file_is_written():
+    """The quiet log4j2 helper writes a readable properties file."""
+    path = Path(_write_quiet_log4j2())
+
+    assert path.exists()
+    contents = path.read_text(encoding="utf-8")
+    assert "rootLogger.level = off" in contents
+    assert "SYSTEM_ERR" in contents

--- a/lib/python/tests/cli/test_session.py
+++ b/lib/python/tests/cli/test_session.py
@@ -24,11 +24,18 @@ without starting Spark.
 Author: John Grimes.
 """
 
+import glob
+import os
+import tempfile
 from pathlib import Path
 
 import pathling.context as context_module
 from pathling.cli.config import CliConfig
-from pathling.cli.session import _build_quiet_spark, _write_quiet_log4j2
+from pathling.cli.session import _build_quiet_spark, quiet_log4j2_path
+
+# The temp-file prefix the pre-fix implementation used; no file with this prefix
+# may be created any more (FR-017).
+_LEAKED_PREFIX = "pathling-cli-log4j2-*"
 
 
 def _capture_build(monkeypatch) -> dict:
@@ -47,14 +54,37 @@ def _capture_build(monkeypatch) -> dict:
     return captured
 
 
-def test_quiet_log4j2_file_is_written():
-    """The quiet log4j2 helper writes a readable properties file."""
-    path = Path(_write_quiet_log4j2())
+def test_quiet_log4j2_resolves_packaged_resource_without_temp_file():
+    """The quiet log4j2 path resolves to the packaged resource and leaves no
+    per-run temporary file behind (FR-017)."""
+    pattern = os.path.join(tempfile.gettempdir(), _LEAKED_PREFIX)
+    before = set(glob.glob(pattern))
 
-    assert path.exists()
-    contents = path.read_text(encoding="utf-8")
+    path = quiet_log4j2_path()
+
+    after = set(glob.glob(pattern))
+    assert after == before, "a per-run temporary log4j2 file was created"
+    resolved = Path(path)
+    assert resolved.exists()
+    assert os.access(resolved, os.R_OK)
+    contents = resolved.read_text(encoding="utf-8")
     assert "rootLogger.level = off" in contents
     assert "SYSTEM_ERR" in contents
+
+
+def test_build_quiet_spark_points_driver_at_readable_quiet_config(monkeypatch):
+    """The driver Java options point at a readable quiet log4j2 configuration."""
+    captured = _capture_build(monkeypatch)
+    config = CliConfig(verbose=False, spark_conf={})
+
+    _build_quiet_spark(config)
+
+    java_options = captured["spark.driver.extraJavaOptions"]
+    prefix = "-Dlog4j2.configurationFile=file:"
+    assert prefix in java_options
+    path = Path(java_options.split(prefix, 1)[1])
+    assert path.exists()
+    assert "rootLogger.level = off" in path.read_text(encoding="utf-8")
 
 
 def test_build_quiet_spark_passes_spark_conf(monkeypatch):

--- a/lib/python/tests/cli/test_session.py
+++ b/lib/python/tests/cli/test_session.py
@@ -93,8 +93,33 @@ def test_build_quiet_spark_empty_conf_keeps_quiet_defaults(monkeypatch):
 
     assert captured["spark.ui.showConsoleProgress"] == "false"
     assert "log4j2.configurationFile" in captured["spark.driver.extraJavaOptions"]
-    # Only the two quiet-logging options are present.
+    # Only the two quiet-logging options and the Arrow transfer option are
+    # present.
     assert set(captured) == {
         "spark.driver.extraJavaOptions",
         "spark.ui.showConsoleProgress",
+        "spark.sql.execution.arrow.pyspark.enabled",
     }
+
+
+def test_build_quiet_spark_enables_arrow_transfer(monkeypatch):
+    """Arrow-based columnar transfer is enabled on the CLI session."""
+    captured = _capture_build(monkeypatch)
+    config = CliConfig(verbose=True, spark_conf={})
+
+    _build_quiet_spark(config)
+
+    assert captured["spark.sql.execution.arrow.pyspark.enabled"] == "true"
+
+
+def test_build_quiet_spark_user_can_disable_arrow(monkeypatch):
+    """A user --spark-conf value overrides the Arrow transfer default."""
+    captured = _capture_build(monkeypatch)
+    config = CliConfig(
+        verbose=True,
+        spark_conf={"spark.sql.execution.arrow.pyspark.enabled": "false"},
+    )
+
+    _build_quiet_spark(config)
+
+    assert captured["spark.sql.execution.arrow.pyspark.enabled"] == "false"

--- a/lib/python/tests/cli/test_sparkconf.py
+++ b/lib/python/tests/cli/test_sparkconf.py
@@ -1,0 +1,253 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for Spark configuration parsing, validation, and merging.
+
+These tests exercise the pure logic in :mod:`pathling.cli.sparkconf` without
+starting Spark: flag parsing, key/value validation and coercion, secret
+resolution, and the merge of the user map against Pathling's managed defaults.
+
+Author: John Grimes.
+"""
+
+import pytest
+
+from pathling._spark_defaults import (
+    CATALOG_KEY,
+    DELTA_CATALOG,
+    DELTA_COORDINATE,
+    DELTA_EXTENSION,
+    EXTENSIONS_KEY,
+    LIBRARY_RUNTIME_COORDINATE,
+    PACKAGES_KEY,
+)
+from pathling.cli.errors import EXIT_USAGE, CliError
+from pathling.cli.sparkconf import (
+    merge_spark_conf,
+    parse_spark_conf_flags,
+    resolve_spark_conf,
+    validate_and_coerce,
+)
+
+
+def _coords(packages: str) -> list:
+    """Splits a comma-separated packages string, dropping empty entries."""
+    return [item for item in packages.split(",") if item]
+
+
+# ========== parse_spark_conf_flags (T022) ==========
+
+
+def test_parse_flags_splits_on_first_equals():
+    """A flag splits on the first =, so the value may itself contain =."""
+    parsed = parse_spark_conf_flags(
+        [
+            "spark.executor.memory=4g",
+            "spark.driver.extraJavaOptions=-Dfoo=bar",
+        ]
+    )
+
+    assert parsed["spark.executor.memory"] == "4g"
+    assert parsed["spark.driver.extraJavaOptions"] == "-Dfoo=bar"
+
+
+def test_parse_flags_last_occurrence_wins():
+    """When a key is repeated, the last occurrence wins."""
+    assert parse_spark_conf_flags(["spark.x=1", "spark.x=2"]) == {"spark.x": "2"}
+
+
+def test_parse_flags_missing_equals_is_usage_error():
+    """An argument with no = is a usage error (exit code 2)."""
+    with pytest.raises(CliError) as exc_info:
+        parse_spark_conf_flags(["spark.executor.memory"])
+
+    assert exc_info.value.exit_code == EXIT_USAGE
+    assert "spark.executor.memory" in exc_info.value.message
+
+
+# ========== validate_and_coerce (T008) ==========
+
+
+def test_validate_rejects_non_spark_key():
+    """A key that does not begin with spark. is a usage error naming the key."""
+    with pytest.raises(CliError) as exc_info:
+        validate_and_coerce("executor.memory", "4g")
+
+    assert exc_info.value.exit_code == EXIT_USAGE
+    assert "executor.memory" in exc_info.value.message
+
+
+def test_validate_rejects_non_scalar_value():
+    """A list or table value is a usage error naming the key."""
+    with pytest.raises(CliError) as exc_info:
+        validate_and_coerce("spark.jars.packages", ["a:b:1", "c:d:2"])
+    assert exc_info.value.exit_code == EXIT_USAGE
+    assert "spark.jars.packages" in exc_info.value.message
+
+    with pytest.raises(CliError):
+        validate_and_coerce("spark.nested", {"a": 1})
+
+
+def test_validate_coerces_scalars_to_strings():
+    """Integers, floats, and booleans coerce to their Spark string form."""
+    assert validate_and_coerce("spark.sql.shuffle.partitions", 16) == "16"
+    assert validate_and_coerce("spark.some.ratio", 1.5) == "1.5"
+    assert validate_and_coerce("spark.sql.adaptive.enabled", True) == "true"
+    assert validate_and_coerce("spark.sql.adaptive.enabled", False) == "false"
+
+
+def test_validate_passes_string_through_unchanged():
+    """A string value is returned unchanged."""
+    assert validate_and_coerce("spark.executor.memory", "4g") == "4g"
+
+
+# ========== resolve_spark_conf (T009) ==========
+
+
+def test_resolve_reads_file_secret_and_passes_literal_through(tmp_path):
+    """A @file value is read via the secret mechanism; a literal passes through."""
+    secret_file = tmp_path / "s3-key"
+    secret_file.write_text("  super-secret\n", encoding="utf-8")
+
+    resolved = resolve_spark_conf(
+        {
+            "spark.hadoop.fs.s3a.secret.key": f"@{secret_file}",
+            "spark.executor.memory": "4g",
+        },
+        {},
+    )
+
+    assert resolved["spark.hadoop.fs.s3a.secret.key"] == "super-secret"
+    assert resolved["spark.executor.memory"] == "4g"
+
+
+# ========== merge_spark_conf: passthrough (T010) ==========
+
+
+def test_merge_empty_map_is_empty():
+    """An empty user map merges to an empty effective map."""
+    assert merge_spark_conf({}) == {}
+
+
+def test_merge_plain_key_passes_through():
+    """A non-managed key is passed through unchanged."""
+    assert merge_spark_conf({"spark.executor.memory": "4g"}) == {
+        "spark.executor.memory": "4g"
+    }
+
+
+# ========== merge_spark_conf: packages (T011, T012) ==========
+
+
+def test_merge_packages_unions_with_managed_defaults():
+    """A user coordinate is unioned with both managed coordinates, deduplicated."""
+    warnings = []
+    result = merge_spark_conf(
+        {PACKAGES_KEY: "org.apache.hadoop:hadoop-aws:3.4.1"},
+        on_warning=warnings.append,
+    )
+
+    coords = _coords(result[PACKAGES_KEY])
+    # Both managed coordinates remain present, plus the user's addition.
+    assert any(c.startswith(f"{LIBRARY_RUNTIME_COORDINATE}:") for c in coords)
+    assert any(c.startswith(f"{DELTA_COORDINATE}:") for c in coords)
+    assert "org.apache.hadoop:hadoop-aws:3.4.1" in coords
+    # No duplicate group:artifact entries.
+    group_artifacts = [":".join(c.split(":")[:2]) for c in coords]
+    assert len(group_artifacts) == len(set(group_artifacts))
+    # Adding a plain package does not warn.
+    assert warnings == []
+
+
+def test_merge_packages_version_override_warns_once():
+    """Overriding a managed coordinate version applies it and warns once."""
+    warnings = []
+    result = merge_spark_conf(
+        {PACKAGES_KEY: f"{DELTA_COORDINATE}:3.9.9"},
+        on_warning=warnings.append,
+    )
+
+    coords = _coords(result[PACKAGES_KEY])
+    # The Delta coordinate appears exactly once, at the user's version, with the
+    # default version replaced rather than duplicated.
+    delta_entries = [c for c in coords if c.startswith(f"{DELTA_COORDINATE}:")]
+    assert delta_entries == [f"{DELTA_COORDINATE}:3.9.9"]
+    # The library-runtime coordinate is still present at its managed version.
+    assert any(c.startswith(f"{LIBRARY_RUNTIME_COORDINATE}:") for c in coords)
+    # Exactly one warning, naming the overridden coordinate.
+    assert len(warnings) == 1
+    assert DELTA_COORDINATE in warnings[0]
+
+
+def test_merge_packages_same_version_is_deduplicated_without_warning():
+    """Supplying a managed coordinate at the default version does not warn."""
+    from pathling._spark_defaults import managed_spark_defaults
+
+    # Extract the managed Delta coordinate at its exact default version.
+    managed_delta = next(
+        c
+        for c in _coords(managed_spark_defaults()[PACKAGES_KEY])
+        if c.startswith(f"{DELTA_COORDINATE}:")
+    )
+    warnings = []
+    result = merge_spark_conf({PACKAGES_KEY: managed_delta}, on_warning=warnings.append)
+
+    coords = _coords(result[PACKAGES_KEY])
+    # The coordinate appears exactly once and no warning is emitted.
+    assert coords.count(managed_delta) == 1
+    assert warnings == []
+
+
+# ========== merge_spark_conf: extensions (T013) ==========
+
+
+def test_merge_extensions_retains_delta_and_unions():
+    """User extensions are unioned with the Delta extension, deduplicated."""
+    result = merge_spark_conf({EXTENSIONS_KEY: "com.example.MyExtension"})
+
+    extensions = result[EXTENSIONS_KEY].split(",")
+    assert DELTA_EXTENSION in extensions
+    assert "com.example.MyExtension" in extensions
+
+
+def test_merge_extensions_deduplicates_delta():
+    """Supplying the Delta extension again keeps it present exactly once."""
+    result = merge_spark_conf(
+        {EXTENSIONS_KEY: f"{DELTA_EXTENSION},com.example.MyExtension"}
+    )
+
+    extensions = result[EXTENSIONS_KEY].split(",")
+    assert extensions.count(DELTA_EXTENSION) == 1
+    assert "com.example.MyExtension" in extensions
+
+
+# ========== merge_spark_conf: catalog (T014) ==========
+
+
+def test_merge_catalog_delta_value_is_dropped():
+    """Setting the catalog to the Delta value is a no-op (dropped)."""
+    assert merge_spark_conf({CATALOG_KEY: DELTA_CATALOG}) == {}
+
+
+def test_merge_catalog_other_value_is_error():
+    """Setting the catalog to any other value names the key and expected value."""
+    with pytest.raises(CliError) as exc_info:
+        merge_spark_conf({CATALOG_KEY: "com.example.OtherCatalog"})
+
+    assert exc_info.value.exit_code == EXIT_USAGE
+    assert CATALOG_KEY in exc_info.value.message
+    assert DELTA_CATALOG in exc_info.value.message

--- a/lib/python/tests/cli/test_terminology.py
+++ b/lib/python/tests/cli/test_terminology.py
@@ -1,0 +1,554 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Integration tests for the terminology commands.
+
+These run against the JVM mock terminology service wired into the shared
+``pathling_ctx`` fixture, using codes whose results are known from the library
+test suite.
+
+Author: John Grimes.
+"""
+
+import csv
+import io
+
+from pytest import fixture
+
+from pathling.cli.main import cli
+
+SNOMED = "http://snomed.info/sct"
+LOINC = "http://loinc.org"
+VALUE_SET = "http://snomed.info/sct?fhir_vs=refset/723264001"
+CONCEPT_MAP = "http://snomed.info/sct?fhir_cm=100"
+
+
+def _write_csv(path, header, rows):
+    """Writes a CSV file with the given header and rows."""
+    with open(path, "w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        writer.writerows(rows)
+    return path
+
+
+@fixture
+def codes_csv(tmp_path):
+    """A CSV of SNOMED codes with a system column."""
+    return _write_csv(
+        tmp_path / "codes.csv",
+        ["code", "system"],
+        [["368529001", SNOMED], ["439319006", SNOMED]],
+    )
+
+
+def _stdout_rows(result):
+    """Parses CSV stdout into a list of rows."""
+    return list(csv.reader(io.StringIO(result.stdout)))
+
+
+# ========== member-of ==========
+
+
+def test_member_of_with_system(runner, patched_context, codes_csv):
+    """member-of appends a boolean membership column."""
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = _stdout_rows(result)
+    assert rows[0] == ["code", "system", "member_of"]
+    # 368529001 is a member of the refset; 439319006 is not.
+    assert rows[1][2] == "True"
+
+
+def test_member_of_with_system_column(runner, patched_context, codes_csv):
+    """member-of can build codings from a per-row system column."""
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--system-column",
+            "system",
+            "--value-set",
+            VALUE_SET,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert _stdout_rows(result)[1][2] == "True"
+
+
+def test_member_of_result_column_override(runner, patched_context, codes_csv):
+    """--result-column renames the appended column."""
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+            "--result-column",
+            "is_member",
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert "is_member" in _stdout_rows(result)[0]
+
+
+# ========== Error paths ==========
+
+
+def test_system_and_system_column_mutually_exclusive(
+    runner, patched_context, codes_csv
+):
+    """--system and --system-column together is a usage error."""
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--system-column",
+            "system",
+            "--value-set",
+            VALUE_SET,
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "mutually exclusive" in result.stderr.lower()
+
+
+def test_no_system_is_usage_error(runner, patched_context, codes_csv):
+    """Omitting both --system and --system-column is a usage error."""
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--value-set",
+            VALUE_SET,
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "code system is required" in result.stderr.lower()
+
+
+def test_missing_dataset_is_usage_error(runner, patched_context, tmp_path):
+    """A missing dataset path fails before Spark with a usage error."""
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(tmp_path / "nope.csv"),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "does not exist" in result.stderr.lower()
+
+
+def test_missing_code_column_lists_columns(runner, patched_context, codes_csv):
+    """A missing code column error lists the columns that do exist."""
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(codes_csv),
+            "--code-column",
+            "nonexistent",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "code" in result.stderr
+    assert "system" in result.stderr
+
+
+# ========== translate ==========
+
+
+def test_translate(runner, patched_context, codes_csv):
+    """translate appends translated system and code columns."""
+    result = runner.invoke(
+        cli,
+        [
+            "translate",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--concept-map",
+            CONCEPT_MAP,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = _stdout_rows(result)
+    assert "translated_code" in rows[0]
+    # 368529001 translates to 368529002 under this concept map.
+    assert any("368529002" in row for row in rows[1:])
+
+
+# ========== subsumes / subsumed-by ==========
+
+
+def test_subsumes(runner, patched_context, tmp_path):
+    """subsumes appends a boolean column comparing two codings."""
+    dataset = _write_csv(
+        tmp_path / "pairs.csv", ["code", "other"], [["107963000", "63816008"]]
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "subsumes",
+            str(dataset),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--other-code-column",
+            "other",
+            "--other-system",
+            SNOMED,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = _stdout_rows(result)
+    assert "subsumes" in rows[0]
+    assert rows[1][2] == "True"
+
+
+def test_subsumed_by(runner, patched_context, tmp_path):
+    """subsumed-by appends a boolean reverse-subsumption column."""
+    dataset = _write_csv(
+        tmp_path / "pairs.csv", ["code", "other"], [["63816008", "107963000"]]
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "subsumed-by",
+            str(dataset),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--other-code-column",
+            "other",
+            "--other-system",
+            SNOMED,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert _stdout_rows(result)[1][2] == "True"
+
+
+# ========== display / property-of / designation ==========
+
+
+def test_display(runner, patched_context, tmp_path):
+    """display appends the canonical display name."""
+    dataset = _write_csv(tmp_path / "loinc.csv", ["code"], [["55915-3"]])
+
+    result = runner.invoke(
+        cli,
+        [
+            "display",
+            str(dataset),
+            "--code-column",
+            "code",
+            "--system",
+            LOINC,
+            "--accept-language",
+            "en",
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert "Beta 2 globulin" in result.stdout
+
+
+def test_property_of(runner, patched_context, codes_csv):
+    """property-of appends the requested property values."""
+    result = runner.invoke(
+        cli,
+        [
+            "property-of",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--property",
+            "parent",
+            "--property-type",
+            "code",
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert "property" in _stdout_rows(result)[0]
+    # 439319006 has parent 785673007.
+    assert "785673007" in result.stdout
+
+
+def test_designation(runner, patched_context, codes_csv):
+    """designation appends designation values, honouring --use."""
+    result = runner.invoke(
+        cli,
+        [
+            "designation",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--use",
+            "http://terminology.hl7.org/CodeSystem/designation-usage|display",
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert "designation" in _stdout_rows(result)[0]
+
+
+# ========== File output ==========
+
+
+def test_output_to_csv_file(runner, patched_context, codes_csv, tmp_path):
+    """Results can be written to a CSV file."""
+    out = tmp_path / "out.csv"
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+            "-o",
+            str(out),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert out.exists()
+
+
+def test_output_to_parquet_file(runner, patched_context, codes_csv, tmp_path):
+    """Results can be written to a Parquet file."""
+    out = tmp_path / "out.parquet"
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+            "-o",
+            str(out),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert out.exists()
+
+
+# ========== Unreachable server ==========
+
+
+# A realistic Spark/HAPI connection failure message, including the square
+# brackets that previously crashed the Rich-based error handler.
+_BRACKETED_CONNECTION_ERROR = (
+    "[FAILED_EXECUTE_UDF] User defined function failed due to: "
+    "FhirClientConnectionException: Connect to 127.0.0.1:9 [/127.0.0.1] "
+    "failed: Connection refused. SQLSTATE: 39000"
+)
+
+
+def test_unreachable_server_names_url(runner, patched_context, codes_csv, monkeypatch):
+    """An unreachable server error names the URL and shows how to set it.
+
+    The simulated error contains square brackets, reproducing the real JVM
+    message that previously crashed the Rich error handler with a MarkupError.
+    """
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError(_BRACKETED_CONNECTION_ERROR)
+
+    monkeypatch.setattr("pathling.udfs.member_of", _boom)
+
+    result = runner.invoke(
+        cli,
+        [
+            "--tx-server",
+            "http://localhost:9999/fhir",
+            "member-of",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "http://localhost:9999/fhir" in result.stderr
+    assert "--tx-server" in result.stderr
+    assert "tx-server" in result.stderr
+    # The bracketed message must render without crashing the error handler.
+    assert "MarkupError" not in result.stderr
+    assert "Traceback" not in result.stderr
+    assert "[FAILED_EXECUTE_UDF]" in result.stderr
+
+
+def test_bracketed_runtime_error_renders_safely(
+    runner, patched_context, codes_csv, monkeypatch
+):
+    """A non-connection error with square brackets renders without a traceback."""
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("[ANALYSIS_ERROR] something [unexpected] happened")
+
+    monkeypatch.setattr("pathling.udfs.member_of", _boom)
+
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "MarkupError" not in result.stderr
+    assert "Traceback" not in result.stderr
+    assert "[ANALYSIS_ERROR]" in result.stderr
+
+
+# ========== Config precedence wiring ==========
+
+
+def test_tx_server_flag_overrides_config(runner, monkeypatch, pathling_ctx, tmp_path):
+    """The configured tx-server is honoured and overridden by the flag."""
+    recorded = {}
+
+    def spy(config, console=None):
+        recorded["tx_server"] = config.tx_server
+        return pathling_ctx
+
+    monkeypatch.setattr("pathling.cli.session.create_context", spy)
+    config_file = tmp_path / "config.toml"
+    config_file.write_text('tx-server = "https://file.example/fhir"\n')
+    codes = _write_csv(tmp_path / "codes.csv", ["code"], [["368529001"]])
+
+    base = [
+        "member-of",
+        str(codes),
+        "--code-column",
+        "code",
+        "--system",
+        SNOMED,
+        "--value-set",
+        VALUE_SET,
+        "--format",
+        "csv",
+    ]
+
+    runner.invoke(cli, ["--config", str(config_file)] + base)
+    assert recorded["tx_server"] == "https://file.example/fhir"
+
+    runner.invoke(
+        cli,
+        ["--config", str(config_file), "--tx-server", "https://flag.example/fhir"]
+        + base,
+    )
+    assert recorded["tx_server"] == "https://flag.example/fhir"

--- a/lib/python/tests/cli/test_terminology.py
+++ b/lib/python/tests/cli/test_terminology.py
@@ -69,7 +69,7 @@ def test_coding_column_uses_fixed_code_literal(pathling_ctx):
     from pathling.cli.terminology import _coding_column
 
     df = pathling_ctx.spark.createDataFrame([("a",), ("b",)], ["code_col"])
-    coding = _coding_column("code_col", SNOMED, None, None, code="FIXED")
+    coding = _coding_column(pathling_ctx, "code_col", SNOMED, None, None, code="FIXED")
     codes = [row[0] for row in df.select(coding.getField("code")).collect()]
     # The per-row code column is ignored in favour of the fixed literal.
     assert codes == ["FIXED", "FIXED"]
@@ -80,10 +80,34 @@ def test_coding_column_uses_code_column_when_no_fixed_code(pathling_ctx):
     from pathling.cli.terminology import _coding_column
 
     df = pathling_ctx.spark.createDataFrame([("a",), ("b",)], ["code_col"])
-    coding = _coding_column("code_col", SNOMED, None, None)
+    coding = _coding_column(pathling_ctx, "code_col", SNOMED, None, None)
     codes = [row[0] for row in df.select(coding.getField("code")).collect()]
     # With no fixed code, each row's code is taken from the column.
     assert codes == ["a", "b"]
+
+
+def test_coding_column_matches_library_schema(pathling_ctx):
+    """The CLI Coding column matches the library's Coding schema (field names and
+    order), so it cannot drift from the library definition (FR-018)."""
+    from pyspark.sql.functions import lit
+
+    from pathling.cli.terminology import _coding_column
+    from pathling.functions import to_coding
+
+    # A dataset with a "code" column so the per-row code reference resolves.
+    base = pathling_ctx.spark.createDataFrame([("368529001",)], ["code"])
+    cli_fields = (
+        base.select(_coding_column(pathling_ctx, "code", SNOMED, None, None).alias("c"))
+        .schema["c"]
+        .dataType.fieldNames()
+    )
+    library_fields = (
+        base.select(to_coding(lit("x"), SNOMED).alias("c"))
+        .schema["c"]
+        .dataType.fieldNames()
+    )
+
+    assert cli_fields == library_fields
 
 
 # ========== member-of ==========

--- a/lib/python/tests/cli/test_terminology.py
+++ b/lib/python/tests/cli/test_terminology.py
@@ -61,6 +61,31 @@ def _stdout_rows(result):
     return list(csv.reader(io.StringIO(result.stdout)))
 
 
+# ========== _coding_column ==========
+
+
+def test_coding_column_uses_fixed_code_literal(pathling_ctx):
+    """_coding_column applies a fixed literal code to every row when code= is set."""
+    from pathling.cli.terminology import _coding_column
+
+    df = pathling_ctx.spark.createDataFrame([("a",), ("b",)], ["code_col"])
+    coding = _coding_column("code_col", SNOMED, None, None, code="FIXED")
+    codes = [row[0] for row in df.select(coding.getField("code")).collect()]
+    # The per-row code column is ignored in favour of the fixed literal.
+    assert codes == ["FIXED", "FIXED"]
+
+
+def test_coding_column_uses_code_column_when_no_fixed_code(pathling_ctx):
+    """_coding_column reads the per-row code column when no fixed code is given."""
+    from pathling.cli.terminology import _coding_column
+
+    df = pathling_ctx.spark.createDataFrame([("a",), ("b",)], ["code_col"])
+    coding = _coding_column("code_col", SNOMED, None, None)
+    codes = [row[0] for row in df.select(coding.getField("code")).collect()]
+    # With no fixed code, each row's code is taken from the column.
+    assert codes == ["a", "b"]
+
+
 # ========== member-of ==========
 
 
@@ -308,6 +333,243 @@ def test_subsumed_by(runner, patched_context, tmp_path):
 
     assert result.exit_code == 0, result.stderr
     assert _stdout_rows(result)[1][2] == "True"
+
+
+def test_subsumes_with_fixed_other_code(runner, patched_context, tmp_path):
+    """subsumes accepts a fixed target code applied to every row."""
+    # A single code column, no target column in the data.
+    dataset = _write_csv(tmp_path / "codes.csv", ["code"], [["107963000"]])
+
+    result = runner.invoke(
+        cli,
+        [
+            "subsumes",
+            str(dataset),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--other-code",
+            "63816008",
+            "--other-system",
+            SNOMED,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = _stdout_rows(result)
+    assert rows[0] == ["code", "subsumes"]
+    # 107963000 subsumes the fixed target 63816008.
+    assert rows[1][1] == "True"
+
+
+def test_subsumed_by_with_fixed_other_code(runner, patched_context, tmp_path):
+    """subsumed-by accepts a fixed target code applied to every row."""
+    dataset = _write_csv(tmp_path / "codes.csv", ["code"], [["63816008"]])
+
+    result = runner.invoke(
+        cli,
+        [
+            "subsumed-by",
+            str(dataset),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--other-code",
+            "107963000",
+            "--other-system",
+            SNOMED,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = _stdout_rows(result)
+    assert rows[0] == ["code", "subsumed_by"]
+    # 63816008 is subsumed by the fixed target 107963000.
+    assert rows[1][1] == "True"
+
+
+def test_subsumes_fixed_other_code_result_column_override(
+    runner, patched_context, tmp_path
+):
+    """--result-column renames the output column when a fixed target code is used."""
+    dataset = _write_csv(tmp_path / "codes.csv", ["code"], [["107963000"]])
+
+    result = runner.invoke(
+        cli,
+        [
+            "subsumes",
+            str(dataset),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--other-code",
+            "63816008",
+            "--other-system",
+            SNOMED,
+            "--result-column",
+            "is_ancestor",
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = _stdout_rows(result)
+    assert rows[0] == ["code", "is_ancestor"]
+    assert rows[1][1] == "True"
+
+
+# ========== subsumes / subsumed-by target validation ==========
+
+
+def test_other_code_and_other_code_column_mutually_exclusive(
+    runner, patched_context, tmp_path
+):
+    """Supplying both --other-code and --other-code-column is a usage error."""
+    dataset = _write_csv(tmp_path / "pairs.csv", ["code", "b"], [["107963000", "x"]])
+
+    result = runner.invoke(
+        cli,
+        [
+            "subsumes",
+            str(dataset),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--other-code",
+            "63816008",
+            "--other-code-column",
+            "b",
+            "--other-system",
+            SNOMED,
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "mutually exclusive" in result.stderr.lower()
+
+
+def test_no_other_code_is_usage_error(runner, patched_context, tmp_path):
+    """Omitting both --other-code and --other-code-column is a usage error."""
+    dataset = _write_csv(tmp_path / "codes.csv", ["code"], [["107963000"]])
+
+    result = runner.invoke(
+        cli,
+        [
+            "subsumes",
+            str(dataset),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--other-system",
+            SNOMED,
+        ],
+    )
+
+    assert result.exit_code == 2
+    message = result.stderr.lower()
+    assert "target code is required" in message
+    # The message names both valid options.
+    assert "--other-code" in result.stderr
+    assert "--other-code-column" in result.stderr
+
+
+def test_other_system_and_other_system_column_mutually_exclusive(
+    runner, patched_context, tmp_path
+):
+    """Supplying both --other-system and --other-system-column is a usage error."""
+    dataset = _write_csv(
+        tmp_path / "codes.csv", ["code", "sys"], [["107963000", SNOMED]]
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "subsumes",
+            str(dataset),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--other-code",
+            "63816008",
+            "--other-system",
+            SNOMED,
+            "--other-system-column",
+            "sys",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "mutually exclusive" in result.stderr.lower()
+
+
+def test_no_other_system_is_usage_error(runner, patched_context, tmp_path):
+    """Omitting both --other-system and --other-system-column is a usage error."""
+    dataset = _write_csv(tmp_path / "codes.csv", ["code"], [["107963000"]])
+
+    result = runner.invoke(
+        cli,
+        [
+            "subsumes",
+            str(dataset),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--other-code",
+            "63816008",
+        ],
+    )
+
+    assert result.exit_code == 2
+    message = result.stderr.lower()
+    assert "target system is required" in message
+    # The message names both valid options.
+    assert "--other-system" in result.stderr
+    assert "--other-system-column" in result.stderr
+
+
+def test_target_validation_runs_before_context_creation(runner, monkeypatch, tmp_path):
+    """Invalid target options fail before any Spark session is created.
+
+    A spy replaces the context factory and fails if invoked, proving the
+    target-side validation runs ahead of the Spark cold start (SC-002).
+    """
+    created = []
+
+    def spy(config, console=None):
+        created.append(True)
+        raise AssertionError("context must not be created on a usage error")
+
+    monkeypatch.setattr("pathling.cli.session.create_context", spy)
+    dataset = _write_csv(tmp_path / "codes.csv", ["code"], [["107963000"]])
+
+    result = runner.invoke(
+        cli,
+        [
+            "subsumes",
+            str(dataset),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--other-system",
+            SNOMED,
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert created == []
 
 
 # ========== display / property-of / designation ==========

--- a/lib/python/tests/cli/test_view.py
+++ b/lib/python/tests/cli/test_view.py
@@ -262,3 +262,69 @@ def test_view_empty_result_prints_zero_rows(
 
     assert result.exit_code == 0, result.stderr
     assert "0 rows" in result.stdout
+
+
+# ========== Bundles read uses the view resource type, no discovery (US5) ==========
+
+
+class _FakeResultDF:
+    """A minimal result frame for stdout table rendering without Spark."""
+
+    columns = ["id"]
+
+    def limit(self, _n):
+        return self
+
+    def collect(self):
+        return []
+
+
+class _FakeViewSource:
+    """A data source whose ``view`` returns a trivial result frame."""
+
+    def view(self, json=None):
+        return _FakeResultDF()
+
+
+def test_view_bundles_uses_view_resource_type(runner, monkeypatch, tmp_path):
+    """A view over a Bundles source reads using the ViewDefinition's resource
+    type and runs no driver-side discovery pass (FR-015)."""
+    import pathling.cli.io as io_module
+
+    discovery_calls = []
+    monkeypatch.setattr(
+        io_module,
+        "discover_bundle_resource_types",
+        lambda path: discovery_calls.append(path) or ["WRONG"],
+    )
+
+    captured = {}
+
+    class _Reader:
+        def bundles(self, path, types):
+            captured["types"] = types
+            return _FakeViewSource()
+
+    class _Pc:
+        read = _Reader()
+
+    monkeypatch.setattr(
+        "pathling.cli.session.create_context", lambda config, console=None: _Pc()
+    )
+
+    bundles = tmp_path / "bundles"
+    bundles.mkdir()
+    (bundles / "b.json").write_text(
+        '{"resourceType":"Bundle","entry":[]}', encoding="utf-8"
+    )
+    view_json = json.dumps(
+        {"resource": "Patient", "select": [{"column": [{"path": "id", "name": "id"}]}]}
+    )
+
+    result = runner.invoke(
+        cli, ["view", str(bundles), "--from", "bundles", "--view-json", view_json]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert discovery_calls == []
+    assert captured["types"] == ["Patient"]

--- a/lib/python/tests/cli/test_view.py
+++ b/lib/python/tests/cli/test_view.py
@@ -84,16 +84,14 @@ def test_view_csv(runner, patched_context, ndjson_source, view_file):
     assert len(rows) == PATIENT_COUNT + 1
 
 
-def test_view_json(runner, patched_context, ndjson_source, view_file):
-    """JSON output is an array of records with the view's columns."""
+def test_view_format_json_rejected(runner, patched_context, ndjson_source, view_file):
+    """The removed json format is rejected as an invalid --format choice."""
     result = runner.invoke(
         cli, ["view", ndjson_source, "--view", str(view_file), "--format", "json"]
     )
 
-    assert result.exit_code == 0, result.stderr
-    records = json.loads(result.stdout)
-    assert len(records) == PATIENT_COUNT
-    assert "family_name" in records[0]
+    assert result.exit_code != 0
+    assert "is not one of" in result.stderr
 
 
 def test_view_ndjson(runner, patched_context, ndjson_source, view_file):
@@ -112,7 +110,7 @@ def test_view_ndjson(runner, patched_context, ndjson_source, view_file):
 
 
 def test_view_to_csv_file(runner, patched_context, ndjson_source, view_file, tmp_path):
-    """Writing to a CSV file reports the row count on stderr."""
+    """Writing to a CSV file confirms the format and path, without a row count."""
     out = tmp_path / "results.csv"
 
     result = runner.invoke(
@@ -120,8 +118,10 @@ def test_view_to_csv_file(runner, patched_context, ndjson_source, view_file, tmp
     )
 
     assert result.exit_code == 0, result.stderr
-    assert out.exists()
-    assert str(PATIENT_COUNT) in result.stderr
+    assert out.is_file()
+    assert "Wrote csv output to" in result.stderr
+    # The row count is intentionally not reported (FR-012).
+    assert "rows" not in result.stderr
 
 
 def test_view_to_parquet_file(
@@ -141,12 +141,12 @@ def test_view_to_parquet_file(
 
 @pytest.mark.parametrize(
     "filename,fmt",
-    [("results.json", None), ("results.ndjson", None), ("results.delta", "delta")],
+    [("results.ndjson", None), ("results.delta", "delta")],
 )
 def test_view_to_other_file_formats(
     runner, patched_context, ndjson_source, view_file, tmp_path, filename, fmt
 ):
-    """Writing to JSON, NDJSON, and Delta file outputs all succeed."""
+    """Writing to NDJSON and Delta file outputs both succeed."""
     out = tmp_path / filename
     args = ["view", ndjson_source, "--view", str(view_file), "-o", str(out)]
     if fmt:
@@ -156,6 +156,21 @@ def test_view_to_other_file_formats(
 
     assert result.exit_code == 0, result.stderr
     assert out.exists()
+
+
+def test_view_json_output_path_rejected(
+    runner, patched_context, ndjson_source, view_file, tmp_path
+):
+    """A .json output path is rejected with a usage error suggesting NDJSON."""
+    out = tmp_path / "results.json"
+
+    result = runner.invoke(
+        cli, ["view", ndjson_source, "--view", str(view_file), "-o", str(out)]
+    )
+
+    assert result.exit_code == 2
+    assert "ndjson" in result.stderr.lower()
+    assert not out.exists()
 
 
 # ========== Inline view ==========

--- a/lib/python/tests/cli/test_view.py
+++ b/lib/python/tests/cli/test_view.py
@@ -1,0 +1,249 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Integration tests for the ``pathling view`` command.
+
+Author: John Grimes.
+"""
+
+import csv
+import io
+import json
+import os
+
+import pytest
+from pytest import fixture
+
+from pathling.cli.main import cli
+
+PATIENT_COUNT = 9
+FIRST_FAMILY = "Krajcik437"
+
+PATIENT_VIEW = {
+    "resource": "Patient",
+    "select": [
+        {
+            "column": [
+                {"path": "id", "name": "id"},
+                {"path": "name.first().family", "name": "family_name"},
+            ]
+        }
+    ],
+}
+
+
+@fixture(scope="module")
+def ndjson_source(test_data_dir):
+    """The shared ndjson test data directory."""
+    return os.path.join(test_data_dir, "ndjson")
+
+
+@fixture
+def view_file(tmp_path):
+    """Writes the patient ViewDefinition to a file and returns its path."""
+    path = tmp_path / "patient_view.json"
+    path.write_text(json.dumps(PATIENT_VIEW), encoding="utf-8")
+    return path
+
+
+# ========== Output formats ==========
+
+
+def test_view_table_default(runner, patched_context, ndjson_source, view_file):
+    """The default output is a formatted table on stdout."""
+    result = runner.invoke(cli, ["view", ndjson_source, "--view", str(view_file)])
+
+    assert result.exit_code == 0, result.stderr
+    assert FIRST_FAMILY in result.stdout
+    assert "family_name" in result.stdout
+
+
+def test_view_csv(runner, patched_context, ndjson_source, view_file):
+    """CSV output has a header row and one row per patient."""
+    result = runner.invoke(
+        cli, ["view", ndjson_source, "--view", str(view_file), "--format", "csv"]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = list(csv.reader(io.StringIO(result.stdout)))
+    assert rows[0] == ["id", "family_name"]
+    assert len(rows) == PATIENT_COUNT + 1
+
+
+def test_view_json(runner, patched_context, ndjson_source, view_file):
+    """JSON output is an array of records with the view's columns."""
+    result = runner.invoke(
+        cli, ["view", ndjson_source, "--view", str(view_file), "--format", "json"]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    records = json.loads(result.stdout)
+    assert len(records) == PATIENT_COUNT
+    assert "family_name" in records[0]
+
+
+def test_view_ndjson(runner, patched_context, ndjson_source, view_file):
+    """NDJSON output is one JSON object per line."""
+    result = runner.invoke(
+        cli, ["view", ndjson_source, "--view", str(view_file), "--format", "ndjson"]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert len(lines) == PATIENT_COUNT
+    assert "family_name" in json.loads(lines[0])
+
+
+# ========== File output ==========
+
+
+def test_view_to_csv_file(runner, patched_context, ndjson_source, view_file, tmp_path):
+    """Writing to a CSV file reports the row count on stderr."""
+    out = tmp_path / "results.csv"
+
+    result = runner.invoke(
+        cli, ["view", ndjson_source, "--view", str(view_file), "-o", str(out)]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert out.exists()
+    assert str(PATIENT_COUNT) in result.stderr
+
+
+def test_view_to_parquet_file(
+    runner, patched_context, ndjson_source, view_file, tmp_path
+):
+    """Writing to a Parquet file creates the file and confirms the count."""
+    out = tmp_path / "results.parquet"
+
+    result = runner.invoke(
+        cli, ["view", ndjson_source, "--view", str(view_file), "-o", str(out)]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert out.exists()
+    assert "Wrote" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "filename,fmt",
+    [("results.json", None), ("results.ndjson", None), ("results.delta", "delta")],
+)
+def test_view_to_other_file_formats(
+    runner, patched_context, ndjson_source, view_file, tmp_path, filename, fmt
+):
+    """Writing to JSON, NDJSON, and Delta file outputs all succeed."""
+    out = tmp_path / filename
+    args = ["view", ndjson_source, "--view", str(view_file), "-o", str(out)]
+    if fmt:
+        args += ["--format", fmt]
+
+    result = runner.invoke(cli, args)
+
+    assert result.exit_code == 0, result.stderr
+    assert out.exists()
+
+
+# ========== Inline view ==========
+
+
+def test_view_json_inline(runner, patched_context, ndjson_source):
+    """An inline --view-json string runs the view."""
+    result = runner.invoke(
+        cli,
+        [
+            "view",
+            ndjson_source,
+            "--view-json",
+            json.dumps(PATIENT_VIEW),
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert "family_name" in result.stdout
+
+
+# ========== Error paths ==========
+
+
+def test_malformed_view_json(runner, patched_context, ndjson_source):
+    """A malformed ViewDefinition JSON string identifies the problem."""
+    result = runner.invoke(
+        cli, ["view", ndjson_source, "--view-json", '{"resource": "Patient", ']
+    )
+
+    assert result.exit_code == 1
+    assert "JSON" in result.stderr
+
+
+def test_unknown_resource_type(runner, patched_context, ndjson_source):
+    """An unknown resource type surfaces an error and exits non-zero."""
+    bad_view = json.dumps(
+        {
+            "resource": "NotARealResource",
+            "select": [{"column": [{"path": "id", "name": "id"}]}],
+        }
+    )
+    result = runner.invoke(cli, ["view", ndjson_source, "--view-json", bad_view])
+
+    assert result.exit_code == 1
+    assert result.stderr.strip() != ""
+
+
+def test_view_filter_restricts_rows(runner, patched_context, ndjson_source, view_file):
+    """A --filter search expression restricts the rows processed."""
+    result = runner.invoke(
+        cli,
+        [
+            "view",
+            ndjson_source,
+            "--view",
+            str(view_file),
+            "--filter",
+            f"family={FIRST_FAMILY}",
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = list(csv.reader(io.StringIO(result.stdout)))
+    # Header plus the matching patients only (fewer than the full set).
+    assert 1 < len(rows) <= PATIENT_COUNT
+    assert all(row[1] == FIRST_FAMILY for row in rows[1:])
+
+
+def test_view_empty_result_prints_zero_rows(
+    runner, patched_context, ndjson_source, view_file
+):
+    """An empty result prints an explicit '0 rows' and exits 0."""
+    result = runner.invoke(
+        cli,
+        [
+            "view",
+            ndjson_source,
+            "--view",
+            str(view_file),
+            "--filter",
+            "family=NoSuchFamilyNameExists",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert "0 rows" in result.stdout

--- a/lib/python/tests/cli/test_write_file.py
+++ b/lib/python/tests/cli/test_write_file.py
@@ -1,0 +1,150 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for single-file output writing in the command line interface.
+
+These tests pin the on-disk content and column types produced by
+:func:`pathling.cli.render._write_file` for each file format, and verify the
+reported row count. Parquet is written via Arrow to preserve column types
+faithfully; CSV, JSON, and NDJSON are written via pandas. A Spark session is
+required to build the result DataFrames, so these tests build small frames
+directly from the shared session fixture.
+
+Author: John Grimes.
+"""
+
+import csv
+import io
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pytest import fixture
+
+from pathling.cli.render import OutputFormat, OutputSpec, _write_file
+
+
+@fixture(scope="module")
+def spark(pathling_ctx):
+    """Provides the Spark session from the shared Pathling context.
+
+    :param pathling_ctx: the shared Pathling context fixture.
+    :return: the underlying Spark session.
+    """
+    return pathling_ctx.spark
+
+
+def _spec(path: Path, fmt: str) -> OutputSpec:
+    """Builds an :class:`OutputSpec` for a file path and format.
+
+    :param path: the output file path.
+    :param fmt: the output format.
+    :return: the output specification.
+    """
+    return OutputSpec(path=path, format=fmt)
+
+
+# ========== Parquet column-type fidelity ==========
+
+
+def test_parquet_preserves_struct_column_field_names(spark, tmp_path):
+    """Struct columns keep their nested field names through Parquet output.
+
+    A pandas round-trip degrades a Spark struct to an anonymous list, dropping
+    the field names; the Arrow-based writer preserves the struct schema.
+    """
+    df = spark.createDataFrame(
+        [(1, ("Perth", "6000")), (2, ("Sydney", None))],
+        "id int, addr struct<city:string,postcode:string>",
+    )
+    out = tmp_path / "out.parquet"
+
+    count = _write_file(df, _spec(out, OutputFormat.PARQUET))
+
+    table = pq.read_table(out)
+    # The column remains a struct rather than collapsing to a list, and its
+    # round-tripped values carry the original field names.
+    assert pa.types.is_struct(table.schema.field("addr").type)
+    assert table.to_pylist() == [
+        {"id": 1, "addr": {"city": "Perth", "postcode": "6000"}},
+        {"id": 2, "addr": {"city": "Sydney", "postcode": None}},
+    ]
+    assert count == 2
+
+
+def test_parquet_preserves_integer_type_with_nulls(spark, tmp_path):
+    """An integer column containing nulls stays an integer type in Parquet.
+
+    A pandas round-trip coerces nullable integers to floating point; the
+    Arrow-based writer keeps the integer type.
+    """
+    df = spark.createDataFrame([(1,), (None,)], "count int")
+    out = tmp_path / "out.parquet"
+
+    _write_file(df, _spec(out, OutputFormat.PARQUET))
+
+    assert pa.types.is_integer(pq.read_table(out).schema.field("count").type)
+
+
+# ========== CSV / JSON / NDJSON content ==========
+
+
+def test_csv_writes_header_values_and_empty_for_null(spark, tmp_path):
+    """CSV output has a header, the row values, and empty fields for nulls."""
+    df = spark.createDataFrame(
+        [("1", "Smith"), ("2", None)], "id string, family string"
+    )
+    out = tmp_path / "out.csv"
+
+    count = _write_file(df, _spec(out, OutputFormat.CSV))
+
+    rows = list(csv.reader(io.StringIO(out.read_text())))
+    assert rows[0] == ["id", "family"]
+    # Compared as a set so the assertion does not depend on row ordering.
+    assert {tuple(row) for row in rows[1:]} == {("1", "Smith"), ("2", "")}
+    assert count == 2
+
+
+def test_json_file_is_pretty_array_of_records(spark, tmp_path):
+    """JSON output is a multi-line array of column-keyed objects."""
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    out = tmp_path / "out.json"
+
+    count = _write_file(df, _spec(out, OutputFormat.JSON))
+
+    text = out.read_text()
+    assert json.loads(text) == [{"id": "1", "family": "Smith"}]
+    # Indented output spans multiple lines rather than a single dense line.
+    assert "\n" in text
+    assert count == 1
+
+
+def test_ndjson_file_is_one_object_per_line(spark, tmp_path):
+    """NDJSON output is one JSON object per line."""
+    df = spark.createDataFrame(
+        [("1", "Smith"), ("2", "Jones")], "id string, family string"
+    )
+    out = tmp_path / "out.ndjson"
+
+    count = _write_file(df, _spec(out, OutputFormat.NDJSON))
+
+    lines = out.read_text().splitlines()
+    assert len(lines) == 2
+    parsed = [json.loads(line) for line in lines]
+    assert {record["family"] for record in parsed} == {"Smith", "Jones"}
+    assert count == 2

--- a/lib/python/tests/cli/test_write_file.py
+++ b/lib/python/tests/cli/test_write_file.py
@@ -15,14 +15,14 @@
 # limitations under the License.
 #
 
-"""Tests for single-file output writing in the command line interface.
+"""Tests for file output writing in the command line interface.
 
-These tests pin the on-disk content and column types produced by
-:func:`pathling.cli.render._write_file` for each file format, and verify the
-reported row count. Parquet is written via Arrow to preserve column types
-faithfully; CSV, JSON, and NDJSON are written via pandas. A Spark session is
-required to build the result DataFrames, so these tests build small frames
-directly from the shared session fixture.
+These pin the on-disk shape and content produced by
+:func:`pathling.cli.render._write_file` and :func:`write_output` for each file
+format. Output is produced by Spark's native writers and then departitioned to
+a single file at the requested path; Delta is written as a Spark table
+directory. A Spark session is required to build and write the result
+DataFrames, so these tests build small frames from the shared session fixture.
 
 Author: John Grimes.
 """
@@ -30,13 +30,17 @@ Author: John Grimes.
 import csv
 import io
 import json
+from io import StringIO
 from pathlib import Path
 
 import pyarrow as pa
 import pyarrow.parquet as pq
+import pytest
 from pytest import fixture
+from rich.console import Console
 
-from pathling.cli.render import OutputFormat, OutputSpec, _write_file
+from pathling.cli.errors import CliError
+from pathling.cli.render import OutputFormat, OutputSpec, _write_file, write_output
 
 
 @fixture(scope="module")
@@ -49,102 +53,284 @@ def spark(pathling_ctx):
     return pathling_ctx.spark
 
 
-def _spec(path: Path, fmt: str) -> OutputSpec:
+def _spec(
+    path: Path, fmt: str, *, overwrite: bool = False, departition: bool = True
+) -> OutputSpec:
     """Builds an :class:`OutputSpec` for a file path and format.
 
     :param path: the output file path.
     :param fmt: the output format.
+    :param overwrite: whether an existing target may be replaced.
+    :param departition: whether single-file departitioning is applied.
     :return: the output specification.
     """
-    return OutputSpec(path=path, format=fmt)
-
-
-# ========== Parquet column-type fidelity ==========
-
-
-def test_parquet_preserves_struct_column_field_names(spark, tmp_path):
-    """Struct columns keep their nested field names through Parquet output.
-
-    A pandas round-trip degrades a Spark struct to an anonymous list, dropping
-    the field names; the Arrow-based writer preserves the struct schema.
-    """
-    df = spark.createDataFrame(
-        [(1, ("Perth", "6000")), (2, ("Sydney", None))],
-        "id int, addr struct<city:string,postcode:string>",
+    return OutputSpec(
+        path=path, format=fmt, overwrite=overwrite, departition=departition
     )
-    out = tmp_path / "out.parquet"
-
-    count = _write_file(df, _spec(out, OutputFormat.PARQUET))
-
-    table = pq.read_table(out)
-    # The column remains a struct rather than collapsing to a list, and its
-    # round-tripped values carry the original field names.
-    assert pa.types.is_struct(table.schema.field("addr").type)
-    assert table.to_pylist() == [
-        {"id": 1, "addr": {"city": "Perth", "postcode": "6000"}},
-        {"id": 2, "addr": {"city": "Sydney", "postcode": None}},
-    ]
-    assert count == 2
 
 
-def test_parquet_preserves_integer_type_with_nulls(spark, tmp_path):
-    """An integer column containing nulls stays an integer type in Parquet.
+def _capture_console():
+    """Builds a Rich console that captures its output to a buffer.
 
-    A pandas round-trip coerces nullable integers to floating point; the
-    Arrow-based writer keeps the integer type.
+    :return: a tuple of the console and the buffer it writes to.
     """
-    df = spark.createDataFrame([(1,), (None,)], "count int")
-    out = tmp_path / "out.parquet"
-
-    _write_file(df, _spec(out, OutputFormat.PARQUET))
-
-    assert pa.types.is_integer(pq.read_table(out).schema.field("count").type)
+    buffer = StringIO()
+    # A wide console keeps long paths on one line so the captured message is
+    # asserted on its content rather than on Rich's display-width wrapping.
+    return Console(file=buffer, width=10_000, markup=False, highlight=False), buffer
 
 
-# ========== CSV / JSON / NDJSON content ==========
+def _assert_only_target(target: Path, parent: Path) -> None:
+    """Asserts the target is the sole entry beside it - a true single file.
+
+    No Spark part files, ``_SUCCESS`` or ``.crc`` markers, and no leftover
+    departition temporary directory remain beside the target.
+
+    :param target: the expected single output file.
+    :param parent: the directory that should contain only the target.
+    """
+    assert target.is_file()
+    leftovers = sorted(entry.name for entry in parent.iterdir() if entry != target)
+    assert leftovers == [], f"unexpected entries beside the target: {leftovers}"
 
 
-def test_csv_writes_header_values_and_empty_for_null(spark, tmp_path):
-    """CSV output has a header, the row values, and empty fields for nulls."""
+# ========== CSV single-file output (T004) ==========
+
+
+def test_csv_yields_single_file_with_header(spark, tmp_path):
+    """``-o out.csv`` is one CSV file with a header and one line per row."""
     df = spark.createDataFrame(
         [("1", "Smith"), ("2", None)], "id string, family string"
     )
     out = tmp_path / "out.csv"
 
-    count = _write_file(df, _spec(out, OutputFormat.CSV))
+    _write_file(df, _spec(out, OutputFormat.CSV))
 
+    _assert_only_target(out, tmp_path)
     rows = list(csv.reader(io.StringIO(out.read_text())))
     assert rows[0] == ["id", "family"]
     # Compared as a set so the assertion does not depend on row ordering.
     assert {tuple(row) for row in rows[1:]} == {("1", "Smith"), ("2", "")}
-    assert count == 2
 
 
-def test_json_file_is_pretty_array_of_records(spark, tmp_path):
-    """JSON output is a multi-line array of column-keyed objects."""
-    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
-    out = tmp_path / "out.json"
-
-    count = _write_file(df, _spec(out, OutputFormat.JSON))
-
-    text = out.read_text()
-    assert json.loads(text) == [{"id": "1", "family": "Smith"}]
-    # Indented output spans multiple lines rather than a single dense line.
-    assert "\n" in text
-    assert count == 1
+# ========== NDJSON single-file output (T005) ==========
 
 
-def test_ndjson_file_is_one_object_per_line(spark, tmp_path):
-    """NDJSON output is one JSON object per line."""
+def test_ndjson_yields_single_file_with_null_fields(spark, tmp_path):
+    """``-o out.ndjson`` is one object per line, each carrying the same keys."""
     df = spark.createDataFrame(
-        [("1", "Smith"), ("2", "Jones")], "id string, family string"
+        [("1", "Smith"), ("2", None)], "id string, family string"
     )
     out = tmp_path / "out.ndjson"
 
-    count = _write_file(df, _spec(out, OutputFormat.NDJSON))
+    _write_file(df, _spec(out, OutputFormat.NDJSON))
 
+    _assert_only_target(out, tmp_path)
     lines = out.read_text().splitlines()
     assert len(lines) == 2
-    parsed = [json.loads(line) for line in lines]
-    assert {record["family"] for record in parsed} == {"Smith", "Jones"}
-    assert count == 2
+    records = [json.loads(line) for line in lines]
+    # Null-valued fields are retained, so every record has the same key set.
+    assert all(set(record.keys()) == {"id", "family"} for record in records)
+    assert {record["family"] for record in records} == {"Smith", None}
+
+
+# ========== Parquet single-file type fidelity (T006) ==========
+
+
+def test_parquet_yields_single_file_preserving_types(spark, tmp_path):
+    """``-o out.parquet`` preserves struct field names, arrays, and int nulls."""
+    df = spark.createDataFrame(
+        [(1, ("Perth", "6000"), [10, 20]), (None, ("Sydney", None), None)],
+        "id int, addr struct<city:string,postcode:string>, scores array<int>",
+    )
+    out = tmp_path / "out.parquet"
+
+    _write_file(df, _spec(out, OutputFormat.PARQUET))
+
+    _assert_only_target(out, tmp_path)
+    schema = pq.read_table(out).schema
+    # A nullable integer column stays an integer (not coerced to float).
+    assert pa.types.is_integer(schema.field("id").type)
+    # The struct keeps its nested field names.
+    assert pa.types.is_struct(schema.field("addr").type)
+    assert [field.name for field in schema.field("addr").type] == ["city", "postcode"]
+    # The array column stays a list.
+    assert pa.types.is_list(schema.field("scores").type)
+
+
+# ========== Delta directory output (T007) ==========
+
+
+def test_delta_output_is_a_table_directory(spark, tmp_path):
+    """``--format delta`` writes a Delta table directory, not a single file."""
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    out = tmp_path / "out.delta"
+
+    _write_file(df, _spec(out, OutputFormat.DELTA))
+
+    assert out.is_dir()
+    assert (out / "_delta_log").is_dir()
+
+
+# ========== Overwrite handling (T008) ==========
+
+
+def test_existing_target_without_overwrite_errors_and_writes_nothing(spark, tmp_path):
+    """An existing target without --overwrite errors and leaves it untouched."""
+    out = tmp_path / "out.csv"
+    out.write_text("original")
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    console, _ = _capture_console()
+
+    with pytest.raises(CliError):
+        write_output(df, _spec(out, OutputFormat.CSV), console)
+
+    assert out.read_text() == "original"
+
+
+def test_overwrite_replaces_an_existing_file(spark, tmp_path):
+    """With --overwrite, an existing file is replaced by the new output."""
+    out = tmp_path / "out.csv"
+    out.write_text("stale,data\n9,9\n")
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+
+    _write_file(df, _spec(out, OutputFormat.CSV, overwrite=True))
+
+    _assert_only_target(out, tmp_path)
+    text = out.read_text()
+    assert "Smith" in text
+    assert "stale" not in text
+
+
+def test_overwrite_replaces_an_existing_directory(spark, tmp_path):
+    """With --overwrite, an existing directory target is replaced by a file."""
+    out = tmp_path / "out.csv"
+    out.mkdir()
+    (out / "part-00000-old-c000.csv").write_text("stale\n")
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+
+    _write_file(df, _spec(out, OutputFormat.CSV, overwrite=True))
+
+    _assert_only_target(out, tmp_path)
+    assert "Smith" in out.read_text()
+
+
+# ========== Empty result (T009) ==========
+
+
+def test_empty_result_csv_is_header_only(spark, tmp_path):
+    """An empty result still yields a valid single CSV with only the header."""
+    df = spark.createDataFrame([], "id string, family string")
+    out = tmp_path / "out.csv"
+
+    _write_file(df, _spec(out, OutputFormat.CSV))
+
+    _assert_only_target(out, tmp_path)
+    assert out.read_text().strip() == "id,family"
+
+
+def test_empty_result_ndjson_is_empty_file(spark, tmp_path):
+    """An empty result yields a valid, empty single NDJSON file."""
+    df = spark.createDataFrame([], "id string, family string")
+    out = tmp_path / "out.ndjson"
+
+    _write_file(df, _spec(out, OutputFormat.NDJSON))
+
+    _assert_only_target(out, tmp_path)
+    assert out.read_text() == ""
+
+
+def test_empty_result_parquet_is_schema_only(spark, tmp_path):
+    """An empty result yields a schema-only single Parquet file with no rows."""
+    df = spark.createDataFrame([], "id string, family string")
+    out = tmp_path / "out.parquet"
+
+    _write_file(df, _spec(out, OutputFormat.PARQUET))
+
+    _assert_only_target(out, tmp_path)
+    table = pq.read_table(out)
+    assert table.num_rows == 0
+    assert table.schema.names == ["id", "family"]
+
+
+# ========== Opt out of departitioning (T013) ==========
+
+
+@pytest.mark.parametrize(
+    "fmt,extension",
+    [
+        (OutputFormat.CSV, "csv"),
+        (OutputFormat.NDJSON, "ndjson"),
+        (OutputFormat.PARQUET, "parquet"),
+    ],
+)
+def test_no_departition_yields_a_directory_of_part_files(
+    spark, tmp_path, fmt, extension
+):
+    """--no-departition writes a Spark directory of part files at the target."""
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    out = tmp_path / f"out.{extension}"
+
+    _write_file(df, _spec(out, fmt, departition=False))
+
+    assert out.is_dir()
+    part_files = [
+        entry.name for entry in out.iterdir() if entry.name.startswith("part-")
+    ]
+    assert part_files, f"expected part files in {out}, found {list(out.iterdir())}"
+
+
+def test_departition_default_yields_a_single_file(spark, tmp_path):
+    """Without the flag, the default departitions to a single file."""
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    out = tmp_path / "out.csv"
+
+    _write_file(df, _spec(out, OutputFormat.CSV))
+
+    assert out.is_file()
+
+
+def test_no_departition_has_no_effect_on_delta(spark, tmp_path):
+    """The departition flag does not change Delta's table-directory output."""
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    out = tmp_path / "out.delta"
+
+    _write_file(df, _spec(out, OutputFormat.DELTA, departition=False))
+
+    assert out.is_dir()
+    assert (out / "_delta_log").is_dir()
+
+
+# ========== Cleanup and confirmation (T010) ==========
+
+
+def test_temp_directory_removed_on_write_failure(spark, tmp_path, monkeypatch):
+    """A failure during departition leaves no temporary directory behind."""
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    out = tmp_path / "out.csv"
+
+    # Simulate a failure after the Spark write has produced the temp directory.
+    def _boom(*args, **kwargs):
+        raise RuntimeError("departition failed")
+
+    monkeypatch.setattr("pathling.cli.render.departition", _boom)
+
+    with pytest.raises(RuntimeError):
+        _write_file(df, _spec(out, OutputFormat.CSV))
+
+    # No target file and no leftover temporary directory beside it.
+    assert not out.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_confirmation_names_format_and_path_without_row_count(spark, tmp_path):
+    """The success confirmation names the format and path, with no row count."""
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    out = tmp_path / "out.csv"
+    console, buffer = _capture_console()
+
+    write_output(df, _spec(out, OutputFormat.CSV), console)
+
+    message = buffer.getvalue()
+    assert message.strip() == f"Wrote csv output to {out}."
+    assert "row" not in message.lower()

--- a/lib/python/tests/test_lazy_imports.py
+++ b/lib/python/tests/test_lazy_imports.py
@@ -1,0 +1,120 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for the package's lazy import shim and submodule attribute access.
+
+Each scenario runs in a fresh subprocess so that the assertions reflect a clean
+import of ``pathling`` rather than the state left by the shared test fixtures
+(which have already imported PySpark and the submodules). This is essential for
+the assertion that a plain ``import pathling`` does not import PySpark (FR-008).
+
+Author: John Grimes.
+"""
+
+import subprocess
+import sys
+
+
+def _run(code: str) -> str:
+    """Runs a snippet in a fresh interpreter and returns its stdout.
+
+    :param code: the Python source to execute.
+    :return: the captured stdout.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+# ========== Submodule attribute access (FR-006) ==========
+
+
+def test_submodule_attribute_access_after_bare_import():
+    """`pathling.udfs.member_of` resolves after a bare `import pathling`."""
+    out = _run(
+        "import pathling\nassert callable(pathling.udfs.member_of)\nprint('ok')\n"
+    )
+    assert "ok" in out
+
+
+def test_functions_submodule_attribute_access():
+    """`pathling.functions.to_coding` resolves after a bare `import pathling`."""
+    out = _run(
+        "import pathling\nassert callable(pathling.functions.to_coding)\nprint('ok')\n"
+    )
+    assert "ok" in out
+
+
+# ========== dir() advertises submodules (FR-007) ==========
+
+
+def test_dir_lists_submodules_and_top_level_names():
+    """`dir(pathling)` advertises submodules alongside top-level public names."""
+    out = _run(
+        "import pathling\n"
+        "names = dir(pathling)\n"
+        "assert 'udfs' in names, names\n"
+        "assert 'functions' in names, names\n"
+        "assert 'member_of' in names, names\n"
+        "print('ok')\n"
+    )
+    assert "ok" in out
+
+
+# ========== Top-level export unchanged (FR-009) ==========
+
+
+def test_top_level_import_still_works():
+    """The documented `from pathling import member_of` continues to work."""
+    out = _run(
+        "from pathling import member_of\nassert callable(member_of)\nprint('ok')\n"
+    )
+    assert "ok" in out
+
+
+# ========== Unknown attribute still raises (edge case) ==========
+
+
+def test_unknown_attribute_raises_attribute_error():
+    """An unknown attribute still raises AttributeError (no false fallback)."""
+    out = _run(
+        "import pathling\n"
+        "try:\n"
+        "    pathling.not_a_thing\n"
+        "    raise SystemExit('expected AttributeError')\n"
+        "except AttributeError:\n"
+        "    print('ok')\n"
+    )
+    assert "ok" in out
+
+
+# ========== Plain import does not import PySpark (FR-008) ==========
+
+
+def test_bare_import_does_not_import_pyspark():
+    """A plain `import pathling` does not import PySpark, keeping startup fast."""
+    out = _run(
+        "import sys\n"
+        "import pathling\n"
+        "assert 'pyspark' not in sys.modules, 'pyspark was imported by import pathling'\n"
+        "print('ok')\n"
+    )
+    assert "ok" in out

--- a/lib/python/tests/test_spark_defaults.py
+++ b/lib/python/tests/test_spark_defaults.py
@@ -1,0 +1,63 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for the managed Spark defaults extraction.
+
+These tests confirm that the PySpark-free defaults module is the single source
+of truth for the managed coordinates, the Delta extension, and the Delta
+catalog, and that its values match those declared in ``_version.py``. They do
+not start Spark.
+
+Author: John Grimes.
+"""
+
+from pathling._spark_defaults import MANAGED_COORDINATES, managed_spark_defaults
+from pathling._version import (
+    __delta_version__,
+    __java_version__,
+    __scala_version__,
+)
+
+
+def test_managed_defaults_match_version_module():
+    """The managed defaults reproduce the exact coordinates from _version.py."""
+    defaults = managed_spark_defaults()
+
+    # The packages string must list both managed coordinates at the versions
+    # declared in _version.py, matching the historical inline literal exactly
+    # (including the trailing comma).
+    expected_packages = (
+        f"au.csiro.pathling:library-runtime:{__java_version__},"
+        f"io.delta:delta-spark_{__scala_version__}:{__delta_version__},"
+    )
+    assert defaults["spark.jars.packages"] == expected_packages
+
+    # The Delta SQL extension and catalog are fixed class names.
+    assert defaults["spark.sql.extensions"] == (
+        "io.delta.sql.DeltaSparkSessionExtension"
+    )
+    assert defaults["spark.sql.catalog.spark_catalog"] == (
+        "org.apache.spark.sql.delta.catalog.DeltaCatalog"
+    )
+
+
+def test_managed_coordinate_identities():
+    """The managed coordinate identities are the group:artifact pairs."""
+    assert "au.csiro.pathling:library-runtime" in MANAGED_COORDINATES
+    assert f"io.delta:delta-spark_{__scala_version__}" in MANAGED_COORDINATES
+    # Exactly the two coordinates Pathling manages, no more.
+    assert len(MANAGED_COORDINATES) == 2

--- a/lib/python/uv.lock
+++ b/lib/python/uv.lock
@@ -22,15 +22,6 @@ wheels = [
 ]
 
 [[package]]
-name = "appnope"
-version = "0.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
-]
-
-[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -46,15 +37,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
-]
-
-[[package]]
-name = "backcall"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/40/764a663805d84deee23043e1426a9175567db89c8b3287b5c2ad9f71aa93/backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e", size = 18041, upload-time = "2020-06-09T15:11:32.931Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/1c/ff6546b6c12603d8dd1070aa3c3d273ad4c07f5771689a7b69a550e8c951/backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255", size = 11157, upload-time = "2020-06-09T15:11:30.87Z" },
 ]
 
 [[package]]
@@ -742,25 +724,95 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "8.10.0"
+version = "8.18.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.10'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "jedi", marker = "python_full_version < '3.10'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.10'" },
+    { name = "pexpect", marker = "python_full_version < '3.10' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "stack-data", marker = "python_full_version < '3.10'" },
+    { name = "traitlets", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/b9/3ba6c45a6df813c09a48bac313c22ff83efa26cbb55011218d925a46e2ad/ipython-8.18.1.tar.gz", hash = "sha256:ca6f079bb33457c66e233e4580ebfc4128855b4cf6370dddd73842a9563e8a27", size = 5486330, upload-time = "2023-11-27T09:58:34.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/6b/d9fdcdef2eb6a23f391251fde8781c38d42acd82abe84d054cb74f7863b0/ipython-8.18.1-py3-none-any.whl", hash = "sha256:e8267419d72d81955ec1177f8a29aaa90ac80ad647499201119e2f05e99aa397", size = 808161, upload-time = "2023-11-27T09:58:30.538Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "8.39.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version == '3.10.*' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version == '3.10.*'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "jedi", marker = "python_full_version == '3.10.*'" },
+    { name = "matplotlib-inline", marker = "python_full_version == '3.10.*'" },
+    { name = "pexpect", marker = "python_full_version == '3.10.*' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version == '3.10.*'" },
+    { name = "pygments", marker = "python_full_version == '3.10.*'" },
+    { name = "stack-data", marker = "python_full_version == '3.10.*'" },
+    { name = "traitlets", marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/56/4cc7fc9e9e3f38fd324f24f8afe0ad8bb5fa41283f37f1aaf9de0612c968/ipython-8.39.0-py3-none-any.whl", hash = "sha256:bb3c51c4fa8148ab1dea07a79584d1c854e234ea44aa1283bcb37bc75054651f", size = 831849, upload-time = "2026-03-27T10:02:07.846Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.14.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/22/58818a63eaf8982b67632b1bc20585c811611b15a8da19d6012323dc76a5/ipython-9.14.1-py3-none-any.whl", hash = "sha256:5d4a9ecaa3b10e6e5f269dd0948bdb58ca9cb851899cd23e07c320d3eb11613c", size = 627770, upload-time = "2026-06-05T08:12:33.045Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
-    { name = "backcall" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'win32'" },
-    { name = "pickleshare" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/a1/7dd9b71ede281a4433b10005ad07aeeb8d114cf6f6424ee48c2bcf082799/ipython-8.10.0.tar.gz", hash = "sha256:b13a1d6c1f5818bd388db53b7107d17454129a70de2b87481d555daede5eb49e", size = 5456256, upload-time = "2023-02-10T09:51:32.497Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/db/d641ee07f319002393524b6c5a8b47370520dcb2b6166a0972cfe9398c60/ipython-8.10.0-py3-none-any.whl", hash = "sha256:b38c31e8fc7eff642fc7c597061fff462537cf2314e3225a19c906b7b0d8a345", size = 784263, upload-time = "2023-02-10T09:51:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
 ]
 
 [[package]]
@@ -1428,6 +1480,9 @@ dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "deprecated" },
+    { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "ipython", version = "9.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyspark" },
     { name = "rich" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -1437,7 +1492,6 @@ dependencies = [
 dev = [
     { name = "build" },
     { name = "http-server-mock" },
-    { name = "ipython" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -1455,6 +1509,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
     { name = "deprecated", specifier = ">=1.2.13" },
+    { name = "ipython", specifier = ">=8.18.1" },
     { name = "pyspark", specifier = ">=4.0.0,<4.1.0" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
@@ -1464,7 +1519,6 @@ requires-dist = [
 dev = [
     { name = "build", specifier = "==1.2.1" },
     { name = "http-server-mock", specifier = "==1.7" },
-    { name = "ipython", specifier = "==8.10.0" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pytest", specifier = "==8.2.0" },
@@ -1481,20 +1535,11 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
-]
-
-[[package]]
-name = "pickleshare"
-version = "0.7.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/b6/df3c1c9b616e9c0edbc4fbab6ddd09df9535849c64ba51fcb6531c32d4d8/pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca", size = 6161, upload-time = "2018-09-25T19:17:37.249Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/41/220f49aaea88bc6fa6cba8d05ecf24676326156c23b991e80b3f2fc24c77/pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56", size = 6877, upload-time = "2018-09-25T19:17:35.817Z" },
 ]
 
 [[package]]
@@ -1516,6 +1561,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]

--- a/lib/python/uv.lock
+++ b/lib/python/uv.lock
@@ -1425,8 +1425,12 @@ wheels = [
 name = "pathling"
 source = { editable = "." }
 dependencies = [
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "deprecated" },
     { name = "pyspark" },
+    { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -1449,8 +1453,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.1.7" },
     { name = "deprecated", specifier = ">=1.2.13" },
     { name = "pyspark", specifier = ">=4.0.0,<4.1.0" },
+    { name = "rich", specifier = ">=13.7.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
 ]
 
 [package.metadata.requires-dev]

--- a/site/bun.lock
+++ b/site/bun.lock
@@ -20,8 +20,8 @@
   },
   "overrides": {
     "js-yaml": "3.14.2",
-    "lodash": "4.18.0",
-    "lodash-es": "4.18.0",
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1",
     "mdast-util-to-hast": "13.2.1",
     "mermaid": "^11.15.0",
     "node-forge": "1.3.3",
@@ -1567,9 +1567,9 @@
 
     "locate-path": ["locate-path@7.2.0", "", { "dependencies": { "p-locate": "^6.0.0" } }, "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA=="],
 
-    "lodash": ["lodash@4.18.0", "", {}, "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA=="],
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
-    "lodash-es": ["lodash-es@4.18.0", "", {}, "sha512-koAgswPPA+UTaPN64Etp+PGP+WT6oqOS2NMi5yDkMaiGw9qY4VxQbQF0mtKMyr4BlTznWyzePV5UpECTJQmSUA=="],
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
 

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -70,7 +70,7 @@ as a human-readable table by default.
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `--format`                       | `table` (default), `csv`, `ndjson`; with `-o` also `parquet`, `delta`.                                                 |
 | `-o PATH`                        | Write to a file instead of stdout; the format is inferred from the extension (`.csv`, `.ndjson`/`.jsonl`, `.parquet`). |
-| `--limit N`                      | Row cap for stdout table output (default 1000).                                                                        |
+| `--limit N`                      | Row cap for stdout table output (default 50).                                                                          |
 | `--overwrite`                    | Allow replacing an existing output path.                                                                               |
 | `--departition/--no-departition` | Write file output as a single file (default) or as a Spark directory of part files. No effect on Delta.                |
 

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -66,15 +66,21 @@ specify `--from`.
 Tabular results (from `view`, `fhirpath`, and the terminology commands) render
 as a human-readable table by default.
 
-| Option        | Behaviour                                                                      |
-| ------------- | ------------------------------------------------------------------------------ |
-| `--format`    | `table` (default), `csv`, `json`, `ndjson`; with `-o` also `parquet`, `delta`. |
-| `-o PATH`     | Write to a file instead of stdout; the format is inferred from the extension.  |
-| `--limit N`   | Row cap for stdout table output (default 1000).                                |
-| `--overwrite` | Allow replacing an existing output path.                                       |
+| Option                           | Behaviour                                                                                                              |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `--format`                       | `table` (default), `csv`, `ndjson`; with `-o` also `parquet`, `delta`.                                                 |
+| `-o PATH`                        | Write to a file instead of stdout; the format is inferred from the extension (`.csv`, `.ndjson`/`.jsonl`, `.parquet`). |
+| `--limit N`                      | Row cap for stdout table output (default 1000).                                                                        |
+| `--overwrite`                    | Allow replacing an existing output path.                                                                               |
+| `--departition/--no-departition` | Write file output as a single file (default) or as a Spark directory of part files. No effect on Delta.                |
 
-For scripted use, prefer `--format csv`, `--format json`, or `--format ndjson`,
-which stream the full result.
+File output is produced by Spark's distributed writers, so results larger than
+driver memory can be written. By default the output is departitioned to a
+single file at the path given; pass `--no-departition` to keep Spark's native
+directory of part files. Delta output is always written as a table directory.
+
+For scripted use, prefer `--format csv` or `--format ndjson`, which stream the
+full result.
 
 ## Commands
 

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -91,11 +91,15 @@ Convert FHIR data between formats.
 ```bash
 pathling convert data/ --to parquet -o warehouse/
 pathling convert bundles/ --from bundles --to ndjson -o out/
+pathling convert bundles/ --from bundles --type Patient --type Condition --to ndjson -o out/
 ```
 
 The `--mode overwrite|error|append|merge` option controls the save mode for
-Parquet and Delta output (`merge` is valid for Delta only). A summary of the
-resource types and row counts written is printed at the end.
+Parquet and Delta output (`merge` is valid for Delta only). For a Bundles
+source, the repeatable `--type` option names the resource types to read; when
+given, those types are used directly and the driver-side discovery pass is
+skipped. A summary of the resource types written and the output location is
+printed at the end.
 
 ### view
 
@@ -376,4 +380,5 @@ Using project config /path/to/pathling.toml (overrides ~/.config/pathling/config
 ```
 
 Passing an explicit `--config` skips project-local discovery, and no such notice
-is printed.
+is printed. An explicit `--config` path must exist; a missing path is an error
+rather than a silent fall-back to another config file.

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -42,6 +42,7 @@ through a configuration file.
 | `--tx-server`                                                               | `tx-server`          | the library default terminology server  |
 | `--tx-client-id`, `--tx-client-secret`, `--tx-token-endpoint`, `--tx-scope` | `[terminology-auth]` | none                                    |
 | `--fhir-version`                                                            | `fhir-version`       | `R4`                                    |
+| `--spark-conf KEY=VALUE`                                                    | `[spark]`            | none                                    |
 | `--config PATH`                                                             | -                    | `$XDG_CONFIG_HOME/pathling/config.toml` |
 | `--verbose`                                                                 | -                    | off                                     |
 
@@ -229,10 +230,72 @@ token-endpoint = "https://auth.example.org/token"
 [bulk-auth]
 client-id = "bulk-client"
 token-endpoint = "https://auth.example.org/token"
+
+[spark]
+"spark.sql.shuffle.partitions" = 16
+"spark.executor.memory" = "4g"
 ```
 
 Command-line flags always take precedence over the config file. Unknown keys
 produce a warning that names the key and lists the valid keys.
+
+### Spark configuration
+
+The `[spark]` table sets arbitrary [Apache Spark](https://spark.apache.org/)
+properties on the session that every data command builds. Use it to tune the
+engine - for example to raise executor memory, change the shuffle partition
+count, or add a cloud storage connector - or pass one or more
+`--spark-conf KEY=VALUE` flags for a single invocation. The flag is repeatable
+and overrides the `[spark]` value for the same key; when the same key is given
+more than once on the command line, the last occurrence wins. Because the value
+is split on the first `=` only, a value may itself contain `=` (for example
+`--spark-conf spark.driver.extraJavaOptions=-Dfoo=bar`).
+
+```toml
+[spark]
+"spark.sql.shuffle.partitions" = 16
+"spark.sql.adaptive.enabled" = true
+"spark.executor.memory" = "4g"
+"spark.jars.packages" = "org.apache.hadoop:hadoop-aws:3.4.1"
+"spark.hadoop.fs.s3a.secret.key" = "@/run/secrets/s3-key"
+```
+
+The resolved settings are merged with Pathling's own required Spark defaults
+rather than replacing them, so Pathling keeps working while your tuning takes
+effect. The full precedence, highest first, is:
+
+1. A `--spark-conf` flag value.
+2. The `[spark]` table value in the chosen config file.
+3. The CLI's quiet-mode logging settings (applied only when not `--verbose`, and
+   only for keys you did not set).
+4. Pathling's managed defaults (always present for the managed keys below).
+
+**Keys and values.** Every key must begin with `spark.`; any other key is an
+error that names the offending key and aborts before a Spark session starts.
+Values may be strings, integers, floats, or booleans, and are coerced to the
+strings Spark expects (booleans become `true`/`false`). TOML arrays and tables
+are not accepted; list-valued properties use Spark's native comma-separated
+string. A string value may be a `@/path/to/file` secret reference, read exactly
+as authentication secrets are.
+
+**Managed keys.** Three keys are owned by Pathling and merged item by item so
+the library is never broken:
+
+- `spark.jars.packages` - your coordinates are unioned with Pathling's managed
+  coordinates (the library runtime and Delta Lake) and deduplicated. Supplying a
+  managed coordinate at a different version is allowed and applies your version,
+  but prints a warning naming the coordinate, since a non-default version may not
+  be supported.
+- `spark.sql.extensions` - your extension class names are unioned with
+  Pathling's, and the Delta extension always remains present.
+- `spark.sql.catalog.spark_catalog` - this is locked to Pathling's Delta
+  catalog. Setting it to that value is a no-op; setting it to anything else is an
+  error.
+
+**Quiet-mode logging.** By default the CLI suppresses Spark and JVM logging by
+setting `spark.driver.extraJavaOptions`. If you set that key yourself, your value
+replaces the CLI's, so Spark logging is no longer suppressed. To keep both, run
+with `--verbose`, or include the quiet log4j2 option in the value you supply.
 
 ### Project-local configuration
 

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 7
-description: The Pathling command line interface surfaces the Python library's functionality - data conversion, SQL on FHIR views, FHIRPath evaluation, bulk export, and terminology operations - through scriptable commands.
+description: The Pathling command line interface surfaces the Python library's functionality - data conversion, SQL on FHIR views, FHIRPath evaluation, bulk export, terminology operations, Python scripting, and an interactive console - through scriptable commands.
 ---
 
 # Command line interface
@@ -140,6 +140,57 @@ SMART backend services authentication is configured with `--client-id`,
 `--client-secret`. Secret values accept a literal, a `@/path/to/file` reference,
 or fall back to the `PATHLING_PRIVATE_KEY_JWK` / `PATHLING_CLIENT_SECRET`
 environment variables so that they need not appear in shell history.
+
+### run
+
+Execute Python code with the Pathling environment ready. The code runs with
+two variables already in scope: `spark` (the Spark session) and `pathling`
+(the configured Pathling context), built with the same configuration
+resolution as every other command.
+
+```bash
+# Run a script file.
+pathling run my_script.py
+
+# Run an inline one-liner.
+pathling run -c "print(spark.version)"
+
+# Pipe a script through stdin.
+cat job.py | pathling run -
+
+# Pass arguments through to the script.
+pathling run etl.py --input data.ndjson out/
+```
+
+The code source is exactly one of a script path, `-` (standard input), or
+`-c CODE`; supplying both a script and `-c`, or neither, is a usage error
+(exit code 2), reported before the Spark session is started.
+
+Execution follows Python interpreter semantics: the module runs as
+`__main__`; for file scripts `__file__` is set and the script's directory is
+prepended to `sys.path`; trailing arguments arrive in `sys.argv` with
+`sys.argv[0]` being the script path, `-c`, or `-` as the interpreter would
+set it. Dash-prefixed arguments pass through to the script rather than being
+parsed by the CLI.
+
+The exit code is `0` on success and `1` for an uncaught exception or syntax
+error, with a standard Python traceback (no CLI frames) printed to standard
+error. `sys.exit(n)` exits with `n` and no traceback. The script's stdout
+passes through unmodified.
+
+### console
+
+Open an interactive [IPython](https://ipython.org/) console with the same
+`spark` and `pathling` variables in scope.
+
+```bash
+pathling console
+```
+
+After the startup progress indicator, a banner identifies the Pathling
+version and the variables in scope. Errors evaluated at the prompt show
+normal tracebacks without ending the session; leave with `exit` or Ctrl-D
+(exit code 0).
 
 ### Terminology commands
 

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -233,3 +233,34 @@ token-endpoint = "https://auth.example.org/token"
 
 Command-line flags always take precedence over the config file. Unknown keys
 produce a warning that names the key and lists the valid keys.
+
+### Project-local configuration
+
+The CLI also looks for a file named `pathling.toml` in the current working
+directory. When present, it is used in place of the user-level config file -
+not merged with it. This lets a project carry its own settings (for example a
+particular terminology server) without editing your personal config or passing
+`--config` on every command.
+
+Exactly one config file is ever read, chosen by this precedence (highest
+first):
+
+1. The path given to `--config`.
+2. A `pathling.toml` in the current working directory.
+3. The user-level `config.toml`.
+4. None, in which case built-in defaults apply.
+
+Because files are never merged, any key the chosen file omits falls back to its
+built-in default rather than to a value from another file. Discovery is limited
+to the current working directory; the CLI does not search parent directories.
+
+When a `pathling.toml` is discovered and used, the CLI prints a one-line notice
+on standard error naming the file (and the user-level file it overrides, when
+one exists), so the active configuration is never a surprise:
+
+```text
+Using project config /path/to/pathling.toml (overrides ~/.config/pathling/config.toml).
+```
+
+Passing an explicit `--config` skips project-local discovery, and no such notice
+is printed.

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -1,0 +1,184 @@
+---
+sidebar_position: 7
+description: The Pathling command line interface surfaces the Python library's functionality - data conversion, SQL on FHIR views, FHIRPath evaluation, bulk export, and terminology operations - through scriptable commands.
+---
+
+# Command line interface
+
+The `pathling` command line interface surfaces the functionality of the
+Pathling Python library through concise, scriptable commands. It is shipped as
+a console script within the `pathling` Python package, so its version always
+matches the library version.
+
+Each invocation starts a fresh Spark session. The cold start (typically 10-30
+seconds) is communicated through a progress indicator on standard error. Data
+is written to standard output, while progress, status, and errors are written
+to standard error, so that piped output stays clean.
+
+## Installation
+
+The CLI is part of the `pathling` package and requires a supported Java runtime
+to be present (as already required by the underlying PySpark dependency). The
+CLI reports the absence of Java clearly but does not install it.
+
+The simplest way to run it is with [uv](https://docs.astral.sh/uv/):
+
+```bash
+# Run without installing.
+uvx pathling --version
+
+# Or install the tool so that `pathling` is on your PATH.
+uv tool install pathling
+pathling --help
+```
+
+## Global options
+
+The following options are accepted before any command and may also be supplied
+through a configuration file.
+
+| Option                                                                      | Config key           | Default                                 |
+| --------------------------------------------------------------------------- | -------------------- | --------------------------------------- |
+| `--tx-server`                                                               | `tx-server`          | the library default terminology server  |
+| `--tx-client-id`, `--tx-client-secret`, `--tx-token-endpoint`, `--tx-scope` | `[terminology-auth]` | none                                    |
+| `--fhir-version`                                                            | `fhir-version`       | `R4`                                    |
+| `--config PATH`                                                             | -                    | `$XDG_CONFIG_HOME/pathling/config.toml` |
+| `--verbose`                                                                 | -                    | off                                     |
+
+Values are resolved with the precedence flag > config file > built-in default.
+The `--verbose` flag re-enables Spark and JVM logging and prints full stack
+traces on error.
+
+Exit codes are `0` for success, `1` for a runtime failure, and `2` for a usage
+error.
+
+## Data source inputs
+
+Commands that read FHIR data take a positional `SOURCE` path. The format is
+auto-detected from the path contents (ndjson, FHIR Bundles, Parquet, or Delta)
+and can be set explicitly with `--from ndjson|bundles|parquet|delta`. If the
+format cannot be determined, the error lists what was found and shows how to
+specify `--from`.
+
+## Output options
+
+Tabular results (from `view`, `fhirpath`, and the terminology commands) render
+as a human-readable table by default.
+
+| Option        | Behaviour                                                                      |
+| ------------- | ------------------------------------------------------------------------------ |
+| `--format`    | `table` (default), `csv`, `json`, `ndjson`; with `-o` also `parquet`, `delta`. |
+| `-o PATH`     | Write to a file instead of stdout; the format is inferred from the extension.  |
+| `--limit N`   | Row cap for stdout table output (default 1000).                                |
+| `--overwrite` | Allow replacing an existing output path.                                       |
+
+For scripted use, prefer `--format csv`, `--format json`, or `--format ndjson`,
+which stream the full result.
+
+## Commands
+
+### convert
+
+Convert FHIR data between formats.
+
+```bash
+pathling convert data/ --to parquet -o warehouse/
+pathling convert bundles/ --from bundles --to ndjson -o out/
+```
+
+The `--mode overwrite|error|append|merge` option controls the save mode for
+Parquet and Delta output (`merge` is valid for Delta only). A summary of the
+resource types and row counts written is printed at the end.
+
+### view
+
+Run a SQL on FHIR ViewDefinition against a data source.
+
+```bash
+pathling view data/ --view patients.json
+pathling view data/ --view patients.json --format csv
+pathling view data/ --view-json '{"resource":"Patient", ...}' -o results.parquet
+```
+
+The view is supplied as a file (`--view`) or inline JSON (`--view-json`). A
+`--filter` FHIR search expression restricts the resources processed.
+
+### fhirpath
+
+Evaluate a FHIRPath expression.
+
+```bash
+# Data source mode: one row per resource with its id and result.
+pathling fhirpath data/ -t Patient -e 'name.family'
+
+# Single resource mode: the typed result values.
+pathling fhirpath patient.json -e 'name.given.first()'
+```
+
+In data source mode, `-t/--type` selects the subject resource type and
+`--filter` restricts the resources processed. In single resource mode (when
+`SOURCE` is a single FHIR resource JSON file), `--context` and repeatable
+`--var name=value` options are supported.
+
+### export
+
+Bulk export data from a FHIR server.
+
+```bash
+pathling export https://server/fhir -o out/ --type Patient
+pathling export https://server/fhir -o out/ --group 123
+```
+
+A system-level export runs by default; `--group ID` and repeatable
+`--patient REF` select group-level and patient-level exports (the two are
+mutually exclusive). The export supports `--type`, `--elements`, `--since`,
+`--type-filter`, `--include-associated-data`, `--timeout`, and
+`--max-downloads`.
+
+SMART backend services authentication is configured with `--client-id`,
+`--token-endpoint`, `--scope`, and exactly one of `--private-key-jwk` or
+`--client-secret`. Secret values accept a literal, a `@/path/to/file` reference,
+or fall back to the `PATHLING_PRIVATE_KEY_JWK` / `PATHLING_CLIENT_SECRET`
+environment variables so that they need not appear in shell history.
+
+### Terminology commands
+
+The `member-of`, `translate`, `subsumes`, `subsumed-by`, `display`,
+`property-of`, and `designation` commands read a tabular dataset (CSV or
+Parquet), build codings from a `--code-column` plus either a fixed `--system`
+URI or a `--system-column`, and append the operation's result column(s).
+
+```bash
+pathling member-of codes.csv --code-column code \
+  --system http://snomed.info/sct \
+  --value-set 'http://snomed.info/sct?fhir_vs=refset/...'
+
+pathling translate codes.csv --code-column code \
+  --system http://snomed.info/sct --concept-map '<uri>'
+```
+
+The default result column names (`member_of`, `translated_system` and
+`translated_code`, `subsumes`, `subsumed_by`, `display`, `property`,
+`designation`) can be overridden with `--result-column`.
+
+## Configuration file
+
+Defaults for the global options can be set in a TOML file at
+`${XDG_CONFIG_HOME:-~/.config}/pathling/config.toml`:
+
+```toml
+tx-server = "https://tx.example.org/fhir"
+fhir-version = "R4"
+
+[terminology-auth]
+client-id = "my-client"
+client-secret = "..."
+token-endpoint = "https://auth.example.org/token"
+
+[bulk-auth]
+client-id = "bulk-client"
+token-endpoint = "https://auth.example.org/token"
+```
+
+Command-line flags always take precedence over the config file. Unknown keys
+produce a warning that names the key and lists the valid keys.

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -235,6 +235,34 @@ The default result column names (`member_of`, `translated_system` and
 `translated_code`, `subsumes`, `subsumed_by`, `display`, `property`,
 `designation`) can be overridden with `--result-column`.
 
+#### Subsumption against a fixed target coding
+
+The `subsumes` and `subsumed-by` commands test each row's coding against a
+target coding. The target code can come from a second column
+(`--other-code-column`) or be a single fixed value applied to every row
+(`--other-code`); exactly one of the two must be given. This lets you test a
+column of codes against one known concept without first adding a constant
+column to the data. The target system is supplied with `--other-system` (a
+fixed URI) or `--other-system-column` (a per-row column), and `--system-version`
+applies to both codings.
+
+```bash
+# Fixed target coding: is each code subsumed by Diabetes mellitus?
+pathling subsumed-by codes.csv --code-column code \
+  --system http://snomed.info/sct \
+  --other-code 73211009 --other-system http://snomed.info/sct
+
+# Two-column comparison: does each code in column a subsume the code in column b?
+pathling subsumes pairs.csv --code-column a \
+  --system http://snomed.info/sct \
+  --other-code-column b --other-system http://snomed.info/sct
+```
+
+Invalid combinations - supplying both or neither of `--other-code` /
+`--other-code-column`, or both or neither of `--other-system` /
+`--other-system-column` - are reported as usage errors before any Spark session
+starts.
+
 ## Configuration file
 
 Defaults for the global options can be set in a TOML file at

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -173,6 +173,18 @@ cat job.py | pathling run -
 pathling run etl.py --input data.ndjson out/
 ```
 
+For example, a script that projects a tabular view of patients and then
+summarises it with Spark SQL:
+
+```python
+patients = pathling.read.ndjson("data").view(
+    "Patient",
+    select=[{"column": [{"path": "gender", "name": "gender"}]}],
+)
+patients.createOrReplaceTempView("patient")
+spark.sql("SELECT gender, count(*) AS count FROM patient GROUP BY gender").show()
+```
+
 The code source is exactly one of a script path, `-` (standard input), or
 `-c CODE`; supplying both a script and `-c`, or neither, is a usage error
 (exit code 2), reported before the Spark session is started.

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -121,6 +121,10 @@ In data source mode, `-t/--type` selects the subject resource type and
 `SOURCE` is a single FHIR resource JSON file), `--context` and repeatable
 `--var name=value` options are supported.
 
+Both modes name the result column `result`: data source mode pairs it with each
+resource's `id` (one row per resource), while single resource mode pairs it with
+each result item's `type` (one row per result item).
+
 ### export
 
 Bulk export data from a FHIR server.

--- a/site/docs/libraries/index.md
+++ b/site/docs/libraries/index.md
@@ -23,3 +23,7 @@ The libraries are available for:
 All the different Pathling library implementations allow you to run queries
 locally (which is the default), or connect to a remote Spark cluster for
 processing of large datasets.
+
+The Python package also ships a [command line interface](cli.md) that surfaces
+this functionality through scriptable commands, installable and runnable with
+`uv tool` or `uvx`.

--- a/site/package.json
+++ b/site/package.json
@@ -39,8 +39,8 @@
     ]
   },
   "overrides": {
-    "lodash-es": "4.18.0",
-    "lodash": "4.18.0",
+    "lodash-es": "4.18.1",
+    "lodash": "4.18.1",
     "node-forge": "1.3.3",
     "qs": "6.15.2",
     "js-yaml": "3.14.2",


### PR DESCRIPTION
This adds a `pathling` console script to the Python package, surfacing the library's functionality through a flat, verb-based command tree. It covers data conversion, SQL on FHIR views, FHIRPath evaluation, bulk export, and terminology operations over code datasets. The CLI is built with Click and Rich, resolves configuration from flags then an optional TOML file, and is installable and runnable via `uv tool` / `uvx` so its version always matches the library.

The package's public names are now exposed lazily, so importing the CLI doesn't pull in PySpark and `--help`/`--version` stay fast. Spark and JVM logging is suppressed by default (and re-enabled with `--verbose`), errors are rendered as concise messages without Java stack traces, data goes to stdout while progress and errors go to stderr, and the Spark worker interpreter is pinned to the driver to avoid version mismatches.

Commands: `convert`, `view`, `fhirpath`, `export`, and the terminology operations `member-of`, `translate`, `subsumes`, `subsumed-by`, `display`, `property-of`, and `designation`.

Tested with unit tests for the parsing, config, rendering, and error-mapping logic, per-command integration tests through Click's runner against the existing Spark and mock-server fixtures, and a subprocess smoke test of the installed entry point. Documentation is added under `site/docs/libraries` and the Python README.