### PR TITLE
feat: Add SQL-on-FHIR benchmark runner as a dedicated module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ together with the core. They are also child modules of the main `pom.xml`.
 - `site` - A website that contains documentation for Pathling.
 - `benchmark` - A benchmark for evaluating the performance of Pathling query
   execution.
+- `sof-benchmark` - A runner for the implementation-agnostic SQL-on-FHIR
+  performance benchmark, executed over the Pathling engine.
 
 The following modules are versioned independently and are **not** children of
 the main `pom.xml`:
@@ -57,6 +59,7 @@ graph TD
     r[lib/R<br/>R bindings]
     site[site<br/>Documentation website]
     benchmark[benchmark<br/>Performance benchmarks]
+    sof-benchmark[sof-benchmark<br/>SQL-on-FHIR benchmark runner]
     server[server<br/>FHIR server]
     ui[ui<br/>Admin UI]
     test-data[test-data<br/>Test data generation]
@@ -79,6 +82,7 @@ graph TD
     site --> python
     site --> r
     benchmark --> test-data
+    sof-benchmark --> library-runtime
 ```
 
 The "public API" of Pathling is defined as the public API of the library API

--- a/openspec/changes/archive/2026-06-30-add-sof-benchmark-runner/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-30-add-sof-benchmark-runner/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-30

--- a/openspec/changes/archive/2026-06-30-add-sof-benchmark-runner/design.md
+++ b/openspec/changes/archive/2026-06-30-add-sof-benchmark-runner/design.md
@@ -1,0 +1,189 @@
+## Context
+
+The `sql-on-fhir` submodule ships an implementation-agnostic SQL-on-FHIR
+benchmark: a declarative Synthea dataset recipe + ViewDefinition cases + per-size
+expected row counts (`benchmark.schema.json`), a Bun/JS reference materializer and
+reference runner (`sof-js`), and a report contract (`benchmark-report.schema.json`).
+The runner contract claims to be satisfiable "in any language," but the reference
+runner locates its data by `import`-ing the JS materializer's `layout.js`
+(`recipeHash = sha256(stableStringify(recipe)).slice(0,8)`), an algorithm specified
+nowhere normative. A second, non-JS implementation is the cheapest way to expose
+that and the other assumptions the spec inherited from its sole implementation.
+
+Pathling is a deliberate adversary: JVM-based (cannot import the JS tooling),
+Spark-based (large fixed startup; lazy evaluation), strongly typed, and
+distributed-by-design (columnar encode is a first-class, expensive phase). The
+predicted spec weaknesses are written up in
+`sql-on-fhir/docs/superpowers/specs/2026-06-30-pathling-second-implementation-findings.md`;
+this runner is the instrument that confirms them with numbers.
+
+The API surfaces below were verified against the actual library-api / `pathling`
+sources, and the timing-harness design was validated against the real
+`QueryableDataSource` / `DataSource` / `DatasetSource` classes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A Java runner (in the dedicated `sof-benchmark` module) and a Python runner (over
+  the `pathling` package) that each satisfy the `sof-benchmark-runner` capability:
+  manifest-first data location, single-view execute+extract timing with warmup
+  discarded, separate load-phase measurement, the row-count correctness guard, and
+  a schema-valid `benchmark-report.json`.
+- Demonstrate finding F1's fix by locating data via `manifest.json` matching,
+  with zero knowledge of the JS recipe hash.
+- Produce evidence for findings F2 (startup/codegen/encode overhead dominates the
+  small size tiers), F4 (load is the hidden cost), and the Java-vs-Python
+  binding-layer overhead.
+
+**Non-Goals:**
+
+- No changes to the existing JMH microbenchmark in `benchmark/`.
+- No changes to the `sql-on-fhir` spec or tooling (improvements remain proposals
+  in the findings doc).
+- No data generation: materialization stays the submodule's `bun run data` tool.
+- No publishing/registration of Pathling on the implementations page.
+- No new benchmark cases; no F3 reference-in-filter probe (separate follow-up).
+
+## Decisions
+
+### D1 — Manifest-first data discovery (not hash recomputation)
+
+`ManifestLocator` scans `<dataRoot>/*/<size>/manifest.json`, parses each, and
+selects the directory whose manifest matches `dataset.name`, the requested `size`,
+and `dataset.sizes[size].population`. The manifest (written by the materializer)
+already carries all three, so the JS canonicalization is never reproduced.
+
+*Alternative considered:* port `stableStringify` + SHA-256 + 8-char truncation to
+Java/Python to compute the same path. Rejected — fragile across languages and
+undocumented; reproducing it would defeat the point of the spike, which is to show
+the contract should not demand it.
+
+### D2 — Both Java and Python runners, table/csv sink
+
+The engine (library-runtime JVM) is identical for both APIs; the Python API is a
+py4j wrapper. Building both isolates the binding-layer overhead as a bonus finding.
+With a **table/csv sink** (Spark writes the result from executors — the design's
+own recommended measurement boundary, "never a lazy count"), the driver language
+barely affects the timed write, keeping Java and Python comparable; under a
+collect-to-memory sink the Python py4j row marshalling would confound it.
+
+### D3 — Clean phase separation under Spark laziness (Java)
+
+`pc.read().ndjson(dir)` and `view(...).execute()` are lazy, so a naive first
+`write()` would secretly include parse + encode. The load phase therefore:
+
+```java
+QueryableDataSource ndjson = pc.read().ndjson(datasetDir);
+Dataset<Row> encoded = ndjson.read(subject).cache();   // DataSource.read(String): the lazy encoded ds
+long inputRows = encoded.count();                       // ACTION: forces parse+encode, populates cache
+DatasetSource cached = pc.read().datasets().dataset(subject, encoded);
+```
+
+`ds.read(subject)` (declared on `fhirpath/.../io/source/DataSource.java`) returns
+the FHIR-encoded dataset — the same pipeline `PathlingBenchmarkState` builds by
+hand. `count()` doubles as the report's `inputRows`. The timed loop then runs the
+view against `cached`, so it measures view evaluation + write over an
+`InMemoryRelation`, not NDJSON parse/encode. `QueryableDataSource.cache()` alone is
+insufficient (still lazy, returns the wider `DataSource` type without `view()`, and
+caches every resource type), so the explicit `read(subject).cache().count()` +
+rebuild-as-`DatasetSource` path is used.
+
+### D4 — Time `write()`, count separately
+
+```java
+Dataset<Row> r = cached.view(subject).json(viewJson).execute();
+long t0 = nanoTime();
+r.write().format(sink).mode(Overwrite).save(outDir);   // execute+extract, fused
+sampleMs = (nanoTime()-t0)/1e6;
+long outputRows = r.count();                            // untimed correctness guard
+```
+
+`count()` is never the timed metric (Catalyst would prune projected columns and
+under-measure); `write()` forces full materialization. `execute` and `extract` are
+**not separable** in a lazy engine — the write fuses them — so they are reported as
+one combined timed region with `phases: ["execute","extract"]`, and `load` is
+recorded separately (D3). This inseparability is itself recorded as a design note
+feeding the findings.
+
+### D5 — Warmup loop in a single JVM
+
+Whole-stage codegen is cached in a JVM-static Guava cache, so warmup iterations in
+the same process correctly absorb codegen + Catalyst warmup; subsequent measured
+iterations reuse generated classes. The runner is a plain `main` (no JMH fork), so
+the cache persists across warmup→measurement. Writes go to one fixed temp dir with
+`SaveMode.Overwrite`. `spark.sql.shuffle.partitions` is set low (≈ cores) so the
+tiny SoF inputs don't spawn ~200 tiny part-files and add scheduling noise.
+
+### D6 — A dedicated module rather than reusing the JMH `benchmark` module
+
+The runner lives in its own `sof-benchmark` module, fully separate from the JMH
+`benchmark` module. The two share no Java code — only the `library-runtime` and
+Spark dependencies any consumer declares — so co-locating them only forced one
+module to carry the other's dependencies (JMH, `test-data`) and a single shaded
+`mainClass`. The dedicated module shades
+`au.csiro.pathling.sof.benchmark.SofBenchmarkRunner` as its own `mainClass` and a
+`ServicesResourceTransformer` merges Spark's CSV/parquet `META-INF/services`,
+which the write path depends on.
+
+### D7 — JSON handling: Jackson to extract, Gson inside Pathling
+
+`com.fasterxml.jackson.core:jackson-databind` is added to `sof-benchmark/pom.xml`
+without a version (managed by the imported `jackson-bom` in the root pom). The
+runner parses the benchmark file with Jackson (`readTree`), iterates `cases[]`, and
+re-serializes each `case.view` node to a string via `writeValueAsString`. That
+string is passed to `FhirViewQuery.json(String)`, which deserializes with Gson
+internally — the hand-off is a plain JSON string, so the Jackson/Gson split is a
+non-issue (never hand Pathling a Jackson node).
+
+### D8 — Python runner mirrors the Java design
+
+`sof-benchmark/python/sof_runner.py` uses `click` (same flags, matching the
+Pathling Python CLI's `click>=8.1.7`), stdlib `json`/
+`pathlib` for manifest discovery, `pc.read.ndjson(dir)`,
+`ds.view(json=view_json_string)` → DataFrame, and `df.write.format(sink)
+.mode("overwrite").save()` timed with `df.count()` as the untimed guard. Phase
+separation uses the analogous Python accessors (`ds.read(resource)`,
+`df.cache()`/`df.count()`, `pc.read.datasets().dataset(...)`) — the exact Python
+method names are confirmed in `lib/python/pathling/datasource.py` at implementation
+time (low risk; a thin wrapper over the same JVM API). It emits the identical
+report structure with `implementation.name = "pathling-python"`.
+
+### Report shape (both runners, per `benchmark-report.schema.json`)
+
+```jsonc
+{ "implementation": {"name":"pathling-java","version":"9.9.0-SNAPSHOT"},
+  "benchmarkVersion": "<submodule git sha>",
+  "environment": {"os":…, "java":…, "spark":…, "cores":…},
+  "measurement": {"phases":["execute","extract"], "sink":"csv", "warmup":1, "iterations":5},
+  "results": {"<benchmark.title>": {"size":"s", "fhirVersion":"4.0.1",
+    "cases":[{"title":"condition flat","status":"ok"|"count_mismatch",
+              "inputRows":N,"outputRows":M,"samplesMs":[…],"stats":{min,mean,median,max},
+              "phaseSamplesMs":{"load":[…],"executeExtract":[…]}}]}}}
+```
+
+## Risks / Trade-offs
+
+- **[Cross-environment Synthea determinism]** `clinical-flat`'s blessed counts
+  (Condition s:6219, Observation s:4794) were recorded on another machine; a
+  different OS/JVM may yield different counts. → Treat a `count_mismatch` as a
+  recorded data point for the spec's §13.6 open question, not a build failure.
+- **[Tiny size tiers vs Spark]** At `s`/`m`, Spark startup + codegen + encode may
+  dwarf the query, so the headline number characterizes overhead, not throughput.
+  → This is expected and is precisely finding F2; the report's separate `load` and
+  the overhead fraction are the evidence, not a defect to hide.
+- **[Python phase-separation accessors unconfirmed]** `ds.read(resource)` /
+  `pc.read.datasets()` Python names assumed by analogy. → Confirm in
+  `lib/python/pathling/datasource.py` before coding; fall back to caching the
+  DataFrame returned by the view's input if the dataset-source builder is not
+  exposed.
+- **[Ivy cache staleness]** Python runs may pick up a stale library-runtime after
+  a Java rebuild. → Clear `~/.ivy2*` before Python runs (known project gotcha).
+
+## Open Questions
+
+- Where the Python runner's dependencies are declared (a `requirements.txt`/`uv`
+  vs. relying on the locally-built `pathling` wheel) — resolve at implementation
+  against how `lib/python` tests are run.
+- Whether to also capture a `--size m` run in v1 for a 2-point scaling read, or
+  defer to a follow-up once `s` is green end-to-end.

--- a/openspec/changes/archive/2026-06-30-add-sof-benchmark-runner/proposal.md
+++ b/openspec/changes/archive/2026-06-30-add-sof-benchmark-runner/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+The `sql-on-fhir` submodule defines an implementation-agnostic SQL-on-FHIR
+performance benchmark (a Synthea dataset recipe + ViewDefinition cases +
+per-size expected row counts), but so far it has been exercised only by its own
+Bun/JS reference runner — meaning the spec and its sole implementation
+co-evolved and share each other's blind spots. Building Pathling (JVM + Apache
+Spark) as an independent second runner both stress-tests that benchmark spec
+from a radically different engine and gives Pathling a reusable, reportable
+SQL-on-FHIR performance harness.
+
+## What Changes
+
+- Add a **Java benchmark runner** in a dedicated `sof-benchmark` module (new
+  `au.csiro.pathling.sof.benchmark` package) that reads a benchmark file, locates
+  its materialized NDJSON, executes each `case.view` through the Pathling
+  library-api, times execute+extract to a table/csv sink, checks output row
+  counts against `expectCount`, and emits a `benchmark-report.json`.
+- Add a **Python benchmark runner** (`sof-benchmark/python/sof_runner.py`) that
+  mirrors the Java runner over the `pathling` package, so the same workload can
+  be measured through the language bindings — isolating binding-layer overhead.
+- **Locate data manifest-first**: discover the materialized dataset directory by
+  matching `manifest.json` on dataset `name` + `size` + `population`, rather than
+  recomputing the reference runner's recipe hash. This deliberately demonstrates
+  the fix proposed in the second-implementation findings (the "any-language"
+  contract should not require reproducing an undocumented JS canonicalization).
+- **Separate the load phase** (NDJSON read + FHIR encode) from the timed
+  execute+extract region, so the report exposes the columnar-ingest cost that an
+  in-memory engine hides.
+- Leave the existing JMH microbenchmark in `benchmark/` **untouched**; the new
+  runner lives in its own `sof-benchmark` module with its own shaded `mainClass`,
+  so the two benchmarks share no code and no build wiring.
+- Record the resulting measurements back into the findings document to convert
+  its predicted spec weaknesses (startup overhead dominating small size tiers;
+  load being the hidden cost; Java-vs-Python binding overhead) into confirmed,
+  evidenced findings.
+
+## Capabilities
+
+### New Capabilities
+
+- `sof-benchmark-runner`: Running the implementation-agnostic SQL-on-FHIR
+  benchmark with Pathling. Covers manifest-first data location, single-view
+  execute+extract timing with warmup discarded, separate load-phase measurement,
+  the output row-count correctness guard (`ok` / `count_mismatch`), schema-valid
+  `benchmark-report.json` emission, and parity between the Java and Python
+  runners.
+
+### Modified Capabilities
+
+<!-- None. No existing Pathling capability's requirements change; the JMH
+     microbenchmark is untouched and the SQL-on-FHIR spec files are not modified. -->
+
+## Impact
+
+- **New code**: `sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/`
+  (`SofBenchmarkRunner`, `ManifestLocator`, `MeasurementHarness`, `ReportWriter`,
+  `BenchmarkFile`); `sof-benchmark/python/sof_runner.py` + a short `README.md`.
+- **Build**: a new `sof-benchmark` module (child of the root `pom.xml`) depending
+  on `library-runtime`, `spark-sql` and
+  `com.fasterxml.jackson.core:jackson-databind` (version managed by the imported
+  `jackson-bom`), shaded with its own `SofBenchmarkRunner` `mainClass`.
+- **Consumes** (read-only) the library-api surface: `PathlingContext`,
+  `QueryableDataSource.read(String)` / `view(...).json(...).execute()`,
+  `DataSourceBuilder.datasets()`, and standard Spark `Dataset.write()`.
+- **Prerequisite, not code**: materialized data from the submodule's
+  `bun run data` tool, which needs `synthea-with-dependencies-3.2.0.jar` and a
+  local `executors.config.json` (both gitignored).
+- **Out of scope**: no changes to the JMH module, no changes to the `sql-on-fhir`
+  spec/tooling (improvements there remain written-up proposals), no publishing of
+  Pathling on the implementations page.

--- a/openspec/changes/archive/2026-06-30-add-sof-benchmark-runner/specs/sof-benchmark-runner/spec.md
+++ b/openspec/changes/archive/2026-06-30-add-sof-benchmark-runner/specs/sof-benchmark-runner/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: Manifest-first data location
+
+The runner SHALL locate a benchmark's materialized NDJSON by scanning the
+`manifest.json` files beneath the configured data root and selecting the dataset
+directory whose manifest matches the benchmark's dataset `name`, the requested
+`size`, and the `population` declared for that size. The runner SHALL NOT require
+recomputing the reference materializer's recipe hash to find the data.
+
+#### Scenario: Matching manifest is selected
+
+- **WHEN** the data root contains a `manifest.json` with `name`, `size` and
+  `population` equal to the benchmark's dataset name, the requested size, and that
+  size's declared population
+- **THEN** the runner uses that manifest's directory and reads each case's
+  `<view.resource>.ndjson` from it
+
+#### Scenario: No matching manifest
+
+- **WHEN** no manifest under the data root matches the dataset name, size and
+  population
+- **THEN** the runner reports a clear error identifying the unmet (name, size,
+  population) rather than silently producing an empty result
+
+### Requirement: Single-view execute-and-extract timing
+
+For each case, the runner SHALL evaluate the case's `view` over the materialized
+data for the chosen size and time a region that covers both evaluation and a full
+materialization of the result to a table/csv sink (never a lazy count). The runner
+SHALL run the warmup iterations before the measured iterations and SHALL discard
+the warmup samples, returning one timing sample per measured iteration.
+
+#### Scenario: Warmup discarded, one sample per measured iteration
+
+- **WHEN** a case is timed with `warmup: 1` and `measurement: 5`
+- **THEN** the report contains exactly five timing samples for that case
+- **AND** none of the samples correspond to the warmup iteration
+
+#### Scenario: Materialization is timed, not a lazy count
+
+- **WHEN** the runner measures a case
+- **THEN** the timed region writes the full result to the configured sink
+- **AND** the output row count is obtained outside the timed region
+
+### Requirement: Load phase measured separately
+
+The runner SHALL read and FHIR-encode the input as a distinct load phase, force
+its materialization before the timed execute+extract region so that region does
+not absorb parse/encode cost, and record the load duration separately in the
+report.
+
+#### Scenario: Load cost excluded from execute+extract
+
+- **WHEN** a benchmark case is measured
+- **THEN** the input has already been materialized when the timed execute+extract
+  region begins
+- **AND** the report records the load duration separately from the execute+extract
+  samples
+
+### Requirement: Output row-count correctness guard
+
+For each case, the runner SHALL compare the output row count against
+`expectCount[size]`: when the expectation is present and equal it SHALL report
+`ok`; when present and unequal it SHALL report `count_mismatch`; when absent it
+SHALL report `ok`. A `count_mismatch` SHALL be recorded in the report rather than
+aborting the run.
+
+#### Scenario: Matching count is ok
+
+- **WHEN** a case's output row count equals its `expectCount[size]`
+- **THEN** the case is reported as `ok`
+
+#### Scenario: Mismatching count is flagged but does not abort
+
+- **WHEN** a case's output row count differs from a present `expectCount[size]`
+- **THEN** the case is reported as `count_mismatch`
+- **AND** the runner continues measuring the remaining cases and still emits a
+  report
+
+### Requirement: Schema-valid benchmark report
+
+The runner SHALL emit a `benchmark-report.json` that conforms to
+`benchmark-report.schema.json`, including the `implementation` (name and version),
+a `measurement` block declaring the timed `phases`, `sink`, and actual `warmup` and
+`iterations` counts, and a `results` entry per benchmark keyed by title with `size`,
+`fhirVersion`, and per-case `status`, `inputRows`, `outputRows`, timing samples and
+stats.
+
+#### Scenario: Report validates against the schema
+
+- **WHEN** the runner completes a benchmark
+- **THEN** the emitted report validates against `benchmark-report.schema.json`
+- **AND** the `measurement` block records the sink and the actual warmup and
+  measurement iteration counts used
+
+### Requirement: Java and Python runner parity
+
+The change SHALL provide two runners — a Java runner over the library-api and a
+Python runner over the `pathling` package — that both implement the runner
+behaviour above. Both runners MUST accept the same inputs (benchmark file, size,
+data root, sink) and MUST emit reports of the same structure, distinguished only
+by `implementation.name`.
+
+#### Scenario: Equivalent inputs produce structurally equivalent reports
+
+- **WHEN** the Java and Python runners are run over the same benchmark file, size
+  and materialized data
+- **THEN** both emit schema-valid reports with the same benchmark and case titles
+  and the same output row counts
+- **AND** the reports differ only in `implementation.name` and the timing values

--- a/openspec/changes/archive/2026-06-30-add-sof-benchmark-runner/tasks.md
+++ b/openspec/changes/archive/2026-06-30-add-sof-benchmark-runner/tasks.md
@@ -1,0 +1,37 @@
+## 1. Data materialization prerequisite (one-off, gitignored)
+
+- [x] 1.1 Download `synthea-with-dependencies-3.2.0.jar` into `sql-on-fhir/benchmark/bin/` and create `sql-on-fhir/benchmark/tools/executors.config.json` from the sample, pointing `jar` at it.
+- [x] 1.2 Run `cd sql-on-fhir/benchmark && bun install && bun run data clinical-flat.json --size s`; confirm `data/synthea-clinical_<hash>/s/{Condition,Observation}.ndjson` + `manifest.json` are produced and note the recorded per-resource counts.
+
+## 2. Java runner — build wiring
+
+- [x] 2.1 Create the dedicated `sof-benchmark` module (child of the root `pom.xml`) depending on `library-runtime`, `spark-sql` and `com.fasterxml.jackson.core:jackson-databind` (no version, BOM-managed), with a shade `mainClass` of `au.csiro.pathling.sof.benchmark.SofBenchmarkRunner`.
+- [x] 2.2 Create the `au.csiro.pathling.sof.benchmark` package; the JMH `benchmark` module stays untouched.
+
+## 3. Java runner — implementation
+
+- [x] 3.1 `BenchmarkFile`: parse a benchmark `*.json` with Jackson (`readTree`), exposing `dataset` (name, sizes, resources) and `cases[]` (title, view node, `view.resource`, `expectCount[size]`); provide the view-node-to-string serialization for `.json(...)`.
+- [x] 3.2 `ManifestLocator`: scan `<dataRoot>/*/<size>/manifest.json` and return the dir whose manifest matches dataset `name` + `size` + `population`; clear error when none matches.
+- [x] 3.3 `MeasurementHarness`: load phase (`ds.read(subject).cache().count()` → `pc.read().datasets().dataset(...)`, capturing `inputRows` and `load` duration); warmup loop (discarded); measured loop timing `write()` to a fixed temp dir with `Overwrite`; untimed `count()` for `outputRows`; set `spark.sql.shuffle.partitions` low.
+- [x] 3.4 `ReportWriter`: emit `benchmark-report.json` per `benchmark-report.schema.json` (implementation, environment, `measurement` with phases/sink/warmup/iterations, per-case status/inputRows/outputRows/samplesMs/stats/phaseSamplesMs).
+- [x] 3.5 `SofBenchmarkRunner.main`: CLI (`<benchmarkFile> --size --data --sink csv|parquet --out`), Spark/PathlingContext setup, orchestrate per distinct subject then per case, write the report; `status` = `ok`/`count_mismatch` vs `expectCount`.
+
+## 4. Python runner
+
+- [x] 4.1 Confirm the Python phase-separation accessors in `lib/python/pathling/datasource.py` (`ds.read(resource)`, `pc.read.datasets().dataset(...)`); choose the fallback if the dataset-source builder is not exposed.
+- [x] 4.2 Implement `sof-benchmark/python/sof_runner.py` mirroring the Java runner (`click` CLI, manifest discovery, `pc.read.ndjson`, `ds.view(json=...)`, timed `df.write...`, untimed `df.count()`), emitting the same report structure with `implementation.name = "pathling-python"`.
+- [x] 4.3 Add `sof-benchmark/python/README.md` documenting how to run it (locally-built `pathling` wheel + JVM; clear `~/.ivy2*` after Java rebuilds).
+
+## 5. End-to-end verification
+
+- [x] 5.1 Build: `mvn install -pl library-runtime -am` then `mvn install -pl sof-benchmark -am` (and `lib/python` for Python).
+- [x] 5.2 Run Java: `java -cp sof-benchmark/target/sof-benchmark-9.9.0-SNAPSHOT.jar au.csiro.pathling.sof.benchmark.SofBenchmarkRunner sql-on-fhir/benchmark/clinical-flat.json --size s --data sql-on-fhir/benchmark/data --sink csv --out report-java.json`.
+- [x] 5.3 Run Python: `python sof-benchmark/python/sof_runner.py <same args> --out report-python.json`.
+- [x] 5.4 Validate both reports: `cd sql-on-fhir/benchmark && bunx ajv -s benchmark-report.schema.json -d <report>` — both must be schema-valid.
+- [x] 5.5 Cross-check: outputRows match between runners; compare vs `expectCount` and record any mismatch as a cross-environment-determinism data point (not a failure).
+
+## 6. Convert predicted findings to evidenced
+
+- [x] 6.1 From the reports, compute the startup+codegen+encode overhead fraction at `s` (F2) and the `load` fraction of total (F4), and the Java-vs-Python timing delta (binding overhead).
+- [x] 6.2 Update `sql-on-fhir/docs/superpowers/specs/2026-06-30-pathling-second-implementation-findings.md` F2/F4 and the binding-overhead note with the measured numbers (PREDICTED → CONFIRMED).
+- [x] 6.3 (Optional) Repeat at `--size m` for a 2-point scaling read.

--- a/openspec/specs/sof-benchmark-runner/spec.md
+++ b/openspec/specs/sof-benchmark-runner/spec.md
@@ -1,0 +1,115 @@
+# sof-benchmark-runner Specification
+
+## Purpose
+TBD - created by archiving change add-sof-benchmark-runner. Update Purpose after archive.
+## Requirements
+### Requirement: Manifest-first data location
+
+The runner SHALL locate a benchmark's materialized NDJSON by scanning the
+`manifest.json` files beneath the configured data root and selecting the dataset
+directory whose manifest matches the benchmark's dataset `name`, the requested
+`size`, and the `population` declared for that size. The runner SHALL NOT require
+recomputing the reference materializer's recipe hash to find the data.
+
+#### Scenario: Matching manifest is selected
+
+- **WHEN** the data root contains a `manifest.json` with `name`, `size` and
+  `population` equal to the benchmark's dataset name, the requested size, and that
+  size's declared population
+- **THEN** the runner uses that manifest's directory and reads each case's
+  `<view.resource>.ndjson` from it
+
+#### Scenario: No matching manifest
+
+- **WHEN** no manifest under the data root matches the dataset name, size and
+  population
+- **THEN** the runner reports a clear error identifying the unmet (name, size,
+  population) rather than silently producing an empty result
+
+### Requirement: Single-view execute-and-extract timing
+
+For each case, the runner SHALL evaluate the case's `view` over the materialized
+data for the chosen size and time a region that covers both evaluation and a full
+materialization of the result to a table/csv sink (never a lazy count). The runner
+SHALL run the warmup iterations before the measured iterations and SHALL discard
+the warmup samples, returning one timing sample per measured iteration.
+
+#### Scenario: Warmup discarded, one sample per measured iteration
+
+- **WHEN** a case is timed with `warmup: 1` and `measurement: 5`
+- **THEN** the report contains exactly five timing samples for that case
+- **AND** none of the samples correspond to the warmup iteration
+
+#### Scenario: Materialization is timed, not a lazy count
+
+- **WHEN** the runner measures a case
+- **THEN** the timed region writes the full result to the configured sink
+- **AND** the output row count is obtained outside the timed region
+
+### Requirement: Load phase measured separately
+
+The runner SHALL read and FHIR-encode the input as a distinct load phase, force
+its materialization before the timed execute+extract region so that region does
+not absorb parse/encode cost, and record the load duration separately in the
+report.
+
+#### Scenario: Load cost excluded from execute+extract
+
+- **WHEN** a benchmark case is measured
+- **THEN** the input has already been materialized when the timed execute+extract
+  region begins
+- **AND** the report records the load duration separately from the execute+extract
+  samples
+
+### Requirement: Output row-count correctness guard
+
+For each case, the runner SHALL compare the output row count against
+`expectCount[size]`: when the expectation is present and equal it SHALL report
+`ok`; when present and unequal it SHALL report `count_mismatch`; when absent it
+SHALL report `ok`. A `count_mismatch` SHALL be recorded in the report rather than
+aborting the run.
+
+#### Scenario: Matching count is ok
+
+- **WHEN** a case's output row count equals its `expectCount[size]`
+- **THEN** the case is reported as `ok`
+
+#### Scenario: Mismatching count is flagged but does not abort
+
+- **WHEN** a case's output row count differs from a present `expectCount[size]`
+- **THEN** the case is reported as `count_mismatch`
+- **AND** the runner continues measuring the remaining cases and still emits a
+  report
+
+### Requirement: Schema-valid benchmark report
+
+The runner SHALL emit a `benchmark-report.json` that conforms to
+`benchmark-report.schema.json`, including the `implementation` (name and version),
+a `measurement` block declaring the timed `phases`, `sink`, and actual `warmup` and
+`iterations` counts, and a `results` entry per benchmark keyed by title with `size`,
+`fhirVersion`, and per-case `status`, `inputRows`, `outputRows`, timing samples and
+stats.
+
+#### Scenario: Report validates against the schema
+
+- **WHEN** the runner completes a benchmark
+- **THEN** the emitted report validates against `benchmark-report.schema.json`
+- **AND** the `measurement` block records the sink and the actual warmup and
+  measurement iteration counts used
+
+### Requirement: Java and Python runner parity
+
+The change SHALL provide two runners — a Java runner over the library-api and a
+Python runner over the `pathling` package — that both implement the runner
+behaviour above. Both runners MUST accept the same inputs (benchmark file, size,
+data root, sink) and MUST emit reports of the same structure, distinguished only
+by `implementation.name`.
+
+#### Scenario: Equivalent inputs produce structurally equivalent reports
+
+- **WHEN** the Java and Python runners are run over the same benchmark file, size
+  and materialized data
+- **THEN** both emit schema-valid reports with the same benchmark and case titles
+  and the same output row counts
+- **AND** the reports differ only in `implementation.name` and the timing values
+

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
     <module>lib/R</module>
     <module>site</module>
     <module>benchmark</module>
+    <module>sof-benchmark</module>
   </modules>
 
   <repositories>

--- a/sof-benchmark/pom.xml
+++ b/sof-benchmark/pom.xml
@@ -1,0 +1,91 @@
+<!--
+
+    Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+    Organisation (CSIRO) ABN 41 687 119 230.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>au.csiro.pathling</groupId>
+    <artifactId>pathling</artifactId>
+    <version>9.9.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>sof-benchmark</artifactId>
+  <packaging>jar</packaging>
+  <name>Pathling SQL-on-FHIR Benchmark</name>
+  <description>A runner for the implementation-agnostic SQL-on-FHIR performance benchmark, executed
+    over the Pathling engine.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>au.csiro.pathling</groupId>
+      <artifactId>library-runtime</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_${pathling.scalaVersion}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <createDependencyReducedPom>true</createDependencyReducedPom>
+          <shadedArtifactAttached>false</shadedArtifactAttached>
+          <useDependencyReducedPomInJar>true</useDependencyReducedPomInJar>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+                <exclude>META-INF/MANIFEST.MF</exclude>
+                <exclude>META-INF/versions/**</exclude>
+              </excludes>
+            </filter>
+          </filters>
+          <transformers>
+            <transformer
+              implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+            <transformer
+              implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+              <mainClass>au.csiro.pathling.sof.benchmark.SofBenchmarkRunner</mainClass>
+            </transformer>
+          </transformers>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/sof-benchmark/python/README.md
+++ b/sof-benchmark/python/README.md
@@ -1,0 +1,83 @@
+# SQL-on-FHIR benchmark runner (Python)
+
+`sof_runner.py` runs the implementation-agnostic SQL-on-FHIR benchmark from the
+`sql-on-fhir` submodule through the Pathling **Python** API. It is the
+language-binding counterpart to the Java `SofBenchmarkRunner` in
+`au.csiro.pathling.sof.benchmark`: same inputs, same report structure, only
+`implementation.name` (`pathling-python`) and the timing values differ. Running
+both isolates the binding-layer (py4j) overhead on top of the shared JVM engine.
+
+## Prerequisites
+
+- Java 21 (the Pathling Python API runs Spark on a JVM).
+- A locally-built `pathling` wheel installed into your Python environment, built
+  from this checkout so it matches the Java runner's engine version:
+
+  ```bash
+  mvn clean install -pl lib/python -am
+  ```
+
+  > **Ivy cache staleness:** after rebuilding any upstream Java module, clear the
+  > Ivy cache before running so the Python API picks up the fresh
+  > `library-runtime`, otherwise Spark may resolve a stale jar:
+  >
+  > ```bash
+  > rm -rf ~/.ivy2*
+  > ```
+
+- Materialized benchmark data. The data is **not** checked in — generate it with
+  the submodule's tool (needs the Synthea jar and a local
+  `executors.config.json`):
+
+  ```bash
+  cd sql-on-fhir/benchmark
+  bun install
+  bun run data clinical-flat.json --size s
+  ```
+
+  This writes `data/<name>_<hash>/s/{Condition,Observation}.ndjson` plus a
+  `manifest.json`. The runner locates the data manifest-first (matching dataset
+  `name` + `size` + `population`), so you never reproduce the materializer's
+  recipe hash.
+
+## Run
+
+From the repository root:
+
+```bash
+python sof-benchmark/python/sof_runner.py \
+  sql-on-fhir/benchmark/clinical-flat.json \
+  --size s \
+  --data sql-on-fhir/benchmark/data \
+  --sink csv \
+  --out report-python.json
+```
+
+| Flag       | Meaning                                                       |
+| ---------- | ------------------------------------------------------------- |
+| positional | Path to the benchmark `*.json` file.                          |
+| `--size`   | Size key to run (`s`, `m`, …) — must be declared in the file. |
+| `--data`   | Root directory of materialized datasets.                      |
+| `--sink`   | Spark write format for the timed region (`csv` or `parquet`). |
+| `--out`    | Report output path (default `benchmark-report.json`).         |
+
+## What it measures
+
+- **Load phase (separate):** reads and FHIR-encodes each subject's NDJSON,
+  caches it, and forces materialization with a `count()` before any timing — so
+  the timed region never absorbs parse/encode cost. The load duration is recorded
+  under `phaseSamplesMs.load`.
+- **Execute + extract (timed):** evaluates each case's view and writes the full
+  result to the sink (never a lazy count). Warmup iterations run first and are
+  discarded; one sample is recorded per measured iteration under
+  `phaseSamplesMs.executeExtract`.
+- **Correctness guard:** the output row count (obtained outside the timed region)
+  is compared to `expectCount[size]` — `ok` when equal or absent, otherwise
+  `count_mismatch`. A mismatch is recorded, not fatal.
+
+## Validate the report
+
+```bash
+cd sql-on-fhir/benchmark
+bunx ajv -s benchmark-report.schema.json -d ../../report-python.json
+```

--- a/sof-benchmark/python/sof_runner.py
+++ b/sof-benchmark/python/sof_runner.py
@@ -1,0 +1,386 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""SQL-on-FHIR benchmark runner over the Pathling Python API.
+
+This mirrors the Java ``SofBenchmarkRunner``: it locates a benchmark's materialized
+NDJSON manifest-first, separates the FHIR load/encode phase from the timed
+execute+extract region, times a full write of each case's result (never a lazy
+count), checks the output row count against ``expectCount``, and emits a report
+conforming to ``benchmark-report.schema.json`` with
+``implementation.name = "pathling-python"``.
+"""
+
+import json
+import logging
+import os
+import platform
+import statistics
+import subprocess
+import tempfile
+import time
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import click
+from pathling import PathlingContext
+from pathling.datasource import DataSource
+
+IMPLEMENTATION_NAME = "pathling-python"
+DEFAULT_SINK = "csv"
+DEFAULT_OUT = "benchmark-report.json"
+DEFAULT_WARMUP = 1
+DEFAULT_MEASUREMENT = 5
+
+# The sink categories permitted by ``benchmark-report.schema.json``.
+SCHEMA_SINKS = frozenset({"table", "csv", "memory", "other"})
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("sof_runner")
+
+
+def locate_data_dir(data_root: Path, name: str, size: str, population: int) -> Path:
+    """Locates the size-specific data directory by matching manifests.
+
+    Scans ``<data_root>/*/<size>/manifest.json`` and returns the directory whose manifest
+    matches the dataset name, size and population, so the reference materializer's recipe
+    hash is never reproduced.
+
+    :param data_root: the root directory containing materialized datasets.
+    :param name: the dataset name to match.
+    :param size: the size key to match.
+    :param population: the population to match.
+    :return: the directory containing the matching size's NDJSON files and manifest.
+    :raises FileNotFoundError: if no manifest under the data root matches all three.
+    """
+    if not data_root.is_dir():
+        raise FileNotFoundError(
+            f"Data root does not exist or is not a directory: {data_root}"
+        )
+    for dataset_dir in sorted(data_root.iterdir()):
+        manifest_path = dataset_dir / size / "manifest.json"
+        if not manifest_path.is_file():
+            continue
+        manifest = json.loads(manifest_path.read_text())
+        if (
+            manifest.get("name") == name
+            and manifest.get("size") == size
+            and manifest.get("population") == population
+        ):
+            return manifest_path.parent
+    raise FileNotFoundError(
+        f"No materialized dataset matches (name={name}, size={size}, population={population}) "
+        f"under {data_root}. Run the materializer first: "
+        f"cd sql-on-fhir/benchmark && bun run data <file> --size {size}"
+    )
+
+
+def schema_sink(sink: str) -> str:
+    """Maps a Spark write format to a sink category permitted by the report schema.
+
+    File formats such as ``parquet`` that are not enumerated by the schema are reported
+    as ``other`` so the report stays schema-valid.
+
+    :param sink: the Spark write format used for the timed region.
+    :return: a schema-valid sink category.
+    """
+    return sink if sink in SCHEMA_SINKS else "other"
+
+
+def stats_for(samples: List[float]) -> Dict[str, float]:
+    """Computes summary statistics for a list of timing samples.
+
+    :param samples: the timing samples in milliseconds.
+    :return: a dict with min, mean, median and max (empty if there are no samples).
+    """
+    if not samples:
+        return {}
+    return {
+        "min": min(samples),
+        "mean": statistics.fmean(samples),
+        "median": statistics.median(samples),
+        "max": max(samples),
+    }
+
+
+def resolve_benchmark_version(benchmark_file: Path) -> Optional[str]:
+    """Best-effort resolution of the benchmark submodule git SHA.
+
+    :param benchmark_file: the path to the benchmark file.
+    :return: the git SHA of the benchmark file's directory, or None if unavailable.
+    """
+    directory = benchmark_file.resolve().parent
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(directory), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    sha = result.stdout.strip()
+    return sha if result.returncode == 0 and sha else None
+
+
+def resolve_version() -> str:
+    """Resolves the installed Pathling package version.
+
+    :return: the Pathling version, or "UNKNOWN" if it cannot be determined.
+    """
+    try:
+        return version("pathling")
+    except PackageNotFoundError:
+        return "UNKNOWN"
+
+
+def environment(pc: PathlingContext) -> Dict[str, object]:
+    """Builds the report's environment block.
+
+    :param pc: the Pathling context.
+    :return: a dict describing the OS, Java, Spark and core count.
+    """
+    java_version = pc.spark._jvm.System.getProperty("java.version")
+    return {
+        "os": platform.platform(),
+        "java": java_version,
+        "spark": pc.spark.version,
+        "cores": os.cpu_count(),
+    }
+
+
+@click.command()
+@click.argument(
+    "benchmark_file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option("--size", required=True, help="Size key to run (e.g. s or m).")
+@click.option(
+    "--data",
+    "data_root",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Root directory of materialized datasets.",
+)
+@click.option(
+    "--sink",
+    type=click.Choice(["csv", "parquet"]),
+    default=DEFAULT_SINK,
+    show_default=True,
+    help="Spark write format for the timed region.",
+)
+@click.option(
+    "--out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=Path(DEFAULT_OUT),
+    show_default=True,
+    help="Report output path.",
+)
+def main(
+    benchmark_file: Path, size: str, data_root: Path, sink: str, out: Path
+) -> None:
+    """Run the SQL-on-FHIR benchmark with the Pathling Python API."""
+    benchmark = json.loads(benchmark_file.read_text())
+    title = benchmark["title"]
+    fhir_version = benchmark["fhirVersion"]
+    dataset = benchmark["dataset"]
+    name = dataset["name"]
+    if size not in dataset["sizes"]:
+        raise click.BadParameter(
+            f"Size '{size}' is not declared for dataset '{name}'.", param_hint="--size"
+        )
+    population = dataset["sizes"][size]["population"]
+    iterations = benchmark.get("iterations", {})
+    warmup = iterations.get("warmup", DEFAULT_WARMUP)
+    measurement = iterations.get("measurement", DEFAULT_MEASUREMENT)
+
+    data_dir = locate_data_dir(data_root, name, size, population)
+    log.info("Located materialized data at %s", data_dir)
+
+    pc = PathlingContext.create()
+    cores = os.cpu_count() or 1
+    # Keep the tiny SoF inputs from spawning ~200 shuffle part-files and adding scheduling noise.
+    pc.spark.conf.set("spark.sql.shuffle.partitions", str(cores))
+
+    out_dir = tempfile.mkdtemp(prefix="sof-benchmark-out-")
+    try:
+        ndjson = pc.read.ndjson(str(data_dir))
+        results = run_cases(
+            benchmark["cases"], size, ndjson, pc, sink, out_dir, warmup, measurement
+        )
+
+        report = {
+            "implementation": {
+                "name": IMPLEMENTATION_NAME,
+                "version": resolve_version(),
+            },
+            "environment": environment(pc),
+            "measurement": {
+                "phases": ["execute", "extract"],
+                "sink": schema_sink(sink),
+                "warmup": warmup,
+                "iterations": measurement,
+            },
+            "results": {
+                title: {"size": size, "fhirVersion": fhir_version, "cases": results}
+            },
+        }
+        benchmark_version = resolve_benchmark_version(benchmark_file)
+        if benchmark_version:
+            report["benchmarkVersion"] = benchmark_version
+
+        Path(out).write_text(json.dumps(report, indent=2))
+        log.info("Wrote benchmark report to %s", out)
+    finally:
+        pc.spark.stop()
+
+
+def run_cases(
+    cases: List[dict],
+    size: str,
+    ndjson: DataSource,
+    pc: PathlingContext,
+    sink: str,
+    out_dir: str,
+    warmup: int,
+    measurement: int,
+) -> List[dict]:
+    """Loads each distinct subject once then measures every case over its loaded subject.
+
+    :param cases: the benchmark cases in file order.
+    :param size: the size key (used to resolve expectCount).
+    :param ndjson: the NDJSON-backed data source.
+    :param pc: the Pathling context.
+    :param sink: the Spark write format.
+    :param out_dir: the fixed output directory the results are written to.
+    :param warmup: the number of warmup iterations to discard.
+    :param measurement: the number of measured iterations to record.
+    :return: the per-case result dicts in file order.
+    """
+    loaded_subjects: Dict[str, dict] = {}
+    results = []
+    for case in cases:
+        subject = case["view"]["resource"]
+        if subject not in loaded_subjects:
+            loaded_subjects[subject] = load_subject(ndjson, subject, pc)
+        results.append(
+            measure_case(
+                loaded_subjects[subject],
+                subject,
+                case,
+                size,
+                sink,
+                out_dir,
+                warmup,
+                measurement,
+            )
+        )
+    return results
+
+
+def load_subject(ndjson: DataSource, subject: str, pc: PathlingContext) -> dict:
+    """Performs the load phase for a subject: reads, FHIR-encodes, caches and forces materialization.
+
+    :param ndjson: the NDJSON-backed data source.
+    :param subject: the subject resource type to load.
+    :param pc: the Pathling context.
+    :return: a dict with the cached data source, input row count and load duration in ms.
+    """
+    log.info("Loading subject %s", subject)
+    start = time.perf_counter()
+    # DataSource.read returns the lazy FHIR-encoded DataFrame; caching plus count() forces the
+    # parse+encode to happen now so the timed region measures only view evaluation and write.
+    encoded = ndjson.read(subject).cache()
+    input_rows = encoded.count()
+    load_ms = (time.perf_counter() - start) * 1000.0
+
+    # Rebuild as a dataset source over the already-cached DataFrame so view(...) is available.
+    cached = pc.read.datasets({subject: encoded})
+    log.info("Loaded subject %s: %s input rows in %.1f ms", subject, input_rows, load_ms)
+    return {"source": cached, "input_rows": input_rows, "load_ms": load_ms}
+
+
+def measure_case(
+    loaded: dict,
+    subject: str,
+    case: dict,
+    size: str,
+    sink: str,
+    out_dir: str,
+    warmup: int,
+    measurement: int,
+) -> dict:
+    """Measures a single case over its already-loaded subject.
+
+    Runs the discarded warmup iterations, then the measured iterations timing each
+    execute+write, and finally obtains the output row count outside the timed region.
+
+    :param loaded: the cached subject the case runs over.
+    :param subject: the subject resource type.
+    :param case: the benchmark case.
+    :param size: the size key (used to resolve expectCount).
+    :param sink: the Spark write format.
+    :param out_dir: the fixed output directory.
+    :param warmup: the number of warmup iterations to discard.
+    :param measurement: the number of measured iterations to record.
+    :return: the measured case result dict.
+    """
+    view_json = json.dumps(case["view"])
+    source = loaded["source"]
+    log.info(
+        "Measuring case '%s' (%s warmup, %s measured)",
+        case["title"],
+        warmup,
+        measurement,
+    )
+
+    for _ in range(warmup):
+        df = source.view(json=view_json)
+        df.write.format(sink).mode("overwrite").save(out_dir)
+
+    samples: List[float] = []
+    last_df = None
+    for _ in range(measurement):
+        df = source.view(json=view_json)
+        start = time.perf_counter()
+        df.write.format(sink).mode("overwrite").save(out_dir)
+        samples.append((time.perf_counter() - start) * 1000.0)
+        last_df = df
+
+    # Untimed correctness guard: count() never times the measured region because Catalyst would
+    # prune projected columns and under-measure.
+    output_rows = last_df.count() if last_df is not None else 0
+    expect = case.get("expectCount", {}).get(size)
+    status = "ok" if expect is None or expect == output_rows else "count_mismatch"
+    log.info(
+        "Case '%s': %s output rows, status %s", case["title"], output_rows, status
+    )
+
+    return {
+        "title": case["title"],
+        "status": status,
+        "inputRows": loaded["input_rows"],
+        "outputRows": output_rows,
+        "samplesMs": samples,
+        "stats": stats_for(samples),
+        "phaseSamplesMs": {"load": [loaded["load_ms"]], "executeExtract": samples},
+    }
+
+
+if __name__ == "__main__":
+    main()

--- a/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/BenchmarkCase.java
+++ b/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/BenchmarkCase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.sof.benchmark;
+
+import jakarta.annotation.Nonnull;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A single benchmark case: a title, the subject resource type the view runs over, the view itself
+ * serialized to a JSON string ready for {@code FhirViewQuery.json(String)}, and the per-size
+ * expected output row counts.
+ */
+public class BenchmarkCase {
+
+  @Nonnull private final String title;
+
+  @Nonnull private final String resource;
+
+  @Nonnull private final String viewJson;
+
+  @Nonnull private final Map<String, Integer> expectCount;
+
+  /**
+   * Constructs a benchmark case.
+   *
+   * @param title the case title
+   * @param resource the subject resource type of the view
+   * @param viewJson the view serialized as a JSON string
+   * @param expectCount a map of size key to the expected output row count for that size
+   */
+  public BenchmarkCase(
+      @Nonnull final String title,
+      @Nonnull final String resource,
+      @Nonnull final String viewJson,
+      @Nonnull final Map<String, Integer> expectCount) {
+    this.title = title;
+    this.resource = resource;
+    this.viewJson = viewJson;
+    this.expectCount = expectCount;
+  }
+
+  /**
+   * Returns the case title.
+   *
+   * @return the case title
+   */
+  @Nonnull
+  public String getTitle() {
+    return title;
+  }
+
+  /**
+   * Returns the subject resource type of the view.
+   *
+   * @return the subject resource type
+   */
+  @Nonnull
+  public String getResource() {
+    return resource;
+  }
+
+  /**
+   * Returns the view serialized as a JSON string, suitable for {@code FhirViewQuery.json(String)}.
+   *
+   * @return the view JSON
+   */
+  @Nonnull
+  public String getViewJson() {
+    return viewJson;
+  }
+
+  /**
+   * Returns the expected output row count for the given size, if one is declared.
+   *
+   * @param size the size key
+   * @return the expected count, or empty when no expectation is declared for the size
+   */
+  @Nonnull
+  public Optional<Integer> expectCountFor(@Nonnull final String size) {
+    return Optional.ofNullable(expectCount.get(size));
+  }
+}

--- a/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/BenchmarkDataset.java
+++ b/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/BenchmarkDataset.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.sof.benchmark;
+
+import jakarta.annotation.Nonnull;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The dataset recipe portion of a benchmark file: the human-readable name, the per-size
+ * populations, and the resource types the materializer is expected to keep.
+ *
+ * <p>These three values are exactly what {@link ManifestLocator} matches a materialized {@code
+ * manifest.json} against, so the runner never reproduces the reference materializer's recipe hash.
+ */
+public class BenchmarkDataset {
+
+  @Nonnull private final String name;
+
+  @Nonnull private final Map<String, Integer> sizePopulations;
+
+  @Nonnull private final List<String> resources;
+
+  /**
+   * Constructs a benchmark dataset descriptor.
+   *
+   * @param name the dataset name, as written into the manifest
+   * @param sizePopulations a map of size key to the population declared for that size
+   * @param resources the resource types the dataset retains
+   */
+  public BenchmarkDataset(
+      @Nonnull final String name,
+      @Nonnull final Map<String, Integer> sizePopulations,
+      @Nonnull final List<String> resources) {
+    this.name = name;
+    this.sizePopulations = sizePopulations;
+    this.resources = resources;
+  }
+
+  /**
+   * Returns the dataset name.
+   *
+   * @return the dataset name
+   */
+  @Nonnull
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Returns the resource types retained by this dataset.
+   *
+   * @return the resource types
+   */
+  @Nonnull
+  public List<String> getResources() {
+    return resources;
+  }
+
+  /**
+   * Returns the population declared for the given size.
+   *
+   * @param size the size key
+   * @return the declared population
+   * @throws IllegalArgumentException if the size is not declared in the benchmark file
+   */
+  public int populationFor(@Nonnull final String size) {
+    final Integer population = sizePopulations.get(size);
+    if (population == null) {
+      throw new IllegalArgumentException(
+          "Size '" + size + "' is not declared for dataset '" + name + "'");
+    }
+    return population;
+  }
+}

--- a/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/BenchmarkFile.java
+++ b/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/BenchmarkFile.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.sof.benchmark;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A parsed SQL-on-FHIR benchmark file (see {@code benchmark.schema.json}).
+ *
+ * <p>The file is parsed with Jackson as a tree; the {@code view} node of each case is re-serialized
+ * to a JSON string so it can be handed to {@code FhirViewQuery.json(String)}, which deserializes it
+ * with Gson internally. A Jackson node is never handed directly to Pathling.
+ */
+public class BenchmarkFile {
+
+  /** Default warmup iterations when the benchmark file omits an {@code iterations} block. */
+  private static final int DEFAULT_WARMUP = 1;
+
+  /** Default measured iterations when the benchmark file omits an {@code iterations} block. */
+  private static final int DEFAULT_MEASUREMENT = 5;
+
+  @Nonnull private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Nonnull private final String title;
+
+  @Nonnull private final String fhirVersion;
+
+  @Nonnull private final BenchmarkDataset dataset;
+
+  @Nonnull private final List<BenchmarkCase> cases;
+
+  private final int warmup;
+
+  private final int measurement;
+
+  private BenchmarkFile(
+      @Nonnull final String title,
+      @Nonnull final String fhirVersion,
+      @Nonnull final BenchmarkDataset dataset,
+      @Nonnull final List<BenchmarkCase> cases,
+      final int warmup,
+      final int measurement) {
+    this.title = title;
+    this.fhirVersion = fhirVersion;
+    this.dataset = dataset;
+    this.cases = cases;
+    this.warmup = warmup;
+    this.measurement = measurement;
+  }
+
+  /**
+   * Parses a benchmark file from disk.
+   *
+   * @param file the path to the benchmark {@code *.json} file
+   * @return the parsed benchmark file
+   * @throws UncheckedIOException if the file cannot be read or parsed
+   */
+  @Nonnull
+  public static BenchmarkFile parse(@Nonnull final Path file) {
+    final JsonNode root;
+    try {
+      root = MAPPER.readTree(Files.readAllBytes(file));
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to read benchmark file: " + file, e);
+    }
+
+    final String title = requiredText(root, "title");
+    final String fhirVersion = requiredText(root, "fhirVersion");
+    final BenchmarkDataset dataset = parseDataset(root.path("dataset"));
+    final List<BenchmarkCase> cases = parseCases(root.path("cases"));
+
+    final JsonNode iterations = root.path("iterations");
+    final int warmup = iterations.path("warmup").asInt(DEFAULT_WARMUP);
+    final int measurement = iterations.path("measurement").asInt(DEFAULT_MEASUREMENT);
+
+    return new BenchmarkFile(title, fhirVersion, dataset, cases, warmup, measurement);
+  }
+
+  @Nonnull
+  private static BenchmarkDataset parseDataset(@Nonnull final JsonNode dataset) {
+    final String name = requiredText(dataset, "name");
+
+    final Map<String, Integer> sizePopulations = new LinkedHashMap<>();
+    final JsonNode sizes = dataset.path("sizes");
+    final Iterator<Map.Entry<String, JsonNode>> sizeFields = sizes.fields();
+    while (sizeFields.hasNext()) {
+      final Map.Entry<String, JsonNode> entry = sizeFields.next();
+      sizePopulations.put(entry.getKey(), entry.getValue().path("population").asInt());
+    }
+
+    final List<String> resources = new ArrayList<>();
+    dataset.path("resources").forEach(node -> resources.add(node.asText()));
+
+    return new BenchmarkDataset(name, sizePopulations, resources);
+  }
+
+  @Nonnull
+  private static List<BenchmarkCase> parseCases(@Nonnull final JsonNode casesNode) {
+    final List<BenchmarkCase> cases = new ArrayList<>();
+    for (final JsonNode caseNode : casesNode) {
+      final String title = requiredText(caseNode, "title");
+      final JsonNode view = caseNode.path("view");
+      final String resource = requiredText(view, "resource");
+      final String viewJson = serialize(view);
+
+      final Map<String, Integer> expectCount = new LinkedHashMap<>();
+      final JsonNode expect = caseNode.path("expectCount");
+      final Iterator<Map.Entry<String, JsonNode>> expectFields = expect.fields();
+      while (expectFields.hasNext()) {
+        final Map.Entry<String, JsonNode> entry = expectFields.next();
+        expectCount.put(entry.getKey(), entry.getValue().asInt());
+      }
+
+      cases.add(new BenchmarkCase(title, resource, viewJson, expectCount));
+    }
+    return cases;
+  }
+
+  @Nonnull
+  private static String serialize(@Nonnull final JsonNode node) {
+    try {
+      return MAPPER.writeValueAsString(node);
+    } catch (final JsonProcessingException e) {
+      throw new IllegalStateException("Failed to serialize view node", e);
+    }
+  }
+
+  @Nonnull
+  private static String requiredText(@Nonnull final JsonNode parent, @Nonnull final String field) {
+    final JsonNode node = parent.get(field);
+    if (node == null || node.isNull()) {
+      throw new IllegalArgumentException("Benchmark file is missing required field: " + field);
+    }
+    return node.asText();
+  }
+
+  /**
+   * Returns the benchmark title (used as the {@code results} key in the report).
+   *
+   * @return the benchmark title
+   */
+  @Nonnull
+  public String getTitle() {
+    return title;
+  }
+
+  /**
+   * Returns the declared FHIR version.
+   *
+   * @return the FHIR version
+   */
+  @Nonnull
+  public String getFhirVersion() {
+    return fhirVersion;
+  }
+
+  /**
+   * Returns the dataset recipe descriptor.
+   *
+   * @return the dataset descriptor
+   */
+  @Nonnull
+  public BenchmarkDataset getDataset() {
+    return dataset;
+  }
+
+  /**
+   * Returns the benchmark cases in file order.
+   *
+   * @return the cases
+   */
+  @Nonnull
+  public List<BenchmarkCase> getCases() {
+    return cases;
+  }
+
+  /**
+   * Returns the number of warmup iterations to discard.
+   *
+   * @return the warmup iteration count
+   */
+  public int getWarmup() {
+    return warmup;
+  }
+
+  /**
+   * Returns the number of measured iterations to record.
+   *
+   * @return the measured iteration count
+   */
+  public int getMeasurement() {
+    return measurement;
+  }
+}

--- a/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/CaseResult.java
+++ b/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/CaseResult.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.sof.benchmark;
+
+import jakarta.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * The measured outcome of a single benchmark case: its correctness status, input and output row
+ * counts, the timed execute+extract samples (one per measured iteration), and the separately
+ * recorded load duration of its subject.
+ */
+public class CaseResult {
+
+  @Nonnull private final String title;
+
+  @Nonnull private final String status;
+
+  private final long inputRows;
+
+  private final long outputRows;
+
+  @Nonnull private final List<Double> executeExtractSamplesMs;
+
+  private final double loadMs;
+
+  /**
+   * Constructs a case result.
+   *
+   * @param title the case title
+   * @param status {@code ok} or {@code count_mismatch}
+   * @param inputRows the input row count of the subject
+   * @param outputRows the output row count of the view
+   * @param executeExtractSamplesMs the timed execute+extract samples in milliseconds
+   * @param loadMs the load duration of the subject in milliseconds
+   */
+  public CaseResult(
+      @Nonnull final String title,
+      @Nonnull final String status,
+      final long inputRows,
+      final long outputRows,
+      @Nonnull final List<Double> executeExtractSamplesMs,
+      final double loadMs) {
+    this.title = title;
+    this.status = status;
+    this.inputRows = inputRows;
+    this.outputRows = outputRows;
+    this.executeExtractSamplesMs = executeExtractSamplesMs;
+    this.loadMs = loadMs;
+  }
+
+  /**
+   * Returns the case title.
+   *
+   * @return the case title
+   */
+  @Nonnull
+  public String getTitle() {
+    return title;
+  }
+
+  /**
+   * Returns the correctness status ({@code ok} or {@code count_mismatch}).
+   *
+   * @return the status
+   */
+  @Nonnull
+  public String getStatus() {
+    return status;
+  }
+
+  /**
+   * Returns the input row count of the subject.
+   *
+   * @return the input row count
+   */
+  public long getInputRows() {
+    return inputRows;
+  }
+
+  /**
+   * Returns the output row count of the view.
+   *
+   * @return the output row count
+   */
+  public long getOutputRows() {
+    return outputRows;
+  }
+
+  /**
+   * Returns the timed execute+extract samples in milliseconds, one per measured iteration.
+   *
+   * @return the execute+extract samples
+   */
+  @Nonnull
+  public List<Double> getExecuteExtractSamplesMs() {
+    return executeExtractSamplesMs;
+  }
+
+  /**
+   * Returns the load duration of the subject in milliseconds.
+   *
+   * @return the load duration
+   */
+  public double getLoadMs() {
+    return loadMs;
+  }
+}

--- a/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/LoadedSubject.java
+++ b/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/LoadedSubject.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.sof.benchmark;
+
+import au.csiro.pathling.library.io.source.DatasetSource;
+import jakarta.annotation.Nonnull;
+
+/**
+ * The result of the load phase for one subject resource type: a cached, FHIR-encoded {@link
+ * DatasetSource} ready to be queried, the number of input rows materialized, and the wall-clock
+ * cost of loading and encoding it.
+ *
+ * <p>Loading is performed once per distinct subject and shared by every case over that subject, so
+ * the cost is amortized and excluded from the timed execute+extract region.
+ */
+public class LoadedSubject {
+
+  @Nonnull private final DatasetSource source;
+
+  private final long inputRows;
+
+  private final double loadMs;
+
+  /**
+   * Constructs a loaded subject.
+   *
+   * @param source the cached, FHIR-encoded dataset source
+   * @param inputRows the number of input rows materialized during loading
+   * @param loadMs the wall-clock load duration in milliseconds
+   */
+  public LoadedSubject(
+      @Nonnull final DatasetSource source, final long inputRows, final double loadMs) {
+    this.source = source;
+    this.inputRows = inputRows;
+    this.loadMs = loadMs;
+  }
+
+  /**
+   * Returns the cached dataset source.
+   *
+   * @return the dataset source
+   */
+  @Nonnull
+  public DatasetSource getSource() {
+    return source;
+  }
+
+  /**
+   * Returns the number of input rows materialized during loading.
+   *
+   * @return the input row count
+   */
+  public long getInputRows() {
+    return inputRows;
+  }
+
+  /**
+   * Returns the wall-clock load duration in milliseconds.
+   *
+   * @return the load duration
+   */
+  public double getLoadMs() {
+    return loadMs;
+  }
+}

--- a/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/ManifestLocator.java
+++ b/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/ManifestLocator.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.sof.benchmark;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+/**
+ * Locates a benchmark's materialized NDJSON by matching {@code manifest.json} files, rather than by
+ * recomputing the reference materializer's recipe hash.
+ *
+ * <p>The materializer writes one directory per recipe under {@code <dataRoot>/<name>_<hash>/<size>}
+ * containing the resource NDJSON files and a {@code manifest.json} recording the dataset {@code
+ * name}, {@code size} and {@code population}. This locator scans those manifests and selects the
+ * directory whose manifest matches all three, so the JS canonicalization that produces {@code
+ * <hash>} is never reproduced.
+ */
+public final class ManifestLocator {
+
+  @Nonnull private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private ManifestLocator() {}
+
+  /**
+   * Locates the size-specific data directory whose manifest matches the requested dataset name,
+   * size and population.
+   *
+   * @param dataRoot the root directory containing materialized datasets
+   * @param name the dataset name to match
+   * @param size the size key to match
+   * @param population the population to match
+   * @return the directory containing the matching size's NDJSON files and manifest
+   * @throws IllegalStateException if no manifest under the data root matches all three
+   */
+  @Nonnull
+  public static Path locate(
+      @Nonnull final Path dataRoot,
+      @Nonnull final String name,
+      @Nonnull final String size,
+      final int population) {
+    if (!Files.isDirectory(dataRoot)) {
+      throw new IllegalStateException(
+          "Data root does not exist or is not a directory: " + dataRoot);
+    }
+
+    try (final Stream<Path> datasetDirs = Files.list(dataRoot)) {
+      return datasetDirs
+          .map(datasetDir -> datasetDir.resolve(size).resolve("manifest.json"))
+          .filter(Files::isRegularFile)
+          .filter(manifest -> manifestMatches(manifest, name, size, population))
+          .map(Path::getParent)
+          .findFirst()
+          .orElseThrow(
+              () ->
+                  new IllegalStateException(
+                      "No materialized dataset matches (name="
+                          + name
+                          + ", size="
+                          + size
+                          + ", population="
+                          + population
+                          + ") under "
+                          + dataRoot
+                          + ". Run the materializer first: cd sql-on-fhir/benchmark && bun run"
+                          + " data <file> --size "
+                          + size));
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to scan data root: " + dataRoot, e);
+    }
+  }
+
+  private static boolean manifestMatches(
+      @Nonnull final Path manifest,
+      @Nonnull final String name,
+      @Nonnull final String size,
+      final int population) {
+    try {
+      final JsonNode node = MAPPER.readTree(Files.readAllBytes(manifest));
+      return name.equals(node.path("name").asText())
+          && size.equals(node.path("size").asText())
+          && population == node.path("population").asInt(-1);
+    } catch (final IOException e) {
+      // A manifest we cannot read is simply not a match.
+      return false;
+    }
+  }
+}

--- a/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/MeasurementHarness.java
+++ b/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/MeasurementHarness.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.sof.benchmark;
+
+import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.DatasetSource;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
+import jakarta.annotation.Nonnull;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs the load phase and the timed execute+extract loop for benchmark cases.
+ *
+ * <p>The load phase reads and FHIR-encodes a subject's NDJSON, caches it, and forces its
+ * materialization with a {@code count()} so that the timed region never absorbs parse/encode cost.
+ * The timed region evaluates the view and writes the full result to a fixed temp directory with
+ * {@link SaveMode#Overwrite}; the output row count is obtained outside the timed region. Warmup
+ * iterations run in the same JVM so whole-stage codegen is cached before the measured iterations.
+ */
+public class MeasurementHarness {
+
+  @Nonnull private static final Logger log = LoggerFactory.getLogger(MeasurementHarness.class);
+
+  private static final double NANOS_PER_MILLI = 1_000_000.0;
+
+  @Nonnull private final PathlingContext pathlingContext;
+
+  private final int warmup;
+
+  private final int iterations;
+
+  @Nonnull private final String sink;
+
+  @Nonnull private final Path outDir;
+
+  /**
+   * Constructs a measurement harness.
+   *
+   * @param pathlingContext the Pathling context used to rebuild a cached dataset source
+   * @param warmup the number of warmup iterations to discard
+   * @param iterations the number of measured iterations to record
+   * @param sink the Spark write format (e.g. {@code csv} or {@code parquet})
+   * @param outDir the fixed temporary directory the results are written to
+   */
+  public MeasurementHarness(
+      @Nonnull final PathlingContext pathlingContext,
+      final int warmup,
+      final int iterations,
+      @Nonnull final String sink,
+      @Nonnull final Path outDir) {
+    this.pathlingContext = pathlingContext;
+    this.warmup = warmup;
+    this.iterations = iterations;
+    this.sink = sink;
+    this.outDir = outDir;
+  }
+
+  /**
+   * Performs the load phase for a subject: reads and FHIR-encodes the subject's data, caches it,
+   * and forces materialization to populate the cache and capture the input row count.
+   *
+   * @param ndjson the NDJSON-backed data source covering all the benchmark's resources
+   * @param subject the subject resource type to load
+   * @return the cached subject with its input row count and load duration
+   */
+  @Nonnull
+  public LoadedSubject load(
+      @Nonnull final QueryableDataSource ndjson, @Nonnull final String subject) {
+    log.info("Loading subject {}", subject);
+    final long start = System.nanoTime();
+    // DataSource.read(String) returns the lazy FHIR-encoded dataset; caching plus count() forces
+    // the
+    // parse+encode to happen now so the timed region measures only view evaluation and write.
+    final Dataset<Row> encoded = ndjson.read(subject).cache();
+    final long inputRows = encoded.count();
+    final double loadMs = (System.nanoTime() - start) / NANOS_PER_MILLI;
+
+    // Rebuild as a DatasetSource over the already-cached dataset so view(subject) is available.
+    final DatasetSource cached = pathlingContext.read().datasets().dataset(subject, encoded);
+    log.info("Loaded subject {}: {} input rows in {} ms", subject, inputRows, loadMs);
+    return new LoadedSubject(cached, inputRows, loadMs);
+  }
+
+  /**
+   * Measures a single case over its already-loaded subject: runs the discarded warmup iterations,
+   * then the measured iterations timing each execute+write, and finally obtains the output row
+   * count outside the timed region to compute the correctness status.
+   *
+   * @param loaded the cached subject the case runs over
+   * @param subject the subject resource type
+   * @param benchmarkCase the case to measure
+   * @param size the size key (used to resolve {@code expectCount})
+   * @return the measured case result
+   */
+  @Nonnull
+  public CaseResult measure(
+      @Nonnull final LoadedSubject loaded,
+      @Nonnull final String subject,
+      @Nonnull final BenchmarkCase benchmarkCase,
+      @Nonnull final String size) {
+    final String viewJson = benchmarkCase.getViewJson();
+    log.info(
+        "Measuring case '{}' ({} warmup, {} measured)",
+        benchmarkCase.getTitle(),
+        warmup,
+        iterations);
+
+    for (int i = 0; i < warmup; i++) {
+      writeOnce(loaded.getSource(), subject, viewJson);
+    }
+
+    final List<Double> samples = new ArrayList<>();
+    Dataset<Row> lastResult = null;
+    for (int i = 0; i < iterations; i++) {
+      final Dataset<Row> result = loaded.getSource().view(subject).json(viewJson).execute();
+      final long start = System.nanoTime();
+      result.write().format(sink).mode(SaveMode.Overwrite).save(outDir.toString());
+      samples.add((System.nanoTime() - start) / NANOS_PER_MILLI);
+      lastResult = result;
+    }
+
+    // Untimed correctness guard: count() never times the measured region because Catalyst would
+    // prune projected columns and under-measure.
+    final long outputRows = lastResult == null ? 0L : lastResult.count();
+    final String status = statusFor(benchmarkCase, size, outputRows);
+    log.info("Case '{}': {} output rows, status {}", benchmarkCase.getTitle(), outputRows, status);
+
+    return new CaseResult(
+        benchmarkCase.getTitle(),
+        status,
+        loaded.getInputRows(),
+        outputRows,
+        samples,
+        loaded.getLoadMs());
+  }
+
+  private void writeOnce(
+      @Nonnull final DatasetSource source,
+      @Nonnull final String subject,
+      @Nonnull final String viewJson) {
+    final Dataset<Row> result = source.view(subject).json(viewJson).execute();
+    result.write().format(sink).mode(SaveMode.Overwrite).save(outDir.toString());
+  }
+
+  @Nonnull
+  private static String statusFor(
+      @Nonnull final BenchmarkCase benchmarkCase,
+      @Nonnull final String size,
+      final long outputRows) {
+    return benchmarkCase
+        .expectCountFor(size)
+        .map(expected -> expected.longValue() == outputRows ? "ok" : "count_mismatch")
+        .orElse("ok");
+  }
+}

--- a/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/ReportWriter.java
+++ b/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/ReportWriter.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.sof.benchmark;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Emits a {@code benchmark-report.json} conforming to {@code benchmark-report.schema.json}.
+ *
+ * <p>The report records the implementation (name and version), the optional benchmark version and
+ * environment, the {@code measurement} block declaring the timed phases, sink and actual warmup and
+ * iteration counts, and one {@code results} entry per benchmark keyed by title with each case's
+ * status, input and output row counts, execute+extract samples, summary statistics, and the
+ * separately recorded load samples.
+ */
+public final class ReportWriter {
+
+  @Nonnull private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /** The sink categories permitted by {@code benchmark-report.schema.json}. */
+  @Nonnull
+  private static final Set<String> SCHEMA_SINKS = Set.of("table", "csv", "memory", "other");
+
+  private ReportWriter() {}
+
+  /**
+   * Builds and writes the benchmark report.
+   *
+   * @param out the path to write the report to
+   * @param implementationName the implementation name (e.g. {@code pathling-java})
+   * @param version the implementation version
+   * @param benchmarkVersion the benchmark submodule git SHA, or null if unavailable
+   * @param environment the environment description (os, java, spark, cores)
+   * @param sink the Spark write format used for the timed region
+   * @param warmup the actual warmup iteration count
+   * @param iterations the actual measured iteration count
+   * @param benchmarkTitle the benchmark title (the {@code results} key)
+   * @param size the size key the benchmark was run at
+   * @param fhirVersion the FHIR version
+   * @param results the per-case results
+   */
+  public static void write(
+      @Nonnull final Path out,
+      @Nonnull final String implementationName,
+      @Nonnull final String version,
+      @Nullable final String benchmarkVersion,
+      @Nonnull final ObjectNode environment,
+      @Nonnull final String sink,
+      final int warmup,
+      final int iterations,
+      @Nonnull final String benchmarkTitle,
+      @Nonnull final String size,
+      @Nonnull final String fhirVersion,
+      @Nonnull final List<CaseResult> results) {
+    final ObjectNode report = MAPPER.createObjectNode();
+
+    final ObjectNode implementation = report.putObject("implementation");
+    implementation.put("name", implementationName);
+    implementation.put("version", version);
+
+    if (benchmarkVersion != null) {
+      report.put("benchmarkVersion", benchmarkVersion);
+    }
+    report.set("environment", environment);
+
+    final ObjectNode measurement = report.putObject("measurement");
+    final ArrayNode phases = measurement.putArray("phases");
+    phases.add("execute");
+    phases.add("extract");
+    measurement.put("sink", schemaSink(sink));
+    measurement.put("warmup", warmup);
+    measurement.put("iterations", iterations);
+
+    final ObjectNode resultsNode = report.putObject("results");
+    final ObjectNode benchmarkNode = resultsNode.putObject(benchmarkTitle);
+    benchmarkNode.put("size", size);
+    benchmarkNode.put("fhirVersion", fhirVersion);
+    final ArrayNode casesNode = benchmarkNode.putArray("cases");
+    for (final CaseResult result : results) {
+      casesNode.add(caseNode(result));
+    }
+
+    try {
+      Files.write(out, MAPPER.writerWithDefaultPrettyPrinter().writeValueAsBytes(report));
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to write benchmark report: " + out, e);
+    }
+  }
+
+  /**
+   * Maps a Spark write format to a sink category permitted by the report schema. File formats such
+   * as {@code parquet} that are not enumerated by the schema are reported as {@code other} so the
+   * report stays schema-valid.
+   *
+   * @param sink the Spark write format used for the timed region
+   * @return a schema-valid sink category
+   */
+  @Nonnull
+  private static String schemaSink(@Nonnull final String sink) {
+    return SCHEMA_SINKS.contains(sink) ? sink : "other";
+  }
+
+  @Nonnull
+  private static ObjectNode caseNode(@Nonnull final CaseResult result) {
+    final ObjectNode node = MAPPER.createObjectNode();
+    node.put("title", result.getTitle());
+    node.put("status", result.getStatus());
+    node.put("inputRows", result.getInputRows());
+    node.put("outputRows", result.getOutputRows());
+
+    final List<Double> samples = result.getExecuteExtractSamplesMs();
+    final ArrayNode samplesNode = node.putArray("samplesMs");
+    samples.forEach(samplesNode::add);
+
+    node.set("stats", statsNode(samples));
+
+    final ObjectNode phaseSamples = node.putObject("phaseSamplesMs");
+    phaseSamples.putArray("load").add(result.getLoadMs());
+    final ArrayNode executeExtract = phaseSamples.putArray("executeExtract");
+    samples.forEach(executeExtract::add);
+
+    return node;
+  }
+
+  @Nonnull
+  private static ObjectNode statsNode(@Nonnull final List<Double> samples) {
+    final ObjectNode stats = MAPPER.createObjectNode();
+    if (samples.isEmpty()) {
+      return stats;
+    }
+    final List<Double> sorted = samples.stream().sorted().toList();
+    final double min = sorted.get(0);
+    final double max = sorted.get(sorted.size() - 1);
+    final double mean = sorted.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+    final double median = median(sorted);
+    stats.put("min", min);
+    stats.put("mean", mean);
+    stats.put("median", median);
+    stats.put("max", max);
+    return stats;
+  }
+
+  private static double median(@Nonnull final List<Double> sorted) {
+    final int size = sorted.size();
+    final int mid = size / 2;
+    if (size % 2 == 0) {
+      return (sorted.get(mid - 1) + sorted.get(mid)) / 2.0;
+    }
+    return sorted.get(mid);
+  }
+}

--- a/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/RunnerOptions.java
+++ b/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/RunnerOptions.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.sof.benchmark;
+
+import jakarta.annotation.Nonnull;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Parsed command-line options for {@link SofBenchmarkRunner}: the positional benchmark file plus
+ * the {@code --size}, {@code --data}, {@code --sink} and {@code --out} flags.
+ */
+public class RunnerOptions {
+
+  @Nonnull private static final String DEFAULT_SINK = "csv";
+
+  @Nonnull private static final String DEFAULT_OUT = "benchmark-report.json";
+
+  @Nonnull private final Path benchmarkFile;
+
+  @Nonnull private final String size;
+
+  @Nonnull private final Path dataRoot;
+
+  @Nonnull private final String sink;
+
+  @Nonnull private final Path out;
+
+  private RunnerOptions(
+      @Nonnull final Path benchmarkFile,
+      @Nonnull final String size,
+      @Nonnull final Path dataRoot,
+      @Nonnull final String sink,
+      @Nonnull final Path out) {
+    this.benchmarkFile = benchmarkFile;
+    this.size = size;
+    this.dataRoot = dataRoot;
+    this.sink = sink;
+    this.out = out;
+  }
+
+  /**
+   * Parses the runner's command-line arguments.
+   *
+   * @param args the command-line arguments
+   * @return the parsed options
+   * @throws IllegalArgumentException if a required option is missing or an unknown option is given
+   */
+  @Nonnull
+  public static RunnerOptions parse(@Nonnull final String[] args) {
+    Path benchmarkFile = null;
+    String size = null;
+    Path dataRoot = null;
+    String sink = DEFAULT_SINK;
+    Path out = Path.of(DEFAULT_OUT);
+
+    for (int i = 0; i < args.length; i++) {
+      final String arg = args[i];
+      switch (arg) {
+        case "--size" -> size = requireValue(args, ++i, "--size");
+        case "--data" -> dataRoot = Path.of(requireValue(args, ++i, "--data"));
+        case "--sink" -> sink = requireValue(args, ++i, "--sink");
+        case "--out" -> out = Path.of(requireValue(args, ++i, "--out"));
+        default -> {
+          if (arg.startsWith("--")) {
+            throw new IllegalArgumentException("Unknown option: " + arg + ". " + usage());
+          }
+          if (benchmarkFile != null) {
+            throw new IllegalArgumentException(
+                "Unexpected extra argument: " + arg + ". " + usage());
+          }
+          benchmarkFile = Path.of(arg);
+        }
+      }
+    }
+
+    if (benchmarkFile == null) {
+      throw new IllegalArgumentException("Missing required benchmark file. " + usage());
+    }
+    if (dataRoot == null) {
+      throw new IllegalArgumentException("Missing required option --data. " + usage());
+    }
+    final Path resolvedBenchmarkFile = benchmarkFile;
+    final String resolvedSize =
+        Optional.ofNullable(size)
+            .orElseThrow(
+                () -> new IllegalArgumentException("Missing required option --size. " + usage()));
+
+    return new RunnerOptions(resolvedBenchmarkFile, resolvedSize, dataRoot, sink, out);
+  }
+
+  @Nonnull
+  private static String requireValue(
+      @Nonnull final String[] args, final int index, @Nonnull final String option) {
+    if (index >= args.length) {
+      throw new IllegalArgumentException("Option " + option + " requires a value. " + usage());
+    }
+    return args[index];
+  }
+
+  @Nonnull
+  private static String usage() {
+    return "Usage: SofBenchmarkRunner <benchmarkFile> --size <size> --data <dataRoot>"
+        + " [--sink csv|parquet] [--out report.json]";
+  }
+
+  /**
+   * Returns the path to the benchmark file.
+   *
+   * @return the benchmark file
+   */
+  @Nonnull
+  public Path getBenchmarkFile() {
+    return benchmarkFile;
+  }
+
+  /**
+   * Returns the requested size key.
+   *
+   * @return the size key
+   */
+  @Nonnull
+  public String getSize() {
+    return size;
+  }
+
+  /**
+   * Returns the data root directory.
+   *
+   * @return the data root
+   */
+  @Nonnull
+  public Path getDataRoot() {
+    return dataRoot;
+  }
+
+  /**
+   * Returns the Spark write format used for the timed region.
+   *
+   * @return the sink format
+   */
+  @Nonnull
+  public String getSink() {
+    return sink;
+  }
+
+  /**
+   * Returns the report output path.
+   *
+   * @return the output path
+   */
+  @Nonnull
+  public Path getOut() {
+    return out;
+  }
+}

--- a/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/SofBenchmarkRunner.java
+++ b/sof-benchmark/src/main/java/au/csiro/pathling/sof/benchmark/SofBenchmarkRunner.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.sof.benchmark;
+
+import au.csiro.pathling.PathlingVersion;
+import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs the implementation-agnostic SQL-on-FHIR benchmark with Pathling over the Java library-api.
+ *
+ * <p>The {@code sof-benchmark} module shades this class as its {@code mainClass}, so it runs
+ * directly from the built jar:
+ *
+ * <pre>{@code
+ * java -jar sof-benchmark-<ver>.jar \
+ *   <benchmarkFile> --size s --data <dataRoot> --sink csv --out report-java.json
+ * }</pre>
+ *
+ * <p>It parses the benchmark file, locates its materialized NDJSON via {@link ManifestLocator},
+ * loads each distinct subject once, measures every case over its subject, and writes a schema-valid
+ * report.
+ */
+public final class SofBenchmarkRunner {
+
+  @Nonnull private static final Logger log = LoggerFactory.getLogger(SofBenchmarkRunner.class);
+
+  @Nonnull private static final String IMPLEMENTATION_NAME = "pathling-java";
+
+  private SofBenchmarkRunner() {}
+
+  /**
+   * Entry point.
+   *
+   * @param args the command-line arguments
+   */
+  public static void main(@Nonnull final String[] args) {
+    final RunnerOptions options = RunnerOptions.parse(args);
+
+    final BenchmarkFile benchmark = BenchmarkFile.parse(options.getBenchmarkFile());
+    final String size = options.getSize();
+    final int population = benchmark.getDataset().populationFor(size);
+    final Path dataDir =
+        ManifestLocator.locate(
+            options.getDataRoot(), benchmark.getDataset().getName(), size, population);
+    log.info("Located materialized data at {}", dataDir);
+
+    final SparkSession spark = buildSpark();
+    final Path outDir = createOutputDir();
+    try {
+      final PathlingContext pathlingContext = PathlingContext.create(spark);
+      final QueryableDataSource ndjson = pathlingContext.read().ndjson(dataDir.toString());
+
+      final MeasurementHarness harness =
+          new MeasurementHarness(
+              pathlingContext,
+              benchmark.getWarmup(),
+              benchmark.getMeasurement(),
+              options.getSink(),
+              outDir);
+
+      final List<CaseResult> results = runCases(benchmark, size, ndjson, harness);
+
+      ReportWriter.write(
+          options.getOut(),
+          IMPLEMENTATION_NAME,
+          resolveVersion(),
+          resolveBenchmarkVersion(options.getBenchmarkFile()),
+          environment(spark),
+          options.getSink(),
+          benchmark.getWarmup(),
+          benchmark.getMeasurement(),
+          benchmark.getTitle(),
+          size,
+          benchmark.getFhirVersion(),
+          results);
+      log.info("Wrote benchmark report to {}", options.getOut());
+    } finally {
+      spark.stop();
+      deleteRecursively(outDir);
+    }
+  }
+
+  /**
+   * Loads each distinct subject once (in case order of first appearance) then measures every case
+   * over its loaded subject, returning the case results in benchmark-file order.
+   */
+  @Nonnull
+  private static List<CaseResult> runCases(
+      @Nonnull final BenchmarkFile benchmark,
+      @Nonnull final String size,
+      @Nonnull final QueryableDataSource ndjson,
+      @Nonnull final MeasurementHarness harness) {
+    final Map<String, LoadedSubject> loadedSubjects = new LinkedHashMap<>();
+    final List<CaseResult> results = new ArrayList<>();
+    for (final BenchmarkCase benchmarkCase : benchmark.getCases()) {
+      final String subject = benchmarkCase.getResource();
+      final LoadedSubject loaded =
+          loadedSubjects.computeIfAbsent(subject, s -> harness.load(ndjson, s));
+      results.add(harness.measure(loaded, subject, benchmarkCase, size));
+    }
+    return results;
+  }
+
+  @Nonnull
+  private static SparkSession buildSpark() {
+    final int cores = Runtime.getRuntime().availableProcessors();
+    return SparkSession.builder()
+        .appName("SofBenchmarkRunner")
+        .master("local[*]")
+        // Keep the tiny SoF inputs from spawning ~200 shuffle part-files and adding scheduling
+        // noise.
+        .config("spark.sql.shuffle.partitions", String.valueOf(cores))
+        .getOrCreate();
+  }
+
+  @Nonnull
+  private static Path createOutputDir() {
+    try {
+      return Files.createTempDirectory("sof-benchmark-out-");
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to create output directory", e);
+    }
+  }
+
+  @Nonnull
+  private static ObjectNode environment(@Nonnull final SparkSession spark) {
+    final ObjectNode environment = new ObjectMapper().createObjectNode();
+    environment.put("os", System.getProperty("os.name") + " " + System.getProperty("os.version"));
+    environment.put("java", System.getProperty("java.version"));
+    environment.put("spark", spark.version());
+    environment.put("cores", Runtime.getRuntime().availableProcessors());
+    return environment;
+  }
+
+  @Nonnull
+  private static String resolveVersion() {
+    return new PathlingVersion().getBuildVersion().orElse("UNKNOWN");
+  }
+
+  /**
+   * Best-effort resolution of the benchmark submodule's git SHA by running {@code git rev-parse
+   * HEAD} in the benchmark file's directory. Returns null when git is unavailable or the directory
+   * is not a checkout.
+   */
+  @Nullable
+  private static String resolveBenchmarkVersion(@Nonnull final Path benchmarkFile) {
+    final Path directory = benchmarkFile.toAbsolutePath().getParent();
+    if (directory == null) {
+      return null;
+    }
+    try {
+      final Process process =
+          new ProcessBuilder("git", "-C", directory.toString(), "rev-parse", "HEAD")
+              .redirectErrorStream(true)
+              .start();
+      final String output =
+          new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+      if (!process.waitFor(10, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        return null;
+      }
+      return process.exitValue() == 0 && !output.isEmpty() ? output : null;
+    } catch (final IOException e) {
+      return null;
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return null;
+    }
+  }
+
+  private static void deleteRecursively(@Nonnull final Path directory) {
+    try (final var paths = Files.walk(directory)) {
+      paths
+          .sorted((a, b) -> b.getNameCount() - a.getNameCount())
+          .forEach(
+              path -> {
+                try {
+                  Files.deleteIfExists(path);
+                } catch (final IOException e) {
+                  log.warn("Failed to delete {}", path, e);
+                }
+              });
+    } catch (final IOException e) {
+      log.warn("Failed to clean up output directory {}", directory, e);
+    }
+  }
+}

--- a/sof-benchmark/src/main/resources/logback.xml
+++ b/sof-benchmark/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="au.csiro.pathling" level="INFO"/>
+  <root level="ERROR">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>


### PR DESCRIPTION
## Summary

Adds a runner for the implementation-agnostic **SQL-on-FHIR performance benchmark** (from the `sql-on-fhir` submodule), executed over the Pathling engine. This lets Pathling act as a second, strongly-typed JVM/Spark implementation that stress-tests the benchmark spec.

The runner lives in a **dedicated `sof-benchmark` module**, separate from the JMH `benchmark` module — the two share no code, so co-locating them only forced one module to carry the other's dependencies and a single shaded main class. The JMH `benchmark` module is left byte-identical to its prior state.

## What's included

- **`sof-benchmark` module** (child of the root `pom.xml`): `library-runtime` + `spark-sql` + `jackson-databind`, shaded with `SofBenchmarkRunner` as its `mainClass` (runs via `java -jar`).
- **Java runner** (`au.csiro.pathling.sof.benchmark`): manifest-first data location, load phase measured separately from the timed execute+extract region, output row-count correctness guard (`ok`/`count_mismatch`), schema-valid `benchmark-report.json`.
- **Python runner** (`sof-benchmark/python/sof_runner.py`): mirrors the Java runner over the `pathling` package using `click` (matching the Pathling Python CLI), isolating language-binding overhead.
- Docs: `CONTRIBUTING.md` module list + diagram, Python `README.md`.
- OpenSpec change `add-sof-benchmark-runner` archived; its spec promoted to `openspec/specs/sof-benchmark-runner/`.

## Verification

- Both modules build; `sof-benchmark` produces a runnable shaded jar.
- Java and Python runners both validated against `benchmark-report.schema.json`.
- Parity confirmed: identical case titles and output rows (`condition flat → 6219`, `observation components → 4794`), differing only in `implementation.name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)