### PR TITLE
Add input format option to terminology CLI commands

### DIFF
--- a/.github/actions/setup-r/action.yml
+++ b/.github/actions/setup-r/action.yml
@@ -40,7 +40,22 @@ runs:
     - name: Set up TinyTeX
       uses: r-lib/actions/setup-tinytex@v2
 
-    # libcurl is required for building the R package documentation.
-    - name: Install libcurl
+    # Native libraries required to build the R package and its documentation
+    # toolchain from source. When the R package cache misses, devtools and
+    # pkgdown are compiled from source, which pulls in systemfonts, textshaping
+    # and ragg. Those packages need the font (fontconfig, freetype, harfbuzz,
+    # fribidi) and image (png, tiff, jpeg) development headers, and libcurl is
+    # needed for the documentation build.
+    - name: Install system libraries
       shell: bash
-      run: sudo apt-get install -y libcurl4-openssl-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libcurl4-openssl-dev \
+          libfontconfig1-dev \
+          libfreetype-dev \
+          libharfbuzz-dev \
+          libfribidi-dev \
+          libpng-dev \
+          libtiff-dev \
+          libjpeg-dev

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -19,9 +19,9 @@
 
 Each command reads a tabular dataset (CSV, Parquet, or Delta), builds codings
 from a named code column plus either a fixed system URI or a per-row system
-column,
-calls the corresponding library terminology function, appends the result
-column(s), and emits the augmented dataset per the shared output options.
+column, calls the corresponding library terminology function, appends the
+result column(s), and emits the augmented dataset per the shared output
+options.
 
 Author: John Grimes.
 """

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -72,6 +72,45 @@ def _common_options(func):
     return func
 
 
+def _detect_tabular_format(path):
+    """Detects the tabular format of a dataset from its name and layout.
+
+    Detection inspects only the path's suffix and, for directories, the names
+    of its immediate entries; it never reads file contents. A file ending in
+    ``.csv`` or ``.parquet`` (case-insensitive) resolves to that format. A
+    directory containing a ``_delta_log`` entry resolves to ``delta``; otherwise
+    a directory containing at least one ``.parquet`` file resolves to
+    ``parquet``. Anything else is a usage error suggesting ``--from``.
+
+    :param path: the dataset :class:`Path`, which is assumed to exist.
+    :return: one of ``csv``, ``parquet``, or ``delta``.
+    :raises CliError: with EXIT_USAGE when the format cannot be determined.
+    """
+    if path.is_dir():
+        names = [entry.name for entry in path.iterdir()]
+        if "_delta_log" in names:
+            return "delta"
+        if any(name.lower().endswith(".parquet") for name in names):
+            return "parquet"
+        contents = ", ".join(sorted(names)) if names else "no entries"
+        raise CliError(
+            f"Could not determine the format of directory {path} "
+            f"(found: {contents}); it has no _delta_log entry and no .parquet "
+            "files. Specify it with --from csv|parquet|delta.",
+            exit_code=EXIT_USAGE,
+        )
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return "csv"
+    if suffix == ".parquet":
+        return "parquet"
+    raise CliError(
+        f"Could not determine the format of {path} from its suffix "
+        f"'{path.suffix}'. Specify it with --from csv|parquet|delta.",
+        exit_code=EXIT_USAGE,
+    )
+
+
 def _read_dataset(pc, dataset):
     """Reads a CSV or Parquet dataset into a Spark DataFrame.
 

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -17,8 +17,9 @@
 
 """The Pathling terminology commands.
 
-Each command reads a tabular dataset (CSV or Parquet), builds codings from a
-named code column plus either a fixed system URI or a per-row system column,
+Each command reads a tabular dataset (CSV, Parquet, or Delta), builds codings
+from a named code column plus either a fixed system URI or a per-row system
+column,
 calls the corresponding library terminology function, appends the result
 column(s), and emits the augmented dataset per the shared output options.
 
@@ -53,6 +54,12 @@ def _common_options(func):
     func = output_options(func)
     options = [
         click.argument("dataset"),
+        click.option(
+            "--from",
+            "from_format",
+            type=click.Choice(("csv", "parquet", "delta")),
+            help="Input format (default: auto-detected from the dataset path).",
+        ),
         click.option(
             "--code-column", "code_column", required=True, help="Code column name."
         ),
@@ -111,28 +118,27 @@ def _detect_tabular_format(path):
     )
 
 
-def _read_dataset(pc, dataset):
-    """Reads a CSV or Parquet dataset into a Spark DataFrame.
+def _read_dataset(pc, dataset, from_format):
+    """Reads a tabular dataset into a Spark DataFrame using a resolved format.
+
+    The format is resolved earlier, before the Spark session starts (see
+    :func:`_execute`), so this function only dispatches to the matching reader.
+    CSV is read with a header row and no schema inference, preserving the
+    previous semantics; Parquet and Delta accept both single-file and directory
+    inputs.
 
     :param pc: the Pathling context.
-    :param dataset: the path to the dataset file.
+    :param dataset: the path to the dataset file or directory.
+    :param from_format: the resolved format, one of ``csv``, ``parquet``, or
+           ``delta``.
     :return: the loaded DataFrame.
-    :raises CliError: when the path is missing or the type is unsupported.
     """
