### PR TITLE
Implement the $sqlquery-export operation and align SQL on FHIR operations to the spec

### DIFF
--- a/ui/src/api/sqlQuery.ts
+++ b/ui/src/api/sqlQuery.ts
@@ -318,7 +318,7 @@ export interface SqlQueryExportKickOffOptions extends AuthOptions {
 }
 
 /**
- * Result of a `$sqlquery-export` kick-off: the polling URL from the {@code Content-Location}
+ * Result of a `$sqlquery-export` kick-off: the polling URL from the `Content-Location`
  * header.
  */
 export interface SqlQueryExportResult {


### PR DESCRIPTION
This adds the SQL on FHIR `$sqlquery-export` operation, the asynchronous counterpart to `$sqlquery-run`, and brings the existing SQL on FHIR operations into line with the specification along the way. Clients can run one or more SQL queries against materialised ViewDefinition tables in the background and download each result set as files, following the FHIR Asynchronous Request Pattern.

## The `$sqlquery-export` operation

The operation is available at the system, type, and instance levels. Each `query` produces one output. Table sources can be supplied at request time, inline or by reference, in addition to being read from server storage. Supported formats are NDJSON (the default), CSV, and Parquet, with `patient`, `group`, and `_since` filtering. A failed query fails the whole export. It is gated by a new `sqlQueryExportEnabled` configuration flag (default `true`) and declared in the CapabilityStatement against the spec canonical `http://sql-on-fhir.org/OperationDefinition/$sqlquery-export`.

## Specification alignment

While implementing the new operation, the existing `$viewdefinition-run`, `$viewdefinition-export`, and `$sqlquery-run` operations were aligned to the spec:

- `viewReference` resolution to a stored ViewDefinition, with per-part exclusivity and presence checks.
- Reference-typed `patient` and `group` with the spec's cardinality, and Bundle unwrapping in the resource parameter.
- The export completion manifest rewritten to the spec shape (`exportId`, `status`, echoed `clientTrackingId` and `_format`, export timing fields, and one output per view carrying `name` and `location` parts), dropping the Bulk Data-style fields. The Bulk Data export kick-off body is unchanged, with a regression test confirming this.
- A Parameters kick-off acknowledgement for the SQL on FHIR async operations.
- 422 for semantically invalid ViewDefinitions, and rejection of an explicitly unsupported `_format` or the unsupported `source` parameter rather than silently ignoring them.
- A supported `_format` media type carrying parameters (e.g. `text/csv;charset=utf-8`) is now accepted rather than rejected.
- Named and positional parameter placeholders are allowed through the strict SQL validator, so parameterised `$sqlquery-run` queries pass static validation.
- The CapabilityStatement now points at the spec canonical OperationDefinition URLs for these operations, and the Pathling-authored OperationDefinitions for them are no longer served.

## Breaking changes

The alignment work changes the wire contract of the existing `$viewdefinition-run`, `$viewdefinition-export`, and `$sqlquery-run` operations. Each change moves Pathling onto the published SQL on FHIR contract, but clients written against the previous behaviour will need updating.

- **Export completion manifest reshaped.** The `$viewdefinition-export` completion manifest no longer carries the Bulk Data-style `transactionTime`, `request`, `requiresAccessToken`, and `output.url` parts. It now follows the SQL on FHIR shape: `exportId`, `status`, the echoed `clientTrackingId` and `_format`, the export timing fields, and one `output` per view with `name` and one or more `location` parts. Clients parsing the old manifest will not find the download URLs in the same place.
- **`patient` and `group` parameter types changed.** On the run and export operations, `patient` moves from bare string IDs to `Reference`, and `group` moves from `id` to `Reference`. Requests sending the old types will be rejected.
- **Async kick-off acknowledgement body changed.** The SQL on FHIR async operations now return a `Parameters` acknowledgement (`status=accepted`, `exportId`) with the 202, in place of the previous OperationOutcome. The FHIR Bulk Data `$export` kick-off body is deliberately unchanged.
- **Unsupported `_format` is now rejected.** A non-blank `_format` that matches no supported code or media type now returns 400 rather than silently falling back to the default. A client relying on a typo or an unsupported value quietly defaulting will now see an error.
- **The `source` parameter is now rejected.** Previously accepted and silently ignored, supplying `source` now returns an error. Low impact in practice, since it never had any effect.
- **Pathling-authored OperationDefinitions removed.** The server no longer serves its own OperationDefinition resources for these operations, and the CapabilityStatement now references the spec canonical URLs under `http://sql-on-fhir.org/OperationDefinition/`. Clients that fetched the Pathling OperationDefinitions or matched on the old canonical URLs will need to point at the spec canonicals.

The internal refactors (the `AsyncPattern` enum replacing `redirectOnComplete`, the shared `SqlQueryPipeline`, and the extracted `operations/export` package) are confined to the server module and do not affect the public library API, so they are not breaking. The new `sqlQueryExportEnabled` flag is additive and defaults to `true`.

## Shared machinery

To avoid duplication, the shared asynchronous-export machinery is extracted into a new `operations/export` package - a generic completion-manifest builder, a file writer, and a filtered data-source builder - reused by both export operations. `$sqlquery-run` and `$sqlquery-export` now share a common `SqlQueryPipeline`. The boolean `redirectOnComplete` marker on the async machinery is replaced with an `AsyncPattern` enum (`STANDARD_ASYNC_PATTERN`, `BULK_DATA`) so `@AsyncSupported` reads as a deliberate choice between two named patterns, and the Javadoc that misattributed redirect-based completion to a "SQL on FHIR unify-async" spec now cites the HL7 Asynchronous Interaction Request Pattern.

## Admin UI

The SQL query result card gains an export affordance, backed by a reusable export-job card shared with the ViewDefinition export flow. The manifest parser reads the spec-shaped output `location` parts (one or more per output), emitting one download entry per file.

## Testing

The branch adds extensive unit and integration coverage for the new operation and the alignment changes, including provider integration tests across all levels and transports, format and disabled-flag integration tests, request-parser and executor unit tests, conformance assertions, and Playwright end-to-end coverage in the admin UI. Documentation for the run, export, and `$sqlquery-run` operations is updated, and a new `sql-export.md` page is added.

Resolves #2633.
