### PR TITLE
Restore the dual-role server image for Spark on Kubernetes

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -847,12 +847,23 @@
                 </tags>
               </to>
               <container>
-                <jvmFlags>
-                  <jvmFlag>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED</jvmFlag>
-                  <jvmFlag>--add-opens=java.base/java.net=ALL-UNNAMED</jvmFlag>
-                  <jvmFlag>--add-opens=java.base/sun.util.calendar=ALL-UNNAMED</jvmFlag>
-                </jvmFlags>
+                <!-- The dispatching entrypoint selects the server or executor role from the
+                     container's first argument. The Pathling JVM module options previously set
+                     here as jvmFlags now live in the entrypoint, since Jib ignores jvmFlags once
+                     an explicit entrypoint is configured. -->
+                <entrypoint>
+                  <command>/usr/bin/entrypoint.sh</command>
+                </entrypoint>
               </container>
+              <extraDirectories>
+                <paths>src/main/jib</paths>
+                <permissions>
+                  <permission>
+                    <file>/usr/bin/entrypoint.sh</file>
+                    <mode>755</mode>
+                  </permission>
+                </permissions>
+              </extraDirectories>
             </configuration>
             <executions>
               <execution>
@@ -868,6 +879,28 @@
                 <goals>
                   <goal>build</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <!-- Verify the dual-role entrypoint's dispatch logic before the image is built.
+                 This runs without Docker, a network, or a cluster. -->
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>entrypoint-dispatch-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <skip>${skipTests}</skip>
+                  <executable>bash</executable>
+                  <arguments>
+                    <argument>${project.basedir}/src/test/sh/entrypoint-test.sh</argument>
+                  </arguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -938,12 +971,23 @@
                 <image>${pathling.fhirServerDockerRepo}:${project.version}</image>
               </to>
               <container>
-                <jvmFlags>
-                  <jvmFlag>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED</jvmFlag>
-                  <jvmFlag>--add-opens=java.base/java.net=ALL-UNNAMED</jvmFlag>
-                  <jvmFlag>--add-opens=java.base/sun.util.calendar=ALL-UNNAMED</jvmFlag>
-                </jvmFlags>
+                <!-- The dispatching entrypoint selects the server or executor role from the
+                     container's first argument. The Pathling JVM module options previously set
+                     here as jvmFlags now live in the entrypoint, since Jib ignores jvmFlags once
+                     an explicit entrypoint is configured. -->
+                <entrypoint>
+                  <command>/usr/bin/entrypoint.sh</command>
+                </entrypoint>
               </container>
+              <extraDirectories>
+                <paths>src/main/jib</paths>
+                <permissions>
+                  <permission>
+                    <file>/usr/bin/entrypoint.sh</file>
+                    <mode>755</mode>
+                  </permission>
+                </permissions>
+              </extraDirectories>
             </configuration>
             <executions>
               <execution>
@@ -959,6 +1003,28 @@
                 <goals>
                   <goal>build</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <!-- Verify the dual-role entrypoint's dispatch logic before the image is built.