-    path = Path(dataset)
-    if not path.exists():
-        raise CliError(
-            f"Dataset does not exist: {path}. Check the path.", exit_code=EXIT_USAGE
-        )
-    suffix = path.suffix.lower()
-    if suffix == ".csv":
-        return pc.spark.read.csv(str(path), header=True, inferSchema=False)
-    if suffix == ".parquet":
-        return pc.spark.read.parquet(str(path))
-    raise CliError(
-        f"Unsupported dataset type '{suffix}'. Use a .csv or .parquet file.",
-        exit_code=EXIT_USAGE,
-    )
+    path = str(dataset)
+    if from_format == "csv":
+        return pc.spark.read.csv(path, header=True, inferSchema=False)
+    if from_format == "parquet":
+        return pc.spark.read.parquet(path)
+    return pc.spark.read.format("delta").load(path)
 
 
 def _validate_columns(df, required, dataset):
@@ -244,6 +250,7 @@ def _validate_coding_source(dataset, system, system_column):
 def _execute(
     obj,
     dataset,
+    from_format,
     system,
     system_column,
     output_format,
@@ -257,6 +264,7 @@ def _execute(
 
     :param obj: the CLI context object.
     :param dataset: the dataset path.
+    :param from_format: the explicit ``--from`` value, or None to auto-detect.
     :param system: a fixed system URI, or None.
     :param system_column: a per-row system column name, or None.
     :param output_format: the ``--format`` value, or None.
@@ -270,11 +278,15 @@ def _execute(
     config = obj.config
     console = obj.console
 
-    # Validate cheap inputs before paying the Spark cold start.
+    # Validate cheap inputs before paying the Spark cold start. Resolving the
+    # input format here means an unknown or undeterminable format fails fast,
+    # before the multi-second Spark cold start (FR-005). An explicit --from
+    # wins; otherwise the format is detected from the path (FR-002/FR-003).
     _validate_coding_source(dataset, system, system_column)
+    resolved_format = from_format or _detect_tabular_format(Path(dataset))
     output_spec = resolve_output(output, output_format, limit, overwrite, departition)
     pc = session.create_context(config, console)
-    df = _read_dataset(pc, dataset)
+    df = _read_dataset(pc, dataset, resolved_format)
 
     try:
         with progress_status(
@@ -304,6 +316,7 @@ def _execute(
 def member_of(
     obj,
     dataset,
+    from_format,
     code_column,
     system,
     system_column,
@@ -335,6 +348,7 @@ def member_of(
     _execute(
         obj,
         dataset,
+        from_format,
         system,
         system_column,
         output_format,
@@ -360,6 +374,7 @@ def member_of(
 def translate(
     obj,
     dataset,
+    from_format,
     code_column,
     system,
     system_column,
@@ -408,6 +423,7 @@ def translate(
     _execute(
         obj,
         dataset,
+        from_format,
         system,
         system_column,
         output_format,
@@ -456,6 +472,7 @@ def _run_subsumption(
     operation,
     default_name,
     dataset,
+    from_format,
     code_column,
     system,
     system_column,
@@ -477,6 +494,7 @@ def _run_subsumption(
     :param operation: the udf attribute name (``subsumes`` or ``subsumed_by``).
     :param default_name: the default result column name.
     :param dataset: the dataset path.
+    :param from_format: the explicit ``--from`` value, or None to auto-detect.
     :param code_column: the left code column.
     :param system: the left fixed system URI, or None.
     :param system_column: the left per-row system column, or None.
@@ -536,6 +554,7 @@ def _run_subsumption(
     _execute(
         obj,
         dataset,
+        from_format,
         system,
         system_column,
         output_format,
@@ -554,6 +573,7 @@ def _run_subsumption(
 def subsumes(
     obj,
     dataset,
+    from_format,
     code_column,
     system,
     system_column,
@@ -587,6 +607,7 @@ def subsumes(
         "subsumes",
         "subsumes",
         dataset,
+        from_format,
         code_column,
         system,
         system_column,
@@ -611,6 +632,7 @@ def subsumes(
 def subsumed_by(
     obj,
     dataset,
+    from_format,
     code_column,
     system,
     system_column,
@@ -644,6 +666,7 @@ def subsumed_by(
         "subsumed_by",
         "subsumed_by",
         dataset,
+        from_format,
         code_column,
         system,
         system_column,
@@ -671,6 +694,7 @@ def subsumed_by(
 def display(
     obj,
     dataset,
+    from_format,
     code_column,
     system,
     system_column,
@@ -701,6 +725,7 @@ def display(
     _execute(
         obj,
         dataset,
+        from_format,
         system,
         system_column,
         output_format,
@@ -730,6 +755,7 @@ def display(
 def property_of(
     obj,
     dataset,
+    from_format,
     code_column,
     system,
     system_column,
@@ -766,6 +792,7 @@ def property_of(
     _execute(
         obj,
         dataset,
+        from_format,
         system,
         system_column,
         output_format,
@@ -788,6 +815,7 @@ def property_of(
 def designation(
     obj,
     dataset,
+    from_format,
     code_column,
     system,
     system_column,
@@ -830,6 +858,7 @@ def designation(
     _execute(
         obj,
         dataset,
+        from_format,
         system,
         system_column,
         output_format,

--- a/lib/python/tests/cli/test_terminology.py
+++ b/lib/python/tests/cli/test_terminology.py
@@ -27,7 +27,7 @@ Author: John Grimes.
 import csv
 import io
 
-from pytest import fixture
+from pytest import fixture, raises
 
 from pathling.cli.main import cli
 
@@ -43,6 +43,31 @@ def _write_csv(path, header, rows):
         writer = csv.writer(handle)
         writer.writerow(header)
         writer.writerows(rows)
+    return path
+
+
+def _write_parquet(spark, path, header, rows):
+    """Writes a Parquet dataset directory with the given header and rows.
+
+    The dataset is written through the shared Spark session, so it takes the
+    same directory-of-part-files form as the CLI's own Parquet output. Both the
+    single-file and directory forms of Parquet are read back through
+    ``spark.read.parquet``, so this directory form exercises the directory case.
+    """
+    spark.createDataFrame([tuple(row) for row in rows], header).write.parquet(str(path))
+    return path
+
+
+def _write_delta(spark, path, header, rows):
+    """Writes a Delta table directory with the given header and rows.
+
+    The table is written through the shared Spark session, which is Delta
+    enabled, producing a directory containing a ``_delta_log`` entry alongside
+    the Parquet data files.
+    """
+    spark.createDataFrame([tuple(row) for row in rows], header).write.format(
+        "delta"
+    ).save(str(path))
     return path
 
 
@@ -108,6 +133,95 @@ def test_coding_column_matches_library_schema(pathling_ctx):
     )
 
     assert cli_fields == library_fields
+
+
+# ========== _detect_tabular_format ==========
+
+
+def test_detect_csv_file(tmp_path):
+    """A file ending in .csv is detected as CSV."""
+    from pathling.cli.terminology import _detect_tabular_format
+
+    path = _write_csv(tmp_path / "codes.csv", ["code"], [["a"]])
+    assert _detect_tabular_format(path) == "csv"
+
+
+def test_detect_csv_file_uppercase_suffix(tmp_path):
+    """Suffix matching is case-insensitive, so .CSV is detected as CSV."""
+    from pathling.cli.terminology import _detect_tabular_format
+
+    path = _write_csv(tmp_path / "codes.CSV", ["code"], [["a"]])
+    assert _detect_tabular_format(path) == "csv"
+
+
+def test_detect_parquet_file(tmp_path):
+    """A file ending in .parquet is detected as Parquet."""
+    from pathling.cli.terminology import _detect_tabular_format
+
+    path = tmp_path / "codes.parquet"
+    path.write_bytes(b"PAR1")
+    assert _detect_tabular_format(path) == "parquet"
+
+
+def test_detect_delta_directory(tmp_path):
+    """A directory containing a _delta_log entry is detected as Delta."""
+    from pathling.cli.terminology import _detect_tabular_format
+
+    directory = tmp_path / "table"
+    (directory / "_delta_log").mkdir(parents=True)
+    (directory / "part-0.parquet").write_bytes(b"PAR1")
+    assert _detect_tabular_format(directory) == "delta"
+
+
+def test_detect_parquet_directory(tmp_path):
+    """A directory with Parquet contents but no _delta_log is detected as Parquet."""
+    from pathling.cli.terminology import _detect_tabular_format
+
+    directory = tmp_path / "data"
+    directory.mkdir()
+    (directory / "part-00000.snappy.parquet").write_bytes(b"PAR1")
+    (directory / "_SUCCESS").write_bytes(b"")
+    assert _detect_tabular_format(directory) == "parquet"
+
+
+def test_detect_delta_wins_over_parquet(tmp_path):
+    """A directory with both _delta_log and .parquet files is detected as Delta."""
+    from pathling.cli.terminology import _detect_tabular_format
+
+    directory = tmp_path / "table"
+    (directory / "_delta_log").mkdir(parents=True)
+    (directory / "stray.parquet").write_bytes(b"PAR1")
+    assert _detect_tabular_format(directory) == "delta"
+
+
+def test_detect_unrecognised_file_suffix_raises(tmp_path):
+    """An unrecognised file suffix is a usage error suggesting --from."""
+    from pathling.cli.errors import EXIT_USAGE, CliError
+    from pathling.cli.terminology import _detect_tabular_format
+
+    path = tmp_path / "codes.txt"
+    path.write_text("code\na\n")
+    with raises(CliError) as info:
+        _detect_tabular_format(path)
+    assert info.value.exit_code == EXIT_USAGE
+    assert "--from csv|parquet|delta" in str(info.value)
+
+
+def test_detect_empty_directory_raises(tmp_path):
+    """An unrecognisable directory is a usage error naming the path and contents."""
+    from pathling.cli.errors import EXIT_USAGE, CliError
+    from pathling.cli.terminology import _detect_tabular_format
+
+    directory = tmp_path / "mystery"
+    directory.mkdir()
+    (directory / "notes.txt").write_text("hello")
+    with raises(CliError) as info:
+        _detect_tabular_format(directory)
+    message = str(info.value)
+    assert info.value.exit_code == EXIT_USAGE
+    # The message names the offending path and suggests the flag.
+    assert str(directory) in message
+    assert "--from csv|parquet|delta" in message
 
 
 # ========== member-of ==========

--- a/lib/python/tests/cli/test_terminology.py
+++ b/lib/python/tests/cli/test_terminology.py
@@ -1062,6 +1062,139 @@ def test_from_csv_missing_path_is_usage_error(runner, monkeypatch, tmp_path):
     assert "does not exist" in result.stderr.lower()
 
 
+# ========== --from input format: auto-detection (US2) ==========
+
+
+def test_autodetect_delta_directory(runner, patched_context, tmp_path):
+    """A Delta directory is auto-detected without --from (acceptance 3)."""
+    table = _write_delta(
+        patched_context.spark, tmp_path / "codes", ["code"], [["55915-3"]]
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "display",
+            str(table),
+            "--code-column",
+            "code",
+            "--system",
+            LOINC,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert "Beta 2 globulin" in result.stdout
+
+
+def test_autodetect_parquet_directory(runner, patched_context, tmp_path):
+    """A Parquet directory is auto-detected without --from (acceptance 4)."""
+    data = _write_parquet(
+        patched_context.spark,
+        tmp_path / "codes",
+        ["code", "system"],
+        [["368529001", SNOMED]],
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(data),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert _stdout_rows(result)[1][2] == "True"
+
+
+def test_roundtrip_own_parquet_output(runner, patched_context, codes_csv, tmp_path):
+    """The CLI's own Parquet output reads back into a second command without
+    --from (SC-002)."""
+    out = tmp_path / "out.parquet"
+    first = runner.invoke(
+        cli,
+        [
+            "display",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "-o",
+            str(out),
+        ],
+    )
+    assert first.exit_code == 0, first.stderr
+    assert out.exists()
+
+    # The second command reads the first command's Parquet output directory,
+    # auto-detected as Parquet with no --from flag.
+    second = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(out),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert second.exit_code == 0, second.stderr
+    assert "member_of" in _stdout_rows(second)[0]
+
+
+def test_autodetect_undeterminable_directory_is_usage_error(
+    runner, monkeypatch, tmp_path
+):
+    """An unrecognisable directory fails before Spark with an actionable error
+    (acceptance 5)."""
+
+    def spy(config, console=None):
+        raise AssertionError("context must not be created on a usage error")
+
+    monkeypatch.setattr("pathling.cli.session.create_context", spy)
+    directory = tmp_path / "mystery"
+    directory.mkdir()
+    (directory / "notes.txt").write_text("nothing tabular here")
+
+    result = runner.invoke(
+        cli,
+        [
+            "display",
+            str(directory),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+        ],
+    )
+
+    assert result.exit_code == 2
+    # The message names the offending path and suggests the flag. Newlines are
+    # stripped first because the console wraps the long message across lines,
+    # which would otherwise split the path and the flag text mid-token.
+    flattened = result.stderr.replace("\n", "")
+    assert str(directory) in flattened
+    assert "--from csv|parquet|delta" in flattened
+
+
 # ========== Config precedence wiring ==========
 
 

--- a/lib/python/tests/cli/test_terminology.py
+++ b/lib/python/tests/cli/test_terminology.py
@@ -914,6 +914,154 @@ def test_bracketed_runtime_error_renders_safely(
     assert "[ANALYSIS_ERROR]" in result.stderr
 
 
+# ========== --from input format: explicit (US1) ==========
+
+
+def test_from_delta_reads_delta_table(runner, patched_context, tmp_path):
+    """display --from delta reads a Delta table directory (acceptance 1)."""
+    table = _write_delta(
+        patched_context.spark, tmp_path / "codes", ["code"], [["55915-3"]]
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "display",
+            str(table),
+            "--from",
+            "delta",
+            "--code-column",
+            "code",
+            "--system",
+            LOINC,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert "Beta 2 globulin" in result.stdout
+
+
+def test_from_parquet_reads_parquet_directory(runner, patched_context, tmp_path):
+    """member-of --from parquet reads a Parquet directory (acceptance 2)."""
+    data = _write_parquet(
+        patched_context.spark,
+        tmp_path / "codes",
+        ["code", "system"],
+        [["368529001", SNOMED]],
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(data),
+            "--from",
+            "parquet",
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert _stdout_rows(result)[1][2] == "True"
+
+
+def test_from_csv_reads_arbitrary_extension(runner, patched_context, tmp_path):
+    """translate --from csv reads a CSV file with an arbitrary extension
+    (acceptance 3)."""
+    dataset = _write_csv(tmp_path / "codes.txt", ["code"], [["368529001"]])
+
+    result = runner.invoke(
+        cli,
+        [
+            "translate",
+            str(dataset),
+            "--from",
+            "csv",
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--concept-map",
+            CONCEPT_MAP,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert any("368529002" in row for row in _stdout_rows(result)[1:])
+
+
+def test_from_invalid_choice_is_usage_error(runner, monkeypatch, codes_csv):
+    """--from with an out-of-range value fails before Spark, listing the choices
+    (acceptance 4)."""
+
+    def spy(config, console=None):
+        raise AssertionError("context must not be created on a usage error")
+
+    monkeypatch.setattr("pathling.cli.session.create_context", spy)
+
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(codes_csv),
+            "--from",
+            "bogus",
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+        ],
+    )
+
+    assert result.exit_code == 2
+    # The Click choice error lists the three valid formats.
+    assert "csv" in result.stderr
+    assert "parquet" in result.stderr
+    assert "delta" in result.stderr
+
+
+def test_from_csv_missing_path_is_usage_error(runner, monkeypatch, tmp_path):
+    """--from with a missing path fails before Spark with the existing error
+    (acceptance 5)."""
+
+    def spy(config, console=None):
+        raise AssertionError("context must not be created on a usage error")
+
+    monkeypatch.setattr("pathling.cli.session.create_context", spy)
+
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(tmp_path / "nope.csv"),
+            "--from",
+            "csv",
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "does not exist" in result.stderr.lower()
+
+
 # ========== Config precedence wiring ==========
 
 

--- a/lib/python/tests/cli/test_terminology.py
+++ b/lib/python/tests/cli/test_terminology.py
@@ -207,7 +207,7 @@ def test_detect_unrecognised_file_suffix_raises(tmp_path):
     assert "--from csv|parquet|delta" in str(info.value)
 
 
-def test_detect_empty_directory_raises(tmp_path):
+def test_detect_unrecognisable_directory_raises(tmp_path):
     """An unrecognisable directory is a usage error naming the path and contents."""
     from pathling.cli.errors import EXIT_USAGE, CliError
     from pathling.cli.terminology import _detect_tabular_format

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -222,8 +222,8 @@ normal tracebacks without ending the session; leave with `exit` or Ctrl-D
 ### Terminology commands
 
 The `member-of`, `translate`, `subsumes`, `subsumed-by`, `display`,
-`property-of`, and `designation` commands read a tabular dataset (CSV or
-Parquet), build codings from a `--code-column` plus either a fixed `--system`
+`property-of`, and `designation` commands read a tabular dataset (CSV, Parquet,
+or Delta), build codings from a `--code-column` plus either a fixed `--system`
 URI or a `--system-column`, and append the operation's result column(s).
 
 ```bash
@@ -233,6 +233,29 @@ pathling member-of codes.csv --code-column code \
 
 pathling translate codes.csv --code-column code \
   --system http://snomed.info/sct --concept-map '<uri>'
+```
+
+The input format is set with `--from csv|parquet|delta`. When omitted, it is
+auto-detected from the dataset path: files ending in `.csv` or `.parquet` are
+read as CSV or Parquet; a directory containing a `_delta_log` entry is read as
+Delta; and any other directory containing at least one `.parquet` file is read
+as Parquet. CSV inputs are read with a header row and all columns as strings.
+Passing `--from` bypasses detection, which is useful for Delta tables or CSV
+files with an unconventional extension. An input whose format cannot be
+determined - an unrecognised suffix, or a directory with neither a `_delta_log`
+entry nor `.parquet` files - is reported as a usage error before any Spark
+session starts. This also lets you read the CLI's own Parquet or Delta output
+directory straight back into another terminology command.
+
+```bash
+# Explicit Delta input.
+pathling display warehouse/codes --from delta \
+  --code-column code --system http://snomed.info/sct
+
+# Auto-detected Delta directory (contains _delta_log).
+pathling member-of warehouse/codes --code-column code \
+  --system http://snomed.info/sct \
+  --value-set 'http://snomed.info/sct?fhir_vs=refset/...'
 ```
 
 The default result column names (`member_of`, `translated_system` and


### PR DESCRIPTION
Adds an explicit input format option to the Python terminology CLI commands and teaches them to auto-detect directory-based inputs.

Previously the terminology commands relied on a suffix-only reader, so Delta tables, Parquet directories, and unusually named files could not be read back. This threads an explicit `--from csv|parquet|delta` choice through the seven terminology commands, and when no flag is given resolves the format from the path's suffix and directory layout. Undeterminable inputs now fail before the Spark session starts with an actionable message suggesting `--from`.

Documentation in the CLI terminology section describes the supported formats, the `--from` flag, and the auto-detection rules.

Closes #2646
