### PR TITLE
Pre-import Pathling functions into the run and console namespace

### DIFF
--- a/.github/actions/setup-r/action.yml
+++ b/.github/actions/setup-r/action.yml
@@ -40,7 +40,22 @@ runs:
     - name: Set up TinyTeX
       uses: r-lib/actions/setup-tinytex@v2
 
-    # libcurl is required for building the R package documentation.
-    - name: Install libcurl
+    # Native libraries required to build the R package and its documentation
+    # toolchain from source. When the R package cache misses, devtools and
+    # pkgdown are compiled from source, which pulls in systemfonts, textshaping
+    # and ragg. Those packages need the font (fontconfig, freetype, harfbuzz,
+    # fribidi) and image (png, tiff, jpeg) development headers, and libcurl is
+    # needed for the documentation build.
+    - name: Install system libraries
       shell: bash
-      run: sudo apt-get install -y libcurl4-openssl-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libcurl4-openssl-dev \
+          libfontconfig1-dev \
+          libfreetype-dev \
+          libharfbuzz-dev \
+          libfribidi-dev \
+          libpng-dev \
+          libtiff-dev \
+          libjpeg-dev

--- a/lib/python/pathling/__init__.py
+++ b/lib/python/pathling/__init__.py
@@ -39,7 +39,12 @@ if TYPE_CHECKING:
     from .core import Expression, VariableExpression
     from .datasource import DataSource, DataSources
     from .fhir import MimeType, Version
-    from .functions import to_coding, to_ecl_value_set, to_snomed_coding
+    from .functions import (
+        to_coding,
+        to_ecl_value_set,
+        to_loinc_coding,
+        to_snomed_coding,
+    )
     from .udfs import (
         Equivalence,
         PropertyType,
@@ -65,6 +70,7 @@ _LAZY_EXPORTS = {
     "Version": "pathling.fhir",
     "to_coding": "pathling.functions",
     "to_snomed_coding": "pathling.functions",
+    "to_loinc_coding": "pathling.functions",
     "to_ecl_value_set": "pathling.functions",
     "member_of": "pathling.udfs",
     "translate": "pathling.udfs",

--- a/lib/python/pathling/cli/console.py
+++ b/lib/python/pathling/cli/console.py
@@ -17,10 +17,13 @@
 
 """The ``pathling console`` command.
 
-Opens an interactive IPython session with ``spark`` (the Spark session) and
-``pathling`` (the configured Pathling context) bound in the user namespace,
-after a banner identifying the version and the variables in scope. IPython is
-imported inside the command body so that ``--help`` stays fast.
+Opens an interactive IPython session with ``spark`` (the Spark session),
+``pathling`` (the configured Pathling context), and the Pathling package's
+public API pre-imported into the user namespace, after a banner identifying the
+version and the variables in scope. The terminology display function is bound as
+``tx_display`` rather than ``display`` so that IPython's built-in ``display``
+remains reachable at the prompt. IPython is imported inside the command body so
+that ``--help`` stays fast.
 
 Author: John Grimes.
 """
@@ -37,7 +40,9 @@ def build_banner() -> str:
     """Builds the banner shown before the console's first prompt.
 
     The banner identifies the Pathling and Python versions, lists the
-    variables in scope, and explains how to exit.
+    variables in scope, notes that the Pathling public functions are
+    pre-imported (with the terminology display available as ``tx_display``),
+    and explains how to exit.
 
     :return: the banner text.
     """
@@ -45,6 +50,10 @@ def build_banner() -> str:
         f"Pathling console (version {__version__}, "
         f"Python {platform.python_version()})\n"
         "Variables in scope: spark (SparkSession), pathling (PathlingContext)\n"
+        "Pathling public functions are pre-imported (member_of, translate, "
+        "to_coding, ...); see https://pathling.csiro.au/docs/python/pathling.html\n"
+        "The terminology display function is available as tx_display "
+        "(display is IPython's built-in).\n"
         "Type exit or press Ctrl-D to leave.\n"
     )
 
@@ -54,8 +63,11 @@ def build_banner() -> str:
 def console(obj):
     """Open an interactive console with the Pathling environment ready.
 
-    Starts an IPython session with two variables in scope: spark (the Spark
-    session) and pathling (the configured Pathling context). Exit with
+    Starts an IPython session with spark (the Spark session) and pathling
+    (the configured Pathling context) in scope. The Pathling public functions
+    (member_of, translate, to_coding, and so on) are pre-imported, so no
+    "from pathling import ..." is needed; the terminology display is available
+    as tx_display, leaving IPython's built-in display unchanged. Exit with
     'exit' or Ctrl-D.
 
     \b
@@ -70,6 +82,14 @@ def console(obj):
     """
     pc = session.create_context(obj.config, obj.console)
 
+    # Pre-import the public API surface, but expose the terminology display as
+    # tx_display only: IPython installs its own `display` into the interpreter's
+    # built-ins, so binding Pathling's display here would silently shadow it.
+    user_ns = session.public_namespace()
+    user_ns["tx_display"] = user_ns.pop("display")
+    user_ns["spark"] = pc.spark
+    user_ns["pathling"] = pc
+
     import IPython
     from traitlets.config import Config
 
@@ -77,6 +97,6 @@ def console(obj):
     config.TerminalInteractiveShell.banner1 = build_banner()
     IPython.start_ipython(
         argv=[],
-        user_ns={"spark": pc.spark, "pathling": pc},
+        user_ns=user_ns,
         config=config,
     )

--- a/lib/python/pathling/cli/run.py
+++ b/lib/python/pathling/cli/run.py
@@ -19,9 +19,13 @@
 
 Executes user-supplied Python code - from a script file, standard input, or an
 inline ``-c`` option - with ``spark`` (the Spark session) and ``pathling`` (the
-configured Pathling context) bound in the code's global scope, reproducing
-Python interpreter script semantics (``sys.argv``, ``__main__``, ``__file__``,
-``sys.path``, traceback fidelity, and ``SystemExit`` propagation).
+configured Pathling context) bound in the code's global scope, along with the
+Pathling package's public API (its terminology and coding functions, argument
+helper types, and API types) so scripts need no explicit ``from pathling import
+...``. The terminology display function is bound as both ``display`` and
+``tx_display``. Python interpreter script semantics (``sys.argv``, ``__main__``,
+``__file__``, ``sys.path``, traceback fidelity, and ``SystemExit`` propagation)
+are reproduced.
 
 Author: John Grimes.
 """
@@ -233,9 +237,12 @@ def run(ctx, script, code, args):
     """Run Python code with the Pathling environment ready.
 
     Executes a script file (or '-' for standard input, or inline code via
-    -c) with two variables already in scope: spark (the Spark session) and
-    pathling (the configured Pathling context). Trailing arguments are
-    passed to the code as sys.argv, following Python interpreter
+    -c) with spark (the Spark session) and pathling (the configured Pathling
+    context) already in scope. The Pathling public functions (to_coding,
+    to_snomed_coding, member_of, translate, subsumes, display, and so on) are
+    pre-imported too, so no "from pathling import ..." is needed; the
+    terminology display is available as both display and tx_display. Trailing
+    arguments are passed to the code as sys.argv, following Python interpreter
     conventions.
 
     \b
