### PR TITLE
Detect and repair Delta table schema drift after encoder upgrades

### DIFF
--- a/server/src/main/java/au/csiro/pathling/Dependencies.java
+++ b/server/src/main/java/au/csiro/pathling/Dependencies.java
@@ -21,11 +21,13 @@ import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.config.StorageConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.io.DynamicDeltaSource;
+import au.csiro.pathling.io.SchemaMigrator;
 import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import jakarta.annotation.Nonnull;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.SparkSession;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -85,13 +87,25 @@ public class Dependencies {
         serverConfiguration.getStorage().getWarehouseUrl()
             + "/"
             + serverConfiguration.getStorage().getDatabaseName();
+    // Migrate any tables whose schemas are behind the current encoders before the delegate scans
+    // the warehouse, so its resource map is built from already-migrated tables. Types that remain
+    // drifted (flag disabled, or migration failure) are reported to the data source so requests
+    // against them fail with an actionable error.
+    final Set<String> driftedTypes =
+        new SchemaMigrator(
+                pathlingContext.getSpark(),
+                pathlingContext.getFhirEncoders(),
+                databaseLocation,
+                serverConfiguration.getStorage().getSchemaAutoMerge())
+            .migrate();
     final QueryableDataSource baseSource = pathlingContext.read().delta(databaseLocation);
     return new DynamicDeltaSource(
         baseSource,
         pathlingContext.getSpark(),
         databaseLocation,
         pathlingContext.getFhirEncoders(),
-        serverConfiguration.getStorage());
+        serverConfiguration.getStorage(),
+        driftedTypes);
   }
 
   @Bean

--- a/server/src/main/java/au/csiro/pathling/errors/ErrorHandlingInterceptor.java
+++ b/server/src/main/java/au/csiro/pathling/errors/ErrorHandlingInterceptor.java
@@ -17,8 +17,10 @@
 
 package au.csiro.pathling.errors;
 
