### PR TITLE
Make FHIRPath evaluation safe under Spark ANSI mode

### DIFF
--- a/encoders/src/test/java/au/csiro/pathling/encoders/AnsiTestSupport.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/AnsiTestSupport.java
@@ -37,16 +37,32 @@ public final class AnsiTestSupport {
   private AnsiTestSupport() {}
 
   /**
-   * Disables ANSI mode on the session when {@code pathling.test.ansiEnabled} is set to {@code
-   * false}; otherwise leaves the session at the Spark 4 default (ANSI on).
+   * Reconciles the supported ANSI default with the optional ANSI-off verification run.
+   *
+   * <p>When the {@code pathling.test.ansiEnabled} system property is set to {@code false}, ANSI
+   * mode is disabled on the session so the suite can be run once under the lenient setting
+   * (FR-011). Otherwise the property is treated as unset: the flag is left at the Spark 4 default
+   * and the resolved value is asserted to be {@code true}, failing loudly so the supported default
+   * cannot regress unnoticed (FR-009).
    *
    * @param spark the session to configure
    * @return the same session, for fluent use directly on a {@code getOrCreate()} call
+   * @throws IllegalStateException if ANSI mode is expected to be enabled but is not
    */
   @Nonnull
   public static SparkSession configureAnsiMode(@Nonnull final SparkSession spark) {
     if ("false".equalsIgnoreCase(System.getProperty("pathling.test.ansiEnabled"))) {
+      // Explicit ANSI-off verification run: relax the session-wide flag.
       spark.conf().set("spark.sql.ansi.enabled", false);
+    } else {
+      // The supported default: leave the flag at Spark's default and assert it resolves to on.
+      final boolean ansiEnabled = Boolean.parseBoolean(spark.conf().get("spark.sql.ansi.enabled"));
+      if (!ansiEnabled) {
+        throw new IllegalStateException(
+            "Pathling tests expect spark.sql.ansi.enabled to resolve to true by default on Spark 4,"
+                + " but it resolved to false. Set -Dpathling.test.ansiEnabled=false to run the"
+                + " suite intentionally under ANSI-off; otherwise this default must not regress.");
+      }
     }
     return spark;
   }

--- a/encoders/src/test/java/au/csiro/pathling/encoders/AnsiTestSupport.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/AnsiTestSupport.java
@@ -1,0 +1,53 @@
+/*
+ * This is a modified version of the Bunsen library, originally published at
+ * https://github.com/cerner/bunsen.
+ *
+ * Bunsen is copyright 2017 Cerner Innovation, Inc., and is licensed under
+ * the Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * These modifications are copyright 2018-2026 Commonwealth Scientific
+ * and Industrial Research Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.csiro.pathling.encoders;
+
+import jakarta.annotation.Nonnull;
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Test support for running the {@code encoders} suite under either {@code spark.sql.ansi.enabled}
+ * setting. Mirrors the toggle in the {@code fhirpath} test harness so the full suite can be run
+ * once under ANSI-off to confirm encoding is independent of the setting (FR-011).
+ *
+ * @author John Grimes
+ */
+public final class AnsiTestSupport {
+
+  private AnsiTestSupport() {}
+
+  /**
+   * Disables ANSI mode on the session when {@code pathling.test.ansiEnabled} is set to {@code
+   * false}; otherwise leaves the session at the Spark 4 default (ANSI on).
+   *
+   * @param spark the session to configure
+   * @return the same session, for fluent use directly on a {@code getOrCreate()} call
+   */
+  @Nonnull
+  public static SparkSession configureAnsiMode(@Nonnull final SparkSession spark) {
+    if ("false".equalsIgnoreCase(System.getProperty("pathling.test.ansiEnabled"))) {
+      spark.conf().set("spark.sql.ansi.enabled", false);
+    }
+    return spark;
+  }
+}

--- a/encoders/src/test/java/au/csiro/pathling/encoders/ExpressionsBothModesTest.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/ExpressionsBothModesTest.java
@@ -55,13 +55,14 @@ public abstract class ExpressionsBothModesTest {
   /** Creates the shared Spark session. Subclasses should call this from their @BeforeAll method. */
   protected static void setUp() {
     spark =
-        SparkSession.builder()
-            .master("local[*]")
-            .appName("testing")
-            .config("spark.driver.bindAddress", "localhost")
-            .config("spark.driver.host", "localhost")
-            .config("spark.ui.enabled", "false")
-            .getOrCreate();
+        AnsiTestSupport.configureAnsiMode(
+            SparkSession.builder()
+                .master("local[*]")
+                .appName("testing")
+                .config("spark.driver.bindAddress", "localhost")
+                .config("spark.driver.host", "localhost")
+                .config("spark.ui.enabled", "false")
+                .getOrCreate());
   }
 
   @Test

--- a/encoders/src/test/java/au/csiro/pathling/encoders/FhirEncodersTest.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/FhirEncodersTest.java
@@ -117,13 +117,14 @@ class FhirEncodersTest {
   @BeforeAll
   static void setUp() {
     spark =
-        SparkSession.builder()
-            .master("local[*]")
-            .appName("testing")
-            .config("spark.driver.bindAddress", "localhost")
-            .config("spark.driver.host", "localhost")
-            .config("spark.ui.enabled", "false")
-            .getOrCreate();
+        AnsiTestSupport.configureAnsiMode(
+            SparkSession.builder()
+                .master("local[*]")
+                .appName("testing")
+                .config("spark.driver.bindAddress", "localhost")
+                .config("spark.driver.host", "localhost")
+                .config("spark.ui.enabled", "false")
+                .getOrCreate());
 
     patientDataset = spark.createDataset(List.of(patient), ENCODERS_L0.of(Patient.class));
     decodedPatient = patientDataset.head();

--- a/encoders/src/test/java/au/csiro/pathling/encoders/VariantHelpersTest.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/VariantHelpersTest.java
@@ -68,13 +68,14 @@ class VariantHelpersTest {
   @BeforeAll
   static void setUp() {
     spark =
-        SparkSession.builder()
-            .master("local[*]")
-            .appName("testing")
-            .config("spark.driver.bindAddress", "localhost")
-            .config("spark.driver.host", "localhost")
-            .config("spark.ui.enabled", "false")
-            .getOrCreate();
+        AnsiTestSupport.configureAnsiMode(
+            SparkSession.builder()
+                .master("local[*]")
+                .appName("testing")
+                .config("spark.driver.bindAddress", "localhost")
+                .config("spark.driver.host", "localhost")
+                .config("spark.ui.enabled", "false")
+                .getOrCreate());
   }
 
   private Dataset<Row> createDataset(final Row... rows) {

--- a/encoders/src/test/java/au/csiro/pathling/encoders/ViewDefinitionEncodingTest.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/ViewDefinitionEncodingTest.java
@@ -80,13 +80,14 @@ class ViewDefinitionEncodingTest {
   @BeforeAll
   static void setUp() {
     spark =
-        SparkSession.builder()
-            .master("local[*]")
-            .appName("ViewDefinitionEncodingTest")
-            .config("spark.driver.bindAddress", "localhost")
-            .config("spark.driver.host", "localhost")
-            .config("spark.ui.enabled", "false")
-            .getOrCreate();
+        AnsiTestSupport.configureAnsiMode(
+            SparkSession.builder()
+                .master("local[*]")
+                .appName("ViewDefinitionEncodingTest")
+                .config("spark.driver.bindAddress", "localhost")
+                .config("spark.driver.host", "localhost")
+                .config("spark.ui.enabled", "false")
+                .getOrCreate());
 
     // Create a FhirContext and register the custom ViewDefinition resource type.
     fhirContext = FhirContext.forR4();

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/Numeric.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/Numeric.java
@@ -83,12 +83,17 @@ public interface Numeric {
 
   /** Represents a type of math operator. */
   enum MathOperation {
-    /** Addition operator. */
-    ADDITION("+", Column::plus),
-    /** Subtraction operator. */
-    SUBTRACTION("-", Column::minus),
-    /** Multiplication operator. */
-    MULTIPLICATION("*", Column::multiply),
+    /** Addition operator. Uses {@code try_add} so overflow yields NULL rather than raising. */
+    ADDITION("+", functions::try_add),
+    /**
+     * Subtraction operator. Uses {@code try_subtract} so overflow yields NULL rather than raising.
+     */
+    SUBTRACTION("-", functions::try_subtract),
+    /**
+     * Multiplication operator. Uses {@code try_multiply} so overflow yields NULL rather than
+     * raising.
+     */
+    MULTIPLICATION("*", functions::try_multiply),
     /** Division operator. */
     DIVISION("/", functions::try_divide),
     /** Modulus operator. */

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/collection/Collection.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/collection/Collection.java
@@ -915,7 +915,9 @@ public class Collection implements Equatable {
     } else if (convertibleTo(other)) {
       return other
           .getType()
-          .map(castType -> other.map(t -> this.getColumn().elementCast(castType.getSqlDataType())))
+          .map(
+              castType ->
+                  other.map(t -> this.getColumn().elementTryCast(castType.getSqlDataType())))
           .orElse(this);
     } else {
       throw new IllegalArgumentException("Cannot cast " + this + " to " + other);

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/collection/DecimalCollection.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/collection/DecimalCollection.java
@@ -171,8 +171,9 @@ public class DecimalCollection extends Collection
    */
   @Nonnull
   public DecimalCollection normalizeDecimalType() {
-    final Column normalizedArray =
-        getColumn().plural().getValue().cast(DataTypes.createArrayType(DECIMAL_TYPE));
+    // Route through the safe-cast helper so an out-of-range value yields NULL rather than raising
+    // under ANSI mode, independent of the session-wide setting.
+    final Column normalizedArray = getColumn().plural().elementTryCast(DECIMAL_TYPE).getValue();
     return (DecimalCollection) copyWithColumn(normalizedArray);
   }
 
@@ -191,7 +192,9 @@ public class DecimalCollection extends Collection
 
       return switch (operation) {
         case ADDITION, SUBTRACTION, MULTIPLICATION, DIVISION, MODULUS -> {
-          result = result.cast(getDecimalType());
+          // Safe cast so a result that overflows DECIMAL(32,6) yields NULL rather than raising
+          // under ANSI mode, independent of the session-wide setting.
+          result = result.try_cast(getDecimalType());
           yield DecimalCollection.build(new DefaultRepresentation(result));
         }
       };

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/column/ColumnRepresentation.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/column/ColumnRepresentation.java
@@ -452,10 +452,13 @@ public abstract class ColumnRepresentation {
    */
   @Nonnull
   public ColumnRepresentation count() {
-    // The operand appears once, so a nondeterministic operand fires exactly once per row. With
-    // spark.sql.legacy.sizeOfNull = false (the default since Spark 3.0), size(null) returns null,
-    // and coalesce maps null to zero.
-    return vectorize(c -> coalesce(size(c), lit(0)), c -> when(c.isNull(), 0).otherwise(1));
+    // size(null) returns -1 under ANSI-off and null under ANSI-on (Spark resolves
+    // legacy.sizeOfNull as LEGACY_SIZE_OF_NULL && !ansiEnabled), so the null array is guarded
+    // explicitly to yield zero identically under both settings. let() binds the operand once so a
+    // nondeterministic operand (e.g. a traced column) fires exactly once per row.
+    return vectorize(
+        c -> let(c, x -> when(x.isNull(), lit(0)).otherwise(size(x))),
+        c -> when(c.isNull(), 0).otherwise(1));
   }
 
   /**
@@ -465,9 +468,11 @@ public abstract class ColumnRepresentation {
    */
   @Nonnull
   public ColumnRepresentation isEmpty() {
-    // `size(null)` returns null when `spark.sql.legacy.sizeOfNull = false` (Spark 3.0+ default).
-    // `coalesce` maps that null to true so a null array reads as empty.
-    return vectorize(c -> coalesce(size(c).equalTo(0), lit(true)), Column::isNull);
+    // size(null) returns -1 under ANSI-off and null under ANSI-on, so the null array is guarded
+    // explicitly to read as empty identically under both settings. let() binds the operand once.
+    return vectorize(
+        c -> let(c, x -> when(x.isNull(), lit(true)).otherwise(size(x).equalTo(0))),
+        Column::isNull);
   }
 
   /**
@@ -478,8 +483,12 @@ public abstract class ColumnRepresentation {
    */
   @Nonnull
   public ColumnRepresentation toBoolean() {
+    // A null array must read as empty (NULL), not true. Because size(null) returns -1 under
+    // ANSI-off (rather than null), the null array is guarded explicitly so a non-empty array
+    // yields true and an empty or null array yields NULL identically under both settings.
     return vectorize(
-        a -> when(size(a).notEqual(0), lit(true)), s -> when(s.isNotNull(), lit(true)));
+        a -> let(a, x -> when(x.isNotNull().and(size(x).notEqual(0)), lit(true))),
+        s -> when(s.isNotNull(), lit(true)));
   }
 
   /**
@@ -630,6 +639,27 @@ public abstract class ColumnRepresentation {
   @Nonnull
   public ColumnRepresentation elementCast(@Nonnull final DataType dataType) {
     return vectorize(a -> a.cast(DataTypes.createArrayType(dataType)), s -> s.cast(dataType));
+  }
+
+  /**
+   * Safely casts (elementwise) the current {@link ColumnRepresentation} to a different data type,
+   * yielding NULL rather than raising an error when a value is non-conforming or out of range. This
+   * is the lenient counterpart of {@link #elementCast}, built on Spark's {@code try_cast}, and its
+   * result does not depend on the session-wide {@code spark.sql.ansi.enabled} setting.
+   *
+   * <p>The array branch applies {@code try_cast} to each element individually (via {@code
+   * transform}) rather than casting the array as a whole. This is deliberate: a whole-array {@code
+   * try_cast} would null the entire collection when any one element fails under ANSI-on, while
+   * yielding per-element NULLs under ANSI-off - diverging across settings. Casting per element
+   * yields the same per-element NULLs under both settings, preserving result parity.
+   *
+   * @param dataType the data type to cast to
+   * @return a new {@link ColumnRepresentation} where each value is either the cast value or NULL
+   */
+  @Nonnull
+  public ColumnRepresentation elementTryCast(@Nonnull final DataType dataType) {
+    return vectorize(
+        a -> functions.transform(a, e -> e.try_cast(dataType)), s -> s.try_cast(dataType));
   }
 
   /**

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/column/ColumnRepresentation.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/column/ColumnRepresentation.java
@@ -452,10 +452,11 @@ public abstract class ColumnRepresentation {
    */
   @Nonnull
   public ColumnRepresentation count() {
-    // size(null) returns -1 under ANSI-off and null under ANSI-on (Spark resolves
-    // legacy.sizeOfNull as LEGACY_SIZE_OF_NULL && !ansiEnabled), so the null array is guarded
-    // explicitly to yield zero identically under both settings. let() binds the operand once so a
-    // nondeterministic operand (e.g. a traced column) fires exactly once per row.
+    // size(null) resolves differently across both spark.sql.legacy.sizeOfNull and
+    // spark.sql.ansi.enabled (Spark uses LEGACY_SIZE_OF_NULL && !ansiEnabled): -1 when sizeOfNull
+    // is on and ANSI is off, null otherwise. Guarding the null array explicitly makes the result
+    // independent of both flags, yielding zero under every configuration. let() binds the operand
+    // once so a nondeterministic operand (e.g. a traced column) fires exactly once per row.
     return vectorize(
         c -> let(c, x -> when(x.isNull(), lit(0)).otherwise(size(x))),
         c -> when(c.isNull(), 0).otherwise(1));
@@ -468,8 +469,9 @@ public abstract class ColumnRepresentation {
    */
   @Nonnull
   public ColumnRepresentation isEmpty() {
-    // size(null) returns -1 under ANSI-off and null under ANSI-on, so the null array is guarded
-    // explicitly to read as empty identically under both settings. let() binds the operand once.
+    // size(null) resolves differently across both spark.sql.legacy.sizeOfNull and
+    // spark.sql.ansi.enabled, so the null array is guarded explicitly to read as empty under every
+    // configuration. let() binds the operand once.
     return vectorize(
         c -> let(c, x -> when(x.isNull(), lit(true)).otherwise(size(x).equalTo(0))),
         Column::isNull);
@@ -483,9 +485,10 @@ public abstract class ColumnRepresentation {
    */
   @Nonnull
   public ColumnRepresentation toBoolean() {
-    // A null array must read as empty (NULL), not true. Because size(null) returns -1 under
-    // ANSI-off (rather than null), the null array is guarded explicitly so a non-empty array
-    // yields true and an empty or null array yields NULL identically under both settings.
+    // A null array must read as empty (NULL), not true. Because size(null) resolves differently
+    // across both spark.sql.legacy.sizeOfNull and spark.sql.ansi.enabled, the null array is guarded
+    // explicitly so a non-empty array yields true and an empty or null array yields NULL under
+    // every configuration.
     return vectorize(
         a -> let(a, x -> when(x.isNotNull().and(size(x).notEqual(0)), lit(true))),
         s -> when(s.isNotNull(), lit(true)));
@@ -520,16 +523,6 @@ public abstract class ColumnRepresentation {
   @Nonnull
   public ColumnRepresentation not() {
     return transform(functions::not);
-  }
-
-  /**
-   * Sums the values in the current {@link ColumnRepresentation}.
-   *
-   * @return A new {@link ColumnRepresentation} that is the sum of values
-   */
-  @Nonnull
-  public ColumnRepresentation sum() {
-    return aggregate(0, Column::plus);
   }
 
   /**

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/encoding/QuantityEncoding.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/encoding/QuantityEncoding.java
@@ -107,7 +107,9 @@ public class QuantityEncoding {
   public Column toStruct() {
     return struct(
         id.as("id"),
-        value.cast(DecimalCustomCoder.decimalType()).as(VALUE_COLUMN),
+        // Safe cast so an out-of-range Quantity value yields NULL rather than raising under ANSI
+        // mode, independent of the session-wide setting.
+        value.try_cast(DecimalCustomCoder.decimalType()).as(VALUE_COLUMN),
         value_scale.as("value_scale"),
         comparator.as("comparator"),
         unit.as(UNIT_COLUMN),
@@ -290,8 +292,9 @@ public class QuantityEncoding {
                     nc.isNotNull(),
                     toStruct(
                         lit(null),
-                        // Cast value to decimal type
-                        nc.cast(DecimalCustomCoder.decimalType()),
+                        // Safe cast to the canonical decimal type so an out-of-range value yields
+                        // NULL rather than raising under ANSI mode.
+                        nc.try_cast(DecimalCustomCoder.decimalType()),
                         // We cannot encode the scale of the results of arithmetic operations.
                         lit(null),
                         lit(null),

--- a/fhirpath/src/test/java/au/csiro/pathling/AnsiHarnessAssertionTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/AnsiHarnessAssertionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import au.csiro.pathling.test.SpringBootUnitTest;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Verifies that the test harness resolves {@code spark.sql.ansi.enabled} consistently with the
+ * {@code pathling.test.ansiEnabled} system property: ANSI is on by default (property unset) and off
+ * only when the property is explicitly {@code false} (FR-009). This guards against the supported
+ * default silently regressing.
+ *
+ * @author John Grimes
+ */
+@SpringBootUnitTest
+class AnsiHarnessAssertionTest {
+
+  @Autowired SparkSession spark;
+
+  @Test
+  void resolvedAnsiSettingMatchesProperty() {
+    // The property defaults to unset, which the harness treats as ANSI-on.
+    final String property = System.getProperty("pathling.test.ansiEnabled");
+    final boolean expected = !"false".equalsIgnoreCase(property);
+    final boolean actual = Boolean.parseBoolean(spark.conf().get("spark.sql.ansi.enabled"));
+    assertEquals(
+        expected,
+        actual,
+        "Resolved spark.sql.ansi.enabled must match the pathling.test.ansiEnabled property");
+  }
+}

--- a/fhirpath/src/test/java/au/csiro/pathling/UnitTestDependencies.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/UnitTestDependencies.java
@@ -88,9 +88,39 @@ public class UnitTestDependencies {
                 "org.apache.spark.sql.delta.catalog.DeltaCatalog")
             .config("spark.sql.mapKeyDedupPolicy", "LAST_WIN")
             .getOrCreate();
+    configureAnsiMode(spark);
     TerminologyUdfRegistrar.registerUdfs(spark, terminologyServiceFactory);
     PathlingUdfConfigurer.registerUdfs(spark);
     return spark;
+  }
+
+  /**
+   * Reconciles the supported ANSI default with the optional ANSI-off verification run.
+   *
+   * <p>When the {@code pathling.test.ansiEnabled} system property is set to {@code false}, ANSI
+   * mode is disabled on the session so the suite can be run once under the lenient setting
+   * (FR-011). Otherwise the property is treated as unset: the flag is left at the Spark 4 default
+   * and the resolved value is asserted to be {@code true}, failing loudly so the supported default
+   * cannot regress unnoticed (FR-009).
+   *
+   * @param spark the session to configure
+   * @throws IllegalStateException if ANSI mode is expected to be enabled but is not
+   */
+  private static void configureAnsiMode(@Nonnull final SparkSession spark) {
+    final String ansiProperty = System.getProperty("pathling.test.ansiEnabled");
+    if ("false".equalsIgnoreCase(ansiProperty)) {
+      // Explicit ANSI-off verification run: relax the session-wide flag.
+      spark.conf().set("spark.sql.ansi.enabled", false);
+    } else {
+      // The supported default: leave the flag at Spark's default and assert it resolves to on.
+      final boolean ansiEnabled = Boolean.parseBoolean(spark.conf().get("spark.sql.ansi.enabled"));
+      if (!ansiEnabled) {
+        throw new IllegalStateException(
+            "Pathling tests expect spark.sql.ansi.enabled to resolve to true by default on Spark 4,"
+                + " but it resolved to false. Set -Dpathling.test.ansiEnabled=false to run the"
+                + " suite intentionally under ANSI-off; otherwise this default must not regress.");
+      }
+    }
   }
 
   @Bean

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/ansi/AnsiModeIndependenceTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/ansi/AnsiModeIndependenceTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.fhirpath.ansi;
+
+import static au.csiro.pathling.views.FhirView.columns;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.test.SpringBootUnitTest;
+import au.csiro.pathling.test.datasource.ObjectDataSource;
+import au.csiro.pathling.views.Column;
+import au.csiro.pathling.views.ColumnTag;
+import au.csiro.pathling.views.FhirView;
+import au.csiro.pathling.views.FhirViewExecutor;
+import jakarta.annotation.Nonnull;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Observation.ObservationComponentComponent;
+import org.hl7.fhir.r4.model.Quantity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Pins FHIRPath and ViewDefinition evaluation to produce <em>identical</em> results under {@code
+ * spark.sql.ansi.enabled} set to either {@code true} or {@code false} (FR-001, FR-010). Each
+ * scenario is evaluated twice - once with ANSI on, once with ANSI off - by rebuilding the entire
+ * query (source encoding and view) under each setting, then asserting the result sets are equal.
+ *
+ * <p>The decimal-overflow and out-of-range scenarios fail today under ANSI-on (the divergence this
+ * feature removes); after the fix they yield empty/NULL identically under both settings.
+ *
+ * @author John Grimes
+ */
+@SpringBootUnitTest
+class AnsiModeIndependenceTest {
+
+  @Autowired FhirEncoders fhirEncoders;
+
+  @Autowired SparkSession spark;
+
+  private String originalAnsiSetting;
+
+  @AfterEach
+  void restoreAnsiSetting() {
+    if (originalAnsiSetting != null) {
+      spark.conf().set("spark.sql.ansi.enabled", originalAnsiSetting);
+    }
+  }
+
+  /**
+   * Builds and runs the view over the given resources under the requested ANSI setting. The source
+   * encoding and the view query are both constructed after the setting is applied, so the result
+   * reflects that setting end to end.
+   */
+  @Nonnull
+  private List<String> evalUnderAnsi(
+      final boolean ansiEnabled,
+      @Nonnull final List<IBaseResource> resources,
+      @Nonnull final FhirView view) {
+    if (originalAnsiSetting == null) {
+      originalAnsiSetting = spark.conf().get("spark.sql.ansi.enabled");
+    }
+    spark.conf().set("spark.sql.ansi.enabled", ansiEnabled);
+    final ObjectDataSource dataSource = new ObjectDataSource(spark, fhirEncoders, resources);
+    final FhirViewExecutor executor = new FhirViewExecutor(fhirEncoders.getContext(), dataSource);
+    return executor.buildQuery(view).collectAsList().stream()
+        .map(Row::toString)
+        .collect(Collectors.toList());
+  }
+
+  /** Asserts the result set is identical whether ANSI mode is enabled or disabled. */
+  private void assertParity(
+      @Nonnull final List<IBaseResource> resources,
+      @Nonnull final FhirView view,
+      @Nonnull final String message) {
+    final List<String> ansiOn = evalUnderAnsi(true, resources, view);
+    final List<String> ansiOff = evalUnderAnsi(false, resources, view);
+    assertEquals(ansiOn, ansiOff, message);
+  }
+
+  @Nonnull
+  private static FhirView singleColumn(@Nonnull final String expression) {
+    return FhirView.ofResource("Observation")
+        .select(columns(Column.builder().name("value").path(expression).collection(false).build()))
+        .build();
+  }
+
+  @Nonnull
+  private static Observation observationWithQuantity(@Nonnull final BigDecimal value) {
+    return (Observation)
+        new Observation().setValue(new Quantity().setValue(value)).setId("Observation/1");
+  }
+
+  // ---------------------------------------------------------------------------
+  // User Story 1: identical results regardless of the ANSI setting.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void decimalMultiplicationOverflowIsIdenticalUnderBothSettings() {
+    // 1e14 * 1e14 = 1e28, which exceeds the 26 integer digits of DECIMAL(32,6); the result must be
+    // empty under both settings rather than aborting under ANSI-on.
+    final List<IBaseResource> resources = List.of(observationWithQuantity(new BigDecimal("1E14")));
+    assertParity(
+        resources,
+        singleColumn("value.ofType(Quantity).value * value.ofType(Quantity).value"),
+        "decimal multiplication overflow");
+  }
+
+  @Test
+  void decimalAdditionIsIdenticalUnderBothSettings() {
+    // A valid decimal addition must yield the same (non-empty) value under both settings.
+    final List<IBaseResource> resources = List.of(observationWithQuantity(new BigDecimal("23.40")));
+    assertParity(
+        resources, singleColumn("value.ofType(Quantity).value + 1.5"), "valid decimal addition");
+  }
+
+  @Test
+  void decimalCombineNormalisationIsIdenticalUnderBothSettings() {
+    // combine() routes decimals through normalizeDecimalType (a DECIMAL(32,6) cast).
+    final List<IBaseResource> resources = List.of(observationWithQuantity(new BigDecimal("23.40")));
+    assertParity(
+        resources,
+        FhirView.ofResource("Observation")
+            .select(
+                columns(
+                    Column.builder()
+                        .name("value")
+                        .path("value.ofType(Quantity).value.combine(1.5)")
+                        .collection(true)
+                        .build()))
+            .build(),
+        "decimal combine normalisation");
+  }
+
+  @Test
+  void mixedNumericCoercionIsIdenticalUnderBothSettings() {
+    // Integer + Decimal coerces the integer to decimal through castAs; results must match.
+    final Observation observation = observationWithQuantity(new BigDecimal("23.40"));
+    observation.addComponent(
+        new ObservationComponentComponent(new CodeableConcept().setText("int"))
+            .setValue(new IntegerType(7)));
+    assertParity(
+        List.of(observation),
+        singleColumn(
+            "component.where(code.text='int').value.ofType(integer) +"
+                + " value.ofType(Quantity).value"),
+        "mixed integer/decimal coercion");
+  }
+
+  @Test
+  void outOfRangeQuantityValueIsIdenticalUnderBothSettings() {
+    // A Quantity value outside the representable DECIMAL(32,6) range must be empty under both
+    // settings rather than aborting under ANSI-on.
+    final List<IBaseResource> resources = List.of(observationWithQuantity(new BigDecimal("1E30")));
+    assertParity(
+        resources, singleColumn("value.ofType(Quantity).value"), "out-of-range Quantity value");
+  }
+
+  @Test
+  void nonConformingViewColumnsAreIdenticalUnderBothSettings() {
+    // A view whose declared column types do not match the input values: the non-conforming cells
+    // must be empty under both settings, with the query completing.
+    final Observation observation =
+        (Observation)
+            new Observation()
+                .setCode(new CodeableConcept().setText("not-a-number"))
+                .setId("Observation/1");
+    final FhirView view =
+        FhirView.ofResource("Observation")
+            .select(
+                columns(
+                    typedColumn("asInt", "code.text", "INT"),
+                    typedColumn("asDecimal", "code.text", "DECIMAL(10,2)"),
+                    typedColumn("asDate", "code.text", "DATE")))
+            .build();
+    assertParity(List.of(observation), view, "non-conforming view columns");
+  }
+
+  @Nonnull
+  private static Column typedColumn(
+      @Nonnull final String name, @Nonnull final String path, @Nonnull final String ansiType) {
+    return Column.builder()
+        .name(name)
+        .path(path)
+        .collection(false)
+        .tag(List.of(ColumnTag.of(ColumnTag.ANSI_TYPE_TAG, ansiType)))
+        .build();
+  }
+
+  // ---------------------------------------------------------------------------
+  // User Story 2: correct values on a stock Spark 4 session (ANSI on, the default).
+  //
+  // These assert the specific expected output under ANSI-on (not merely parity): a non-conforming
+  // or out-of-range value yields an empty cell while the query completes for every other row.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void decimalOverflowProducesEmptyUnderAnsiOn() {
+    final List<String> result =
+        evalUnderAnsi(
+            true,
+            List.of(observationWithQuantity(new BigDecimal("1E14"))),
+            singleColumn("value.ofType(Quantity).value * value.ofType(Quantity).value"));
+    assertEquals(List.of("[null]"), result, "decimal overflow yields an empty cell under ANSI-on");
+  }
+
+  @Test
+  void nonConformingViewColumnYieldsEmptyCellAndQueryCompletesUnderAnsiOn() {
+    // One row has a value that conforms to the declared INT column, the other does not. Under
+    // ANSI-on the non-conforming cell must be empty while the conforming row survives.
+    final Observation conforming =
+        (Observation)
+            new Observation().setCode(new CodeableConcept().setText("123")).setId("Observation/1");
+    final Observation nonConforming =
+        (Observation)
+            new Observation().setCode(new CodeableConcept().setText("abc")).setId("Observation/2");
+    final FhirView view =
+        FhirView.ofResource("Observation")
+            .select(columns(typedColumn("v", "code.text", "INT")))
+            .build();
+
+    final List<String> result =
+        new ArrayList<>(evalUnderAnsi(true, List.of(conforming, nonConforming), view));
+    Collections.sort(result);
+    assertEquals(
+        List.of("[123]", "[null]"),
+        result,
+        "non-conforming cell is empty and the conforming row survives under ANSI-on");
+  }
+
+  @Test
+  void conversionFunctionOnInvalidInputProducesEmptyUnderAnsiOn() {
+    final List<String> result =
+        evalUnderAnsi(
+            true,
+            List.of(observationWithQuantity(new BigDecimal("1"))),
+            singleColumn("'abc'.toInteger()"));
+    assertEquals(
+        List.of("[null]"), result, "conversion of invalid input yields empty under ANSI-on");
+  }
+}

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/column/ColumnRepresentationSafeCastTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/column/ColumnRepresentationSafeCastTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.fhirpath.column;
+
+import static org.apache.spark.sql.functions.array;
+import static org.apache.spark.sql.functions.lit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import au.csiro.pathling.test.SpringBootUnitTest;
+import jakarta.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Verifies the centralised safe-cast helper ({@link ColumnRepresentation#elementTryCast}). The
+ * helper must return NULL (never raise) for out-of-range and non-conforming values, element-wise
+ * for both array (plural) and scalar (singular) representations, and must behave identically under
+ * {@code spark.sql.ansi.enabled} set to either {@code true} or {@code false}.
+ *
+ * @author John Grimes
+ */
+@SpringBootUnitTest
+class ColumnRepresentationSafeCastTest {
+
+  /** The canonical decimal type used by Pathling, permitting 26 integer digits. */
+  private static final DataType DECIMAL_TYPE = DataTypes.createDecimalType(32, 6);
+
+  private static final boolean[] ANSI_SETTINGS = {true, false};
+
+  @Autowired SparkSession spark;
+
+  private String originalAnsiSetting;
+
+  @AfterEach
+  void restoreAnsiSetting() {
+    // Restore whatever the harness configured so other tests are unaffected by the toggling here.
+    if (originalAnsiSetting != null) {
+      spark.conf().set("spark.sql.ansi.enabled", originalAnsiSetting);
+    }
+  }
+
+  /**
+   * Builds the column under the given ANSI setting and materialises the single result row. The
+   * column is constructed after the setting is applied so that any cast eval mode is resolved under
+   * that setting.
+   */
+  @Nonnull
+  private Row evalUnderAnsi(final boolean ansiEnabled, @Nonnull final Supplier<Column> column) {
+    if (originalAnsiSetting == null) {
+      originalAnsiSetting = spark.conf().get("spark.sql.ansi.enabled");
+    }
+    spark.conf().set("spark.sql.ansi.enabled", ansiEnabled);
+    return spark.range(1).select(column.get().alias("v")).first();
+  }
+
+  @Nonnull
+  private static ColumnRepresentation scalar(@Nonnull final Object value) {
+    return new DefaultRepresentation(lit(value));
+  }
+
+  @Nonnull
+  private static ColumnRepresentation arrayOf(@Nonnull final Object... values) {
+    return new DefaultRepresentation(
+        array(Arrays.stream(values).map(functions::lit).toArray(Column[]::new)));
+  }
+
+  @Test
+  void scalarNonConformingStringToIntegerYieldsNull() {
+    for (final boolean ansi : ANSI_SETTINGS) {
+      final Row row =
+          evalUnderAnsi(ansi, () -> scalar("abc").elementTryCast(DataTypes.IntegerType).getValue());
+      assertNull(row.isNullAt(0) ? null : row.get(0), "non-conforming scalar string, ansi=" + ansi);
+    }
+  }
+
+  @Test
+  void scalarOutOfRangeDecimalYieldsNull() {
+    // 1e30 has 31 integer digits, exceeding the 26 permitted by DECIMAL(32,6).
+    for (final boolean ansi : ANSI_SETTINGS) {
+      final Row row =
+          evalUnderAnsi(ansi, () -> scalar("1e30").elementTryCast(DECIMAL_TYPE).getValue());
+      assertNull(row.isNullAt(0) ? null : row.get(0), "out-of-range scalar decimal, ansi=" + ansi);
+    }
+  }
+
+  @Test
+  void scalarConformingValueIsRetained() {
+    for (final boolean ansi : ANSI_SETTINGS) {
+      final Row row =
+          evalUnderAnsi(ansi, () -> scalar("42").elementTryCast(DataTypes.IntegerType).getValue());
+      assertEquals(42, row.get(0), "conforming scalar, ansi=" + ansi);
+    }
+  }
+
+  @Test
+  void arrayNonConformingElementsYieldNullPerElementUnderBothSettings() {
+    for (final boolean ansi : ANSI_SETTINGS) {
+      final List<Object> result =
+          evalUnderAnsi(
+                  ansi,
+                  () -> arrayOf("1", "abc", "3").elementTryCast(DataTypes.IntegerType).getValue())
+              .getList(0);
+      // The non-conforming element becomes NULL while conforming elements are retained. This
+      // per-element behaviour is what keeps results identical across ANSI settings.
+      assertEquals(Arrays.asList(1, null, 3), result, "array integer cast, ansi=" + ansi);
+    }
+  }
+
+  @Test
+  void arrayOutOfRangeDecimalYieldsNullPerElementUnderBothSettings() {
+    for (final boolean ansi : ANSI_SETTINGS) {
+      final List<Object> result =
+          evalUnderAnsi(ansi, () -> arrayOf("1.5", "1e30").elementTryCast(DECIMAL_TYPE).getValue())
+              .getList(0);
+      assertEquals(2, result.size(), "array size, ansi=" + ansi);
+      assertNotNull(result.get(0), "conforming decimal retained, ansi=" + ansi);
+      assertNull(result.get(1), "out-of-range decimal nulled, ansi=" + ansi);
+    }
+  }
+}

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/column/DefaultRepresentationTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/column/DefaultRepresentationTest.java
@@ -174,17 +174,6 @@ class DefaultRepresentationTest {
   }
 
   @Test
-  void testSum() {
-    new ColumnAsserts()
-        .assertEquals(0, nullValue().sum())
-        .assertEquals(17, valueOf(17).sum())
-        .assertEquals(0, nullArray().sum())
-        .assertEquals(0, emptyArray().sum())
-        .assertEquals(6, arrayOf(1, 2, 3).sum())
-        .check();
-  }
-
-  @Test
   void testNot() {
     new ColumnAsserts()
         .assertNull(nullValue().not())

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/column/DefaultRepresentationTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/column/DefaultRepresentationTest.java
@@ -208,6 +208,19 @@ class DefaultRepresentationTest {
   }
 
   @Test
+  void testToBoolean() {
+    // A non-empty collection reads as true; null and empty collections read as empty (NULL). This
+    // must hold regardless of spark.sql.ansi.enabled, which alters size(null).
+    new ColumnAsserts()
+        .assertNull(nullValue().toBoolean())
+        .assertEquals(true, valueOf(17).toBoolean())
+        .assertNull(nullArray().toBoolean())
+        .assertNull(emptyArray().toBoolean())
+        .assertEquals(true, arrayOf(1, 2).toBoolean())
+        .check();
+  }
+
+  @Test
   void testMax() {
     new ColumnAsserts()
         .assertNull(nullValue().max())

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/dsl/MathOperatorsDslTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/dsl/MathOperatorsDslTest.java
@@ -124,6 +124,23 @@ public class MathOperatorsDslTest extends FhirPathDslTestBase {
   }
 
   @FhirPathTest
+  public Stream<DynamicTest> testDivisionAndModuloByZeroYieldEmpty() {
+    // FHIRPath defines division and modulo by zero as an empty result. This is implemented with
+    // try_divide/try_mod, which are independent of spark.sql.ansi.enabled. The assertions run
+    // under the default ANSI-on harness to guard against a regression to the unsafe operators.
+    return builder()
+        .withSubject(sb -> sb.integer("int1", 5).decimal("dec1", 5.5))
+        .group("Division and modulo by zero")
+        .testEmpty("int1 / 0", "Integer division by zero variable and literal")
+        .testEmpty("5 / 0", "Integer division by zero literals")
+        .testEmpty("int1 mod 0", "Integer modulo by zero variable and literal")
+        .testEmpty("5 mod 0", "Integer modulo by zero literals")
+        .testEmpty("dec1 / 0.0", "Decimal division by zero variable and literal")
+        .testEmpty("dec1 mod 0.0", "Decimal modulo by zero variable and literal")
+        .build();
+  }
+
+  @FhirPathTest
   public Stream<DynamicTest> testMathWithEmptyArguments() {
     return builder()
         .withSubject(

--- a/lib/R/pom.xml
+++ b/lib/R/pom.xml
@@ -227,6 +227,15 @@
                 <argument>install.packages("remotes", type="source")</argument>
                 <argument>-e</argument>
                 <argument>devtools::install_dev_deps(type="source")</argument>
+                <!-- Pin dbplyr to the last release before 2.6.0. dbplyr 2.6.0 is
+                     incompatible with sparklyr 1.9.4: its query-fields probe
+                     emits standard SQL (double-quoted identifiers) that the
+                     Spark parser rejects, breaking all tbl_spark operations.
+                     Run after install_dev_deps so the pin holds regardless of
+                     what the package cache restored. Remove once a sparklyr
+                     release supports dbplyr 2.6.0. -->
+                <argument>-e</argument>
+                <argument>remotes::install_version("dbplyr", version = "2.5.2", type = "source", upgrade = "never")</argument>
                 <argument>-e</argument>
                 <argument>installed.packages()[,c("Package","Version")]</argument>
                 <argument>-e</argument>

--- a/site/docs/libraries/installation/spark.md
+++ b/site/docs/libraries/installation/spark.md
@@ -10,6 +10,20 @@ description: Instructions for configuring Apache Spark to use the Pathling libra
 Pathling is built and tested against **Apache Spark 4.0.x**. The Python library
 requires PySpark 4.0.x, and the R library requires sparklyr with Spark 4.0.x.
 
+## ANSI mode
+
+Pathling evaluates FHIRPath expressions and ViewDefinitions identically and
+correctly whether `spark.sql.ansi.enabled` is set to `true` or `false`. Spark 4
+enables ANSI mode by default, and Pathling works correctly on a stock session: a
+value that does not conform to a declared type, an out-of-range decimal, or a
+decimal arithmetic result that overflows yields an empty result for that value
+rather than aborting the query.
+
+Because the setting is session-wide, you may keep it disabled
+(`spark.sql.ansi.enabled=false`) to support portable, vendor-neutral transform
+SQL that relies on lenient casts, without affecting how Pathling behaves.
+Pathling neither sets nor requires any particular value for this flag.
+
 ## Session configuration
 
 When you create a `PathlingContext` within your Spark application, it will


### PR DESCRIPTION
Spark 4 enables `spark.sql.ansi.enabled` by default, which makes invalid or out-of-range casts and numeric overflow raise errors rather than returning empty. In practice that meant a single non-conforming value in real-world FHIR data could abort an entire query. It also left open the concern raised in the issue: consumers who disable ANSI mode to run portable transform SQL on the same session might be unknowingly masking a Pathling incompatibility.

This makes the core `fhirpath` and `encoders` evaluation produce identical, correct results regardless of the setting. Failure-prone decimal and Quantity casts now route through a single safe-cast helper built on `try_cast`, the `+`/`-`/`*` operators use their `try_*` counterparts so overflow yields empty, and `count`/`isEmpty`/`toBoolean` no longer rely on `size(null)` (which Spark resolves differently depending on the flag). On failure the result is empty/NULL under both settings, matching FHIRPath and SQL on FHIR semantics, and no production code reads or sets the flag.

A new parameterised test suite evaluates the divergent cases under both settings and asserts identical results, and the test harness now asserts it starts under ANSI-on so the supported default cannot regress unnoticed. The full `fhirpath` and `encoders` suites pass with ANSI mode both on and off. The Spark configuration documentation now records that either setting is supported.

Closes #2629.
