### PR TITLE
Add a CSV delimiter option to the CLI

### DIFF
--- a/.github/actions/setup-r/action.yml
+++ b/.github/actions/setup-r/action.yml
@@ -40,7 +40,22 @@ runs:
     - name: Set up TinyTeX
       uses: r-lib/actions/setup-tinytex@v2
 
-    # libcurl is required for building the R package documentation.
-    - name: Install libcurl
+    # Native libraries required to build the R package and its documentation
+    # toolchain from source. When the R package cache misses, devtools and
+    # pkgdown are compiled from source, which pulls in systemfonts, textshaping
+    # and ragg. Those packages need the font (fontconfig, freetype, harfbuzz,
+    # fribidi) and image (png, tiff, jpeg) development headers, and libcurl is
+    # needed for the documentation build.
+    - name: Install system libraries
       shell: bash
-      run: sudo apt-get install -y libcurl4-openssl-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libcurl4-openssl-dev \
+          libfontconfig1-dev \
+          libfreetype-dev \
+          libharfbuzz-dev \
+          libfribidi-dev \
+          libpng-dev \
+          libtiff-dev \
+          libjpeg-dev

--- a/lib/python/pathling/cli/fhirpath.py
+++ b/lib/python/pathling/cli/fhirpath.py
@@ -100,6 +100,8 @@ def fhirpath(
     limit,
     overwrite,
     departition,
+    delimiter,
+    header,
 ):
     """Evaluate a FHIRPath expression against FHIR data.
 
@@ -117,7 +119,9 @@ def fhirpath(
     console = obj.console
 
     spec = resolve_source(source, from_format, allow_resource=True)
-    output_spec = resolve_output(output, output_format, limit, overwrite, departition)
+    output_spec = resolve_output(
+        output, output_format, limit, overwrite, departition, delimiter, header
+    )
     parsed_variables = _parse_variables(variables)
 
     # --context and --var only apply to single-resource evaluation; reject them

--- a/lib/python/pathling/cli/render.py
+++ b/lib/python/pathling/cli/render.py
@@ -27,6 +27,7 @@ piped output stays clean.
 Author: John Grimes.
 """
 
+import codecs
 import csv
 import io
 import json
@@ -82,13 +83,68 @@ OUTPUT_FORMAT_CHOICE = click.Choice(
 )
 
 
+def decode_delimiter(value: str) -> str:
+    """Decodes and validates a CSV field separator supplied on the command line.
+
+    The raw value is escape-decoded so a tab can be supplied as ``\\t`` rather
+    than a literal tab, then validated to be exactly one character that is not a
+    CSV row terminator. Validation runs at option-parse time (before any Spark
+    session starts) by raising :class:`click.BadParameter`, which Click renders
+    as a usage error with a non-zero exit code.
+
+    :param value: the raw ``--delimiter`` value.
+    :return: the decoded single-character delimiter.
+    :raises click.BadParameter: when the value cannot be escape-decoded, is not
+            exactly one character (including empty), or decodes to a carriage
+            return or line feed.
+    :example:
+        >>> decode_delimiter("\\t")
+        '\\t'
+        >>> decode_delimiter(";")
+        ';'
+    """
+    try:
+        decoded = codecs.decode(value, "unicode_escape")
+    except UnicodeDecodeError as exc:
+        raise click.BadParameter(
+            f"could not decode {value!r}. Provide a single character, "
+            "optionally as a backslash escape such as '\\t'."
+        ) from exc
+    if len(decoded) != 1:
+        raise click.BadParameter(
+            f"must be a single character, but {value!r} is "
+            f"{'empty' if decoded == '' else f'{len(decoded)} characters'}."
+        )
+    if decoded in ("\r", "\n"):
+        raise click.BadParameter(
+            "must not be a carriage return or line feed, which would collide "
+            "with CSV row terminators."
+        )
+    return decoded
+
+
+def _delimiter_callback(ctx, param, value: str) -> str:
+    """Click callback that decodes and validates the ``--delimiter`` value.
+
+    :param ctx: the Click context (unused).
+    :param param: the Click parameter (unused).
+    :param value: the raw option value.
+    :return: the decoded single-character delimiter.
+    :raises click.BadParameter: when the value is invalid (see
+            :func:`decode_delimiter`).
+    """
+    return decode_delimiter(value)
+
+
 def output_options(func):
     """Applies the shared output options to a command callback.
 
     These options form the common output surface of every command that emits a
     result DataFrame - ``--format``, ``-o``/``--output``, ``--limit``,
-    ``--overwrite``, and ``--departition/--no-departition`` - and are resolved
-    together by :func:`resolve_output` and consumed by :func:`write_output`.
+    ``--overwrite``, ``--departition/--no-departition``, ``--delimiter``, and
+    ``--header/--no-header`` - and are resolved together by
+    :func:`resolve_output` and consumed by :func:`write_output`. The delimiter
+    and header apply to CSV output only and are no-ops for other formats.
 
     :param func: the command callback to decorate.
     :return: the decorated callback.
@@ -118,6 +174,20 @@ def output_options(func):
             help="Write file output as a single file (or a Spark directory of "
             "part files).",
         ),
+        click.option(
+            "--delimiter",
+            "delimiter",
+            default=",",
+            callback=_delimiter_callback,
+            help="Field separator for CSV input and output (default: ',').",
+        ),
+        click.option(
+            "--header/--no-header",
+            "header",
+            default=True,
+            show_default=True,
+            help="Include a header row in CSV output (default: enabled).",
+        ),
     ]
     for option in reversed(options):
         func = option(func)
@@ -143,6 +213,10 @@ class OutputSpec:
     :param overwrite: whether an existing output path may be replaced.
     :param departition: whether file output is departitioned to a single file
            (the default) rather than left as a Spark directory of part files.
+    :param delimiter: the field separator for CSV output (stdout and file);
+           applies to CSV only, a no-op for other formats.
+    :param header: whether CSV output includes a header row; applies to CSV
+           only, a no-op for other formats.
     """
 
     path: Optional[Path]
@@ -150,6 +224,8 @@ class OutputSpec:
     limit: int = DEFAULT_LIMIT
     overwrite: bool = False
     departition: bool = True
+    delimiter: str = ","
+    header: bool = True
 
 
 def infer_format_from_extension(path: Path) -> Optional[str]:
@@ -167,6 +243,8 @@ def resolve_output(
     limit: int = DEFAULT_LIMIT,
     overwrite: bool = False,
     departition: bool = True,
+    delimiter: str = ",",
+    header: bool = True,
 ) -> OutputSpec:
     """Resolves and validates output options.
 
@@ -175,6 +253,10 @@ def resolve_output(
     :param limit: the stdout table row cap.
     :param overwrite: whether replacing an existing output path is allowed.
     :param departition: whether file output is departitioned to a single file.
+    :param delimiter: the CSV field separator, already decoded and validated by
+           the option callback; a no-op for non-CSV formats.
+    :param header: whether CSV output includes a header row; a no-op for non-CSV
+           formats.
     :return: the resolved :class:`OutputSpec`.
     :raises CliError: when the combination of options is invalid.
     """