@@ -258,6 +265,14 @@ def run(ctx, script, code, args):
 
     obj = ctx.obj
     pc = session.create_context(obj.config, obj.console)
-    namespace = {"spark": pc.spark, "pathling": pc}
+    # Pre-import the whole public API surface so scripts need no explicit
+    # `from pathling import ...`. The terminology display is bound under its
+    # natural name `display` and also aliased as `tx_display`, so a snippet
+    # developed at the console (where `display` is IPython's built-in and the
+    # terminology display is `tx_display`) pastes into a script unchanged.
+    namespace = session.public_namespace()
+    namespace["tx_display"] = namespace["display"]
+    namespace["spark"] = pc.spark
+    namespace["pathling"] = pc
 
     _execute(source, program_args, namespace)

--- a/lib/python/pathling/cli/session.py
+++ b/lib/python/pathling/cli/session.py
@@ -53,6 +53,24 @@ _RESOURCE_STACK = ExitStack()
 atexit.register(_RESOURCE_STACK.close)
 
 
+def public_namespace() -> dict:
+    """Builds the mapping of the package's public API names to their objects.
+
+    The set of names is derived from the ``pathling`` package's public API list
+    (``pathling.__all__``) so that it stays in sync automatically and no second,
+    hand-maintained list exists. The ``pathling`` package is imported inside the
+    function so that the ``--help`` and ``--version`` fast paths are not slowed
+    and do not trigger the JVM-backed imports; resolving the names here forces
+    those imports, which is only appropriate after a command has decided to
+    start the environment.
+
+    :return: a mapping of each public name to the object it exports.
+    """
+    import pathling
+
+    return {name: getattr(pathling, name) for name in pathling.__all__}
+
+
 def quiet_log4j2_path() -> str:
     """Resolves a filesystem path to the packaged quiet log4j2 configuration.
 

--- a/lib/python/tests/cli/test_console.py
+++ b/lib/python/tests/cli/test_console.py
@@ -27,6 +27,7 @@ Author: John Grimes.
 
 import IPython
 
+import pathling
 from pathling._version import __version__
 from pathling.cli.console import build_banner
 from pathling.cli.main import cli
@@ -42,6 +43,16 @@ def test_banner_contains_version_variables_and_exit_hint():
     assert "spark" in banner
     assert "pathling" in banner
     assert "exit" in banner.lower()
+
+
+def test_banner_mentions_preimported_functions_and_tx_display():
+    """The banner announces the pre-imported functions and names tx_display
+    (FR-008)."""
+    banner = build_banner()
+
+    # A couple of representative pre-imported names and the tx_display note.
+    assert "member_of" in banner
+    assert "tx_display" in banner
 
 
 # ========== IPython embedding ==========
@@ -64,13 +75,58 @@ def test_console_starts_ipython_with_namespace(runner, patched_context, monkeypa
     assert result.exit_code == 0, result.stderr
     # IPython must not consume the process's own argv.
     assert captured["argv"] == []
-    # The namespace contains exactly spark and pathling, correctly bound.
-    assert captured["user_ns"] == {
-        "spark": patched_context.spark,
-        "pathling": patched_context,
+    user_ns = captured["user_ns"]
+    # spark and pathling remain correctly bound.
+    assert user_ns["spark"] is patched_context.spark
+    assert user_ns["pathling"] is patched_context
+    # The namespace is the public API minus display, plus spark, pathling, and
+    # tx_display (INV-2), derived from __all__ rather than a hard-coded list.
+    expected = (set(pathling.__all__) - {"display"}) | {
+        "spark",
+        "pathling",
+        "tx_display",
     }
+    assert set(user_ns) == expected
     # The configuration carries the banner.
     assert captured["config"].TerminalInteractiveShell.banner1 == build_banner()
+
+
+def test_console_namespace_display_split(runner, patched_context, monkeypatch):
+    """display is absent so IPython's built-in wins; tx_display is Pathling's
+    terminology display (INV-4, FR-005)."""
+    captured = {}
+
+    def fake_start_ipython(argv=None, user_ns=None, config=None, **kwargs):
+        captured["user_ns"] = user_ns
+
+    monkeypatch.setattr(IPython, "start_ipython", fake_start_ipython)
+
+    result = runner.invoke(cli, ["console"])
+
+    assert result.exit_code == 0, result.stderr
+    user_ns = captured["user_ns"]
+    # Pathling's display is not bound, leaving IPython's built-in reachable.
+    assert "display" not in user_ns
+    # The terminology display is available under tx_display.
+    assert user_ns["tx_display"] is pathling.display
+
+
+def test_console_namespace_binds_public_functions(runner, patched_context, monkeypatch):
+    """Other public names are bound under their own names, as in run (FR-002)."""
+    captured = {}
+
+    def fake_start_ipython(argv=None, user_ns=None, config=None, **kwargs):
+        captured["user_ns"] = user_ns
+
+    monkeypatch.setattr(IPython, "start_ipython", fake_start_ipython)
+
+    result = runner.invoke(cli, ["console"])
+
+    assert result.exit_code == 0, result.stderr
+    user_ns = captured["user_ns"]
+    assert user_ns["member_of"] is pathling.member_of
+    assert user_ns["to_coding"] is pathling.to_coding
+    assert user_ns["Coding"] is pathling.Coding
 
 
 def test_console_creates_context_before_starting_ipython(

--- a/lib/python/tests/cli/test_run.py
+++ b/lib/python/tests/cli/test_run.py
@@ -331,3 +331,81 @@ def test_missing_script_is_usage_error_without_session(
 
     assert result.exit_code == 2
     assert "missing.py" in result.stderr
+
+
+# ========== Pre-imported Pathling functions (US1) ==========
+
+
+def test_public_functions_available_without_import(runner, patched_context, tmp_path):
+    """A script uses public functions and types with no import (FR-001)."""
+    script = _write_script(
+        tmp_path,
+        "print(callable(to_snomed_coding))\n"
+        "print(callable(member_of))\n"
+        "print(Coding.__name__)\n",
+    )
+
+    result = runner.invoke(cli, ["run", script])
+
+    assert result.exit_code == 0, result.stderr
+    lines = result.stdout.splitlines()
+    assert lines[0] == "True"
+    assert lines[1] == "True"
+    assert lines[2] == "Coding"
+
+
+def test_inline_and_stdin_resolve_public_function(runner, patched_context):
+    """Inline -c and piped stdin programs resolve a public name with no import."""
+    inline = runner.invoke(cli, ["run", "-c", "print(callable(translate))"])
+    piped = runner.invoke(cli, ["run", "-"], input="print(callable(subsumes))\n")
+
+    assert inline.exit_code == 0, inline.stderr
+    assert inline.stdout.splitlines()[0] == "True"
+    assert piped.exit_code == 0, piped.stderr
+    assert piped.stdout.splitlines()[0] == "True"
+
+
+def test_display_and_tx_display_are_the_same_object(runner, patched_context):
+    """In run, display and tx_display are the same terminology function (FR-004)."""
+    result = runner.invoke(cli, ["run", "-c", "print(display is tx_display)"])
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout.splitlines()[0] == "True"
+
+
+def test_user_code_overrides_injected_name(runner, patched_context):
+    """A user definition of an injected name takes precedence (FR-006)."""
+    result = runner.invoke(
+        cli, ["run", "-c", "translate = lambda x: 'mine'\nprint(translate('x'))"]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout.splitlines()[0] == "mine"
+
+
+def test_explicit_import_still_works(runner, patched_context):
+    """An explicit from-import continues to work unchanged (FR-007)."""
+    result = runner.invoke(
+        cli,
+        ["run", "-c", "from pathling import member_of\nprint(callable(member_of))"],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout.splitlines()[0] == "True"
+
+
+def test_every_public_name_is_in_program_globals(runner, patched_context):
+    """Every name in pathling.__all__ is bound in the program globals (INV-1)."""
+    # dir() is captured before `import pathling` rebinds the injected name, so
+    # the expectation is derived from __all__ rather than a hard-coded list.
+    program = (
+        "names = set(dir())\n"
+        "import pathling\n"
+        "missing = [n for n in pathling.__all__ if n not in names]\n"
+        "print(missing)\n"
+    )
+
+    result = runner.invoke(cli, ["run", "-c", program])
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout.splitlines()[0] == "[]"

--- a/lib/python/tests/cli/test_session.py
+++ b/lib/python/tests/cli/test_session.py
@@ -29,9 +29,14 @@ import os
 import tempfile
 from pathlib import Path
 
+import pathling
 import pathling.context as context_module
 from pathling.cli.config import CliConfig
-from pathling.cli.session import _build_quiet_spark, quiet_log4j2_path
+from pathling.cli.session import (
+    _build_quiet_spark,
+    public_namespace,
+    quiet_log4j2_path,
+)
 
 # The temp-file prefix the pre-fix implementation used; no file with this prefix
 # may be created any more (FR-017).
@@ -153,3 +158,64 @@ def test_build_quiet_spark_user_can_disable_arrow(monkeypatch):
     _build_quiet_spark(config)
 
     assert captured["spark.sql.execution.arrow.pyspark.enabled"] == "false"
+
+
+# ========== Public namespace helper ==========
+
+
+def test_public_namespace_keys_equal_all():
+    """The helper's keys are exactly the package's public API list (FR-003)."""
+    namespace = public_namespace()
+
+    assert set(namespace) == set(pathling.__all__)
+
+
+def test_public_namespace_values_are_the_resolved_objects():
+    """Each key maps to the object resolved from the package (INV-5)."""
+    namespace = public_namespace()
+
+    # A representative function, argument type, and API type all resolve to the
+    # same objects the package exports.
+    assert namespace["member_of"] is pathling.member_of
+    assert namespace["Coding"] is pathling.Coding
+    assert namespace["PathlingContext"] is pathling.PathlingContext
+
+
+def test_public_namespace_covers_every_public_name():
+    """Every name in __all__ resolves to its package attribute (INV-5)."""
+    namespace = public_namespace()
+
+    for name in pathling.__all__:
+        assert namespace[name] is getattr(pathling, name)
+
+
+# ========== Namespace sync invariant (INV-5) ==========
+
+
+def test_run_namespace_is_superset_of_public_api():
+    """The run namespace is derived from __all__ plus the run-only extras (INV-1)."""
+    expected = set(pathling.__all__) | {"spark", "pathling", "tx_display"}
+
+    namespace = dict(public_namespace())
+    namespace["tx_display"] = namespace["display"]
+    namespace["spark"] = object()
+    namespace["pathling"] = object()
+
+    assert set(namespace) >= expected
+
+
+def test_console_namespace_equals_public_api_minus_display():
+    """The console namespace is __all__ minus display plus the console extras
+    (INV-2)."""
+    expected = (set(pathling.__all__) - {"display"}) | {
+        "spark",
+        "pathling",
+        "tx_display",
+    }
+
+    namespace = dict(public_namespace())
+    namespace["tx_display"] = namespace.pop("display")
+    namespace["spark"] = object()
+    namespace["pathling"] = object()
+
+    assert set(namespace) == expected

--- a/lib/python/tests/test_lazy_imports.py
+++ b/lib/python/tests/test_lazy_imports.py
@@ -118,3 +118,26 @@ def test_bare_import_does_not_import_pyspark():
         "print('ok')\n"
     )
     assert "ok" in out
+
+
+# ========== to_loinc_coding exposed in the public API (FR-013) ==========
+
+
+def test_to_loinc_coding_in_public_api():
+    """`to_loinc_coding` is a member of the public API list, like its siblings."""
+    out = _run(
+        "import pathling\n"
+        "assert 'to_loinc_coding' in pathling.__all__, pathling.__all__\n"
+        "print('ok')\n"
+    )
+    assert "ok" in out
+
+
+def test_to_loinc_coding_importable_and_callable():
+    """`from pathling import to_loinc_coding` succeeds and is callable."""
+    out = _run(
+        "from pathling import to_loinc_coding\n"
+        "assert callable(to_loinc_coding)\n"
+        "print('ok')\n"
+    )
+    assert "ok" in out

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -163,6 +163,19 @@ two variables already in scope: `spark` (the Spark session) and `pathling`
 (the configured Pathling context), built with the same configuration
 resolution as every other command.
 
+The Pathling public functions are also pre-imported, so no
+`from pathling import ...` line is needed. This covers the terminology and
+coding functions (`to_coding`, `to_snomed_coding`, `to_loinc_coding`,
+`member_of`, `translate`, `subsumes`, and so on), the argument helper types
+(`Coding`, `PropertyType`, `Equivalence`), and the API types (`PathlingContext`,
+`DataSource`, and the rest). See the
+[Python API reference](https://pathling.csiro.au/docs/python/pathling.html) for
+the full list. The terminology
+display function is bound under both its natural name `display` and the alias
+`tx_display`. Any pre-imported name is only a default: assigning or defining the
+same name in your own code takes precedence, and an explicit
+`from pathling import ...` continues to work unchanged.
+
 ```bash
 # Run a script file.
 pathling run my_script.py
@@ -208,16 +221,22 @@ passes through unmodified.
 ### console
 
 Open an interactive [IPython](https://ipython.org/) console with the same
-`spark` and `pathling` variables in scope.
+`spark` and `pathling` variables in scope, and the Pathling public functions
+pre-imported just as in [`run`](#run).
 
 ```bash
 pathling console
 ```
 
 After the startup progress indicator, a banner identifies the Pathling
-version and the variables in scope. Errors evaluated at the prompt show
-normal tracebacks without ending the session; leave with `exit` or Ctrl-D
-(exit code 0).
+version, the variables in scope, and the pre-imported functions. Errors
+evaluated at the prompt show normal tracebacks without ending the session;
+leave with `exit` or Ctrl-D (exit code 0).
+
+The one difference from `run` is the terminology display function. IPython
+installs its own `display` at the prompt, so Pathling's terminology display is
+bound as `tx_display` only; `display` remains IPython's built-in. A snippet that
+uses `tx_display` therefore behaves the same in the console and in a script.
 
 ### Terminology commands
 


### PR DESCRIPTION
Pre-imports Pathling's public functions into the namespace used by the `run` and `console` CLI commands, so users can call functions like `to_loinc_coding`, `member_of` and friends directly without having to import them first.

A new `public_namespace` helper derives the pre-import set from the library's public API, keeping the CLI namespace in sync with what Pathling exposes. The `run` and `console` commands now seed their execution namespace from this helper. `to_loinc_coding` is also now exposed in the public API so it is included in the set.

The CLI reference documentation has been updated to describe the pre-imported functions.

Closes #2648