+                 This runs without Docker, a network, or a cluster. -->
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>entrypoint-dispatch-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <skip>${skipTests}</skip>
+                  <executable>bash</executable>
+                  <arguments>
+                    <argument>${project.basedir}/src/test/sh/entrypoint-test.sh</argument>
+                  </arguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/server/src/main/jib/usr/bin/entrypoint.sh
+++ b/server/src/main/jib/usr/bin/entrypoint.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Copyright © 2025, Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+# ABN 41 687 119 230. Licensed under the Apache License, Version 2.0.
+#
+# @author John Grimes
+#
+# Role-dispatching entrypoint for the dual-role Pathling server image. The image
+# runs as either the FHIR server (the default) or a Spark Kubernetes executor,
+# selected by the container's first argument. Spark on Kubernetes launches
+# executor pods from this image with the single argument "executor" and no
+# command override, so the role selection must live in the image entrypoint.
+#
+# Modified from the Spark Kubernetes Docker image entrypoint script:
+# https://github.com/apache/spark/blob/v4.0.0/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+
+set -e
+
+# The Pathling JVM module options required on Java 21. Both roles must run with
+# these, so they are defined once here and referenced from each branch. They
+# were previously supplied by the Jib build's jvmFlags, which Jib ignores once
+# an explicit entrypoint is configured.
+PATHLING_JVM_OPTS=(
+  --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+  --add-opens=java.base/java.net=ALL-UNNAMED
+  --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+)
+
+case "$1" in
+  # The "executor" argument runs the container as a Spark Kubernetes executor.
+  executor)
+    echo "Starting Pathling in Spark executor role." >&2
+    # Collect the per-executor JVM options Spark injects via SPARK_JAVA_OPT_*.
+    # The grep returns a non-zero status when there are no matches, so it is
+    # guarded to avoid aborting the script under "set -e".
+    readarray -t SPARK_EXECUTOR_JAVA_OPTS < <(env | grep SPARK_JAVA_OPT_ | sort -t_ -k4 -n | sed 's/[^=]*=\(.*\)/\1/g' || true)
+    CMD=(
+      java
+      "${PATHLING_JVM_OPTS[@]}"
+      "${SPARK_EXECUTOR_JAVA_OPTS[@]}"
+      -Xms"$SPARK_EXECUTOR_MEMORY"
+      -Xmx"$SPARK_EXECUTOR_MEMORY"
+      -cp @/app/jib-classpath-file
+      org.apache.spark.scheduler.cluster.k8s.KubernetesExecutorBackend
+      --driver-url "$SPARK_DRIVER_URL"
+      --executor-id "$SPARK_EXECUTOR_ID"
+      --cores "$SPARK_EXECUTOR_CORES"
+      --app-id "$SPARK_APPLICATION_ID"
+      --hostname "$SPARK_EXECUTOR_POD_IP"
+      --resourceProfileId "$SPARK_RESOURCE_PROFILE_ID"
+      --podName "$SPARK_EXECUTOR_POD_NAME"
+    )
+    ;;
+
+  # Any other argument (including none) runs the FHIR server.
+  *)
+    echo "Starting Pathling in FHIR server role." >&2
+    CMD=(
+      java
+      "${PATHLING_JVM_OPTS[@]}"
+      -cp @/app/jib-classpath-file
+      au.csiro.pathling.PathlingServer
+    )
+    ;;
+esac
+
+# In dry-run mode, print the resolved command for testing instead of running it.
+if [ -n "${PATHLING_ENTRYPOINT_DRY_RUN:-}" ]; then
+  echo "${CMD[@]:-}"
+else
+  exec "${CMD[@]}"
+fi

--- a/server/src/main/jib/usr/bin/entrypoint.sh
+++ b/server/src/main/jib/usr/bin/entrypoint.sh
@@ -11,7 +11,7 @@
 # command override, so the role selection must live in the image entrypoint.
 #
 # Modified from the Spark Kubernetes Docker image entrypoint script:
-# https://github.com/apache/spark/blob/v4.0.0/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+# https://github.com/apache/spark/blob/v4.0.2/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
 
 set -e
 