@@ -220,6 +302,8 @@ def resolve_output(
         limit=limit,
         overwrite=overwrite,
         departition=departition,
+        delimiter=delimiter,
+        header=header,
     )
 
 

--- a/lib/python/pathling/cli/render.py
+++ b/lib/python/pathling/cli/render.py
@@ -349,15 +349,18 @@ def render_table(columns: Sequence[str], rows: Sequence[Sequence]) -> str:
     return buffer.getvalue()
 
 
-def render_csv(columns: Sequence[str], rows: Sequence[Sequence]) -> str:
+def render_csv(
+    columns: Sequence[str], rows: Sequence[Sequence], delimiter: str = ","
+) -> str:
     """Renders rows as CSV with a header line.
 
     :param columns: the column names.
     :param rows: the row values.
+    :param delimiter: the field separator (default comma).
     :return: the CSV text.
     """
     buffer = io.StringIO()
-    writer = csv.writer(buffer, lineterminator="\n")
+    writer = csv.writer(buffer, delimiter=delimiter, lineterminator="\n")
     writer.writerow(list(columns))
     for row in rows:
         writer.writerow(["" if value is None else value for value in row])
@@ -386,19 +389,25 @@ def render_ndjson(columns: Sequence[str], rows: Sequence[Sequence]) -> str:
     )
 
 
-def render_rows(columns: Sequence[str], rows: Sequence[Sequence], fmt: str) -> str:
+def render_rows(
+    columns: Sequence[str],
+    rows: Sequence[Sequence],
+    fmt: str,
+    delimiter: str = ",",
+) -> str:
     """Renders rows in the requested stdout format.
 
     :param columns: the column names.
     :param rows: the row values.
     :param fmt: one of table, csv, or ndjson.
+    :param delimiter: the CSV field separator; ignored for non-CSV formats.
     :return: the rendered text.
     :raises CliError: when the format cannot render to stdout.
     """
     if fmt == OutputFormat.TABLE:
         return render_table(columns, rows)
     if fmt == OutputFormat.CSV:
-        return render_csv(columns, rows)
+        return render_csv(columns, rows, delimiter)
     if fmt == OutputFormat.NDJSON:
         return render_ndjson(columns, rows)
     raise CliError(
@@ -456,7 +465,7 @@ def write_output(df, spec: OutputSpec, console: Console) -> None:
             rows = [list(row) for row in df.limit(spec.limit).collect()]
         else:
             rows = [list(row) for row in df.collect()]
-        text = render_rows(columns, rows, spec.format)
+        text = render_rows(columns, rows, spec.format, spec.delimiter)
         # Strip any trailing newline so print's own newline does not introduce
         # a spurious blank line (which would parse as an empty CSV row).
         print(text.rstrip("\n"))
@@ -506,7 +515,7 @@ def _write_file(df, spec: OutputSpec) -> None:
     if not spec.departition:
         # Leave Spark's native directory of part files at the target, written
         # with full parallelism (no repartition to a single partition).
-        _write_spark_directory(df, spec.format, path)
+        _write_spark_directory(df, spec.format, path, spec.delimiter)
         return
 
     part_extension = _PART_EXTENSIONS[spec.format]
@@ -514,24 +523,25 @@ def _write_file(df, spec: OutputSpec) -> None:
     # on the same filesystem so departitioning moves rather than copies.
     temp_dir = path.parent / f".{path.name}.departition-{uuid.uuid4().hex}"
     try:
-        _write_spark_directory(df.repartition(1), spec.format, temp_dir)
+        _write_spark_directory(df.repartition(1), spec.format, temp_dir, spec.delimiter)
         departition(spark, temp_dir, path, part_extension)
     finally:
         # Always remove the temporary directory, including on a write failure.
         remove_path(spark, temp_dir)
 
 
-def _write_spark_directory(frame, fmt: str, target_dir) -> None:
+def _write_spark_directory(frame, fmt: str, target_dir, delimiter: str = ",") -> None:
     """Writes a frame to a Spark directory of part files in the given format.
 
     :param frame: the Spark DataFrame to write (already repartitioned as
            required by the caller).
     :param fmt: the file format - CSV, NDJSON, or Parquet.
     :param target_dir: the directory Spark writes its part files into.
+    :param delimiter: the CSV field separator; ignored for non-CSV formats.
     """
     writer = frame.write.mode("overwrite")
     if fmt == OutputFormat.CSV:
-        writer.option("header", "true").csv(str(target_dir))
+        writer.option("header", "true").option("sep", delimiter).csv(str(target_dir))
     elif fmt == OutputFormat.NDJSON:
         # Retain null-valued fields so every record carries the same keys,
         # matching the prior driver-side behaviour.

--- a/lib/python/pathling/cli/render.py
+++ b/lib/python/pathling/cli/render.py
@@ -197,6 +197,8 @@ def output_options(func):
 # Maps file extensions to output formats for inference.
 _EXTENSION_FORMATS = {
     ".csv": OutputFormat.CSV,
+    # A .tsv file is CSV output; tab separation is selected with --delimiter.
+    ".tsv": OutputFormat.CSV,
     ".ndjson": OutputFormat.NDJSON,
     ".jsonl": OutputFormat.NDJSON,
     ".parquet": OutputFormat.PARQUET,

--- a/lib/python/pathling/cli/render.py
+++ b/lib/python/pathling/cli/render.py
@@ -350,18 +350,23 @@ def render_table(columns: Sequence[str], rows: Sequence[Sequence]) -> str:
 
 
 def render_csv(
-    columns: Sequence[str], rows: Sequence[Sequence], delimiter: str = ","
+    columns: Sequence[str],
+    rows: Sequence[Sequence],
+    delimiter: str = ",",
+    header: bool = True,
 ) -> str:
-    """Renders rows as CSV with a header line.
+    """Renders rows as CSV, optionally with a header line.
 
     :param columns: the column names.
     :param rows: the row values.
     :param delimiter: the field separator (default comma).
+    :param header: whether to emit the header line (default True).
     :return: the CSV text.
     """
     buffer = io.StringIO()
     writer = csv.writer(buffer, delimiter=delimiter, lineterminator="\n")
-    writer.writerow(list(columns))
+    if header:
+        writer.writerow(list(columns))
     for row in rows:
         writer.writerow(["" if value is None else value for value in row])
     return buffer.getvalue()
@@ -394,6 +399,7 @@ def render_rows(
     rows: Sequence[Sequence],
     fmt: str,
     delimiter: str = ",",
+    header: bool = True,
 ) -> str:
     """Renders rows in the requested stdout format.
 
@@ -401,13 +407,15 @@ def render_rows(
     :param rows: the row values.
     :param fmt: one of table, csv, or ndjson.
     :param delimiter: the CSV field separator; ignored for non-CSV formats.
+    :param header: whether CSV output includes a header line; ignored for
+           non-CSV formats.
     :return: the rendered text.
     :raises CliError: when the format cannot render to stdout.
     """
     if fmt == OutputFormat.TABLE:
         return render_table(columns, rows)
     if fmt == OutputFormat.CSV:
-        return render_csv(columns, rows, delimiter)
+        return render_csv(columns, rows, delimiter, header)
     if fmt == OutputFormat.NDJSON:
         return render_ndjson(columns, rows)
     raise CliError(
@@ -465,7 +473,7 @@ def write_output(df, spec: OutputSpec, console: Console) -> None:
             rows = [list(row) for row in df.limit(spec.limit).collect()]
         else:
             rows = [list(row) for row in df.collect()]
-        text = render_rows(columns, rows, spec.format, spec.delimiter)
+        text = render_rows(columns, rows, spec.format, spec.delimiter, spec.header)
         # Strip any trailing newline so print's own newline does not introduce
         # a spurious blank line (which would parse as an empty CSV row).
         print(text.rstrip("\n"))
@@ -515,7 +523,7 @@ def _write_file(df, spec: OutputSpec) -> None:
     if not spec.departition:
         # Leave Spark's native directory of part files at the target, written
         # with full parallelism (no repartition to a single partition).
-        _write_spark_directory(df, spec.format, path, spec.delimiter)
+        _write_spark_directory(df, spec.format, path, spec.delimiter, spec.header)
         return
 
     part_extension = _PART_EXTENSIONS[spec.format]
@@ -523,14 +531,18 @@ def _write_file(df, spec: OutputSpec) -> None:
     # on the same filesystem so departitioning moves rather than copies.
     temp_dir = path.parent / f".{path.name}.departition-{uuid.uuid4().hex}"
     try:
-        _write_spark_directory(df.repartition(1), spec.format, temp_dir, spec.delimiter)
+        _write_spark_directory(
+            df.repartition(1), spec.format, temp_dir, spec.delimiter, spec.header
+        )
         departition(spark, temp_dir, path, part_extension)
     finally:
         # Always remove the temporary directory, including on a write failure.
         remove_path(spark, temp_dir)
 
 
-def _write_spark_directory(frame, fmt: str, target_dir, delimiter: str = ",") -> None:
+def _write_spark_directory(
+    frame, fmt: str, target_dir, delimiter: str = ",", header: bool = True
+) -> None:
     """Writes a frame to a Spark directory of part files in the given format.
 
     :param frame: the Spark DataFrame to write (already repartitioned as
@@ -538,10 +550,14 @@ def _write_spark_directory(frame, fmt: str, target_dir, delimiter: str = ",") ->
     :param fmt: the file format - CSV, NDJSON, or Parquet.
     :param target_dir: the directory Spark writes its part files into.
     :param delimiter: the CSV field separator; ignored for non-CSV formats.
+    :param header: whether a CSV header row is written; ignored for non-CSV
+           formats.
     """
     writer = frame.write.mode("overwrite")
     if fmt == OutputFormat.CSV:
-        writer.option("header", "true").option("sep", delimiter).csv(str(target_dir))
+        writer.option("header", "true" if header else "false").option(
+            "sep", delimiter
+        ).csv(str(target_dir))
     elif fmt == OutputFormat.NDJSON:
         # Retain null-valued fields so every record carries the same keys,
         # matching the prior driver-side behaviour.

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -212,6 +212,8 @@ def _execute(
     limit,
     overwrite,
     departition,
+    delimiter,
+    header,
     build,
 ):
     """Runs a terminology operation and emits the augmented dataset.
@@ -225,6 +227,9 @@ def _execute(
     :param limit: the table row cap.
     :param overwrite: whether to replace an existing output path.
     :param departition: whether file output is departitioned to a single file.
+    :param delimiter: the CSV field separator for both the input read and the
+           output write.
+    :param header: whether CSV output includes a header row.
     :param build: a callback ``(pc, df) -> result_df`` performing the operation.
     :raises CliError: for validation and unreachable-server failures.
     """
@@ -233,7 +238,9 @@ def _execute(
 
     # Validate cheap inputs before paying the Spark cold start.
     _validate_coding_source(dataset, system, system_column)
-    output_spec = resolve_output(output, output_format, limit, overwrite, departition)
+    output_spec = resolve_output(
+        output, output_format, limit, overwrite, departition, delimiter, header
+    )
     pc = session.create_context(config, console)
     df = _read_dataset(pc, dataset)
 
@@ -275,6 +282,8 @@ def member_of(
     limit,
     overwrite,
     departition,
+    delimiter,
+    header,
     value_set,
 ):
     """Test codes for membership of a value set.
@@ -303,6 +312,8 @@ def member_of(
         limit,
         overwrite,
         departition,
+        delimiter,
+        header,
         build,
     )
 
@@ -331,6 +342,8 @@ def translate(
     limit,
     overwrite,
     departition,
+    delimiter,
+    header,
     concept_map,
     reverse,
     equivalences,
@@ -376,6 +389,8 @@ def translate(
         limit,
         overwrite,
         departition,
+        delimiter,
+        header,
         build,
     )
 
@@ -427,6 +442,8 @@ def _run_subsumption(
     limit,
     overwrite,
     departition,
+    delimiter,
+    header,
     other_code,
     other_code_column,
     other_system,
@@ -447,6 +464,9 @@ def _run_subsumption(
     :param output: the output path, or None.
     :param limit: the table row cap.
     :param overwrite: whether to replace an existing output path.
+    :param departition: whether file output is departitioned to a single file.
+    :param delimiter: the CSV field separator for the input read and output write.
+    :param header: whether CSV output includes a header row.
     :param other_code: a fixed target code applied to every row, or None.
     :param other_code_column: the right code column, or None when a fixed target
            code is supplied.
@@ -504,6 +524,8 @@ def _run_subsumption(
         limit,
         overwrite,
         departition,
+        delimiter,
+        header,
         build,
     )
 
@@ -525,6 +547,8 @@ def subsumes(
     limit,
     overwrite,
     departition,
+    delimiter,
+    header,
     other_code,
     other_code_column,
     other_system,
@@ -558,6 +582,8 @@ def subsumes(
         limit,
         overwrite,
         departition,
+        delimiter,
+        header,
         other_code,
         other_code_column,
         other_system,
@@ -582,6 +608,8 @@ def subsumed_by(
     limit,
     overwrite,
     departition,
+    delimiter,
+    header,
     other_code,
     other_code_column,
     other_system,
@@ -615,6 +643,8 @@ def subsumed_by(
         limit,
         overwrite,
         departition,
+        delimiter,
+        header,
         other_code,
         other_code_column,
         other_system,
@@ -642,6 +672,8 @@ def display(
     limit,
     overwrite,
     departition,
+    delimiter,
+    header,
     accept_language,
 ):
     """Look up display names for codes.
@@ -669,6 +701,8 @@ def display(
         limit,
         overwrite,
         departition,
+        delimiter,
+        header,
         build,
     )
 
@@ -701,6 +735,8 @@ def property_of(
     limit,
     overwrite,
     departition,
+    delimiter,
+    header,
     property_code,
     property_type,
     accept_language,
@@ -734,6 +770,8 @@ def property_of(
         limit,
         overwrite,
         departition,
+        delimiter,
+        header,
         build,
     )
 
@@ -759,6 +797,8 @@ def designation(
     limit,
     overwrite,
     departition,
+    delimiter,
+    header,
     use,
     language,
 ):
@@ -798,6 +838,8 @@ def designation(
         limit,
         overwrite,
         departition,
+        delimiter,
+        header,
         build,
     )
 

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -98,14 +98,15 @@ def _read_dataset(pc, dataset, delimiter=",", input_header=True):
             f"Dataset does not exist: {path}. Check the path.", exit_code=EXIT_USAGE
         )
     suffix = path.suffix.lower()
-    if suffix == ".csv":
+    # A .tsv file is read as CSV; the tab separator is supplied via --delimiter.
+    if suffix in (".csv", ".tsv"):
         return pc.spark.read.csv(
             str(path), header=input_header, inferSchema=False, sep=delimiter
         )
     if suffix == ".parquet":
         return pc.spark.read.parquet(str(path))
     raise CliError(
-        f"Unsupported dataset type '{suffix}'. Use a .csv or .parquet file.",
+        f"Unsupported dataset type '{suffix}'. Use a .csv, .tsv, or .parquet file.",
         exit_code=EXIT_USAGE,
     )
 

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -72,11 +72,13 @@ def _common_options(func):
     return func
 
 
-def _read_dataset(pc, dataset):
+def _read_dataset(pc, dataset, delimiter=","):
     """Reads a CSV or Parquet dataset into a Spark DataFrame.
 
     :param pc: the Pathling context.
     :param dataset: the path to the dataset file.
+    :param delimiter: the CSV field separator; applied to ``.csv`` inputs only
+           (Parquet carries its own schema).
     :return: the loaded DataFrame.
     :raises CliError: when the path is missing or the type is unsupported.
     """
@@ -87,7 +89,9 @@ def _read_dataset(pc, dataset):
         )
     suffix = path.suffix.lower()
     if suffix == ".csv":
-        return pc.spark.read.csv(str(path), header=True, inferSchema=False)
+        return pc.spark.read.csv(
+            str(path), header=True, inferSchema=False, sep=delimiter
+        )
     if suffix == ".parquet":
         return pc.spark.read.parquet(str(path))
     raise CliError(
@@ -242,7 +246,7 @@ def _execute(
         output, output_format, limit, overwrite, departition, delimiter, header
     )
     pc = session.create_context(config, console)
-    df = _read_dataset(pc, dataset)
+    df = _read_dataset(pc, dataset, delimiter)
 
     try:
         with progress_status(

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -54,6 +54,13 @@ def _common_options(func):
     options = [
         click.argument("dataset"),
         click.option(
+            "--input-header/--no-input-header",
+            "input_header",
+            default=True,
+            show_default=True,
+            help="Treat the first line of a CSV input as a header (default: enabled).",
+        ),
+        click.option(
             "--code-column", "code_column", required=True, help="Code column name."
         ),
         click.option("--system", "system", help="Fixed code system URI."),
@@ -72,13 +79,16 @@ def _common_options(func):
     return func
 
 
-def _read_dataset(pc, dataset, delimiter=","):
+def _read_dataset(pc, dataset, delimiter=",", input_header=True):
     """Reads a CSV or Parquet dataset into a Spark DataFrame.
 
     :param pc: the Pathling context.
     :param dataset: the path to the dataset file.
     :param delimiter: the CSV field separator; applied to ``.csv`` inputs only
            (Parquet carries its own schema).
+    :param input_header: whether the first line of a CSV input is a header row;
+           applied to ``.csv`` inputs only. When False, Spark assigns positional
+           column names ``_c0``, ``_c1``, ... referenced via ``--code-column``.
     :return: the loaded DataFrame.
     :raises CliError: when the path is missing or the type is unsupported.
     """
@@ -90,7 +100,7 @@ def _read_dataset(pc, dataset, delimiter=","):
     suffix = path.suffix.lower()
     if suffix == ".csv":
         return pc.spark.read.csv(
-            str(path), header=True, inferSchema=False, sep=delimiter
+            str(path), header=input_header, inferSchema=False, sep=delimiter
         )
     if suffix == ".parquet":
         return pc.spark.read.parquet(str(path))
@@ -218,6 +228,7 @@ def _execute(
     departition,
     delimiter,
     header,
+    input_header,
     build,
 ):
     """Runs a terminology operation and emits the augmented dataset.
@@ -234,6 +245,7 @@ def _execute(
     :param delimiter: the CSV field separator for both the input read and the
            output write.
     :param header: whether CSV output includes a header row.
+    :param input_header: whether the first line of a CSV input is a header row.
     :param build: a callback ``(pc, df) -> result_df`` performing the operation.
     :raises CliError: for validation and unreachable-server failures.
     """
@@ -246,7 +258,7 @@ def _execute(
         output, output_format, limit, overwrite, departition, delimiter, header
     )
     pc = session.create_context(config, console)
-    df = _read_dataset(pc, dataset, delimiter)
+    df = _read_dataset(pc, dataset, delimiter, input_header)
 
     try:
         with progress_status(
@@ -288,6 +300,7 @@ def member_of(
     departition,
     delimiter,
     header,
+    input_header,
     value_set,
 ):
     """Test codes for membership of a value set.
@@ -318,6 +331,7 @@ def member_of(
         departition,
         delimiter,
         header,
+        input_header,
         build,
     )
 
@@ -348,6 +362,7 @@ def translate(
     departition,
     delimiter,
     header,
+    input_header,
     concept_map,
     reverse,
     equivalences,
@@ -395,6 +410,7 @@ def translate(
         departition,
         delimiter,
         header,
+        input_header,
         build,
     )
 
@@ -448,6 +464,7 @@ def _run_subsumption(
     departition,
     delimiter,
     header,
+    input_header,
     other_code,
     other_code_column,
     other_system,
@@ -471,6 +488,7 @@ def _run_subsumption(
     :param departition: whether file output is departitioned to a single file.
     :param delimiter: the CSV field separator for the input read and output write.
     :param header: whether CSV output includes a header row.
+    :param input_header: whether the first line of a CSV input is a header row.
     :param other_code: a fixed target code applied to every row, or None.
     :param other_code_column: the right code column, or None when a fixed target
            code is supplied.
@@ -530,6 +548,7 @@ def _run_subsumption(
         departition,
         delimiter,
         header,
+        input_header,
         build,
     )
 
@@ -553,6 +572,7 @@ def subsumes(
     departition,
     delimiter,
     header,
+    input_header,
     other_code,
     other_code_column,
     other_system,
@@ -588,6 +608,7 @@ def subsumes(
         departition,
         delimiter,
         header,
+        input_header,
         other_code,
         other_code_column,
         other_system,
@@ -614,6 +635,7 @@ def subsumed_by(
     departition,
     delimiter,
     header,
+    input_header,
     other_code,
     other_code_column,
     other_system,
@@ -649,6 +671,7 @@ def subsumed_by(
         departition,
         delimiter,
         header,
+        input_header,
         other_code,
         other_code_column,
         other_system,
@@ -678,6 +701,7 @@ def display(
     departition,
     delimiter,
     header,
+    input_header,
     accept_language,
 ):
     """Look up display names for codes.
@@ -707,6 +731,7 @@ def display(
         departition,
         delimiter,
         header,
+        input_header,
         build,
     )
 
@@ -741,6 +766,7 @@ def property_of(
     departition,
     delimiter,
     header,
+    input_header,
     property_code,
     property_type,
     accept_language,
@@ -776,6 +802,7 @@ def property_of(
         departition,
         delimiter,
         header,
+        input_header,
         build,
     )
 
@@ -803,6 +830,7 @@ def designation(
     departition,
     delimiter,
     header,
+    input_header,
     use,
     language,
 ):
@@ -844,6 +872,7 @@ def designation(
         departition,
         delimiter,
         header,
+        input_header,
         build,
     )
 

--- a/lib/python/pathling/cli/view.py
+++ b/lib/python/pathling/cli/view.py
@@ -115,6 +115,8 @@ def view(
     limit,
     overwrite,
     departition,
+    delimiter,
+    header,
 ):
     """Run a SQL on FHIR ViewDefinition against a data source.
 
@@ -135,7 +137,9 @@ def view(
 
     spec = resolve_source(source, from_format)
     view_text, resource_type = _load_view(view_path, view_json)
-    output_spec = resolve_output(output, output_format, limit, overwrite, departition)
+    output_spec = resolve_output(
+        output, output_format, limit, overwrite, departition, delimiter, header
+    )
 
     pc = session.create_context(config, console)
     # The view already knows its single subject resource type, so pass it to the

--- a/lib/python/tests/cli/conftest.py
+++ b/lib/python/tests/cli/conftest.py
@@ -26,10 +26,52 @@ shared mock-backed context instead of starting a fresh Spark session.
 Author: John Grimes.
 """
 
+import csv
 import inspect
 
 from click.testing import CliRunner
 from pytest import fixture
+
+
+def _write_delimited_csv(path, header, rows, delimiter):
+    """Writes a delimited CSV file, optionally omitting the header line.
+
+    This mirrors the ``_write_csv`` helper in ``test_terminology.py`` but
+    parameterises the field separator and whether a header row is written, so
+    tests can build the tab-separated, semicolon-separated, and headerless
+    inputs the delimiter and input-header options need.
+
+    :param path: the file path to write.
+    :param header: the header row, or None to write no header line.
+    :param rows: the data rows.
+    :param delimiter: the field separator to use.
+    :return: the path that was written.
+    """
+    with open(path, "w", newline="") as handle:
+        writer = csv.writer(handle, delimiter=delimiter)
+        if header is not None:
+            writer.writerow(header)
+        writer.writerows(rows)
+    return path
+
+
+@fixture
+def delimited_csv(tmp_path):
+    """Provides a factory that writes a delimited (and optionally headerless) CSV.
+
+    The returned factory writes a CSV file under the test's temporary directory
+    with a caller-supplied field separator, and can omit the header line so the
+    headerless-input path can be exercised.
+
+    :param tmp_path: the pytest temporary directory fixture.
+    :return: a callable ``(rows, *, header=None, delimiter=',', name='data.csv')``
+             that writes the file and returns its path.
+    """
+
+    def _factory(rows, *, header=None, delimiter=",", name="data.csv"):
+        return _write_delimited_csv(tmp_path / name, header, rows, delimiter)
+
+    return _factory
 
 
 def make_cli_runner(runner_cls=CliRunner):

--- a/lib/python/tests/cli/test_fhirpath.py
+++ b/lib/python/tests/cli/test_fhirpath.py
@@ -80,6 +80,37 @@ def test_data_source_mode(runner, patched_context, ndjson_source):
     assert len(rows) == 10
 
 
+def test_fhirpath_accepts_delimiter_and_header_options(
+    runner, patched_context, ndjson_source
+):
+    """fhirpath inherits --delimiter/--header from the shared output options and runs.
+
+    This guards ``fhirpath`` against the regression that adding the two options
+    to the shared ``output_options`` decorator would otherwise cause (T007).
+    """
+    result = runner.invoke(
+        cli,
+        [
+            "fhirpath",
+            ndjson_source,
+            "-t",
+            "Patient",
+            "-e",
+            "name.first().family",
+            "--format",
+            "csv",
+            "--delimiter",
+            ";",
+            "--no-header",
+        ],
+    )
+
+    # The command must accept the shared options and still produce its result;
+    # the delimiter/header behaviour itself is covered by the render tests.
+    assert result.exit_code == 0, result.stderr
+    assert "Krajcik437" in result.stdout
+
+
 def test_data_source_mode_requires_type(runner, patched_context, ndjson_source):
     """Omitting -t in data source mode is a usage error."""
     result = runner.invoke(cli, ["fhirpath", ndjson_source, "-e", "name.family"])

--- a/lib/python/tests/cli/test_render.py
+++ b/lib/python/tests/cli/test_render.py
@@ -26,12 +26,14 @@ import csv
 import io
 import json
 
+import click
 import pytest
 
 from pathling.cli.errors import CliError
 from pathling.cli.render import (
     OutputFormat,
     check_overwrite,
+    decode_delimiter,
     infer_format_from_extension,
     output_options,
     render_csv,
@@ -83,6 +85,55 @@ def test_csv_has_header_and_rows():
     assert parsed[1] == ["1", "Smith"]
     # None is rendered as an empty field.
     assert parsed[2] == ["2", ""]
+
+
+# ========== Delimiter decoding and validation (T002) ==========
+
+
+def test_decode_delimiter_defaults_and_passes_single_chars():
+    """A comma default and single characters decode to themselves."""
+    assert decode_delimiter(",") == ","
+    assert decode_delimiter(";") == ";"
+    assert decode_delimiter("|") == "|"
+
+
+def test_decode_delimiter_decodes_escape_sequences():
+    """A backslash escape such as ``\\t`` decodes to its single character."""
+    # The command-line value is the two characters backslash-t.
+    assert decode_delimiter("\\t") == "\t"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "ab",  # more than one character after decoding
+        "",  # empty
+        "\\",  # a lone trailing backslash cannot be escape-decoded
+        "\\n",  # a line feed would collide with CSV row terminators
+        "\\r",  # a carriage return would collide with CSV row terminators
+    ],
+)
+def test_decode_delimiter_rejects_invalid(value):
+    """Multi-character, empty, undecodable, and line-terminator values are rejected."""
+    with pytest.raises(click.BadParameter):
+        decode_delimiter(value)
+
+
+def test_delimiter_callback_rejects_before_spark_via_usage_error():
+    """An invalid --delimiter is a usage error (exit code 2) at parse time."""
+    from click.testing import CliRunner
+
+    @click.command()
+    @output_options
+    def cmd(**kwargs):
+        pass
+
+    result = CliRunner().invoke(cmd, ["--delimiter", "ab", "--format", "csv"])
+
+    # Click renders a BadParameter as a usage error with a non-zero exit code,
+    # so validation happens before any command body (and any Spark) runs.
+    assert result.exit_code == 2
+    assert "delimiter" in result.output.lower()
 
 
 # ========== NDJSON ==========
@@ -220,6 +271,41 @@ def test_departition_flag_appears_in_command_help():
     result = CliRunner().invoke(cmd, ["--help"])
 
     assert "--no-departition" in result.output
+
+
+# ========== Delimiter and header resolution (T005) ==========
+
+
+def test_resolve_output_delimiter_and_header_default():
+    """By default the resolved spec carries a comma delimiter and a header."""
+    spec = resolve_output("out.csv", None)
+
+    assert spec.delimiter == ","
+    assert spec.header is True
+
+
+def test_resolve_output_carries_delimiter_and_header():
+    """resolve_output records the supplied delimiter and header on the spec."""
+    spec = resolve_output("out.csv", None, delimiter="\t", header=False)
+
+    assert spec.delimiter == "\t"
+    assert spec.header is False
+
+
+def test_delimiter_and_header_flags_appear_in_command_help():
+    """The new output options are offered in command help."""
+    import click
+    from click.testing import CliRunner
+
+    @click.command()
+    @output_options
+    def cmd(**kwargs):
+        pass
+
+    result = CliRunner().invoke(cmd, ["--help"])
+
+    assert "--delimiter" in result.output
+    assert "--no-header" in result.output
 
 
 # ========== Overwrite handling ==========

--- a/lib/python/tests/cli/test_render.py
+++ b/lib/python/tests/cli/test_render.py
@@ -103,6 +103,23 @@ def test_render_csv_semicolon_delimiter():
     assert output.splitlines()[0] == "id;family"
 
 
+def test_render_csv_omits_header_when_disabled():
+    """render_csv omits the header line when the header is disabled (T015)."""
+    output = render_csv(COLUMNS, ROWS, header=False)
+
+    parsed = list(csv.reader(io.StringIO(output)))
+    # The first line is a data row, not the column names.
+    assert parsed[0] == ["1", "Smith"]
+    assert COLUMNS not in parsed
+
+
+def test_render_csv_includes_header_by_default():
+    """render_csv includes the header line by default (T015)."""
+    output = render_csv(COLUMNS, ROWS)
+
+    assert list(csv.reader(io.StringIO(output)))[0] == COLUMNS
+
+
 # ========== Delimiter decoding and validation (T002) ==========
 
 

--- a/lib/python/tests/cli/test_render.py
+++ b/lib/python/tests/cli/test_render.py
@@ -87,6 +87,22 @@ def test_csv_has_header_and_rows():
     assert parsed[2] == ["2", ""]
 
 
+def test_render_csv_uses_supplied_delimiter():
+    """render_csv separates fields with a supplied delimiter (T008)."""
+    output = render_csv(COLUMNS, ROWS, delimiter="\t")
+
+    parsed = list(csv.reader(io.StringIO(output), delimiter="\t"))
+    assert parsed[0] == COLUMNS
+    assert parsed[1] == ["1", "Smith"]
+
+
+def test_render_csv_semicolon_delimiter():
+    """render_csv honours a semicolon delimiter (T008)."""
+    output = render_csv(COLUMNS, ROWS, delimiter=";")
+
+    assert output.splitlines()[0] == "id;family"
+
+
 # ========== Delimiter decoding and validation (T002) ==========
 
 

--- a/lib/python/tests/cli/test_render.py
+++ b/lib/python/tests/cli/test_render.py
@@ -223,6 +223,8 @@ def test_infer_format_from_extension():
     from pathlib import Path
 
     assert infer_format_from_extension(Path("out.csv")) == OutputFormat.CSV
+    # A .tsv extension is a CSV output (tab separation is chosen via --delimiter).
+    assert infer_format_from_extension(Path("out.tsv")) == OutputFormat.CSV
     # The json-array format is removed, so a .json extension is not inferred.
     assert infer_format_from_extension(Path("out.json")) is None
     assert infer_format_from_extension(Path("out.ndjson")) == OutputFormat.NDJSON

--- a/lib/python/tests/cli/test_terminology.py
+++ b/lib/python/tests/cli/test_terminology.py
@@ -26,6 +26,7 @@ Author: John Grimes.
 
 import csv
 import io
+import json
 
 from pytest import fixture
 
@@ -232,6 +233,72 @@ def test_member_of_headerless_input(runner, patched_context, delimited_csv):
     # The positional column names carry through to the output header.
     assert rows[0] == ["_c0", "_c1", "member_of"]
     assert rows[1][2] == "True"
+
+
+# ========== Non-CSV no-op (T023) ==========
+
+
+def test_output_options_ignored_for_ndjson(runner, patched_context, delimited_csv):
+    """--delimiter/--header are accepted but do not affect NDJSON output (T023).
+
+    The delimiter still applies to the CSV *input* read (here a semicolon file),
+    but the NDJSON output path never consults the delimiter or header, so the
+    result is unaffected JSON objects.
+    """
+    dataset = delimited_csv(
+        [["368529001", SNOMED]],
+        header=["code", "system"],
+        delimiter=";",
+        name="semi.csv",
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(dataset),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+            "--format",
+            "ndjson",
+            "--delimiter",
+            ";",
+            "--no-header",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    line = result.stdout.splitlines()[0]
+    record = json.loads(line)
+    # The record keeps its keys and values; the header/delimiter had no effect.
+    assert record["code"] == "368529001"
+    assert "member_of" in record
+
+
+def test_output_options_ignored_for_table(runner, patched_context, codes_csv):
+    """--no-header does not suppress the table's header (T023)."""
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(codes_csv),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+            "--no-header",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    # The table always carries its column names, regardless of --no-header.
+    assert "member_of" in result.stdout
 
 
 # ========== member-of ==========

--- a/lib/python/tests/cli/test_terminology.py
+++ b/lib/python/tests/cli/test_terminology.py
@@ -149,6 +149,57 @@ def test_read_dataset_parses_semicolon_separated(pathling_ctx, delimited_csv):
     assert df.collect()[0]["code"] == "368529001"
 
 
+def test_read_dataset_reads_tsv_extension(pathling_ctx, delimited_csv):
+    """_read_dataset reads a .tsv file as CSV with the supplied delimiter (T024)."""
+    from pathling.cli.terminology import _read_dataset
+
+    path = delimited_csv(
+        [["368529001", SNOMED]],
+        header=["code", "system"],
+        delimiter="\t",
+        name="codes.tsv",
+    )
+
+    df = _read_dataset(pathling_ctx, str(path), delimiter="\t")
+
+    assert df.columns == ["code", "system"]
+    assert df.collect()[0]["code"] == "368529001"
+
+
+def test_member_of_tsv_round_trip(runner, patched_context, delimited_csv, tmp_path):
+    """member-of round-trips a .tsv file to a .tsv output (quickstart P1)."""
+    dataset = delimited_csv(
+        [["368529001", SNOMED], ["439319006", SNOMED]],
+        header=["code", "system"],
+        delimiter="\t",
+        name="codes.tsv",
+    )
+    out = tmp_path / "out.tsv"
+
+    # No explicit --format: the output format is inferred from the .tsv extension.
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(dataset),
+            "--code-column",
+            "code",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+            "--delimiter",
+            "\\t",
+            "-o",
+            str(out),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = list(csv.reader(io.StringIO(out.read_text()), delimiter="\t"))
+    assert rows[0] == ["code", "system", "member_of"]
+
+
 def test_member_of_tab_separated_round_trip(
     runner, patched_context, delimited_csv, tmp_path
 ):

--- a/lib/python/tests/cli/test_terminology.py
+++ b/lib/python/tests/cli/test_terminology.py
@@ -110,6 +110,82 @@ def test_coding_column_matches_library_schema(pathling_ctx):
     assert cli_fields == library_fields
 
 
+# ========== CSV read delimiter (US1) ==========
+
+
+def test_read_dataset_parses_tab_separated(pathling_ctx, delimited_csv):
+    """_read_dataset parses a tab-separated CSV into the correct columns (T010)."""
+    from pathling.cli.terminology import _read_dataset
+
+    path = delimited_csv(
+        [["368529001", SNOMED]],
+        header=["code", "system"],
+        delimiter="\t",
+        name="tab.csv",
+    )
+
+    df = _read_dataset(pathling_ctx, str(path), delimiter="\t")
+
+    # Without the delimiter the tabbed line would collapse into one column.
+    assert df.columns == ["code", "system"]
+    assert df.collect()[0]["code"] == "368529001"
+
+
+def test_read_dataset_parses_semicolon_separated(pathling_ctx, delimited_csv):
+    """_read_dataset parses a semicolon-separated CSV into columns (T010)."""
+    from pathling.cli.terminology import _read_dataset
+
+    path = delimited_csv(
+        [["368529001", SNOMED]],
+        header=["code", "system"],
+        delimiter=";",
+        name="semi.csv",
+    )
+
+    df = _read_dataset(pathling_ctx, str(path), delimiter=";")
+
+    assert df.columns == ["code", "system"]
+    assert df.collect()[0]["code"] == "368529001"
+
+
+def test_member_of_tab_separated_round_trip(
+    runner, patched_context, delimited_csv, tmp_path
+):
+    """member-of round-trips a tab-separated dataset to stdout and a file (T011)."""
+    dataset = delimited_csv(
+        [["368529001", SNOMED], ["439319006", SNOMED]],
+        header=["code", "system"],
+        delimiter="\t",
+        name="codes_tab.csv",
+    )
+    base = [
+        "member-of",
+        str(dataset),
+        "--code-column",
+        "code",
+        "--system",
+        SNOMED,
+        "--value-set",
+        VALUE_SET,
+        "--delimiter",
+        "\\t",
+    ]
+
+    # Stdout: the input parses correctly and the output is tab-separated.
+    result = runner.invoke(cli, base + ["--format", "csv"])
+    assert result.exit_code == 0, result.stderr
+    rows = list(csv.reader(io.StringIO(result.stdout), delimiter="\t"))
+    assert rows[0] == ["code", "system", "member_of"]
+    assert rows[1][2] == "True"
+
+    # File: the written file is tab-separated with the same columns.
+    out = tmp_path / "out.csv"
+    file_result = runner.invoke(cli, base + ["-o", str(out)])
+    assert file_result.exit_code == 0, file_result.stderr
+    file_rows = list(csv.reader(io.StringIO(out.read_text()), delimiter="\t"))
+    assert file_rows[0] == ["code", "system", "member_of"]
+
+
 # ========== member-of ==========
 
 

--- a/lib/python/tests/cli/test_terminology.py
+++ b/lib/python/tests/cli/test_terminology.py
@@ -186,6 +186,54 @@ def test_member_of_tab_separated_round_trip(
     assert file_rows[0] == ["code", "system", "member_of"]
 
 
+# ========== Headerless CSV input (US3) ==========
+
+
+def test_read_dataset_headerless_uses_positional_columns(pathling_ctx, delimited_csv):
+    """_read_dataset treats the first line as data when input-header is off (T019)."""
+    from pathling.cli.terminology import _read_dataset
+
+    path = delimited_csv([["368529001", SNOMED]], header=None, name="headerless.csv")
+
+    df = _read_dataset(pathling_ctx, str(path), input_header=False)
+
+    # Spark assigns positional column names when there is no header row.
+    assert df.columns == ["_c0", "_c1"]
+    assert df.collect()[0]["_c0"] == "368529001"
+
+
+def test_member_of_headerless_input(runner, patched_context, delimited_csv):
+    """member-of runs against a headerless dataset via --no-input-header (T020)."""
+    dataset = delimited_csv(
+        [["368529001", SNOMED], ["439319006", SNOMED]],
+        header=None,
+        name="headerless.csv",
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "member-of",
+            str(dataset),
+            "--no-input-header",
+            "--code-column",
+            "_c0",
+            "--system",
+            SNOMED,
+            "--value-set",
+            VALUE_SET,
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = _stdout_rows(result)
+    # The positional column names carry through to the output header.
+    assert rows[0] == ["_c0", "_c1", "member_of"]
+    assert rows[1][2] == "True"
+
+
 # ========== member-of ==========
 
 

--- a/lib/python/tests/cli/test_view.py
+++ b/lib/python/tests/cli/test_view.py
@@ -84,6 +84,36 @@ def test_view_csv(runner, patched_context, ndjson_source, view_file):
     assert len(rows) == PATIENT_COUNT + 1
 
 
+def test_view_accepts_delimiter_and_header_options(
+    runner, patched_context, ndjson_source, view_file
+):
+    """view inherits --delimiter/--header from the shared output options and runs.
+
+    Adding the two options to the shared ``output_options`` decorator would break
+    every command that applies it unless each accepts and forwards them; this
+    guards ``view`` against that regression (T007).
+    """
+    result = runner.invoke(
+        cli,
+        [
+            "view",
+            ndjson_source,
+            "--view",
+            str(view_file),
+            "--format",
+            "csv",
+            "--delimiter",
+            ";",
+            "--no-header",
+        ],
+    )
+
+    # The command must accept the shared options and still produce its result;
+    # the delimiter/header behaviour itself is covered by the render tests.
+    assert result.exit_code == 0, result.stderr
+    assert FIRST_FAMILY in result.stdout
+
+
 def test_view_format_json_rejected(runner, patched_context, ndjson_source, view_file):
     """The removed json format is rejected as an invalid --format choice."""
     result = runner.invoke(

--- a/lib/python/tests/cli/test_write_file.py
+++ b/lib/python/tests/cli/test_write_file.py
@@ -54,7 +54,13 @@ def spark(pathling_ctx):
 
 
 def _spec(
-    path: Path, fmt: str, *, overwrite: bool = False, departition: bool = True
+    path: Path,
+    fmt: str,
+    *,
+    overwrite: bool = False,
+    departition: bool = True,
+    delimiter: str = ",",
+    header: bool = True,
 ) -> OutputSpec:
     """Builds an :class:`OutputSpec` for a file path and format.
 
@@ -62,10 +68,17 @@ def _spec(
     :param fmt: the output format.
     :param overwrite: whether an existing target may be replaced.
     :param departition: whether single-file departitioning is applied.
+    :param delimiter: the CSV field separator.
+    :param header: whether CSV output includes a header row.
     :return: the output specification.
     """
     return OutputSpec(
-        path=path, format=fmt, overwrite=overwrite, departition=departition
+        path=path,
+        format=fmt,
+        overwrite=overwrite,
+        departition=departition,
+        delimiter=delimiter,
+        header=header,
     )
 
 
@@ -111,6 +124,25 @@ def test_csv_yields_single_file_with_header(spark, tmp_path):
     assert rows[0] == ["id", "family"]
     # Compared as a set so the assertion does not depend on row ordering.
     assert {tuple(row) for row in rows[1:]} == {("1", "Smith"), ("2", "")}
+
+
+# ========== CSV delimiter on file output (T009) ==========
+
+
+def test_csv_file_written_with_supplied_delimiter(spark, tmp_path):
+    """A CSV file is written with the spec's delimiter via Spark's ``sep``."""
+    df = spark.createDataFrame(
+        [("1", "Smith"), ("2", "Jones")], "id string, family string"
+    )
+    out = tmp_path / "out.csv"
+
+    _write_file(df, _spec(out, OutputFormat.CSV, delimiter="\t"))
+
+    _assert_only_target(out, tmp_path)
+    # The file parses as tab-separated with the expected columns and data.
+    rows = list(csv.reader(io.StringIO(out.read_text()), delimiter="\t"))
+    assert rows[0] == ["id", "family"]
+    assert {tuple(row) for row in rows[1:]} == {("1", "Smith"), ("2", "Jones")}
 
 
 # ========== NDJSON single-file output (T005) ==========

--- a/lib/python/tests/cli/test_write_file.py
+++ b/lib/python/tests/cli/test_write_file.py
@@ -145,6 +145,22 @@ def test_csv_file_written_with_supplied_delimiter(spark, tmp_path):
     assert {tuple(row) for row in rows[1:]} == {("1", "Smith"), ("2", "Jones")}
 
 
+# ========== CSV output header control (T016) ==========
+
+
+def test_csv_file_omits_header_when_disabled(spark, tmp_path):
+    """A CSV file omits the header row when the spec disables it (T016)."""
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    out = tmp_path / "out.csv"
+
+    _write_file(df, _spec(out, OutputFormat.CSV, header=False))
+
+    _assert_only_target(out, tmp_path)
+    rows = list(csv.reader(io.StringIO(out.read_text())))
+    # The only line is the data row; there is no header line.
+    assert rows == [["1", "Smith"]]
+
+
 # ========== NDJSON single-file output (T005) ==========
 
 

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -73,6 +73,8 @@ as a human-readable table by default.
 | `--limit N`                      | Row cap for stdout table output (default 50).                                                                          |
 | `--overwrite`                    | Allow replacing an existing output path.                                                                               |
 | `--departition/--no-departition` | Write file output as a single file (default) or as a Spark directory of part files. No effect on Delta.                |
+| `--delimiter CHAR`               | Field separator for CSV input and output (default `,`). Accepts a backslash escape such as `\t` for a tab.             |
+| `--header/--no-header`           | Include a header row in CSV output (default enabled).                                                                  |
 
 File output is produced by Spark's distributed writers, so results larger than
 driver memory can be written. By default the output is departitioned to a
@@ -81,6 +83,17 @@ directory of part files. Delta output is always written as a table directory.
 
 For scripted use, prefer `--format csv` or `--format ndjson`, which stream the
 full result.
+
+The `--delimiter` and `--header/--no-header` options apply to CSV output for
+`view`, `fhirpath`, and the terminology commands, and are ignored for non-CSV
+formats. The delimiter is also used to read CSV input in the terminology
+commands, so a tab-separated dataset round-trips in a single invocation:
+
+```bash
+pathling member-of codes.tsv --code-column code \
+  --system http://snomed.info/sct --value-set <uri> \
+  --delimiter '\t' --format csv
+```
 
 ## Commands
 
@@ -238,6 +251,17 @@ pathling translate codes.csv --code-column code \
 The default result column names (`member_of`, `translated_system` and
 `translated_code`, `subsumes`, `subsumed_by`, `display`, `property`,
 `designation`) can be overridden with `--result-column`.
+
+CSV input is read with the shared `--delimiter` (so a tab- or semicolon-separated
+dataset is read correctly). Pass `--no-input-header` to read a headerless CSV; its
+columns are then addressable by the positional names Spark assigns (`_c0`, `_c1`,
+...), which you reference via `--code-column`, `--system-column`, and the other
+column options.
+
+```bash
+pathling member-of headerless.csv --no-input-header --code-column _c0 \
+  --system http://snomed.info/sct --value-set '<uri>'
+```
 
 #### Subsumption against a fixed target coding
 

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -66,15 +66,15 @@ specify `--from`.
 Tabular results (from `view`, `fhirpath`, and the terminology commands) render
 as a human-readable table by default.
 
-| Option                           | Behaviour                                                                                                              |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `--format`                       | `table` (default), `csv`, `ndjson`; with `-o` also `parquet`, `delta`.                                                 |
-| `-o PATH`                        | Write to a file instead of stdout; the format is inferred from the extension (`.csv`, `.ndjson`/`.jsonl`, `.parquet`). |
-| `--limit N`                      | Row cap for stdout table output (default 50).                                                                          |
-| `--overwrite`                    | Allow replacing an existing output path.                                                                               |
-| `--departition/--no-departition` | Write file output as a single file (default) or as a Spark directory of part files. No effect on Delta.                |
-| `--delimiter CHAR`               | Field separator for CSV input and output (default `,`). Accepts a backslash escape such as `\t` for a tab.             |
-| `--header/--no-header`           | Include a header row in CSV output (default enabled).                                                                  |
+| Option                           | Behaviour                                                                                                                     |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `--format`                       | `table` (default), `csv`, `ndjson`; with `-o` also `parquet`, `delta`.                                                        |
+| `-o PATH`                        | Write to a file instead of stdout; the format is inferred from the extension (`.csv`/`.tsv`, `.ndjson`/`.jsonl`, `.parquet`). |
+| `--limit N`                      | Row cap for stdout table output (default 50).                                                                                 |
+| `--overwrite`                    | Allow replacing an existing output path.                                                                                      |
+| `--departition/--no-departition` | Write file output as a single file (default) or as a Spark directory of part files. No effect on Delta.                       |
+| `--delimiter CHAR`               | Field separator for CSV input and output (default `,`). Accepts a backslash escape such as `\t` for a tab.                    |
+| `--header/--no-header`           | Include a header row in CSV output (default enabled).                                                                         |
 
 File output is produced by Spark's distributed writers, so results larger than
 driver memory can be written. By default the output is departitioned to a
@@ -253,7 +253,8 @@ The default result column names (`member_of`, `translated_system` and
 `designation`) can be overridden with `--result-column`.
 
 CSV input is read with the shared `--delimiter` (so a tab- or semicolon-separated
-dataset is read correctly). Pass `--no-input-header` to read a headerless CSV; its
+dataset is read correctly); a `.tsv` file is read as CSV. Pass `--no-input-header`
+to read a headerless CSV; its
 columns are then addressable by the positional names Spark assigns (`_c0`, `_c1`,
 ...), which you reference via `--code-column`, `--system-column`, and the other
 column options.


### PR DESCRIPTION
Adds control over the CSV delimiter and header row across the CLI, so tab- and semicolon-separated data can be round-tripped rather than being locked to a comma with a header.

Changes:

- A shared `--delimiter` option and a `--no-header` flag on the output options, threaded through the fhirpath, view and terminology commands.
- The delimiter is honoured on CSV read, on the stdout writer and on the Spark file writer.
- Headerless CSV input is supported in the terminology commands.
- `.tsv` files are inferred as CSV on both read and output.
- Documentation for the new options in the CLI guide.

Unit tests cover the read path, the stdout writer, the file writer and the header handling.

Closes #2647