+import static java.util.Objects.requireNonNull;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 
+import au.csiro.pathling.io.SchemaDriftError;
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
@@ -135,6 +137,13 @@ public class ErrorHandlingInterceptor {
       return new InvalidRequestException(e);
     } catch (final AccessDeniedError e) {
       return buildException(HttpServletResponse.SC_FORBIDDEN, e.getMessage(), IssueType.FORBIDDEN);
+    } catch (final SchemaDriftError e) {
+      // A drifted, unmigrated table is a server-side deployment state; surface the actionable
+      // message instead of the generic "Unexpected error occurred".
+      return buildException(
+          HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+          requireNonNull(e.getMessage()),
+          IssueType.PROCESSING);
     } catch (final SparkRuntimeException e) {
       // SparkRuntimeException with USER_RAISED_EXCEPTION indicates an intentionally raised
       // error (via raise_error() in Spark SQL) that should be surfaced to the client.
@@ -154,7 +163,6 @@ public class ErrorHandlingInterceptor {
   }
 
   @Nonnull
-  @SuppressWarnings("SameParameterValue")
   private static BaseServerResponseException buildException(
       final int theStatusCode, @Nonnull final String message, @Nonnull final IssueType issueType) {
     final OperationOutcome opOutcome = new OperationOutcome();

--- a/server/src/main/java/au/csiro/pathling/io/DriftGuardedSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DriftGuardedSource.java
@@ -31,34 +31,38 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
 /**
- * A {@link QueryableDataSource} wrapper that carries the schema drift guard of a {@link
- * DynamicDeltaSource} into sources derived from it through {@code map} or {@code
- * filterByResourceType}. Reads of a drifted type fail with {@link SchemaDriftError} instead of an
- * opaque Spark analysis failure. View queries are guarded on their subject resource type when the
- * query is constructed, because the executed query resolves datasets through the wrapped source's
- * own dispatcher rather than the guarded {@code read}.
+ * A {@link QueryableDataSource} wrapper that guards reads against schema drift, and carries that
+ * guard into sources derived from it through {@code map} or {@code filterByResourceType}. Reads of
+ * a drifted type fail with {@link SchemaDriftError} instead of an opaque Spark analysis failure.
+ * View queries are guarded on their subject resource type when the query is constructed, because
+ * the executed query resolves datasets through the wrapped source's own dispatcher rather than the
+ * guarded {@code read}.
  *
- * <p>The drifted types are snapshotted at construction; derived sources are created per request, so
- * they reflect the drift state at the time of derivation.
+ * <p>The drifted types set is held by reference, so guard decisions reflect its current contents.
+ * This allows a mutable set shared with a refreshing source to clear the guard when a type is
+ * successfully migrated.
  *
  * @author John Grimes
  */
 public class DriftGuardedSource implements QueryableDataSource {
 
-  @Nonnull private final QueryableDataSource delegate;
+  /** The underlying QueryableDataSource that guarded operations delegate to. */
+  @Nonnull protected final QueryableDataSource delegate;
 
-  @Nonnull private final Set<String> driftedTypes;
+  /** The resource types whose tables are drifted and unmigrated. */
+  @Nonnull protected final Set<String> driftedTypes;
 
   /**
    * Constructs a new DriftGuardedSource.
    *
    * @param delegate the underlying QueryableDataSource to delegate to
-   * @param driftedTypes the resource types whose tables are drifted and unmigrated
+   * @param driftedTypes the resource types whose tables are drifted and unmigrated; held by
+   *     reference so that mutations are reflected in guard decisions
    */
   public DriftGuardedSource(
       @Nonnull final QueryableDataSource delegate, @Nonnull final Set<String> driftedTypes) {
     this.delegate = delegate;
-    this.driftedTypes = Set.copyOf(driftedTypes);
+    this.driftedTypes = driftedTypes;
   }
 
   @Override
@@ -120,7 +124,12 @@ public class DriftGuardedSource implements QueryableDataSource {
         : cached;
   }
 
-  private void checkNotDrifted(@Nullable final String resourceCode) {
+  /**
+   * Fails with a {@link SchemaDriftError} if the given resource type is marked as drifted.
+   *
+   * @param resourceCode the resource type code to check, or null to skip the check
+   */
+  protected final void checkNotDrifted(@Nullable final String resourceCode) {
     if (resourceCode != null && driftedTypes.contains(resourceCode)) {
       throw new SchemaDriftError(resourceCode);
     }

--- a/server/src/main/java/au/csiro/pathling/io/DriftGuardedSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DriftGuardedSource.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.io;
+
+import au.csiro.pathling.io.source.DataSource;
+import au.csiro.pathling.library.io.sink.DataSinkBuilder;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
+import au.csiro.pathling.library.query.FhirViewQuery;
+import au.csiro.pathling.views.FhirView;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+
+/**
+ * A {@link QueryableDataSource} wrapper that carries the schema drift guard of a {@link
+ * DynamicDeltaSource} into sources derived from it through {@code map} or {@code
+ * filterByResourceType}. Reads of a drifted type fail with {@link SchemaDriftError} instead of an
+ * opaque Spark analysis failure. View queries are guarded on their subject resource type when the
+ * query is constructed, because the executed query resolves datasets through the wrapped source's
+ * own dispatcher rather than the guarded {@code read}.
+ *
+ * <p>The drifted types are snapshotted at construction; derived sources are created per request, so
+ * they reflect the drift state at the time of derivation.
+ *
+ * @author John Grimes
+ */
+public class DriftGuardedSource implements QueryableDataSource {
+
+  @Nonnull private final QueryableDataSource delegate;
+
+  @Nonnull private final Set<String> driftedTypes;
+
+  /**
+   * Constructs a new DriftGuardedSource.
+   *
+   * @param delegate the underlying QueryableDataSource to delegate to
+   * @param driftedTypes the resource types whose tables are drifted and unmigrated
+   */
+  public DriftGuardedSource(
+      @Nonnull final QueryableDataSource delegate, @Nonnull final Set<String> driftedTypes) {
+    this.delegate = delegate;
+    this.driftedTypes = Set.copyOf(driftedTypes);
+  }
+
+  @Override
+  @Nonnull
+  public Dataset<Row> read(@Nullable final String resourceCode) {
+    checkNotDrifted(resourceCode);
+    return delegate.read(resourceCode);
+  }
+
+  @Override
+  @Nonnull
+  public Set<String> getResourceTypes() {
+    return delegate.getResourceTypes();
+  }
+
+  @Override
+  @Nonnull
+  public DataSinkBuilder write() {
+    return delegate.write();
+  }
+
+  @Override
+  @Nonnull
+  public FhirViewQuery view(@Nullable final String subjectResource) {
+    checkNotDrifted(subjectResource);
+    return delegate.view(subjectResource);
+  }
+
+  @Override
+  @Nonnull
+  public FhirViewQuery view(@Nullable final FhirView view) {
+    if (view != null) {
+      checkNotDrifted(view.getResource());
+    }
+    return delegate.view(view);
+  }
+
+  @Override
+  @Nonnull
+  public QueryableDataSource map(
+      @Nonnull final BiFunction<String, Dataset<Row>, Dataset<Row>> operator) {
+    return new DriftGuardedSource(delegate.map(operator), driftedTypes);
+  }
+
+  @Override
+  @Nonnull
+  public QueryableDataSource filterByResourceType(
+      @Nonnull final Predicate<String> resourceTypePredicate) {
+    return new DriftGuardedSource(
+        delegate.filterByResourceType(resourceTypePredicate), driftedTypes);
+  }
+
+  @Override
+  @Nonnull
+  public DataSource cache() {
+    final DataSource cached = delegate.cache();
+    return cached instanceof final QueryableDataSource queryable
+        ? new DriftGuardedSource(queryable, driftedTypes)
+        : cached;
+  }
+
+  private void checkNotDrifted(@Nullable final String resourceCode) {
+    if (resourceCode != null && driftedTypes.contains(resourceCode)) {
+      throw new SchemaDriftError(resourceCode);
+    }
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
@@ -63,7 +63,13 @@ public class DynamicDeltaSource implements QueryableDataSource {
   @Nonnull private final Set<String> dynamicallyDiscoveredTypes = ConcurrentHashMap.newKeySet();
 
   /**
-   * Constructs a new DynamicDeltaSource.
+   * The resource types whose tables were found drifted and could not be migrated at startup. Reads
+   * of these types fail with an actionable error until a successful refresh clears them.
+   */
+  @Nonnull private final Set<String> driftedTypes = ConcurrentHashMap.newKeySet();
+
+  /**
+   * Constructs a new DynamicDeltaSource with no drifted types.
    *
    * @param delegate the underlying QueryableDataSource to delegate to
    * @param spark the Spark session for Delta table operations
@@ -77,11 +83,32 @@ public class DynamicDeltaSource implements QueryableDataSource {
       @Nonnull final String databasePath,
       @Nonnull final FhirEncoders fhirEncoders,
       @Nonnull final StorageConfiguration storageConfiguration) {
+    this(delegate, spark, databasePath, fhirEncoders, storageConfiguration, Set.of());
+  }
+
+  /**
+   * Constructs a new DynamicDeltaSource.
+   *
+   * @param delegate the underlying QueryableDataSource to delegate to
+   * @param spark the Spark session for Delta table operations
+   * @param databasePath the path to the Delta database
+   * @param fhirEncoders the FHIR encoders for creating empty datasets
+   * @param storageConfiguration the storage configuration
+   * @param driftedTypes the resource types left drifted and unmigrated at startup
+   */
+  public DynamicDeltaSource(
+      @Nonnull final QueryableDataSource delegate,
+      @Nonnull final SparkSession spark,
+      @Nonnull final String databasePath,
+      @Nonnull final FhirEncoders fhirEncoders,
+      @Nonnull final StorageConfiguration storageConfiguration,
+      @Nonnull final Set<String> driftedTypes) {
     this.delegate = delegate;
     this.spark = spark;
     this.databasePath = databasePath;
     this.fhirEncoders = fhirEncoders;
     this.cacheDatasets = storageConfiguration.getCacheDatasets();
+    this.driftedTypes.addAll(driftedTypes);
   }
 
   @Override

--- a/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
@@ -118,6 +118,12 @@ public class DynamicDeltaSource implements QueryableDataSource {
       throw new IllegalArgumentException("Resource code must not be null");
     }
 
+    // A type whose table is drifted and unmigrated cannot be queried; fail with an actionable
+    // error rather than an opaque analysis failure.
+    if (driftedTypes.contains(resourceCode)) {
+      throw new SchemaDriftError(resourceCode);
+    }
+
     // If delegate knows about this type, use it.
     if (delegate.getResourceTypes().contains(resourceCode)) {
       return cacheIfEnabled(delegate.read(resourceCode));
@@ -173,6 +179,11 @@ public class DynamicDeltaSource implements QueryableDataSource {
       // the Delta table on each read.
       dynamicallyDiscoveredTypes.add(resourceCode);
       log.info("Registered resource type {} for dynamic discovery following refresh", resourceCode);
+    }
+
+    // The freshly loaded table carries the current schema, so the type is no longer drifted.
+    if (driftedTypes.remove(resourceCode)) {
+      log.info("Cleared drifted mark for resource type {}", resourceCode);
     }
   }
 

--- a/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
@@ -120,9 +120,7 @@ public class DynamicDeltaSource implements QueryableDataSource {
 
     // A type whose table is drifted and unmigrated cannot be queried; fail with an actionable
     // error rather than an opaque analysis failure.
-    if (driftedTypes.contains(resourceCode)) {
-      throw new SchemaDriftError(resourceCode);
-    }
+    checkNotDrifted(resourceCode);
 
     // If delegate knows about this type, use it.
     if (delegate.getResourceTypes().contains(resourceCode)) {
@@ -204,12 +202,20 @@ public class DynamicDeltaSource implements QueryableDataSource {
   @Override
   @Nonnull
   public FhirViewQuery view(@Nullable final String subjectResource) {
+    // The executed query resolves its subject dataset through the delegate's own dispatcher
+    // rather than the guarded read(), so the drift guard is applied at query construction.
+    checkNotDrifted(subjectResource);
     return delegate.view(subjectResource);
   }
 
   @Override
   @Nonnull
   public FhirViewQuery view(@Nullable final FhirView view) {
+    // The executed query resolves its subject dataset through the delegate's own dispatcher
+    // rather than the guarded read(), so the drift guard is applied at query construction.
+    if (view != null) {
+      checkNotDrifted(view.getResource());
+    }
     return delegate.view(view);
   }
 
@@ -217,20 +223,34 @@ public class DynamicDeltaSource implements QueryableDataSource {
   @Nonnull
   public QueryableDataSource map(
       @Nonnull final BiFunction<String, Dataset<Row>, Dataset<Row>> operator) {
-    return delegate.map(operator);
+    // Derived sources resolve datasets from the delegate directly, so the drift guard is carried
+    // into them explicitly.
+    return new DriftGuardedSource(delegate.map(operator), driftedTypes);
   }
 
   @Override
   @Nonnull
   public QueryableDataSource filterByResourceType(
       @Nonnull final Predicate<String> resourceTypePredicate) {
-    return delegate.filterByResourceType(resourceTypePredicate);
+    // Derived sources resolve datasets from the delegate directly, so the drift guard is carried
+    // into them explicitly.
+    return new DriftGuardedSource(
+        delegate.filterByResourceType(resourceTypePredicate), driftedTypes);
   }
 
   @Override
   @Nonnull
   public DataSource cache() {
-    return delegate.cache();
+    final DataSource cached = delegate.cache();
+    return cached instanceof final QueryableDataSource queryable
+        ? new DriftGuardedSource(queryable, driftedTypes)
+        : cached;
+  }
+
+  private void checkNotDrifted(@Nullable final String resourceCode) {
+    if (resourceCode != null && driftedTypes.contains(resourceCode)) {
+      throw new SchemaDriftError(resourceCode);
+    }
   }
 
   @Nonnull

--- a/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
@@ -20,37 +20,33 @@ package au.csiro.pathling.io;
 import au.csiro.pathling.QueryHelpers;
 import au.csiro.pathling.config.StorageConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
-import au.csiro.pathling.io.source.DataSource;
 import au.csiro.pathling.library.io.FileSystemPersistence;
-import au.csiro.pathling.library.io.sink.DataSinkBuilder;
 import au.csiro.pathling.library.io.source.DatasetSource;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
-import au.csiro.pathling.library.query.FhirViewQuery;
-import au.csiro.pathling.views.FhirView;
 import io.delta.tables.DeltaTable;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiFunction;
-import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 
 /**
- * A QueryableDataSource wrapper that dynamically discovers new resource types created after
- * startup. Delegates to the underlying data source for known types, and attempts on-demand
- * discovery for unknown types by checking if a Delta table exists at the expected path.
+ * A {@link DriftGuardedSource} that dynamically discovers new resource types created after startup.
+ * Delegates to the underlying data source for known types, and attempts on-demand discovery for
+ * unknown types by checking if a Delta table exists at the expected path.
+ *
+ * <p>The drift guard behaviour, including its propagation into derived sources, is inherited from
+ * {@link DriftGuardedSource}. The drifted types set is mutable so that a successful {@link
+ * #refresh} clears the guard for the refreshed type.
  *
  * @author John Grimes
  */
 @Slf4j
-public class DynamicDeltaSource implements QueryableDataSource {
-
-  @Nonnull private final QueryableDataSource delegate;
+public class DynamicDeltaSource extends DriftGuardedSource {
 
   @Nonnull private final SparkSession spark;
 
@@ -61,12 +57,6 @@ public class DynamicDeltaSource implements QueryableDataSource {
   private final boolean cacheDatasets;
 
   @Nonnull private final Set<String> dynamicallyDiscoveredTypes = ConcurrentHashMap.newKeySet();
-
-  /**
-   * The resource types whose tables were found drifted and could not be migrated at startup. Reads
-   * of these types fail with an actionable error until a successful refresh clears them.
-   */
-  @Nonnull private final Set<String> driftedTypes = ConcurrentHashMap.newKeySet();
 
   /**
    * Constructs a new DynamicDeltaSource with no drifted types.
@@ -103,12 +93,25 @@ public class DynamicDeltaSource implements QueryableDataSource {
       @Nonnull final FhirEncoders fhirEncoders,
       @Nonnull final StorageConfiguration storageConfiguration,
       @Nonnull final Set<String> driftedTypes) {
-    this.delegate = delegate;
+    super(delegate, concurrentCopyOf(driftedTypes));
     this.spark = spark;
     this.databasePath = databasePath;
     this.fhirEncoders = fhirEncoders;
     this.cacheDatasets = storageConfiguration.getCacheDatasets();
-    this.driftedTypes.addAll(driftedTypes);
+  }
+
+  /**
+   * Copies the given types into a mutable concurrent set, so that the drifted mark can be cleared
+   * by {@link #refresh} and observed by derived sources.
+   *
+   * @param types the types to copy
+   * @return a mutable concurrent set containing the given types
+   */
+  @Nonnull
+  private static Set<String> concurrentCopyOf(@Nonnull final Set<String> types) {
+    final Set<String> copy = ConcurrentHashMap.newKeySet();
+    copy.addAll(types);
+    return copy;
   }
 
   @Override
@@ -191,66 +194,6 @@ public class DynamicDeltaSource implements QueryableDataSource {
     final Set<String> types = new HashSet<>(delegate.getResourceTypes());
     types.addAll(dynamicallyDiscoveredTypes);
     return types;
-  }
-
-  @Override
-  @Nonnull
-  public DataSinkBuilder write() {
-    return delegate.write();
-  }
-
-  @Override
-  @Nonnull
-  public FhirViewQuery view(@Nullable final String subjectResource) {
-    // The executed query resolves its subject dataset through the delegate's own dispatcher
-    // rather than the guarded read(), so the drift guard is applied at query construction.
-    checkNotDrifted(subjectResource);
-    return delegate.view(subjectResource);
-  }
-
-  @Override
-  @Nonnull
-  public FhirViewQuery view(@Nullable final FhirView view) {
-    // The executed query resolves its subject dataset through the delegate's own dispatcher
-    // rather than the guarded read(), so the drift guard is applied at query construction.
-    if (view != null) {
-      checkNotDrifted(view.getResource());
-    }
-    return delegate.view(view);
-  }
-
-  @Override
-  @Nonnull
-  public QueryableDataSource map(
-      @Nonnull final BiFunction<String, Dataset<Row>, Dataset<Row>> operator) {
-    // Derived sources resolve datasets from the delegate directly, so the drift guard is carried
-    // into them explicitly.
-    return new DriftGuardedSource(delegate.map(operator), driftedTypes);
-  }
-
-  @Override
-  @Nonnull
-  public QueryableDataSource filterByResourceType(
-      @Nonnull final Predicate<String> resourceTypePredicate) {
-    // Derived sources resolve datasets from the delegate directly, so the drift guard is carried
-    // into them explicitly.
-    return new DriftGuardedSource(
-        delegate.filterByResourceType(resourceTypePredicate), driftedTypes);
-  }
-
-  @Override
-  @Nonnull
-  public DataSource cache() {
-    final DataSource cached = delegate.cache();
-    return cached instanceof final QueryableDataSource queryable
-        ? new DriftGuardedSource(queryable, driftedTypes)
-        : cached;
-  }
-
-  private void checkNotDrifted(@Nullable final String resourceCode) {
-    if (resourceCode != null && driftedTypes.contains(resourceCode)) {
-      throw new SchemaDriftError(resourceCode);
-    }
   }
 
   @Nonnull

--- a/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
@@ -23,6 +23,7 @@ import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.io.source.DataSource;
 import au.csiro.pathling.library.io.FileSystemPersistence;
 import au.csiro.pathling.library.io.sink.DataSinkBuilder;
+import au.csiro.pathling.library.io.source.DatasetSource;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.library.query.FhirViewQuery;
 import au.csiro.pathling.views.FhirView;
@@ -111,6 +112,41 @@ public class DynamicDeltaSource implements QueryableDataSource {
     // No data found - return an empty dataset with the correct schema.
     log.debug("No data found for resource type: {}, returning empty dataset", resourceCode);
     return QueryHelpers.createEmptyDataset(spark, fhirEncoders, resourceCode);
+  }
+
+  /**
+   * Re-loads the Delta table for the given resource type and replaces the dataset served for it, so
+   * that all consumers observe the table's current schema. Intended to be called after a
+   * schema-evolving write. When dataset caching is enabled, the stale cached dataset is
+   * unpersisted. If no Delta table exists for the type, the call is a no-op.
+   *
+   * @param resourceCode the resource type code to refresh
+   */
+  public void refresh(@Nonnull final String resourceCode) {
+    final String tablePath = getTablePath(resourceCode);
+    if (!DeltaTable.isDeltaTable(spark, tablePath)) {
+      log.debug("No Delta table found for resource type {}, nothing to refresh", resourceCode);
+      return;
+    }
+
+    // Unpersist the stale cached dataset before replacing it, so the cached plan for the old
+    // snapshot does not linger in the Spark cache.
+    if (cacheDatasets && delegate.getResourceTypes().contains(resourceCode)) {
+      delegate.read(resourceCode).unpersist();
+    }
+
+    final Dataset<Row> refreshed = spark.read().format("delta").load(tablePath);
+    if (delegate instanceof final DatasetSource datasetSource) {
+      // Replace the pinned entry in the delegate's resource map, so every consumer that resolves
+      // datasets through the delegate observes the evolved schema.
+      datasetSource.dataset(resourceCode, refreshed);
+      log.info("Refreshed dataset for resource type {}", resourceCode);
+    } else {
+      // The delegate cannot be mutated; serve the type through dynamic discovery, which re-loads
+      // the Delta table on each read.
+      dynamicallyDiscoveredTypes.add(resourceCode);
+      log.info("Registered resource type {} for dynamic discovery following refresh", resourceCode);
+    }
   }
 
   @Override

--- a/server/src/main/java/au/csiro/pathling/io/SchemaDrift.java
+++ b/server/src/main/java/au/csiro/pathling/io/SchemaDrift.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.io;
+
+import jakarta.annotation.Nonnull;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Detects schema drift between the schema produced by the current FHIR encoders and the schema of
+ * an existing Delta table. Only field paths present in the source but absent from the target count
+ * as drift; nullability and column metadata differences are ignored, and extra target-only fields
+ * are tolerated.
+ *
+ * @author John Grimes
+ */
+public final class SchemaDrift {
+
+  private SchemaDrift() {}
+
+  /**
+   * Returns true if the source schema contains any field path (recursing through structs, arrays
+   * and maps) that is absent from the target schema.
+   *
+   * @param source the candidate schema (typically the encoder output)
+   * @param target the existing table schema
+   * @return true if {@code source} introduces at least one field name not present in {@code target}
+   */
+  public static boolean hasMissingFields(
+      @Nonnull final StructType source, @Nonnull final StructType target) {
+    return !missingFieldPaths(source, target).isEmpty();
+  }
+
+  /**
+   * Returns the field paths present in the source schema but absent from the target schema, in
+   * lexicographic order.
+   *
+   * @param source the candidate schema (typically the encoder output)
+   * @param target the existing table schema
+   * @return the missing field paths, dot-separated
+   */
+  @Nonnull
+  public static SortedSet<String> missingFieldPaths(
+      @Nonnull final StructType source, @Nonnull final StructType target) {
+    final SortedSet<String> missing = new TreeSet<>(collectFieldPaths(source));
+    missing.removeAll(collectFieldPaths(target));
+    return missing;
+  }
+
+  @Nonnull
+  private static Set<String> collectFieldPaths(@Nonnull final StructType schema) {
+    final Set<String> paths = new HashSet<>();
+    collectFieldPaths(schema, "", paths);
+    return paths;
+  }
+
+  private static void collectFieldPaths(
+      @Nonnull final DataType type, @Nonnull final String prefix, @Nonnull final Set<String> out) {
+    if (type instanceof final StructType struct) {
+      for (final StructField field : struct.fields()) {
+        final String path = prefix.isEmpty() ? field.name() : prefix + "." + field.name();
+        out.add(path);
+        collectFieldPaths(field.dataType(), path, out);
+      }
+    } else if (type instanceof final ArrayType array) {
+      collectFieldPaths(array.elementType(), prefix, out);
+    } else if (type instanceof final MapType map) {
+      collectFieldPaths(map.valueType(), prefix, out);
+    }
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/io/SchemaDriftError.java
+++ b/server/src/main/java/au/csiro/pathling/io/SchemaDriftError.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.io;
+
+import jakarta.annotation.Nonnull;
+
+/**
+ * Raised when a request requires the data of a resource type whose Delta table schema is behind
+ * this server's encoders and has not been migrated. The message names the affected type, the
+ * condition, and the available remedies, and is surfaced to API clients through an
+ * OperationOutcome.
+ *
+ * @author John Grimes
+ */
+public class SchemaDriftError extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  @Nonnull private final String resourceCode;
+
+  /**
+   * Constructs a new SchemaDriftError for the given resource type.
+   *
+   * @param resourceCode the resource type whose table is drifted and unmigrated
+   */
+  public SchemaDriftError(@Nonnull final String resourceCode) {
+    super(
+        "The stored table for resource type '"
+            + resourceCode
+            + "' has a schema that is behind this server's encoders and cannot be queried. "
+            + "Enable pathling.storage.schemaAutoMerge (or restore write access to the "
+            + "warehouse) and restart, or update a resource of this type, to migrate the table.");
+    this.resourceCode = resourceCode;
+  }
+
+  /**
+   * Returns the resource type whose table is drifted.
+   *
+   * @return the resource type code
+   */
+  @Nonnull
+  public String getResourceCode() {
+    return resourceCode;
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/io/SchemaMigrator.java
+++ b/server/src/main/java/au/csiro/pathling/io/SchemaMigrator.java
@@ -101,7 +101,7 @@ public class SchemaMigrator {
    */
   private void checkTable(
       @Nonnull final String resourceCode, @Nonnull final Set<String> driftedTypes) {
-    final String tablePath = safelyJoinPaths(databasePath, resourceCode + ".parquet");
+    final String tablePath = safelyJoinPaths(databasePath, resourceCode + TABLE_EXTENSION);
     final SortedSet<String> missingFields;
     try {
       if (!DeltaTable.isDeltaTable(spark, tablePath)) {

--- a/server/src/main/java/au/csiro/pathling/io/SchemaMigrator.java
+++ b/server/src/main/java/au/csiro/pathling/io/SchemaMigrator.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.io;
+
+import static au.csiro.pathling.library.io.FileSystemPersistence.safelyJoinPaths;
+
+import au.csiro.pathling.QueryHelpers;
+import au.csiro.pathling.encoders.FhirEncoders;
+import io.delta.tables.DeltaTable;
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Detects Delta tables in the warehouse whose schemas are missing fields relative to the current
+ * FHIR encoders, and migrates them at startup when {@code schemaAutoMerge} is enabled. Tables that
+ * remain drifted (flag disabled, or migration failure) are reported so that requests against them
+ * can fail with an actionable error instead of a generic one.
+ *
+ * @author John Grimes
+ */
+@Slf4j
+public class SchemaMigrator {
+
+  /** The file extension used for Delta table directories within the warehouse. */
+  private static final String TABLE_EXTENSION = ".parquet";
+
+  @Nonnull private final SparkSession spark;
+
+  @Nonnull private final FhirEncoders fhirEncoders;
+
+  @Nonnull private final String databasePath;
+
+  private final boolean schemaAutoMerge;
+
+  /**
+   * Constructs a new SchemaMigrator.
+   *
+   * @param spark the Spark session for Delta table operations
+   * @param fhirEncoders the FHIR encoders whose schemas are the migration target
+   * @param databasePath the path to the Delta database
+   * @param schemaAutoMerge whether schema migration is enabled
+   */
+  public SchemaMigrator(
+      @Nonnull final SparkSession spark,
+      @Nonnull final FhirEncoders fhirEncoders,
+      @Nonnull final String databasePath,
+      final boolean schemaAutoMerge) {
+    this.spark = spark;
+    this.fhirEncoders = fhirEncoders;
+    this.databasePath = databasePath;
+    this.schemaAutoMerge = schemaAutoMerge;
+  }
+
+  /**
+   * Compares every Delta table in the database path against the current encoder schema for its
+   * resource type, migrating drifted tables when {@code schemaAutoMerge} is enabled. Migration is
+   * additive only and never fails startup: per-table failures are logged and reported through the
+   * returned set.
+   *
+   * @return the resource type codes that remain drifted and unmigrated
+   */
+  @Nonnull
+  public Set<String> migrate() {
+    final Set<String> driftedTypes = new HashSet<>();
+    for (final String resourceCode : listTableResourceCodes()) {
+      checkTable(resourceCode, driftedTypes);
+    }
+    return driftedTypes;
+  }
+
+  /**
+   * Compares one table against its encoder schema and migrates it if drifted and permitted,
+   * recording the type in the drifted set when it remains unmigrated. Never throws (FR-006).
+   */
+  private void checkTable(
+      @Nonnull final String resourceCode, @Nonnull final Set<String> driftedTypes) {
+    final String tablePath = safelyJoinPaths(databasePath, resourceCode + ".parquet");
+    final SortedSet<String> missingFields;
+    try {
+      if (!DeltaTable.isDeltaTable(spark, tablePath)) {
+        return;
+      }
+      final StructType encoderSchema = fhirEncoders.of(resourceCode).schema();
+      final StructType tableSchema = spark.read().format("delta").load(tablePath).schema();
+      missingFields = SchemaDrift.missingFieldPaths(encoderSchema, tableSchema);
+    } catch (final Exception e) {
+      // A table that cannot be inspected (for example, an unencodable name) is skipped.
+      log.debug("Skipping schema drift check for {}: {}", resourceCode, e.getMessage());
+      return;
+    }
+
+    if (missingFields.isEmpty()) {
+      return;
+    }
+
+    if (!schemaAutoMerge) {
+      log.warn(
+          "The {} table schema is behind this server's encoders (missing fields: {}). Requests "
+              + "against this type will fail until it is migrated. Enable "
+              + "pathling.storage.schemaAutoMerge and restart, or update a resource of this type "
+              + "with the flag enabled, to migrate the table.",
+          resourceCode,
+          missingFields);
+      driftedTypes.add(resourceCode);
+      return;
+    }
+
+    try {
+      // A zero-row append with mergeSchema adds the missing fields (including fields nested
+      // inside structs, arrays and maps) to the table schema without touching any data; existing
+      // rows present the new fields as null.
+      QueryHelpers.createEmptyDataset(spark, fhirEncoders, resourceCode)
+          .write()
+          .format("delta")
+          .mode(SaveMode.Append)
+          .option("mergeSchema", "true")
+          .save(tablePath);
+      log.info("Migrated schema of {} table, added fields: {}", resourceCode, missingFields);
+    } catch (final Exception e) {
+      log.error(
+          "Failed to migrate the schema of the {} table (missing fields: {}). Requests against "
+              + "this type will fail until it is migrated.",
+          resourceCode,
+          missingFields,
+          e);
+      driftedTypes.add(resourceCode);
+    }
+  }
+
+  /**
+   * Lists the resource type codes for which a Delta table directory exists in the database path.
+   * Non-directories and entries without the expected extension are skipped; a missing or empty
+   * database path yields an empty list.
+   */
+  @Nonnull
+  private List<String> listTableResourceCodes() {
+    final List<String> resourceCodes = new ArrayList<>();
+    try {
+      final Path dbPath = new Path(databasePath);
+      final FileSystem fileSystem =
+          dbPath.getFileSystem(spark.sparkContext().hadoopConfiguration());
+      if (!fileSystem.exists(dbPath)) {
+        return resourceCodes;
+      }
+      for (final FileStatus status : fileSystem.listStatus(dbPath)) {
+        final String name = status.getPath().getName();
+        if (status.isDirectory() && name.endsWith(TABLE_EXTENSION)) {
+          resourceCodes.add(name.substring(0, name.length() - TABLE_EXTENSION.length()));
+        }
+      }
+    } catch (final IOException e) {
+      log.warn("Unable to scan the warehouse for schema drift: {}", e.getMessage());
+    }
+    return resourceCodes;
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitExecutor.java
@@ -161,8 +161,11 @@ public class BulkSubmitExecutor {
    * @param manifestJob The manifest job to process.
    * @param fileRequestHeaders Custom HTTP headers to include when downloading files.
    * @param fhirServerBase The FHIR server base URL for building result manifests.
+   * @return A future that completes when the asynchronous download work has reached a terminal
+   *     state, allowing callers to await it.
    */
-  public void downloadManifestJob(
+  @Nonnull
+  public CompletableFuture<Void> downloadManifestJob(
       @Nonnull final Submission submission,
       @Nonnull final ManifestJob manifestJob,
       @Nonnull final List<FileRequestHeader> fileRequestHeaders,
@@ -197,7 +200,7 @@ public class BulkSubmitExecutor {
     }
 
     // Execute asynchronously to not block the request thread.
-    CompletableFuture.runAsync(
+    return CompletableFuture.runAsync(
         () ->
             downloadManifestJobInternal(
                 submission, manifestJob, fileRequestHeaders, fhirServerBase, jobId, resultFuture));

--- a/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
@@ -23,22 +23,16 @@ import static au.csiro.pathling.utilities.Preconditions.checkUserInput;
 import au.csiro.pathling.cache.CacheableDatabase;
 import au.csiro.pathling.config.StorageConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.io.SchemaDrift;
 import au.csiro.pathling.library.PathlingContext;
 import io.delta.tables.DeltaTable;
 import jakarta.annotation.Nonnull;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.types.ArrayType;
-import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.MapType;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Enumerations.ResourceType;
 import org.springframework.beans.factory.annotation.Value;
@@ -145,7 +139,8 @@ public class UpdateExecutor {
     if (deltaTableExists(spark, tablePath)) {
       DeltaTable table = DeltaTable.forPath(spark, tablePath);
 
-      if (schemaAutoMerge && hasMissingFields(updates.schema(), table.toDF().schema())) {
+      if (schemaAutoMerge
+          && SchemaDrift.hasMissingFields(updates.schema(), table.toDF().schema())) {
         // Delta's MERGE - even with spark.databricks.delta.schema.autoMerge.enabled=true - does
         // not support adding new fields to nested structs inside arrays. This is the exact failure
         // mode when the FHIR encoder gains new value-type columns (e.g. valueDecimal,
@@ -241,44 +236,5 @@ public class UpdateExecutor {
   private static boolean deltaTableExists(
       @Nonnull final SparkSession spark, @Nonnull final String tablePath) {
     return DeltaTable.isDeltaTable(spark, tablePath);
-  }
-
-  /**
-   * Returns true if the source schema contains any field path (recursing through structs, arrays
-   * and maps) that is absent from the target schema. Compares field names only - nullability and
-   * column metadata are ignored, so two schemas that differ only in those respects are treated as
-   * equivalent.
-   *
-   * @param source the candidate schema (typically the encoder output)
-   * @param target the existing table schema
-   * @return true if {@code source} introduces at least one field name not present in {@code target}
-   */
-  static boolean hasMissingFields(
-      @Nonnull final StructType source, @Nonnull final StructType target) {
-    final Set<String> sourcePaths = collectFieldPaths(source);
-    final Set<String> targetPaths = collectFieldPaths(target);
-    return !targetPaths.containsAll(sourcePaths);
-  }
-
-  @Nonnull
-  private static Set<String> collectFieldPaths(@Nonnull final StructType schema) {
-    final Set<String> paths = new HashSet<>();
-    collectFieldPaths(schema, "", paths);
-    return paths;
-  }
-
-  private static void collectFieldPaths(
-      @Nonnull final DataType type, @Nonnull final String prefix, @Nonnull final Set<String> out) {
-    if (type instanceof final StructType struct) {
-      for (final StructField field : struct.fields()) {
-        final String path = prefix.isEmpty() ? field.name() : prefix + "." + field.name();
-        out.add(path);
-        collectFieldPaths(field.dataType(), path, out);
-      }
-    } else if (type instanceof final ArrayType array) {
-      collectFieldPaths(array.elementType(), prefix, out);
-    } else if (type instanceof final MapType map) {
-      collectFieldPaths(map.valueType(), prefix, out);
-    }
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
@@ -32,6 +32,8 @@ import jakarta.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -62,6 +64,16 @@ public class UpdateExecutor {
   private final boolean schemaAutoMerge;
 
   @Nonnull private final QueryableDataSource dataSource;
+
+  /**
+   * Per-resource-code locks serialising the create-new-table branch of {@link #merge(String,
+   * List)}. Without this, concurrent first-creates of the same resource type can all pass the
+   * table-existence check and race the initial write, failing every loser with a Delta concurrency
+   * error. This executor is a singleton component, so an instance-scoped map covers the whole
+   * server process; cross-process coordination is out of scope.
+   */
+  @Nonnull
+  private final ConcurrentMap<String, Object> tableCreationLocks = new ConcurrentHashMap<>();
 
   /**
    * Constructs a new UpdateExecutor.
@@ -146,69 +158,100 @@ public class UpdateExecutor {
     final String tablePath = getTablePath(resourceCode);
 
     if (deltaTableExists(spark, tablePath)) {
-      DeltaTable table = DeltaTable.forPath(spark, tablePath);
-      boolean schemaEvolved = false;
-
-      final SortedSet<String> missingFields =
-          schemaAutoMerge
-              ? SchemaDrift.missingFieldPaths(updates.schema(), table.toDF().schema())
-              : Collections.emptySortedSet();
-      if (!missingFields.isEmpty()) {
-        // Delta's MERGE - even with spark.databricks.delta.schema.autoMerge.enabled=true - does
-        // not support adding new fields to nested structs inside arrays. This is the exact failure
-        // mode when the FHIR encoder gains new value-type columns (e.g. valueDecimal,
-        // valueDecimal_scale inside the extension element struct): the MERGE planner throws
-        // DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION because it cannot cast the richer source struct
-        // to the narrower target struct.
-        //
-        // A regular write with mergeSchema=true DOES support nested-struct field evolution.
-        // Writing limit(0) - zero rows, same schema as the encoder output - causes Delta to add
-        // any missing nested fields to the target table schema (with null for existing rows)
-        // without inserting any data. The MERGE that follows then sees compatible schemas and
-        // succeeds.
-        //
-        // SchemaDrift compares only field names and structural shape, ignoring nullability and
-        // column metadata. This avoids paying the warmup transaction when the schemas are
-        // semantically equivalent but differ in metadata (e.g. parquet-side annotations).
-        //
-        // After the warmup write the table snapshot has changed, so we re-resolve DeltaTable
-        // before the MERGE.
-        updates
-            .limit(0)
-            .write()
-            .format("delta")
-            .mode(SaveMode.Append)
-            .option("mergeSchema", "true")
-            .save(tablePath);
-        table = DeltaTable.forPath(spark, tablePath);
-        schemaEvolved = true;
-        log.info("Evolved schema of {} table, added fields: {}", resourceCode, missingFields);
-      }
-
-      // Perform a merge operation on the existing table.
-      table
-          .as("original")
-          .merge(updates.as("updates"), "original.id = updates.id")
-          .whenMatched()
-          .updateAll()
-          .whenNotMatched()
-          .insertAll()
-          .execute();
-
-      // After a schema-evolving write, refresh the dataset served for this resource type so that
-      // all in-process consumers observe the evolved schema without a server restart.
-      if (schemaEvolved && dataSource instanceof final DynamicDeltaSource dynamicDataSource) {
-        dynamicDataSource.refresh(resourceCode);
-      }
+      mergeIntoExistingTable(spark, resourceCode, tablePath, updates);
     } else {
-      // Create a new table with the resources.
-      log.debug("Creating new Delta table for resource type: {}", resourceCode);
-      updates.write().format("delta").mode(SaveMode.ErrorIfExists).save(tablePath);
+      // Serialise first-creates of this resource type so that concurrent requests cannot race the
+      // initial write. The existence check is repeated inside the lock: the loser of a race finds
+      // the table already created and recovers by merging into it instead of failing.
+      final Object creationLock =
+          tableCreationLocks.computeIfAbsent(resourceCode, key -> new Object());
+      synchronized (creationLock) {
+        if (deltaTableExists(spark, tablePath)) {
+          log.debug(
+              "Delta table for resource type {} was created concurrently; merging instead",
+              resourceCode);
+          mergeIntoExistingTable(spark, resourceCode, tablePath, updates);
+        } else {
+          // Create a new table with the resources.
+          log.debug("Creating new Delta table for resource type: {}", resourceCode);
+          updates.write().format("delta").mode(SaveMode.ErrorIfExists).save(tablePath);
+        }
+      }
     }
 
     // Invalidate the cache to ensure subsequent requests see the updated data. Use the optimised
     // single-table invalidation since we know exactly which table was modified.
     cacheableDatabase.invalidate(tablePath);
+  }
+
+  /**
+   * Merges updates into an existing Delta table, evolving the table schema first when {@code
+   * schemaAutoMerge} is enabled and the encoder output contains fields the table lacks.
+   *
+   * @param spark the Spark session
+   * @param resourceCode the type code of the resources being merged
+   * @param tablePath the path of the existing Delta table
+   * @param updates the dataset of resources to merge
+   */
+  private void mergeIntoExistingTable(
+      @Nonnull final SparkSession spark,
+      @Nonnull final String resourceCode,
+      @Nonnull final String tablePath,
+      @Nonnull final Dataset<Row> updates) {
+    DeltaTable table = DeltaTable.forPath(spark, tablePath);
+    boolean schemaEvolved = false;
+
+    final SortedSet<String> missingFields =
+        schemaAutoMerge
+            ? SchemaDrift.missingFieldPaths(updates.schema(), table.toDF().schema())
+            : Collections.emptySortedSet();
+    if (!missingFields.isEmpty()) {
+      // Delta's MERGE - even with spark.databricks.delta.schema.autoMerge.enabled=true - does
+      // not support adding new fields to nested structs inside arrays. This is the exact failure
+      // mode when the FHIR encoder gains new value-type columns (e.g. valueDecimal,
+      // valueDecimal_scale inside the extension element struct): the MERGE planner throws
+      // DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION because it cannot cast the richer source struct
+      // to the narrower target struct.
+      //
+      // A regular write with mergeSchema=true DOES support nested-struct field evolution.
+      // Writing limit(0) - zero rows, same schema as the encoder output - causes Delta to add
+      // any missing nested fields to the target table schema (with null for existing rows)
+      // without inserting any data. The MERGE that follows then sees compatible schemas and
+      // succeeds.
+      //
+      // SchemaDrift compares only field names and structural shape, ignoring nullability and
+      // column metadata. This avoids paying the warmup transaction when the schemas are
+      // semantically equivalent but differ in metadata (e.g. parquet-side annotations).
+      //
+      // After the warmup write the table snapshot has changed, so we re-resolve DeltaTable
+      // before the MERGE.
+      updates
+          .limit(0)
+          .write()
+          .format("delta")
+          .mode(SaveMode.Append)
+          .option("mergeSchema", "true")
+          .save(tablePath);
+      table = DeltaTable.forPath(spark, tablePath);
+      schemaEvolved = true;
+      log.info("Evolved schema of {} table, added fields: {}", resourceCode, missingFields);
+    }
+
+    // Perform a merge operation on the existing table.
+    table
+        .as("original")
+        .merge(updates.as("updates"), "original.id = updates.id")
+        .whenMatched()
+        .updateAll()
+        .whenNotMatched()
+        .insertAll()
+        .execute();
+
+    // After a schema-evolving write, refresh the dataset served for this resource type so that
+    // all in-process consumers observe the evolved schema without a server restart.
+    if (schemaEvolved && dataSource instanceof final DynamicDeltaSource dynamicDataSource) {
+      dynamicDataSource.refresh(resourceCode);
+    }
   }
 
   /**

--- a/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
@@ -23,11 +23,15 @@ import static au.csiro.pathling.utilities.Preconditions.checkUserInput;
 import au.csiro.pathling.cache.CacheableDatabase;
 import au.csiro.pathling.config.StorageConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.io.DynamicDeltaSource;
 import au.csiro.pathling.io.SchemaDrift;
 import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
 import io.delta.tables.DeltaTable;
 import jakarta.annotation.Nonnull;
+import java.util.Collections;
 import java.util.List;
+import java.util.SortedSet;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -57,6 +61,8 @@ public class UpdateExecutor {
 
   private final boolean schemaAutoMerge;
 
+  @Nonnull private final QueryableDataSource dataSource;
+
   /**
    * Constructs a new UpdateExecutor.
    *
@@ -66,6 +72,7 @@ public class UpdateExecutor {
    * @param cacheableDatabase the cacheable database for cache invalidation
    * @param storageConfiguration the storage configuration, used to read the {@code schemaAutoMerge}
    *     flag
+   * @param dataSource the data source serving queries, refreshed after a schema-evolving write
    */
   public UpdateExecutor(
       @Nonnull final PathlingContext pathlingContext,
@@ -73,12 +80,14 @@ public class UpdateExecutor {
       @Value("${pathling.storage.warehouseUrl}/${pathling.storage.databaseName}") @Nonnull
           final String databasePath,
       @Nonnull final CacheableDatabase cacheableDatabase,
-      @Nonnull final StorageConfiguration storageConfiguration) {
+      @Nonnull final StorageConfiguration storageConfiguration,
+      @Nonnull final QueryableDataSource dataSource) {
     this.pathlingContext = pathlingContext;
     this.fhirEncoders = fhirEncoders;
     this.databasePath = databasePath;
     this.cacheableDatabase = cacheableDatabase;
     this.schemaAutoMerge = storageConfiguration.getSchemaAutoMerge();
+    this.dataSource = dataSource;
   }
 
   /**
@@ -138,9 +147,13 @@ public class UpdateExecutor {
 
     if (deltaTableExists(spark, tablePath)) {
       DeltaTable table = DeltaTable.forPath(spark, tablePath);
+      boolean schemaEvolved = false;
 
-      if (schemaAutoMerge
-          && SchemaDrift.hasMissingFields(updates.schema(), table.toDF().schema())) {
+      final SortedSet<String> missingFields =
+          schemaAutoMerge
+              ? SchemaDrift.missingFieldPaths(updates.schema(), table.toDF().schema())
+              : Collections.emptySortedSet();
+      if (!missingFields.isEmpty()) {
         // Delta's MERGE - even with spark.databricks.delta.schema.autoMerge.enabled=true - does
         // not support adding new fields to nested structs inside arrays. This is the exact failure
         // mode when the FHIR encoder gains new value-type columns (e.g. valueDecimal,
@@ -154,8 +167,8 @@ public class UpdateExecutor {
         // without inserting any data. The MERGE that follows then sees compatible schemas and
         // succeeds.
         //
-        // hasMissingFields() compares only field names and structural shape, ignoring nullability
-        // and column metadata. This avoids paying the warmup transaction when the schemas are
+        // SchemaDrift compares only field names and structural shape, ignoring nullability and
+        // column metadata. This avoids paying the warmup transaction when the schemas are
         // semantically equivalent but differ in metadata (e.g. parquet-side annotations).
         //
         // After the warmup write the table snapshot has changed, so we re-resolve DeltaTable
@@ -168,6 +181,8 @@ public class UpdateExecutor {
             .option("mergeSchema", "true")
             .save(tablePath);
         table = DeltaTable.forPath(spark, tablePath);
+        schemaEvolved = true;
+        log.info("Evolved schema of {} table, added fields: {}", resourceCode, missingFields);
       }
 
       // Perform a merge operation on the existing table.
@@ -179,6 +194,12 @@ public class UpdateExecutor {
           .whenNotMatched()
           .insertAll()
           .execute();
+
+      // After a schema-evolving write, refresh the dataset served for this resource type so that
+      // all in-process consumers observe the evolved schema without a server restart.
+      if (schemaEvolved && dataSource instanceof final DynamicDeltaSource dynamicDataSource) {
+        dynamicDataSource.refresh(resourceCode);
+      }
     } else {
       // Create a new table with the resources.
       log.debug("Creating new Delta table for resource type: {}", resourceCode);

--- a/server/src/test/java/au/csiro/pathling/errors/ErrorHandlingInterceptorTest.java
+++ b/server/src/test/java/au/csiro/pathling/errors/ErrorHandlingInterceptorTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import au.csiro.pathling.io.SchemaDriftError;
 import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
@@ -33,6 +34,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import org.apache.spark.SparkException;
 import org.apache.spark.SparkRuntimeException;
+import org.hl7.fhir.r4.model.OperationOutcome;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -41,6 +43,29 @@ import org.junit.jupiter.api.Test;
  * @author John Grimes
  */
 class ErrorHandlingInterceptorTest {
+
+  // SchemaDriftError should map to a 500 response whose OperationOutcome diagnostics name the
+  // affected resource type, the condition, and the remedies, rather than the generic
+  // "Unexpected error occurred" message.
+  @Test
+  void convertsSchemaDriftErrorTo500WithActionableDiagnostics() {
+    final SchemaDriftError e = new SchemaDriftError("ViewDefinition");
+
+    final BaseServerResponseException result = ErrorHandlingInterceptor.convertError(e);
+
+    assertThat(result.getStatusCode()).isEqualTo(500);
+    assertThat(result.getOperationOutcome()).isInstanceOf(OperationOutcome.class);
+    final OperationOutcome outcome = (OperationOutcome) result.getOperationOutcome();
+    assertThat(outcome.getIssue()).hasSize(1);
+    final OperationOutcome.OperationOutcomeIssueComponent issue = outcome.getIssueFirstRep();
+    assertThat(issue.getSeverity()).isEqualTo(OperationOutcome.IssueSeverity.ERROR);
+    assertThat(issue.getCode()).isEqualTo(OperationOutcome.IssueType.PROCESSING);
+    assertThat(issue.getDiagnostics())
+        .contains("ViewDefinition")
+        .contains("behind this server's encoders")
+        .contains("schemaAutoMerge")
+        .contains("update a resource of this type");
+  }
 
   @Test
   void convertsUserRaisedExceptionTo400() {

--- a/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
@@ -27,12 +27,20 @@ import au.csiro.pathling.test.SpringBootUnitTest;
 import au.csiro.pathling.util.FhirServerTestConfiguration;
 import jakarta.annotation.Nonnull;
 import java.nio.file.Path;
+import java.util.List;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.apache.spark.storage.StorageLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
@@ -105,12 +113,118 @@ class DynamicDeltaSourceTest {
     assertThat(result.storageLevel()).isEqualTo(StorageLevel.NONE());
   }
 
+  // Verifies that after the underlying Delta table's schema evolves, refresh() replaces the
+  // pinned delegate entry so that read() returns a dataset with the new schema.
+  @Test
+  void refreshReplacesPinnedDatasetAfterSchemaEvolution(@TempDir final Path tempDir) {
+    // Arrange: a Delta table for Patient with only an id column, pinned at construction.
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    writePatientTable(databasePath, "id");
+    final DynamicDeltaSource source = newTempDirSource(databasePath, false);
+    assertThat(source.read("Patient").schema().fieldNames()).doesNotContain("newField");
+
+    // Act: evolve the table schema by appending zero rows carrying an extra column, which leaves
+    // the pinned dataset behind the table, then refresh.
+    evolvePatientTable(databasePath, "id", "newField");
+    assertThat(source.read("Patient").schema().fieldNames()).doesNotContain("newField");
+    source.refresh("Patient");
+
+    // Assert: the replacement dataset presents the evolved schema and still reads the data.
+    final Dataset<Row> refreshed = source.read("Patient");
+    assertThat(refreshed.schema().fieldNames()).contains("id", "newField");
+    assertThat(refreshed.count()).isEqualTo(1);
+  }
+
+  // Verifies that with dataset caching enabled, refresh() unpersists the stale cached dataset and
+  // subsequent reads serve the refreshed dataset with caching applied.
+  @Test
+  void refreshUnpersistsStaleCachedDataset(@TempDir final Path tempDir) {
+    // Arrange: a cached source over a Patient table with only an id column.
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    writePatientTable(databasePath, "id");
+    final DynamicDeltaSource source = newTempDirSource(databasePath, true);
+    final Dataset<Row> stale = source.read("Patient");
+    assertThat(stale.storageLevel()).isEqualTo(StorageLevel.MEMORY_AND_DISK());
+
+    // Act: evolve the table and refresh.
+    evolvePatientTable(databasePath, "id", "newField");
+    source.refresh("Patient");
+
+    // Assert: the stale dataset is no longer persisted, and the refreshed dataset is served with
+    // the evolved schema and caching applied.
+    assertThat(stale.storageLevel()).isEqualTo(StorageLevel.NONE());
+    final Dataset<Row> refreshed = source.read("Patient");
+    try {
+      assertThat(refreshed.schema().fieldNames()).contains("newField");
+      assertThat(refreshed.storageLevel()).isEqualTo(StorageLevel.MEMORY_AND_DISK());
+    } finally {
+      refreshed.unpersist();
+    }
+  }
+
+  // Verifies that refreshing a type with no Delta table is a harmless no-op.
+  @Test
+  void refreshOfMissingTableIsNoOp(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    final DynamicDeltaSource source = newTempDirSource(databasePath, false);
+
+    source.refresh("ImmunizationEvaluation");
+
+    assertThat(source.read("ImmunizationEvaluation").count()).isZero();
+  }
+
+  // ---- helpers ----
+
   @Nonnull
   private DynamicDeltaSource newDynamicDeltaSource(final boolean cacheDatasets) {
+    return newTempDirSource(DATABASE_PATH, cacheDatasets);
+  }
+
+  @Nonnull
+  private DynamicDeltaSource newTempDirSource(
+      @Nonnull final String databasePath, final boolean cacheDatasets) {
     final StorageConfiguration storageConfiguration = new StorageConfiguration();
     storageConfiguration.setCacheDatasets(cacheDatasets);
-    final QueryableDataSource baseSource = pathlingContext.read().delta(DATABASE_PATH);
+    final QueryableDataSource baseSource = pathlingContext.read().delta(databasePath);
     return new DynamicDeltaSource(
-        baseSource, sparkSession, DATABASE_PATH, fhirEncoders, storageConfiguration);
+        baseSource, sparkSession, databasePath, fhirEncoders, storageConfiguration);
+  }
+
+  /** Writes a single-row Patient Delta table whose schema has only the given string columns. */
+  private void writePatientTable(
+      @Nonnull final String databasePath, @Nonnull final String... columns) {
+    patientDataset(1, columns)
+        .write()
+        .format("delta")
+        .mode(SaveMode.ErrorIfExists)
+        .save(databasePath + "/Patient.parquet");
+  }
+
+  /**
+   * Evolves the Patient table's schema by appending zero rows carrying the given columns with the
+   * {@code mergeSchema} option, mirroring the warmup write performed on update.
+   */
+  private void evolvePatientTable(
+      @Nonnull final String databasePath, @Nonnull final String... columns) {
+    patientDataset(0, columns)
+        .write()
+        .format("delta")
+        .mode(SaveMode.Append)
+        .option("mergeSchema", "true")
+        .save(databasePath + "/Patient.parquet");
+  }
+
+  /** Creates a dataset with the given number of rows and string columns. */
+  @Nonnull
+  private Dataset<Row> patientDataset(final int rowCount, @Nonnull final String... columns) {
+    final StructField[] fields = new StructField[columns.length];
+    for (int i = 0; i < columns.length; i++) {
+      fields[i] = new StructField(columns[i], DataTypes.StringType, true, Metadata.empty());
+    }
+    final List<Row> rows =
+        rowCount == 0
+            ? List.of()
+            : List.of(RowFactory.create((Object[]) new String[columns.length]));
+    return sparkSession.createDataFrame(rows, new StructType(fields));
   }
 }

--- a/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
@@ -18,6 +18,7 @@
 package au.csiro.pathling.io;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import au.csiro.pathling.config.StorageConfiguration;
@@ -26,6 +27,7 @@ import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import au.csiro.pathling.util.FhirServerTestConfiguration;
+import au.csiro.pathling.views.FhirView;
 import jakarta.annotation.Nonnull;
 import java.nio.file.Path;
 import java.util.List;
@@ -192,6 +194,69 @@ class DynamicDeltaSourceTest {
     source.refresh("Patient");
 
     assertThat(source.read("Patient").count()).isEqualTo(1);
+  }
+
+  // Verifies that constructing a view query over a drifted subject type throws SchemaDriftError.
+  // The executed query resolves its subject dataset through the delegate's own dispatcher rather
+  // than the guarded read(), so the guard must be applied when the query is constructed.
+  @Test
+  void viewOverDriftedTypeThrowsSchemaDriftError(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    writePatientTable(databasePath, "id");
+    final DynamicDeltaSource source = newTempDirSource(databasePath, false, Set.of("Patient"));
+    final FhirView view =
+        FhirView.ofResource("Patient")
+            .select(FhirView.columns(FhirView.column("id", "id")))
+            .build();
+
+    assertThatThrownBy(() -> source.view(view))
+        .isInstanceOf(SchemaDriftError.class)
+        .hasMessageContaining("Patient");
+    assertThatThrownBy(() -> source.view("Patient")).isInstanceOf(SchemaDriftError.class);
+    // A view over a type that is not drifted can still be constructed.
+    assertThatNoException().isThrownBy(() -> source.view("Observation"));
+  }
+
+  // Verifies that a source derived through map() keeps the drift guard, covering filtered view
+  // runs and exports which resolve datasets through the derived source rather than this one.
+  @Test
+  void mappedSourcePreservesDriftGuard(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    writePatientTable(databasePath, "id");
+    final DynamicDeltaSource source = newTempDirSource(databasePath, false, Set.of("Patient"));
+
+    final QueryableDataSource mapped = source.map((resourceType, dataset) -> dataset);
+
+    assertThatThrownBy(() -> mapped.read("Patient")).isInstanceOf(SchemaDriftError.class);
+    // The guard survives further derivation and applies to view construction on the derived
+    // source.
+    assertThatThrownBy(() -> mapped.map((resourceType, dataset) -> dataset).read("Patient"))
+        .isInstanceOf(SchemaDriftError.class);
+    assertThatThrownBy(() -> mapped.view("Patient")).isInstanceOf(SchemaDriftError.class);
+  }
+
+  // Verifies that a source derived through filterByResourceType() keeps the drift guard.
+  @Test
+  void filteredSourcePreservesDriftGuard(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    writePatientTable(databasePath, "id");
+    final DynamicDeltaSource source = newTempDirSource(databasePath, false, Set.of("Patient"));
+
+    final QueryableDataSource filtered = source.filterByResourceType(resourceType -> true);
+
+    assertThatThrownBy(() -> filtered.read("Patient")).isInstanceOf(SchemaDriftError.class);
+  }
+
+  // Verifies that once refresh() clears the drifted mark, newly derived sources read normally.
+  @Test
+  void derivedSourceAfterRefreshReadsSuccessfully(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    writePatientTable(databasePath, "id");
+    final DynamicDeltaSource source = newTempDirSource(databasePath, false, Set.of("Patient"));
+
+    source.refresh("Patient");
+
+    assertThat(source.map((resourceType, dataset) -> dataset).read("Patient").count()).isEqualTo(1);
   }
 
   // Verifies that refreshing a type with no Delta table is a harmless no-op.

--- a/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
@@ -18,6 +18,7 @@
 package au.csiro.pathling.io;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import au.csiro.pathling.config.StorageConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
@@ -28,6 +29,7 @@ import au.csiro.pathling.util.FhirServerTestConfiguration;
 import jakarta.annotation.Nonnull;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -162,6 +164,36 @@ class DynamicDeltaSourceTest {
     }
   }
 
+  // Verifies that reading a type recorded as drifted and unmigrated throws SchemaDriftError
+  // naming the type, and that other types are unaffected (FR-005, FR-006).
+  @Test
+  void readOfDriftedTypeThrowsSchemaDriftError(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    writePatientTable(databasePath, "id");
+    final DynamicDeltaSource source = newTempDirSource(databasePath, false, Set.of("Patient"));
+
+    assertThatThrownBy(() -> source.read("Patient"))
+        .isInstanceOf(SchemaDriftError.class)
+        .hasMessageContaining("Patient")
+        .hasMessageContaining("schemaAutoMerge");
+    // A type that is not drifted continues to work.
+    assertThat(source.read("ImmunizationEvaluation").count()).isZero();
+  }
+
+  // Verifies that a successful refresh clears the drifted mark, so a later schema-evolving update
+  // recovers the type without a restart (update-driven recovery).
+  @Test
+  void refreshClearsDriftedMark(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    writePatientTable(databasePath, "id");
+    final DynamicDeltaSource source = newTempDirSource(databasePath, false, Set.of("Patient"));
+    assertThatThrownBy(() -> source.read("Patient")).isInstanceOf(SchemaDriftError.class);
+
+    source.refresh("Patient");
+
+    assertThat(source.read("Patient").count()).isEqualTo(1);
+  }
+
   // Verifies that refreshing a type with no Delta table is a harmless no-op.
   @Test
   void refreshOfMissingTableIsNoOp(@TempDir final Path tempDir) {
@@ -183,11 +215,19 @@ class DynamicDeltaSourceTest {
   @Nonnull
   private DynamicDeltaSource newTempDirSource(
       @Nonnull final String databasePath, final boolean cacheDatasets) {
+    return newTempDirSource(databasePath, cacheDatasets, Set.of());
+  }
+
+  @Nonnull
+  private DynamicDeltaSource newTempDirSource(
+      @Nonnull final String databasePath,
+      final boolean cacheDatasets,
+      @Nonnull final Set<String> driftedTypes) {
     final StorageConfiguration storageConfiguration = new StorageConfiguration();
     storageConfiguration.setCacheDatasets(cacheDatasets);
     final QueryableDataSource baseSource = pathlingContext.read().delta(databasePath);
     return new DynamicDeltaSource(
-        baseSource, sparkSession, databasePath, fhirEncoders, storageConfiguration);
+        baseSource, sparkSession, databasePath, fhirEncoders, storageConfiguration, driftedTypes);
   }
 
   /** Writes a single-row Patient Delta table whose schema has only the given string columns. */

--- a/server/src/test/java/au/csiro/pathling/io/SchemaDriftTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/SchemaDriftTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.annotation.Nonnull;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SchemaDrift}. The comparison must count only missing field paths as drift,
+ * recursing through structs, arrays and maps, while ignoring nullability and column metadata
+ * differences and tolerating extra fields that exist only in the target schema.
+ *
+ * @author John Grimes
+ */
+class SchemaDriftTest {
+
+  // Verifies that a source field absent from the target at the top level is detected as drift.
+  @Test
+  void missingTopLevelFieldIsDrift() {
+    final StructType source =
+        struct(field("id", DataTypes.StringType), field("url", DataTypes.StringType));
+    final StructType target = struct(field("id", DataTypes.StringType));
+
+    assertThat(SchemaDrift.hasMissingFields(source, target)).isTrue();
+    assertThat(SchemaDrift.missingFieldPaths(source, target)).containsExactly("url");
+  }
+
+  // Verifies that a field missing inside a nested struct is detected as drift.
+  @Test
+  void missingNestedStructFieldIsDrift() {
+    final StructType sourceInner =
+        struct(field("name", DataTypes.StringType), field("version", DataTypes.StringType));
+    final StructType targetInner = struct(field("name", DataTypes.StringType));
+    final StructType source = struct(field("id", DataTypes.StringType), field("meta", sourceInner));
+    final StructType target = struct(field("id", DataTypes.StringType), field("meta", targetInner));
+
+    assertThat(SchemaDrift.hasMissingFields(source, target)).isTrue();
+    assertThat(SchemaDrift.missingFieldPaths(source, target)).containsExactly("meta.version");
+  }
+
+  // Verifies that a field missing from a struct nested inside an array element is detected as
+  // drift.
+  @Test
+  void missingFieldInsideArrayElementStructIsDrift() {
+    final StructType sourceElement =
+        struct(field("path", DataTypes.StringType), field("forEach", DataTypes.StringType));
+    final StructType targetElement = struct(field("path", DataTypes.StringType));
+    final StructType source = struct(field("select", ArrayType.apply(sourceElement)));
+    final StructType target = struct(field("select", ArrayType.apply(targetElement)));
+
+    assertThat(SchemaDrift.hasMissingFields(source, target)).isTrue();
+    assertThat(SchemaDrift.missingFieldPaths(source, target)).containsExactly("select.forEach");
+  }
+
+  // Verifies that a field missing from a struct used as a map value type is detected as drift.
+  @Test
+  void missingFieldInsideMapValueStructIsDrift() {
+    final StructType sourceValue =
+        struct(field("code", DataTypes.StringType), field("display", DataTypes.StringType));
+    final StructType targetValue = struct(field("code", DataTypes.StringType));
+    final StructType source =
+        struct(field("codings", MapType.apply(DataTypes.StringType, sourceValue)));
+    final StructType target =
+        struct(field("codings", MapType.apply(DataTypes.StringType, targetValue)));
+
+    assertThat(SchemaDrift.hasMissingFields(source, target)).isTrue();
+    assertThat(SchemaDrift.missingFieldPaths(source, target)).containsExactly("codings.display");
+  }
+
+  // Verifies that a difference in nullability alone is not treated as drift.
+  @Test
+  void nullabilityOnlyDifferenceIsNotDrift() {
+    final StructType source =
+        new StructType(
+            new StructField[] {
+              new StructField("id", DataTypes.StringType, false, Metadata.empty())
+            });
+    final StructType target =
+        new StructType(
+            new StructField[] {
+              new StructField("id", DataTypes.StringType, true, Metadata.empty())
+            });
+
+    assertThat(SchemaDrift.hasMissingFields(source, target)).isFalse();
+    assertThat(SchemaDrift.missingFieldPaths(source, target)).isEmpty();
+  }
+
+  // Verifies that a difference in column metadata alone is not treated as drift.
+  @Test
+  void metadataOnlyDifferenceIsNotDrift() {
+    final Metadata metadata = new MetadataBuilder().putString("comment", "annotated").build();
+    final StructType source =
+        new StructType(
+            new StructField[] {new StructField("id", DataTypes.StringType, true, metadata)});
+    final StructType target =
+        new StructType(
+            new StructField[] {
+              new StructField("id", DataTypes.StringType, true, Metadata.empty())
+            });
+
+    assertThat(SchemaDrift.hasMissingFields(source, target)).isFalse();
+    assertThat(SchemaDrift.missingFieldPaths(source, target)).isEmpty();
+  }
+
+  // Verifies that fields present only in the target schema (for example, data written by a newer
+  // server version) are not treated as drift.
+  @Test
+  void extraTargetOnlyFieldIsNotDrift() {
+    final StructType source = struct(field("id", DataTypes.StringType));
+    final StructType target =
+        struct(field("id", DataTypes.StringType), field("newField", DataTypes.StringType));
+
+    assertThat(SchemaDrift.hasMissingFields(source, target)).isFalse();
+    assertThat(SchemaDrift.missingFieldPaths(source, target)).isEmpty();
+  }
+
+  // Verifies that identical schemas produce no drift.
+  @Test
+  void identicalSchemasAreNotDrift() {
+    final StructType schema =
+        struct(field("id", DataTypes.StringType), field("status", DataTypes.StringType));
+
+    assertThat(SchemaDrift.hasMissingFields(schema, schema)).isFalse();
+    assertThat(SchemaDrift.missingFieldPaths(schema, schema)).isEmpty();
+  }
+
+  // ---- helpers ----
+
+  @Nonnull
+  private static StructField field(@Nonnull final String name, @Nonnull final DataType type) {
+    return new StructField(name, type, true, Metadata.empty());
+  }
+
+  @Nonnull
+  private static StructType struct(@Nonnull final StructField... fields) {
+    return new StructType(fields);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/io/SchemaMigratorTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/SchemaMigratorTest.java
@@ -39,6 +39,7 @@ import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.functions;
 import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -162,6 +163,66 @@ class SchemaMigratorTest {
     }
   }
 
+  // Verifies that with the flag off, drifted tables are not written, a WARN names the type, the
+  // missing fields, and the remedy, and the type is reported in the drifted set (FR-004).
+  @Test
+  void flagOffLogsWarningAndReportsDriftedType(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    seedOldSchemaViewDefinitionTable(databasePath);
+    final long versionBefore = latestTableVersion(databasePath, "ViewDefinition");
+
+    try (final LogCapture logCapture = LogCapture.forClass(SchemaMigrator.class)) {
+      final Set<String> drifted = newMigrator(databasePath, false).migrate();
+
+      assertThat(drifted).containsExactly("ViewDefinition");
+      assertThat(latestTableVersion(databasePath, "ViewDefinition")).isEqualTo(versionBefore);
+      assertThat(logCapture.events())
+          .anySatisfy(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                assertThat(event.getFormattedMessage())
+                    .contains("ViewDefinition")
+                    .contains("url")
+                    .contains("version")
+                    .contains("schemaAutoMerge");
+              });
+    }
+  }
+
+  // Verifies that a migration failure for one table is logged with its cause, does not propagate,
+  // does not prevent other tables from migrating, and reports the failed type in the drifted set
+  // (FR-006).
+  @Test
+  void migrationFailureIsIsolatedAndReported(@TempDir final Path tempDir) throws IOException {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    seedOldSchemaViewDefinitionTable(databasePath);
+    seedOldSchemaPatientTable(databasePath);
+    // Make the Patient table's Delta log read-only so its migration write fails.
+    final Path patientLogDir = tempDir.resolve("Patient.parquet").resolve("_delta_log");
+    setWritable(patientLogDir, false);
+
+    try (final LogCapture logCapture = LogCapture.forClass(SchemaMigrator.class)) {
+      final Set<String> drifted;
+      try {
+        drifted = newMigrator(databasePath, true).migrate();
+      } finally {
+        setWritable(patientLogDir, true);
+      }
+
+      // The failed type is reported; the other drifted table has still been migrated.
+      assertThat(drifted).containsExactly("Patient");
+      assertThat(readTable(databasePath, "ViewDefinition").schema().fieldNames())
+          .contains("url", "version");
+      assertThat(logCapture.events())
+          .anySatisfy(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+                assertThat(event.getFormattedMessage()).contains("Patient");
+                assertThat(event.getThrowableProxy()).isNotNull();
+              });
+    }
+  }
+
   // ---- helpers ----
 
   @Nonnull
@@ -181,6 +242,28 @@ class SchemaMigratorTest {
         .format("delta")
         .mode(SaveMode.ErrorIfExists)
         .save(databasePath + "/ViewDefinition.parquet");
+  }
+
+  /**
+   * Writes a Patient Delta table from encoder output with the top-level {@code gender} column
+   * dropped, simulating a table written by an older encoder version.
+   */
+  private void seedOldSchemaPatientTable(@Nonnull final String databasePath) {
+    final Patient patient = new Patient();
+    patient.setId("test-patient");
+    sparkSession
+        .createDataset(List.of(patient), fhirEncoders.of("Patient"))
+        .toDF()
+        .drop("gender")
+        .write()
+        .format("delta")
+        .mode(SaveMode.ErrorIfExists)
+        .save(databasePath + "/Patient.parquet");
+  }
+
+  /** Sets the writability of a directory, used to provoke migration write failures. */
+  private static void setWritable(@Nonnull final Path directory, final boolean writable) {
+    assertThat(directory.toFile().setWritable(writable, false)).isTrue();
   }
 
   /** Writes a ViewDefinition Delta table whose schema matches the current encoder output. */

--- a/server/src/test/java/au/csiro/pathling/io/SchemaMigratorTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/SchemaMigratorTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.encoders.ViewDefinitionResource;
+import au.csiro.pathling.test.SpringBootUnitTest;
+import au.csiro.pathling.util.FhirServerTestConfiguration;
+import au.csiro.pathling.util.LogCapture;
+import ch.qos.logback.classic.Level;
+import io.delta.tables.DeltaTable;
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Unit tests for {@link SchemaMigrator}, which detects Delta tables whose schemas are behind the
+ * current FHIR encoders at startup and migrates them when {@code schemaAutoMerge} is enabled.
+ *
+ * @author John Grimes
+ */
+@Import(FhirServerTestConfiguration.class)
+@SpringBootUnitTest
+class SchemaMigratorTest {
+
+  @Autowired private SparkSession sparkSession;
+
+  @Autowired private FhirEncoders fhirEncoders;
+
+  // Verifies that a drifted table is migrated when the flag is enabled: the schema gains the
+  // missing fields, no rows are added, and existing rows present the new fields as null (FR-002,
+  // FR-007).
+  @Test
+  void driftedTableIsMigratedWhenFlagEnabled(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    seedOldSchemaViewDefinitionTable(databasePath);
+
+    final Set<String> drifted = newMigrator(databasePath, true).migrate();
+
+    assertThat(drifted).isEmpty();
+    final Dataset<Row> migrated = readTable(databasePath, "ViewDefinition");
+    assertThat(migrated.schema().fieldNames()).contains("url", "version");
+    assertThat(migrated.count()).isEqualTo(1);
+    final Row row = migrated.select("id", "url", "version").first();
+    assertThat(row.getString(0)).isEqualTo("test-view");
+    assertThat(row.isNullAt(1)).isTrue();
+    assertThat(row.isNullAt(2)).isTrue();
+  }
+
+  // Verifies that an undrifted table produces no Delta write: the table version is unchanged
+  // after migration runs (FR-008).
+  @Test
+  void undriftedTableIsNotWritten(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    seedCurrentSchemaViewDefinitionTable(databasePath);
+    final long versionBefore = latestTableVersion(databasePath, "ViewDefinition");
+
+    final Set<String> drifted = newMigrator(databasePath, true).migrate();
+
+    assertThat(drifted).isEmpty();
+    assertThat(latestTableVersion(databasePath, "ViewDefinition")).isEqualTo(versionBefore);
+  }
+
+  // Verifies that a table whose only difference is extra on-disk fields unknown to the encoder is
+  // not migrated (edge case: data written by a newer server version).
+  @Test
+  void extraFieldsOnlyTableIsNotMigrated(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    encoderDataset()
+        .withColumn("fieldFromTheFuture", functions.lit((String) null))
+        .write()
+        .format("delta")
+        .mode(SaveMode.ErrorIfExists)
+        .save(databasePath + "/ViewDefinition.parquet");
+    final long versionBefore = latestTableVersion(databasePath, "ViewDefinition");
+
+    final Set<String> drifted = newMigrator(databasePath, true).migrate();
+
+    assertThat(drifted).isEmpty();
+    assertThat(latestTableVersion(databasePath, "ViewDefinition")).isEqualTo(versionBefore);
+  }
+
+  // Verifies that non-table files, directories that are not Delta tables, and directory names
+  // that do not map to an encodable resource type are all skipped without error.
+  @Test
+  void nonTableEntriesAreSkipped(@TempDir final Path tempDir) throws IOException {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    Files.writeString(tempDir.resolve("stray-file.txt"), "not a table");
+    Files.createDirectory(tempDir.resolve("Empty.parquet"));
+    // A valid Delta table whose name does not map to an encodable resource type.
+    sparkSession
+        .createDataFrame(List.of(), encoderDataset().schema())
+        .write()
+        .format("delta")
+        .save(databasePath + "/NotAResource.parquet");
+
+    assertThatNoException().isThrownBy(() -> newMigrator(databasePath, true).migrate());
+    assertThat(newMigrator(databasePath, true).migrate()).isEmpty();
+  }
+
+  // Verifies that an empty or missing database path does not break startup drift detection.
+  @Test
+  void emptyOrMissingDatabasePathIsHarmless(@TempDir final Path tempDir) {
+    final String emptyPath = tempDir.toAbsolutePath().toString();
+    final String missingPath = tempDir.resolve("does-not-exist").toAbsolutePath().toString();
+
+    assertThat(newMigrator(emptyPath, true).migrate()).isEmpty();
+    assertThat(newMigrator(missingPath, true).migrate()).isEmpty();
+  }
+
+  // Verifies that each migration is logged at INFO with the resource type and the added fields
+  // (FR-010).
+  @Test
+  void migrationIsLoggedWithTypeAndFields(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    seedOldSchemaViewDefinitionTable(databasePath);
+
+    try (final LogCapture logCapture = LogCapture.forClass(SchemaMigrator.class)) {
+      newMigrator(databasePath, true).migrate();
+
+      assertThat(logCapture.events())
+          .anySatisfy(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.INFO);
+                assertThat(event.getFormattedMessage())
+                    .contains("ViewDefinition")
+                    .contains("url")
+                    .contains("version");
+              });
+    }
+  }
+
+  // ---- helpers ----
+
+  @Nonnull
+  private SchemaMigrator newMigrator(
+      @Nonnull final String databasePath, final boolean schemaAutoMerge) {
+    return new SchemaMigrator(sparkSession, fhirEncoders, databasePath, schemaAutoMerge);
+  }
+
+  /**
+   * Writes a ViewDefinition Delta table from encoder output with the top-level {@code url} and
+   * {@code version} columns dropped, simulating a table written by an older encoder version.
+   */
+  private void seedOldSchemaViewDefinitionTable(@Nonnull final String databasePath) {
+    encoderDataset()
+        .drop("url", "version")
+        .write()
+        .format("delta")
+        .mode(SaveMode.ErrorIfExists)
+        .save(databasePath + "/ViewDefinition.parquet");
+  }
+
+  /** Writes a ViewDefinition Delta table whose schema matches the current encoder output. */
+  private void seedCurrentSchemaViewDefinitionTable(@Nonnull final String databasePath) {
+    encoderDataset()
+        .write()
+        .format("delta")
+        .mode(SaveMode.ErrorIfExists)
+        .save(databasePath + "/ViewDefinition.parquet");
+  }
+
+  /** Encodes a single minimal ViewDefinition using the current encoder. */
+  @Nonnull
+  private Dataset<Row> encoderDataset() {
+    final ViewDefinitionResource viewDefinition = new ViewDefinitionResource();
+    viewDefinition.setId("test-view");
+    viewDefinition.setName(new StringType("test_view"));
+    viewDefinition.setResource(new CodeType("Patient"));
+    viewDefinition.setStatus(new CodeType("active"));
+    return sparkSession
+        .createDataset(List.of(viewDefinition), fhirEncoders.of("ViewDefinition"))
+        .toDF();
+  }
+
+  /** Reads the Delta table for a resource type. */
+  @Nonnull
+  private Dataset<Row> readTable(
+      @Nonnull final String databasePath, @Nonnull final String resourceCode) {
+    return sparkSession.read().format("delta").load(databasePath + "/" + resourceCode + ".parquet");
+  }
+
+  /** Returns the latest Delta log version of a table. */
+  private long latestTableVersion(
+      @Nonnull final String databasePath, @Nonnull final String resourceCode) {
+    final DeltaTable table =
+        DeltaTable.forPath(sparkSession, databasePath + "/" + resourceCode + ".parquet");
+    return table.history(1).select("version").first().getLong(0);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitExecutorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitExecutorTest.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.UnaryOperator;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
@@ -167,7 +168,7 @@ class BulkSubmitExecutorTest {
   @Test
   @DisplayName("downloadManifestJob creates and registers job when async enabled")
   @SuppressWarnings("unchecked")
-  void downloadManifestJobCreatesAndRegistersJobWhenAsyncEnabled() {
+  void downloadManifestJobCreatesAndRegistersJobWhenAsyncEnabled() throws Exception {
     // Given: a submission and manifest job with async enabled.
     final Submission submission = createTestSubmission();
     final ManifestJob manifestJob = createTestManifestJob();
@@ -176,19 +177,17 @@ class BulkSubmitExecutorTest {
     // Capture the job registered.
     final ArgumentCaptor<Job<?>> jobCaptor = ArgumentCaptor.forClass(Job.class);
 
-    // When: calling downloadManifestJob.
-    executor.downloadManifestJob(submission, manifestJob, List.of(), FHIR_SERVER_BASE);
+    // When: calling downloadManifestJob and awaiting the async download work, so that no file
+    // writes race the JUnit temp-dir cleanup after the test completes.
+    final CompletableFuture<Void> download =
+        executor.downloadManifestJob(submission, manifestJob, List.of(), FHIR_SERVER_BASE);
+    download.get(30, TimeUnit.SECONDS);
 
     // Then: should register a Job in the JobRegistry.
-    await()
-        .atMost(Duration.ofSeconds(5))
-        .untilAsserted(
-            () -> {
-              verify(jobRegistry).register(jobCaptor.capture());
-              final Job<?> registeredJob = jobCaptor.getValue();
-              assertThat(registeredJob).isNotNull();
-              assertThat(registeredJob.getOwnerId()).isEqualTo(Optional.empty());
-            });
+    verify(jobRegistry).register(jobCaptor.capture());
+    final Job<?> registeredJob = jobCaptor.getValue();
+    assertThat(registeredJob).isNotNull();
+    assertThat(registeredJob.getOwnerId()).isEqualTo(Optional.empty());
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/operations/create/CreateProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/create/CreateProviderTest.java
@@ -19,12 +19,14 @@ package au.csiro.pathling.operations.create;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import au.csiro.pathling.cache.CacheableDatabase;
 import au.csiro.pathling.config.StorageConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.errors.InvalidUserInputError;
 import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.operations.update.UpdateExecutor;
 import au.csiro.pathling.security.OperationAccess;
 import au.csiro.pathling.test.SpringBootUnitTest;
@@ -91,7 +93,8 @@ class CreateProviderTest {
             fhirEncoders,
             tempDatabasePath.toAbsolutePath().toString(),
             cacheableDatabase,
-            new StorageConfiguration());
+            new StorageConfiguration(),
+            mock(QueryableDataSource.class));
 
     // Create the CreateProvider.
     createProvider = new CreateProvider(configuration, updateExecutor, fhirContext, Patient.class);

--- a/server/src/test/java/au/csiro/pathling/operations/delete/DeleteProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/delete/DeleteProviderTest.java
@@ -19,6 +19,7 @@ package au.csiro.pathling.operations.delete;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import au.csiro.pathling.cache.CacheableDatabase;
 import au.csiro.pathling.config.StorageConfiguration;
@@ -26,6 +27,7 @@ import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.errors.InvalidUserInputError;
 import au.csiro.pathling.errors.ResourceNotFoundError;
 import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.operations.update.UpdateExecutor;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import au.csiro.pathling.util.FhirServerTestConfiguration;
@@ -88,7 +90,8 @@ class DeleteProviderTest {
             fhirEncoders,
             tempDatabasePath.toAbsolutePath().toString(),
             cacheableDatabase,
-            new StorageConfiguration());
+            new StorageConfiguration(),
+            mock(QueryableDataSource.class));
 
     // Create DeleteExecutor with the temp database path.
     final DeleteExecutor deleteExecutor =

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/AbstractSqlQueryExportIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/AbstractSqlQueryExportIT.java
@@ -51,10 +51,13 @@ abstract class AbstractSqlQueryExportIT {
 
   @BeforeEach
   void setUpClient() {
+    // The 60-second response timeout matches the other server integration tests; the 5-second
+    // default is exceeded by Spark warmup on loaded CI runners.
     webTestClient =
         webTestClient
             .mutate()
             .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024))
+            .responseTimeout(java.time.Duration.ofSeconds(60))
             .build();
   }
 

--- a/server/src/test/java/au/csiro/pathling/operations/update/BatchProviderCreateTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/BatchProviderCreateTest.java
@@ -18,12 +18,14 @@
 package au.csiro.pathling.operations.update;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import au.csiro.pathling.cache.CacheableDatabase;
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.config.StorageConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.operations.delete.DeleteExecutor;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import au.csiro.pathling.util.FhirServerTestConfiguration;
@@ -88,7 +90,8 @@ class BatchProviderCreateTest {
             fhirEncoders,
             tempDatabasePath.toAbsolutePath().toString(),
             cacheableDatabase,
-            new StorageConfiguration());
+            new StorageConfiguration(),
+            mock(QueryableDataSource.class));
 
     // Create DeleteExecutor with the temp database path.
     deleteExecutor =

--- a/server/src/test/java/au/csiro/pathling/operations/update/SchemaDriftFlagOffIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/SchemaDriftFlagOffIT.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import au.csiro.pathling.util.DeltaSchemaFixtures;
+import au.csiro.pathling.util.TestDataSetup;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * End-to-end test for the diagnostics served when a drifted table cannot be migrated because {@code
+ * schemaAutoMerge} is disabled (user story 3). This lives in its own class because the application
+ * context must be started with a different configuration from {@link SchemaEvolutionReadIT}.
+ *
+ * @author John Grimes
+ */
+@Slf4j
+@Tag("IntegrationTest")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+      "pathling.storage.schemaAutoMerge=false",
+      // Bind the Spark driver to localhost so that executor class fetches do not depend on the
+      // machine's LAN address being reachable (e.g. under a firewall or VPN).
+      "spark.driver.bindAddress=localhost",
+      "spark.driver.host=localhost"
+    })
+@ActiveProfiles({"integration-test"})
+class SchemaDriftFlagOffIT {
+
+  @LocalServerPort int port;
+
+  @Autowired WebTestClient webTestClient;
+
+  @TempDir private static java.nio.file.Path warehouseDir;
+
+  @BeforeEach
+  void setUp() {
+    webTestClient =
+        webTestClient
+            .mutate()
+            .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024))
+            .responseTimeout(java.time.Duration.ofSeconds(120))
+            .build();
+  }
+
+  @DynamicPropertySource
+  static void configureProperties(final DynamicPropertyRegistry registry) throws Exception {
+    // Copy the prebuilt Delta test data into a temporary warehouse, then downgrade the Patient
+    // table's schema on disk so it is missing the gender field relative to the current encoder.
+    TestDataSetup.copyTestDataToTempDir(warehouseDir);
+    DeltaSchemaFixtures.removeFieldsFromTableSchema(
+        warehouseDir.resolve("delta").resolve("Patient.parquet"), Set.of("gender"));
+    registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir.toAbsolutePath());
+  }
+
+  /**
+   * User story 3, acceptance scenario 2: a request against the drifted type returns a 500 whose
+   * OperationOutcome diagnostics name the type, the condition, and the remedies, per the
+   * drifted-table-error contract.
+   */
+  @Test
+  void getOfDriftedTypeReturnsActionableError() {
+    webTestClient
+        .get()
+        .uri("http://localhost:" + port + "/fhir/Patient/any-id")
+        .header("Accept", "application/fhir+json")
+        .exchange()
+        .expectStatus()
+        .isEqualTo(500)
+        .expectBody()
+        .jsonPath("$.resourceType")
+        .isEqualTo("OperationOutcome")
+        .jsonPath("$.issue[0].severity")
+        .isEqualTo("error")
+        .jsonPath("$.issue[0].code")
+        .isEqualTo("processing")
+        .jsonPath("$.issue[0].diagnostics")
+        .value(
+            diagnostics ->
+                assertThat(diagnostics.toString())
+                    .contains("Patient")
+                    .contains("behind this server's encoders")
+                    .contains("schemaAutoMerge"));
+  }
+
+  /** User story 3: resource types whose tables are not drifted continue to work normally. */
+  @Test
+  void getOfUndriftedTypeStillSucceeds() {
+    webTestClient
+        .get()
+        .uri("http://localhost:" + port + "/fhir/Condition?_count=1")
+        .header("Accept", "application/fhir+json")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.resourceType")
+        .isEqualTo("Bundle");
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/update/SchemaEvolutionReadIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/SchemaEvolutionReadIT.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.update;
+
+import au.csiro.pathling.util.DeltaSchemaFixtures;
+import au.csiro.pathling.util.TestDataSetup;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * End-to-end test for schema drift handling with {@code schemaAutoMerge} enabled, mirroring the
+ * production incident where a server upgrade left the on-disk table schema behind the encoders.
+ *
+ * <p>The warehouse is prepared before the application context starts: the Patient Delta table's
+ * schema is downgraded on disk by removing the {@code gender} field, simulating a table written by
+ * an older server version whose encoder lacked that field.
+ *
+ * <p>Covers the acceptance scenarios of user stories 1 and 2: a resource of the drifted type is
+ * readable from boot without any prior write (startup migration), and a PUT followed immediately by
+ * a GET and a type-level search succeeds with no restart (runtime refresh).
+ *
+ * @author John Grimes
+ */
+@Slf4j
+@Tag("IntegrationTest")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+      "pathling.storage.schemaAutoMerge=true",
+      // Bind the Spark driver to localhost so that executor class fetches do not depend on the
+      // machine's LAN address being reachable (e.g. under a firewall or VPN).
+      "spark.driver.bindAddress=localhost",
+      "spark.driver.host=localhost"
+    })
+@ActiveProfiles({"integration-test"})
+@TestMethodOrder(OrderAnnotation.class)
+class SchemaEvolutionReadIT {
+
+  private static final String NEW_PATIENT_ID = "schema-drift-test-patient";
+
+  @LocalServerPort int port;
+
+  @Autowired WebTestClient webTestClient;
+
+  @TempDir private static java.nio.file.Path warehouseDir;
+
+  @BeforeEach
+  void setUp() {
+    // The first write against a fresh Spark session can take well over the default five second
+    // response timeout.
+    webTestClient =
+        webTestClient
+            .mutate()
+            .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024))
+            .responseTimeout(java.time.Duration.ofSeconds(120))
+            .build();
+  }
+
+  @DynamicPropertySource
+  static void configureProperties(final DynamicPropertyRegistry registry) throws Exception {
+    // Copy the prebuilt Delta test data into a temporary warehouse, then downgrade the Patient
+    // table's schema on disk so it is missing the gender field relative to the current encoder.
+    TestDataSetup.copyTestDataToTempDir(warehouseDir);
+    DeltaSchemaFixtures.removeFieldsFromTableSchema(
+        warehouseDir.resolve("delta").resolve("Patient.parquet"), Set.of("gender"));
+    registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir.toAbsolutePath());
+  }
+
+  /**
+   * User story 1, acceptance scenarios 1 and 2: a PUT of a resource whose type's table schema is
+   * behind the encoder succeeds, and an immediate GET by id and type-level search both succeed
+   * without a server restart.
+   */
+  @Test
+  @Order(2)
+  void putThenGetAndSearchSucceedWithoutRestart() {
+    final String patientJson =
+        """
+        {
+          "resourceType": "Patient",
+          "id": "%s",
+          "gender": "female",
+          "name": [
+            {
+              "family": "Drift",
+              "given": ["Schema"]
+            }
+          ]
+        }
+        """
+            .formatted(NEW_PATIENT_ID);
+
+    // PUT the resource; with schemaAutoMerge enabled this succeeds regardless of table drift.
+    webTestClient
+        .put()
+        .uri("http://localhost:" + port + "/fhir/Patient/" + NEW_PATIENT_ID)
+        .header("Content-Type", "application/fhir+json")
+        .header("Accept", "application/fhir+json")
+        .bodyValue(patientJson)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    // An immediate GET by id must return the stored resource.
+    webTestClient
+        .get()
+        .uri("http://localhost:" + port + "/fhir/Patient/" + NEW_PATIENT_ID)
+        .header("Accept", "application/fhir+json")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.resourceType")
+        .isEqualTo("Patient")
+        .jsonPath("$.id")
+        .isEqualTo(NEW_PATIENT_ID)
+        .jsonPath("$.gender")
+        .isEqualTo("female");
+
+    // A type-level search must also succeed and include the resource.
+    webTestClient
+        .get()
+        .uri("http://localhost:" + port + "/fhir/Patient?_count=200")
+        .header("Accept", "application/fhir+json")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.resourceType")
+        .isEqualTo("Bundle")
+        .jsonPath("$.entry[?(@.resource.id == '%s')]".formatted(NEW_PATIENT_ID))
+        .exists();
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/update/SchemaEvolutionReadIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/SchemaEvolutionReadIT.java
@@ -65,6 +65,9 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @TestMethodOrder(OrderAnnotation.class)
 class SchemaEvolutionReadIT {
 
+  /** A Patient id that exists in the prebuilt test data. */
+  private static final String EXISTING_PATIENT_ID = "72df0f76-2758-fac4-67cd-de33c4a2c95e";
+
   private static final String NEW_PATIENT_ID = "schema-drift-test-patient";
 
   @LocalServerPort int port;
@@ -93,6 +96,28 @@ class SchemaEvolutionReadIT {
     DeltaSchemaFixtures.removeFieldsFromTableSchema(
         warehouseDir.resolve("delta").resolve("Patient.parquet"), Set.of("gender"));
     registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir.toAbsolutePath());
+  }
+
+  /**
+   * User story 2, acceptance scenario 2: with {@code schemaAutoMerge} enabled, a resource of the
+   * drifted type is readable immediately after startup, with no prior write, because the table was
+   * migrated at startup. This test must run before any write against the type.
+   */
+  @Test
+  @Order(1)
+  void getSucceedsAfterStartupWithNoPriorWrite() {
+    webTestClient
+        .get()
+        .uri("http://localhost:" + port + "/fhir/Patient/" + EXISTING_PATIENT_ID)
+        .header("Accept", "application/fhir+json")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.resourceType")
+        .isEqualTo("Patient")
+        .jsonPath("$.id")
+        .isEqualTo(EXISTING_PATIENT_ID);
   }
 
   /**

--- a/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorConcurrentCreateTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorConcurrentCreateTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import au.csiro.pathling.cache.CacheableDatabase;
+import au.csiro.pathling.config.StorageConfiguration;
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.encoders.ViewDefinitionResource;
+import au.csiro.pathling.encoders.ViewDefinitionResource.ColumnComponent;
+import au.csiro.pathling.encoders.ViewDefinitionResource.SelectComponent;
+import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
+import au.csiro.pathling.test.SpringBootUnitTest;
+import au.csiro.pathling.util.FhirServerTestConfiguration;
+import jakarta.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Regression tests for the concurrent first-create race in {@link UpdateExecutor}.
+ *
+ * <p>When two or more threads call {@code merge} for a resource type that has no Delta table in the
+ * warehouse yet, all of them can pass the table-existence check before any of them has written, so
+ * every loser of the race fails its {@code ErrorIfExists} write with {@code DELTA_PATH_EXISTS}. The
+ * fix serialises only the create-new-table branch with a per-resource-code lock and rechecks
+ * existence inside it, so the loser recovers by merging into the freshly created table.
+ *
+ * @author John Grimes
+ */
+@Import(FhirServerTestConfiguration.class)
+@SpringBootUnitTest
+class UpdateExecutorConcurrentCreateTest {
+
+  private static final String RESOURCE_CODE = "ViewDefinition";
+
+  @Autowired private PathlingContext pathlingContext;
+
+  @Autowired private FhirEncoders fhirEncoders;
+
+  @Autowired private CacheableDatabase cacheableDatabase;
+
+  private Path tempDatabasePath;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    tempDatabasePath = Files.createTempDirectory("concurrent-create-test-");
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    if (tempDatabasePath != null && Files.exists(tempDatabasePath)) {
+      Files.walk(tempDatabasePath)
+          .sorted(Comparator.reverseOrder())
+          .map(Path::toFile)
+          .forEach(File::delete);
+    }
+  }
+
+  /**
+   * Two threads released simultaneously each create the first ever resource of a type. Both calls
+   * must complete without error and both resources must be persisted (FR-001, acceptance scenario
+   * 1).
+   */
+  @Test
+  void twoConcurrentCreatesBothSucceed() throws Exception {
+    final List<Throwable> failures = raceCreates(2);
+
+    assertThat(failures).isEmpty();
+    assertThat(readPersistedIds()).containsExactlyInAnyOrder("vd-0", "vd-1");
+  }
+
+  /**
+   * More than two threads racing the same first create must all succeed and persist their resources
+   * (edge case: more than two concurrent creates).
+   */
+  @Test
+  void fourConcurrentCreatesAllSucceed() throws Exception {
+    final List<Throwable> failures = raceCreates(4);
+
+    assertThat(failures).isEmpty();
+    assertThat(readPersistedIds()).containsExactlyInAnyOrder("vd-0", "vd-1", "vd-2", "vd-3");
+  }
+
+  /**
+   * A single uncontended create must behave exactly as before the fix: the table is created and the
+   * resource is persisted (acceptance scenario 2, regression guard).
+   */
+  @Test
+  void uncontendedCreateSucceeds() {
+    final UpdateExecutor executor = newExecutor(tempDatabasePath.toAbsolutePath().toString());
+
+    executor.merge(RESOURCE_CODE, createViewDefinition("vd-solo"));
+
+    assertThat(readPersistedIds()).containsExactly("vd-solo");
+  }
+
+  /**
+   * A create that fails for a reason unrelated to concurrent table creation - here a database path
+   * whose parent is a regular file, so the table directory cannot be created - must still surface
+   * its original error rather than being masked by the race handling (FR-002, acceptance scenario
+   * 3).
+   */
+  @Test
+  void unrelatedCreateFailureStillSurfaces() throws IOException {
+    final Path blockingFile = tempDatabasePath.resolve("not-a-directory");
+    Files.createFile(blockingFile);
+    final UpdateExecutor executor = newExecutor(blockingFile.toAbsolutePath().toString());
+
+    assertThatThrownBy(() -> executor.merge(RESOURCE_CODE, createViewDefinition("vd-fail")))
+        .isInstanceOf(Exception.class);
+  }
+
+  // ---- helpers ----
+
+  /**
+   * Releases {@code threadCount} threads from a {@link CyclicBarrier}, each calling {@code merge}
+   * on a shared executor for the same previously absent resource type with a distinct resource ID
+   * ({@code vd-0} to {@code vd-n}), and returns any exceptions the calls threw.
+   */
+  @Nonnull
+  private List<Throwable> raceCreates(final int threadCount) throws Exception {
+    final UpdateExecutor executor = newExecutor(tempDatabasePath.toAbsolutePath().toString());
+    final CyclicBarrier barrier = new CyclicBarrier(threadCount);
+    final List<Throwable> failures = new CopyOnWriteArrayList<>();
+    final ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+    try {
+      final List<Future<?>> tasks =
+          IntStream.range(0, threadCount)
+              .mapToObj(
+                  i ->
+                      pool.submit(
+                          () -> {
+                            try {
+                              final ViewDefinitionResource resource =
+                                  createViewDefinition("vd-" + i);
+                              barrier.await(30, TimeUnit.SECONDS);
+                              executor.merge(RESOURCE_CODE, resource);
+                            } catch (final Throwable t) {
+                              failures.add(t);
+                            }
+                          }))
+              .collect(Collectors.toList());
+      for (final Future<?> task : tasks) {
+        task.get(120, TimeUnit.SECONDS);
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+    return new ArrayList<>(failures);
+  }
+
+  /** Reads the IDs of all resources persisted in the test table. */
+  @Nonnull
+  private List<String> readPersistedIds() {
+    final Path tablePath = tempDatabasePath.resolve(RESOURCE_CODE + ".parquet");
+    return pathlingContext
+        .getSpark()
+        .read()
+        .format("delta")
+        .load(tablePath.toAbsolutePath().toString())
+        .select("id")
+        .collectAsList()
+        .stream()
+        .map(row -> row.getString(0))
+        .collect(Collectors.toList());
+  }
+
+  @Nonnull
+  private UpdateExecutor newExecutor(@Nonnull final String databasePath) {
+    final StorageConfiguration storageConfiguration = new StorageConfiguration();
+    return new UpdateExecutor(
+        pathlingContext,
+        fhirEncoders,
+        databasePath,
+        cacheableDatabase,
+        storageConfiguration,
+        mock(QueryableDataSource.class));
+  }
+
+  @Nonnull
+  private ViewDefinitionResource createViewDefinition(@Nonnull final String id) {
+    final ViewDefinitionResource viewDef = new ViewDefinitionResource();
+    viewDef.setId(id);
+    viewDef.setName(new StringType("view_" + id.replace('-', '_')));
+    viewDef.setResource(new CodeType("Patient"));
+    viewDef.setStatus(new CodeType("active"));
+
+    final SelectComponent select = new SelectComponent();
+    final ColumnComponent column = new ColumnComponent();
+    column.setName(new StringType("id"));
+    column.setPath(new StringType("id"));
+    select.getColumn().add(column);
+    viewDef.getSelect().add(select);
+
+    return viewDef;
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorPathExistsTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorPathExistsTest.java
@@ -19,11 +19,13 @@ package au.csiro.pathling.operations.update;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
 
 import au.csiro.pathling.cache.CacheableDatabase;
 import au.csiro.pathling.config.StorageConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import au.csiro.pathling.util.FhirServerTestConfiguration;
 import io.delta.tables.DeltaTable;
@@ -128,7 +130,8 @@ class UpdateExecutorPathExistsTest {
         fhirEncoders,
         tempDatabasePath.toAbsolutePath().toString(),
         cacheableDatabase,
-        storageConfiguration);
+        storageConfiguration,
+        mock(QueryableDataSource.class));
   }
 
   @Nonnull

--- a/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorSchemaAutoMergeTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorSchemaAutoMergeTest.java
@@ -37,12 +37,9 @@ import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import au.csiro.pathling.util.DeltaSchemaFixtures;
 import au.csiro.pathling.util.FhirServerTestConfiguration;
+import au.csiro.pathling.util.LogCapture;
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -54,7 +51,6 @@ import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
@@ -151,22 +147,19 @@ class UpdateExecutorSchemaAutoMergeTest {
     final UpdateExecutor executor = newExecutor(true, dataSource);
     final ViewDefinitionResource update = createViewDefinition(VIEW_ID, "updated_view", "Patient");
 
-    final ListAppender<ILoggingEvent> appender = attachLogAppender();
-    try {
+    try (final LogCapture logCapture = LogCapture.forClass(UpdateExecutor.class)) {
       executor.merge("ViewDefinition", update);
-    } finally {
-      detachLogAppender(appender);
-    }
 
-    verify(dataSource).refresh("ViewDefinition");
-    assertThat(appender.list)
-        .anySatisfy(
-            event -> {
-              assertThat(event.getLevel()).isEqualTo(Level.INFO);
-              assertThat(event.getFormattedMessage())
-                  .contains("ViewDefinition")
-                  .contains("forEach");
-            });
+      verify(dataSource).refresh("ViewDefinition");
+      assertThat(logCapture.events())
+          .anySatisfy(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.INFO);
+                assertThat(event.getFormattedMessage())
+                    .contains("ViewDefinition")
+                    .contains("forEach");
+              });
+    }
   }
 
   /**
@@ -188,35 +181,6 @@ class UpdateExecutorSchemaAutoMergeTest {
   }
 
   // ---- helpers ----
-
-  /**
-   * Attaches a list appender to the {@link UpdateExecutor} logger to capture log events, lowering
-   * the logger level to INFO so the events under test are not filtered out by the test profile.
-   */
-  @Nonnull
-  private static ListAppender<ILoggingEvent> attachLogAppender() {
-    final Logger logger = (Logger) LoggerFactory.getLogger(UpdateExecutor.class);
-    previousLogLevel = logger.getLevel();
-    logger.setLevel(Level.INFO);
-    final ListAppender<ILoggingEvent> appender = new ListAppender<>();
-    appender.start();
-    logger.addAppender(appender);
-    return appender;
-  }
-
-  /**
-   * Detaches a previously attached list appender from the {@link UpdateExecutor} logger and
-   * restores the logger level.
-   */
-  private static void detachLogAppender(@Nonnull final ListAppender<ILoggingEvent> appender) {
-    final Logger logger = (Logger) LoggerFactory.getLogger(UpdateExecutor.class);
-    logger.detachAppender(appender);
-    logger.setLevel(previousLogLevel);
-    appender.stop();
-  }
-
-  /** The logger level in force before the list appender was attached, restored on detach. */
-  @Nullable private static Level previousLogLevel;
 
   /**
    * Two-stage setup: write a ViewDefinition through {@link UpdateExecutor} so the Delta log is

--- a/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorSchemaAutoMergeTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorSchemaAutoMergeTest.java
@@ -20,6 +20,10 @@ package au.csiro.pathling.operations.update;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import au.csiro.pathling.cache.CacheableDatabase;
 import au.csiro.pathling.config.StorageConfiguration;
@@ -27,27 +31,30 @@ import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.encoders.ViewDefinitionResource;
 import au.csiro.pathling.encoders.ViewDefinitionResource.ColumnComponent;
 import au.csiro.pathling.encoders.ViewDefinitionResource.SelectComponent;
+import au.csiro.pathling.io.DynamicDeltaSource;
 import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.test.SpringBootUnitTest;
+import au.csiro.pathling.util.DeltaSchemaFixtures;
 import au.csiro.pathling.util.FhirServerTestConfiguration;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Set;
 import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
@@ -131,22 +138,107 @@ class UpdateExecutorSchemaAutoMergeTest {
     assertThatNoException().isThrownBy(() -> executor.merge("ViewDefinition", update));
   }
 
+  /**
+   * When the warmup write evolves the table schema, the executor must refresh the data source entry
+   * for the resource type so that in-process consumers see the evolved schema (FR-001), and must
+   * log the fields that were added at INFO level (FR-010).
+   */
+  @Test
+  void warmupWriteTriggersRefreshAndLogsAddedFields() throws Exception {
+    seedTableAndDowngradeSchema();
+
+    final DynamicDeltaSource dataSource = mock(DynamicDeltaSource.class);
+    final UpdateExecutor executor = newExecutor(true, dataSource);
+    final ViewDefinitionResource update = createViewDefinition(VIEW_ID, "updated_view", "Patient");
+
+    final ListAppender<ILoggingEvent> appender = attachLogAppender();
+    try {
+      executor.merge("ViewDefinition", update);
+    } finally {
+      detachLogAppender(appender);
+    }
+
+    verify(dataSource).refresh("ViewDefinition");
+    assertThat(appender.list)
+        .anySatisfy(
+            event -> {
+              assertThat(event.getLevel()).isEqualTo(Level.INFO);
+              assertThat(event.getFormattedMessage())
+                  .contains("ViewDefinition")
+                  .contains("forEach");
+            });
+  }
+
+  /**
+   * When the table schema already matches the encoder output, no warmup write occurs and no refresh
+   * must be invoked, so undrifted updates carry no extra cost (FR-008 analogue for the update
+   * path).
+   */
+  @Test
+  void mergeWithoutDriftDoesNotTriggerRefresh() {
+    seedTable();
+
+    final DynamicDeltaSource dataSource = mock(DynamicDeltaSource.class);
+    final UpdateExecutor executor = newExecutor(true, dataSource);
+    final ViewDefinitionResource update = createViewDefinition(VIEW_ID, "updated_view", "Patient");
+
+    executor.merge("ViewDefinition", update);
+
+    verify(dataSource, never()).refresh(anyString());
+  }
+
   // ---- helpers ----
+
+  /**
+   * Attaches a list appender to the {@link UpdateExecutor} logger to capture log events, lowering
+   * the logger level to INFO so the events under test are not filtered out by the test profile.
+   */
+  @Nonnull
+  private static ListAppender<ILoggingEvent> attachLogAppender() {
+    final Logger logger = (Logger) LoggerFactory.getLogger(UpdateExecutor.class);
+    previousLogLevel = logger.getLevel();
+    logger.setLevel(Level.INFO);
+    final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    return appender;
+  }
+
+  /**
+   * Detaches a previously attached list appender from the {@link UpdateExecutor} logger and
+   * restores the logger level.
+   */
+  private static void detachLogAppender(@Nonnull final ListAppender<ILoggingEvent> appender) {
+    final Logger logger = (Logger) LoggerFactory.getLogger(UpdateExecutor.class);
+    logger.detachAppender(appender);
+    logger.setLevel(previousLogLevel);
+    appender.stop();
+  }
+
+  /** The logger level in force before the list appender was attached, restored on detach. */
+  @Nullable private static Level previousLogLevel;
 
   /**
    * Two-stage setup: write a ViewDefinition through {@link UpdateExecutor} so the Delta log is
    * created in the correct format, then rewrite the {@code schemaString} on disk to simulate an
-   * older encoder version.
+   * older encoder version. Struct-level removal is used rather than a wholesale schema replacement
+   * because Delta 4.x {@code updateAll()} silently ignores extra top-level columns in the source;
+   * {@code DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION} only fires when a struct-typed column in the
+   * target has fewer fields than the corresponding struct in the source.
    */
   private void seedTableAndDowngradeSchema() throws IOException {
+    seedTable();
+
+    final Path tablePath = tempDatabasePath.resolve("ViewDefinition.parquet");
+    DeltaSchemaFixtures.removeFieldsFromTableSchema(tablePath, Set.of("forEach", "forEachOrNull"));
+    invalidateDeltaMetadataCache(tablePath);
+  }
+
+  /** Writes an initial ViewDefinition through {@link UpdateExecutor} to create the Delta table. */
+  private void seedTable() {
     final UpdateExecutor seed = newExecutor(true);
     final ViewDefinitionResource initial = createViewDefinition(VIEW_ID, "initial_view", "Patient");
     seed.merge("ViewDefinition", initial);
-
-    final Path tablePath = tempDatabasePath.resolve("ViewDefinition.parquet");
-    final Path deltaLogDir = tablePath.resolve("_delta_log");
-    downgradeDeltaSchema(deltaLogDir);
-    invalidateDeltaMetadataCache(tablePath);
   }
 
   private void invalidateDeltaMetadataCache(@Nonnull final Path tablePath) {
@@ -156,6 +248,12 @@ class UpdateExecutorSchemaAutoMergeTest {
 
   @Nonnull
   private UpdateExecutor newExecutor(final boolean schemaAutoMerge) {
+    return newExecutor(schemaAutoMerge, mock(QueryableDataSource.class));
+  }
+
+  @Nonnull
+  private UpdateExecutor newExecutor(
+      final boolean schemaAutoMerge, @Nonnull final QueryableDataSource dataSource) {
     final StorageConfiguration storageConfiguration = new StorageConfiguration();
     storageConfiguration.setSchemaAutoMerge(schemaAutoMerge);
     return new UpdateExecutor(
@@ -163,71 +261,8 @@ class UpdateExecutorSchemaAutoMergeTest {
         fhirEncoders,
         tempDatabasePath.toAbsolutePath().toString(),
         cacheableDatabase,
-        storageConfiguration);
-  }
-
-  /**
-   * Rewrites the {@code metaData} action in the first Delta log commit to remove the {@code
-   * forEach} and {@code forEachOrNull} fields from all nested struct definitions in the table's
-   * {@code schemaString}. Also removes the Delta and Hadoop CRC side-cars so checksum validation
-   * does not reject the modified commit.
-   *
-   * <p>Why struct-level removal rather than a wholesale schema replacement: Delta 4.x {@code
-   * updateAll()} silently ignores extra top-level columns in the source, so a target with only
-   * {@code {id}} does not trigger {@code DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION}. The error only
-   * fires when a struct-typed column in the target has fewer fields than the corresponding struct
-   * in the source.
-   */
-  private static void downgradeDeltaSchema(@Nonnull final Path deltaLogDir) throws IOException {
-    final Path logFile = deltaLogDir.resolve("00000000000000000000.json");
-    assertThat(logFile).exists();
-
-    final ObjectMapper mapper = new ObjectMapper();
-    final List<String> original = Files.readAllLines(logFile);
-    final List<String> patched = new ArrayList<>(original.size());
-
-    for (final String line : original) {
-      final JsonNode node = mapper.readTree(line);
-      if (node.has("metaData")) {
-        final String schemaString = node.get("metaData").get("schemaString").asText();
-        final JsonNode schema = mapper.readTree(schemaString);
-        removeStructFields(schema, Set.of("forEach", "forEachOrNull"));
-        ((ObjectNode) node.get("metaData")).put("schemaString", mapper.writeValueAsString(schema));
-        patched.add(mapper.writeValueAsString(node));
-      } else {
-        patched.add(line);
-      }
-    }
-
-    Files.write(logFile, patched);
-
-    Files.deleteIfExists(deltaLogDir.resolve("00000000000000000000.crc"));
-    Files.deleteIfExists(deltaLogDir.resolve(".00000000000000000000.json.crc"));
-  }
-
-  /**
-   * Recursively removes fields with the given names from all struct-type definitions within a Spark
-   * schema JSON node (as serialised by Delta Lake). Struct nodes are identified by having a {@code
-   * fields} array; array-type nodes by having an {@code elementType} object.
-   */
-  private static void removeStructFields(
-      @Nonnull final JsonNode node, @Nonnull final Set<String> fieldNames) {
-    if (!node.isObject()) {
-      return;
-    }
-    if (node.has("fields")) {
-      final ArrayNode fields = (ArrayNode) node.get("fields");
-      for (int i = fields.size() - 1; i >= 0; i--) {
-        if (fieldNames.contains(fields.get(i).get("name").asText())) {
-          fields.remove(i);
-        }
-      }
-      for (final JsonNode field : fields) {
-        removeStructFields(field.get("type"), fieldNames);
-      }
-    } else if (node.has("elementType")) {
-      removeStructFields(node.get("elementType"), fieldNames);
-    }
+        storageConfiguration,
+        dataSource);
   }
 
   @Nonnull

--- a/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionCreateTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionCreateTest.java
@@ -18,6 +18,7 @@
 package au.csiro.pathling.operations.view;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import au.csiro.pathling.cache.CacheableDatabase;
 import au.csiro.pathling.config.StorageConfiguration;
@@ -26,6 +27,7 @@ import au.csiro.pathling.encoders.ViewDefinitionResource;
 import au.csiro.pathling.encoders.ViewDefinitionResource.ColumnComponent;
 import au.csiro.pathling.encoders.ViewDefinitionResource.SelectComponent;
 import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.operations.create.CreateProvider;
 import au.csiro.pathling.operations.update.UpdateExecutor;
 import au.csiro.pathling.test.SpringBootUnitTest;
@@ -87,7 +89,8 @@ class ViewDefinitionCreateTest {
             fhirEncoders,
             tempDatabasePath.toAbsolutePath().toString(),
             cacheableDatabase,
-            new StorageConfiguration());
+            new StorageConfiguration(),
+            mock(QueryableDataSource.class));
 
     // Create the CreateProvider for ViewDefinition.
     createProvider =

--- a/server/src/test/java/au/csiro/pathling/util/DeltaSchemaFixtures.java
+++ b/server/src/test/java/au/csiro/pathling/util/DeltaSchemaFixtures.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Test fixtures that simulate Delta tables written by an older server version. The schema of an
+ * existing table is downgraded by appending a new commit to the Delta log whose {@code metaData}
+ * action carries a {@code schemaString} with named fields removed from every struct definition.
+ * Delta applies the most recent {@code metaData} action, so the table presents the downgraded
+ * schema without any checkpoint or data file being touched.
+ *
+ * @author John Grimes
+ */
+public final class DeltaSchemaFixtures {
+
+  private DeltaSchemaFixtures() {}
+
+  /**
+   * Downgrades the table's schema by removing the named fields from every struct definition. The
+   * most recent {@code metaData} action in the JSON commit log is copied, its {@code schemaString}
+   * rewritten, and the result appended as a new commit. The result looks like a table written by an
+   * older encoder version that lacked those fields.
+   *
+   * @param tablePath the path to the Delta table directory
+   * @param fieldNames the names of the fields to remove wherever they occur
+   * @throws IOException if the Delta log cannot be read or written
+   */
+  public static void removeFieldsFromTableSchema(
+      @Nonnull final Path tablePath, @Nonnull final Set<String> fieldNames) throws IOException {
+    final Path deltaLogDir = tablePath.resolve("_delta_log");
+    final ObjectMapper mapper = new ObjectMapper();
+
+    final List<Path> commits = listJsonCommits(deltaLogDir);
+    if (commits.isEmpty()) {
+      throw new IllegalStateException("No JSON commits found in Delta log: " + deltaLogDir);
+    }
+
+    // Find the most recent metaData action in the JSON commit log. The metaData action is written
+    // in the first commit and only rewritten on schema or configuration changes, so scanning the
+    // JSON commits is sufficient for tables produced by test data generation.
+    final JsonNode metaData = findLatestMetaData(mapper, commits);
+    if (metaData == null) {
+      throw new IllegalStateException("No metaData action found in Delta log: " + deltaLogDir);
+    }
+
+    // Rewrite the schemaString with the named fields removed.
+    final JsonNode schema = mapper.readTree(metaData.get("schemaString").asText());
+    removeStructFields(schema, fieldNames);
+    ((ObjectNode) metaData).put("schemaString", mapper.writeValueAsString(schema));
+
+    // Append the downgraded metaData as a new commit, so it becomes the table's current schema.
+    final long lastVersion = commitVersion(commits.get(commits.size() - 1));
+    final long newVersion = lastVersion + 1;
+    final ObjectNode commitInfo = mapper.createObjectNode();
+    final ObjectNode commitInfoBody = commitInfo.putObject("commitInfo");
+    commitInfoBody.put("timestamp", System.currentTimeMillis());
+    commitInfoBody.put("operation", "CHANGE SCHEMA");
+    commitInfoBody.putObject("operationParameters");
+    commitInfoBody.put("readVersion", lastVersion);
+    commitInfoBody.put("isBlindAppend", false);
+    final ObjectNode metaDataAction = mapper.createObjectNode();
+    metaDataAction.set("metaData", metaData);
+
+    final Path newCommit = deltaLogDir.resolve(String.format("%020d.json", newVersion));
+    Files.write(
+        newCommit,
+        List.of(mapper.writeValueAsString(commitInfo), mapper.writeValueAsString(metaDataAction)));
+  }
+
+  /** Lists the JSON commit files of a Delta log in version order. */
+  @Nonnull
+  private static List<Path> listJsonCommits(@Nonnull final Path deltaLogDir) throws IOException {
+    try (final Stream<Path> entries = Files.list(deltaLogDir)) {
+      return entries
+          .filter(path -> path.getFileName().toString().matches("\\d{20}\\.json"))
+          .sorted()
+          .toList();
+    }
+  }
+
+  /** Extracts the numeric version from a commit file name. */
+  private static long commitVersion(@Nonnull final Path commit) {
+    final String name = commit.getFileName().toString();
+    return Long.parseLong(name.substring(0, name.length() - ".json".length()));
+  }
+
+  /** Returns the most recent {@code metaData} action found in the given commits, if any. */
+  @Nullable
+  private static JsonNode findLatestMetaData(
+      @Nonnull final ObjectMapper mapper, @Nonnull final List<Path> commits) throws IOException {
+    JsonNode latest = null;
+    for (final Path commit : commits) {
+      for (final String line : Files.readAllLines(commit)) {
+        final JsonNode node = mapper.readTree(line);
+        if (node.has("metaData")) {
+          latest = node.get("metaData");
+        }
+      }
+    }
+    return latest;
+  }
+
+  /**
+   * Recursively removes fields with the given names from all struct-type definitions within a Spark
+   * schema JSON node (as serialised by Delta Lake). Struct nodes are identified by having a {@code
+   * fields} array; array-type nodes by having an {@code elementType} object; map-type nodes by
+   * having a {@code valueType} object.
+   */
+  private static void removeStructFields(
+      @Nonnull final JsonNode node, @Nonnull final Set<String> fieldNames) {
+    if (!node.isObject()) {
+      return;
+    }
+    if (node.has("fields")) {
+      final ArrayNode fields = (ArrayNode) node.get("fields");
+      for (int i = fields.size() - 1; i >= 0; i--) {
+        if (fieldNames.contains(fields.get(i).get("name").asText())) {
+          fields.remove(i);
+        }
+      }
+      for (final JsonNode field : fields) {
+        removeStructFields(field.get("type"), fieldNames);
+      }
+    } else if (node.has("elementType")) {
+      removeStructFields(node.get("elementType"), fieldNames);
+    } else if (node.has("valueType")) {
+      removeStructFields(node.get("valueType"), fieldNames);
+    }
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/util/LogCapture.java
+++ b/server/src/test/java/au/csiro/pathling/util/LogCapture.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.util;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Captures log events emitted by a class under test. The logger level is lowered so that events
+ * filtered out by the test profile are still captured, and restored when the capture is closed.
+ * Intended for use in a try-with-resources block.
+ *
+ * @author John Grimes
+ */
+public final class LogCapture implements AutoCloseable {
+
+  @Nonnull private final Logger logger;
+
+  @Nullable private final Level previousLevel;
+
+  @Nonnull private final ListAppender<ILoggingEvent> appender;
+
+  private LogCapture(@Nonnull final Class<?> loggerClass, @Nonnull final Level level) {
+    logger = (Logger) LoggerFactory.getLogger(loggerClass);
+    previousLevel = logger.getLevel();
+    logger.setLevel(level);
+    appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+  }
+
+  /**
+   * Starts capturing events for the given class's logger at INFO level and below.
+   *
+   * @param loggerClass the class whose logger should be captured
+   * @return the active capture
+   */
+  @Nonnull
+  public static LogCapture forClass(@Nonnull final Class<?> loggerClass) {
+    return new LogCapture(loggerClass, Level.INFO);
+  }
+
+  /**
+   * Returns the events captured so far.
+   *
+   * @return the captured log events
+   */
+  @Nonnull
+  public List<ILoggingEvent> events() {
+    return appender.list;
+  }
+
+  @Override
+  public void close() {
+    logger.detachAppender(appender);
+    logger.setLevel(previousLevel);
+    appender.stop();
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/util/TestDataSetup.java
+++ b/server/src/test/java/au/csiro/pathling/util/TestDataSetup.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.apache.spark.sql.delta.DeltaLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -73,6 +74,11 @@ public class TestDataSetup {
    */
   public static void copyTestDataToTempDir(
       @Nonnull final Path tempDir, @Nullable final String... resourceTypes) {
+    // Replacing table directories on the filesystem invalidates any DeltaLog instances that Spark
+    // has cached for those paths. A stale cached log disagrees with the restored transaction log
+    // (which is at an older version), causing intermittent failures such as DELTA_PATH_EXISTS on
+    // subsequent writes. Clearing the cache forces Delta to re-resolve every table from disk.
+    DeltaLog.clearCache();
     try {
       final Path deltaPath = Path.of("src/test/resources/test-data/bulk/fhir/delta");
       if (resourceTypes == null || resourceTypes.length == 0) {

--- a/site/docs/server/configuration.md
+++ b/site/docs/server/configuration.md
@@ -226,14 +226,25 @@ limits are always applied; they cannot be disabled per request.
   threshold, the table will be repartitioned back to the default number of
   partitions. This prevents large numbers of small updates causing poor
   subsequent query performance.
-- `pathling.storage.schemaAutoMerge` - (default: `false`) When enabled, update
-  operations will automatically evolve the schema of an existing Delta table to
-  accommodate new fields produced by the FHIR encoder. This is useful when
-  upgrading to a Pathling version whose encoder emits additional columns or
-  nested struct fields that are not yet present in tables written by an earlier
-  version. There is a small additional write cost the first time a merge runs
-  against a table whose schema has drifted; in the steady state the cost is
-  negligible.
+- `pathling.storage.schemaAutoMerge` - (default: `false`) When enabled, the
+  schema of an existing Delta table is automatically evolved to accommodate new
+  fields produced by the FHIR encoder. This is useful when upgrading to a
+  Pathling version whose encoder emits additional columns or nested struct
+  fields that are not yet present in tables written by an earlier version.
+  Evolution happens in two places: at startup, every table in the warehouse
+  whose schema is missing encoder fields is migrated before it is served; and
+  on update, a table whose schema is behind the incoming data is evolved before
+  the merge, with the in-memory dataset refreshed so subsequent reads see the
+  new schema without a restart. Migration is additive only - no existing field
+  or row is modified, and existing rows present newly added fields as absent
+  values. When no table has drifted, startup adds only the cost of comparing
+  schemas. When the setting is disabled and a drifted table is detected, the
+  server logs a warning naming the table, the missing fields, and the remedy,
+  and requests against that resource type return an error that describes the
+  condition rather than a generic failure. In multi-replica deployments, a
+  runtime schema evolution is only visible to the replica that performed it;
+  other replicas require a restart, although redeploys (which replace all
+  replicas and re-run startup migration) are self-correcting.
 
 Pathling will automatically detect AWS authentication details within the
 environment and use them to access S3 buckets. It uses a chain of authentication


### PR DESCRIPTION
Fixes #2642.

After an encoder upgrade, existing Delta tables could fall behind the encoder's expected schema. A PUT to a resource like ViewDefinition would succeed (200), but every subsequent read of that resource type would fail with a 500 because the pinned dataset and the underlying table no longer matched the encoder schema.

This change addresses the problem in a few layers:

- Extracts schema drift detection into a shared `SchemaDrift` utility so the update path and startup checks compare tables against encoder schemas consistently.
- Refreshes pinned datasets after schema-evolving updates, so a write that widens a table no longer leaves stale dataset references behind.
- Adds a `SchemaMigrator` that migrates drifted Delta tables at server startup (behind configuration), bringing existing tables up to the current encoder schema before any requests are served.
- When migration is disabled and a drifted table is encountered, serves an actionable error (`SchemaDriftError`) instead of an opaque 500, explaining which table has drifted and how to resolve it.
- Guards view execution and derived sources: `DynamicDeltaSource.view(...)` checks the subject type eagerly, and derived sources (`map`, `filterByResourceType`, `cache`) propagate drift guarding via `DriftGuardedSource`, covering filtered view runs and exports.

Documentation in `site/docs/server/configuration.md` describes the startup migration behaviour and drift diagnostics. Unit tests cover drift detection, migration, error mapping, and derived-source guarding; integration tests cover the schema evolution read path and the flag-off behaviour.