--- a/server/src/test/sh/entrypoint-test.sh
+++ b/server/src/test/sh/entrypoint-test.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Copyright © 2025, Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+# ABN 41 687 119 230. Licensed under the Apache License, Version 2.0.
+#
+# @author John Grimes
+#
+# Dry-run test of the dual-role image entrypoint's role-selection logic. It runs
+# the entrypoint with PATHLING_ENTRYPOINT_DRY_RUN set, capturing the resolved
+# start-up command rather than executing it, and asserts on that command. The
+# test needs no Docker, no network, and no cluster.
+
+set -euo pipefail
+
+# Resolve the entrypoint path relative to this script so the test works
+# regardless of the working directory it is invoked from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENTRYPOINT="$SCRIPT_DIR/../../main/jib/usr/bin/entrypoint.sh"
+
+# Dry-run mode makes the entrypoint print the resolved command instead of
+# exec-ing it.
+export PATHLING_ENTRYPOINT_DRY_RUN=1
+
+PASS=0
+FAIL=0
+
+# Asserts that the resolved command contains an expected substring.
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "    expected to contain: $needle"
+    echo "    actual: $haystack"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Asserts that the resolved command does not contain a substring.
+assert_not_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "    expected NOT to contain: $needle"
+    echo "    actual: $haystack"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# User Story 1: the "executor" argument resolves to a Spark executor backend.
+echo "User Story 1: executor role"
+executor_cmd="$(env \
+  SPARK_EXECUTOR_MEMORY=1g \
+  SPARK_DRIVER_URL=spark://driver:7077 \
+  SPARK_EXECUTOR_ID=1 \
+  SPARK_EXECUTOR_CORES=2 \
+  SPARK_APPLICATION_ID=app-test \
+  SPARK_EXECUTOR_POD_IP=10.0.0.1 \
+  SPARK_RESOURCE_PROFILE_ID=0 \
+  SPARK_EXECUTOR_POD_NAME=exec-1 \
+  SPARK_JAVA_OPT_0=-Dsample.java.opt=on \
+  bash "$ENTRYPOINT" executor 2>/dev/null)"
+
+assert_contains "launches the Spark Kubernetes executor backend" "$executor_cmd" \
+  "org.apache.spark.scheduler.cluster.k8s.KubernetesExecutorBackend"
+assert_contains "passes the driver URL" "$executor_cmd" "--driver-url spark://driver:7077"
+assert_contains "passes the executor id" "$executor_cmd" "--executor-id 1"
+assert_contains "passes the executor cores" "$executor_cmd" "--cores 2"
+assert_contains "passes the application id" "$executor_cmd" "--app-id app-test"
+assert_contains "passes the hostname" "$executor_cmd" "--hostname 10.0.0.1"
+assert_contains "passes the resource profile id" "$executor_cmd" "--resourceProfileId 0"
+assert_contains "passes the pod name" "$executor_cmd" "--podName exec-1"
+assert_contains "sizes the minimum heap from executor memory" "$executor_cmd" "-Xms1g"
+assert_contains "sizes the maximum heap from executor memory" "$executor_cmd" "-Xmx1g"
+assert_contains "applies the Spark-injected JVM options" "$executor_cmd" "-Dsample.java.opt=on"
+assert_contains "uses the generated classpath file" "$executor_cmd" "@/app/jib-classpath-file"
+assert_not_contains "does not launch the FHIR server" "$executor_cmd" \
+  "au.csiro.pathling.PathlingServer"
+
+# User Story 2: no argument (and an unrecognised argument) resolve to the FHIR
+# server.
+echo "User Story 2: default server role"
+server_cmd="$(bash "$ENTRYPOINT" 2>/dev/null)"
+unknown_cmd="$(bash "$ENTRYPOINT" anything-else 2>/dev/null)"
+
+assert_contains "no argument launches the FHIR server" "$server_cmd" \
+  "au.csiro.pathling.PathlingServer"
+assert_contains "no argument uses the generated classpath file" "$server_cmd" \
+  "@/app/jib-classpath-file"
+assert_not_contains "no argument does not launch the executor backend" "$server_cmd" \
+  "KubernetesExecutorBackend"
+assert_contains "unrecognised argument launches the FHIR server" "$unknown_cmd" \
+  "au.csiro.pathling.PathlingServer"
+assert_not_contains "unrecognised argument does not launch the executor backend" \
+  "$unknown_cmd" "KubernetesExecutorBackend"
+
+# User Story 3: both roles carry the three Pathling JVM module options.
+echo "User Story 3: JVM module options in both roles"
+for opt in \
+  "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED" \
+  "--add-opens=java.base/java.net=ALL-UNNAMED" \
+  "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED"; do
+  assert_contains "executor command carries $opt" "$executor_cmd" "$opt"
+  assert_contains "server command carries $opt" "$server_cmd" "$opt"
+done
+
+# Pass/fail summary. Exits non-zero if any assertion failed.
+echo
+echo "Passed: $PASS, Failed: $FAIL"
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
Cluster-mode (Spark on Kubernetes) deployments of the 3.0.0 server image never reach Ready. Spark launches executor pods from the same image with the single argument `executor`, but the image's default entrypoint always starts the FHIR server, so executor pods never register and the driver hangs. This regressed in the 3.0.0 `server/` rewrite, which dropped the v7.2.0 dispatching entrypoint.

This restores a role-dispatching entrypoint (`server/src/main/jib/usr/bin/entrypoint.sh`): `executor` launches `KubernetesExecutorBackend`, anything else launches the FHIR server. Since Jib ignores `jvmFlags` once an explicit entrypoint is set, the Java 21 module options move into the script for both roles. A Bash dry-run test (`entrypoint-test.sh`) verifies the dispatch logic without Docker or a cluster, run via exec-maven-plugin in the `docker` and `dockerPreRelease` profiles.

Verified locally with `mvn clean package -Pdocker`. The CSIRO cluster redeploy and live executor-registration check remain a manual follow-up.

Targets `release/server/3.0.0` rather than `main`, since it builds on the v3.0.0 release branch (PR #2635).