### PR TITLE
Reject VOID columns in Parquet output with a clear error

### DIFF
--- a/server/src/main/java/au/csiro/pathling/operations/ParquetSchemaValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/ParquetSchemaValidator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations;
+
+import au.csiro.pathling.errors.InvalidUserInputError;
+import jakarta.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.NullType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Validates that a Spark result schema can be written to Parquet, rejecting schemas that contain an
+ * unresolved ({@code NullType}, displayed as "VOID") type with a clear, user-correctable error.
+ *
+ * <p>Spark's Parquet writer rejects a {@code NullType} anywhere in the schema, not just at the top
+ * level (for example, an {@code array()} literal produces an array of {@code NullType}). The walk
+ * therefore recurses into structs, arrays, and maps and reports every offending field path in a
+ * single message.
+ *
+ * @author John Grimes
+ */
+public final class ParquetSchemaValidator {
+
+  private ParquetSchemaValidator() {
+    // Utility class; not instantiable.
+  }
+
+  /**
+   * Validates that the given schema contains no unresolved (VOID) types anywhere in its structure.
+   *
+   * @param schema the result schema to validate
+   * @throws InvalidUserInputError if the schema contains one or more {@code NullType} fields; the
+   *     message names every offending field path and suggests both remediations
+   */
+  public static void validateSchemaForParquet(@Nonnull final StructType schema) {
+    final List<String> voidPaths = new ArrayList<>();
+    walkStruct(schema, "", voidPaths);
+
+    if (!voidPaths.isEmpty()) {
+      final String columns =
+          voidPaths.stream().map(path -> "'" + path + "'").collect(Collectors.joining(", "));
+      throw new InvalidUserInputError(
+          "The result contains column(s) with an unresolved (VOID) type that cannot be written to "
+              + "Parquet: "
+              + columns
+              + ". Add an explicit CAST to the query or view (e.g. CAST(column AS STRING)), or "
+              + "choose a different output format.");
+    }
+  }
+
+  /** Recurses over the fields of a struct, extending the accumulated field path for each. */
+  private static void walkStruct(
+      @Nonnull final StructType struct,
+      @Nonnull final String path,
+      @Nonnull final List<String> voidPaths) {
+    for (final StructField field : struct.fields()) {
+      final String fieldPath = path.isEmpty() ? field.name() : path + "." + field.name();
+      walkType(field.dataType(), fieldPath, voidPaths);
+    }
+  }
+
+  /** Recurses over a single data type, recording the path when a {@code NullType} is reached. */
+  private static void walkType(
+      @Nonnull final DataType dataType,
+      @Nonnull final String path,
+      @Nonnull final List<String> voidPaths) {
+    if (dataType instanceof NullType) {
+      voidPaths.add(path);
+    } else if (dataType instanceof final StructType struct) {
+      walkStruct(struct, path, voidPaths);
+    } else if (dataType instanceof final ArrayType array) {
+      walkType(array.elementType(), path + "[]", voidPaths);
+    } else if (dataType instanceof final MapType map) {
+      walkType(map.keyType(), path + ".key", voidPaths);
+      walkType(map.valueType(), path + ".value", voidPaths);
+    }
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamer.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamer.java
@@ -17,6 +17,7 @@
 
 package au.csiro.pathling.operations.sqlquery;
 
+import au.csiro.pathling.operations.ParquetSchemaValidator;
 import au.csiro.pathling.operations.view.ResultStreamingHelper;
 import au.csiro.pathling.views.ViewDefinitionGson;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
@@ -140,6 +141,10 @@ public class SqlQueryResultStreamer {
   private void streamParquet(
       @Nonnull final Dataset<Row> result, @Nonnull final HttpServletResponse response)
       throws IOException {
+
+    // Reject unresolved (VOID) columns before any filesystem work, since Spark's Parquet writer
+    // would otherwise fail with an opaque internal error.
+    ParquetSchemaValidator.validateSchemaForParquet(result.schema());
 
     final Path tempDir = Files.createTempDirectory("sqlquery-parquet-", OWNER_ONLY_DIR_ATTRS);
     final String outputPath = tempDir.resolve("result").toString();

--- a/server/src/main/java/au/csiro/pathling/operations/view/ViewDefinitionExportExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/view/ViewDefinitionExportExecutor.java
@@ -19,6 +19,7 @@ package au.csiro.pathling.operations.view;
 
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
+import au.csiro.pathling.operations.ParquetSchemaValidator;
 import au.csiro.pathling.operations.export.ExportDataSourceBuilder;
 import au.csiro.pathling.operations.export.ExportFileWriter;
 import au.csiro.pathling.views.FhirView;
@@ -151,7 +152,12 @@ public class ViewDefinitionExportExecutor {
     return switch (format) {
       case NDJSON -> fileWriter.writeNdjson(result, viewName, jobDirPath);
       case CSV -> fileWriter.writeCsv(result, viewName, includeHeader, jobDirPath);
-      case PARQUET -> fileWriter.writeParquet(result, viewName, jobDirPath);
+      case PARQUET -> {
+        // Reject unresolved (VOID) columns before writing, since Spark's Parquet writer would
+        // otherwise fail the job with an opaque internal error.
+        ParquetSchemaValidator.validateSchemaForParquet(result.schema());
+        yield fileWriter.writeParquet(result, viewName, jobDirPath);
+      }
     };
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/ParquetSchemaValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/ParquetSchemaValidatorTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import au.csiro.pathling.errors.InvalidUserInputError;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ParquetSchemaValidator}. These tests exercise the recursive schema walk and
+ * the construction of the user-facing error message directly against Spark {@link StructType}
+ * schemas, with no Spark session required.
+ *
+ * @author John Grimes
+ */
+class ParquetSchemaValidatorTest {
+
+  @Test
+  void cleanSchemaPasses() {
+    // A schema with only concrete, writable types must not throw.
+    final StructType schema =
+        new StructType()
+            .add("id", DataTypes.IntegerType, false)
+            .add("name", DataTypes.StringType, true);
+
+    assertThatCode(() -> ParquetSchemaValidator.validateSchemaForParquet(schema))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void singleTopLevelVoidColumnThrowsNamingIt() {
+    // A single top-level NullType column must be rejected and named in the message.
+    final StructType schema =
+        new StructType()
+            .add("id", DataTypes.IntegerType, false)
+            .add("foo", DataTypes.NullType, true);
+
+    assertThatThrownBy(() -> ParquetSchemaValidator.validateSchemaForParquet(schema))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("'foo'");
+  }
+
+  @Test
+  void multipleVoidColumnsAreAllNamedInOneMessage() {
+    // Every offending column must appear in a single message, not just the first.
+    final StructType schema =
+        new StructType()
+            .add("foo", DataTypes.NullType, true)
+            .add("bar", DataTypes.IntegerType, false)
+            .add("baz", DataTypes.NullType, true);
+
+    assertThatThrownBy(() -> ParquetSchemaValidator.validateSchemaForParquet(schema))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("'foo'")
+        .hasMessageContaining("'baz'");
+  }
+
+  @Test
+  void voidNestedInStructIsReportedWithDottedPath() {
+    // A NullType nested inside a struct is reported using dot-separated field paths.
+    final StructType nested = new StructType().add("code", DataTypes.NullType, true);
+    final StructType schema = new StructType().add("details", nested, true);
+
+    assertThatThrownBy(() -> ParquetSchemaValidator.validateSchemaForParquet(schema))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("'details.code'");
+  }
+
+  @Test
+  void voidNestedInArrayElementIsReportedWithBracketPath() {
+    // A NullType reached through an array element is reported with a "[]" segment.
+    final StructType elementType = new StructType().add("code", DataTypes.NullType, true);
+    final StructType schema =
+        new StructType().add("details", DataTypes.createArrayType(elementType, true), true);
+
+    assertThatThrownBy(() -> ParquetSchemaValidator.validateSchemaForParquet(schema))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("'details[].code'");
+  }
+
+  @Test
+  void voidAsDirectArrayElementIsReportedWithBracketPath() {
+    // An array whose element type is itself VOID (e.g. an array() literal) is reported.
+    final StructType schema =
+        new StructType().add("tags", DataTypes.createArrayType(DataTypes.NullType, true), true);
+
+    assertThatThrownBy(() -> ParquetSchemaValidator.validateSchemaForParquet(schema))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("'tags[]'");
+  }
+
+  @Test
+  void voidAsMapKeyIsReportedWithKeyPath() {
+    // A NullType map key is reported with a ".key" segment.
+    final StructType schema =
+        new StructType()
+            .add(
+                "attributes",
+                DataTypes.createMapType(DataTypes.NullType, DataTypes.StringType, true),
+                true);
+
+    assertThatThrownBy(() -> ParquetSchemaValidator.validateSchemaForParquet(schema))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("'attributes.key'");
+  }
+
+  @Test
+  void voidAsMapValueIsReportedWithValuePath() {
+    // A NullType map value is reported with a ".value" segment.
+    final StructType schema =
+        new StructType()
+            .add(
+                "attributes",
+                DataTypes.createMapType(DataTypes.StringType, DataTypes.NullType, true),
+                true);
+
+    assertThatThrownBy(() -> ParquetSchemaValidator.validateSchemaForParquet(schema))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("'attributes.value'");
+  }
+
+  @Test
+  void messageContainsBothRemediations() {
+    // The message must offer both remediations: an explicit CAST and a different output format.
+    final StructType schema = new StructType().add("foo", DataTypes.NullType, true);
+
+    assertThatThrownBy(() -> ParquetSchemaValidator.validateSchemaForParquet(schema))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("CAST")
+        .hasMessageContaining("output format");
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamerTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryResultStreamerTest.java
@@ -18,10 +18,19 @@
 package au.csiro.pathling.operations.sqlquery;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import au.csiro.pathling.errors.InvalidUserInputError;
 import au.csiro.pathling.test.SpringBootUnitTest;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -113,6 +122,69 @@ class SqlQueryResultStreamerTest {
     final byte[] bytes = response.getContentAsByteArray();
     assertThat(bytes).isNotEmpty();
     assertThat(new String(bytes, 0, 4, StandardCharsets.US_ASCII)).isEqualTo("PAR1");
+  }
+
+  @Test
+  void parquetWithVoidColumnRejectedBeforeCreatingTempDirectory() throws IOException {
+    // A NullType (VOID) column cannot be written to Parquet. The streamer must reject it with an
+    // InvalidUserInputError (mapped to a 400) rather than letting Spark fail deep in the writer.
+    final Set<Path> tempDirsBefore = sqlQueryParquetTempDirs();
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assertThatThrownBy(
+            () ->
+                streamer.stream(voidColumnDataset(), SqlQueryOutputFormat.PARQUET, false, response))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("'foo'")
+        .hasMessageContaining("CAST")
+        .hasMessageContaining("output format");
+
+    // The validation fires before any temporary directory is created, so no filesystem work
+    // happens for a rejected request.
+    assertThat(sqlQueryParquetTempDirs()).isEqualTo(tempDirsBefore);
+  }
+
+  @Test
+  void csvWithVoidColumnStillSucceeds() {
+    // Non-Parquet formats are unaffected by the new validation.
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assertThatCode(
+            () -> streamer.stream(voidColumnDataset(), SqlQueryOutputFormat.CSV, true, response))
+        .doesNotThrowAnyException();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    final String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+    assertThat(body).startsWith("id,foo");
+  }
+
+  @Test
+  void parquetWithFullyTypedDatasetStillSucceeds() {
+    // A fully typed dataset must still be written to Parquet exactly as before.
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assertThatCode(
+            () -> streamer.stream(twoRowDataset(), SqlQueryOutputFormat.PARQUET, false, response))
+        .doesNotThrowAnyException();
+
+    final byte[] bytes = response.getContentAsByteArray();
+    assertThat(bytes).isNotEmpty();
+    assertThat(new String(bytes, 0, 4, StandardCharsets.US_ASCII)).isEqualTo("PAR1");
+  }
+
+  /** Lists the streamer's Parquet temporary directories currently present under the temp root. */
+  private Set<Path> sqlQueryParquetTempDirs() throws IOException {
+    final Path tempRoot = Path.of(System.getProperty("java.io.tmpdir"));
+    try (final Stream<Path> entries = Files.list(tempRoot)) {
+      return entries
+          .filter(p -> p.getFileName().toString().startsWith("sqlquery-parquet-"))
+          .collect(Collectors.toSet());
+    }
+  }
+
+  private Dataset<Row> voidColumnDataset() {
+    // A literal NULL projection produces a NullType (VOID) column, reproducing the failure mode.
+    return spark.range(2).toDF("id").selectExpr("id", "NULL AS foo");
   }
 
   private Dataset<Row> twoRowDataset() {

--- a/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionExportExecutorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionExportExecutorTest.java
@@ -18,10 +18,12 @@
 package au.csiro.pathling.operations.view;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.errors.InvalidUserInputError;
 import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.operations.compartment.PatientCompartmentService;
@@ -247,6 +249,88 @@ class ViewDefinitionExportExecutorTest {
     assertThat(filename).matches(".*patients\\.\\d{5}\\.parquet$");
   }
 
+  @Test
+  void parquetExportWithVoidColumnThrowsInvalidUserInputError() throws IOException {
+    // A view column that resolves to an empty FHIRPath collection has an unresolved (VOID) type,
+    // which Spark's Parquet writer cannot handle. The export must fail with a clear, user-facing
+    // error rather than an internal Spark error, and must write nothing to the job directory.
+    final Patient patient = createPatient("test-1", "Smith");
+    executor = createExecutor(patient);
+
+    final ViewInput viewInput = new ViewInput("patients", createVoidColumnView());
+    final ViewDefinitionExportRequest request =
+        new ViewDefinitionExportRequest(
+            "http://example.org/$viewdefinition-export",
+            "http://example.org/fhir",
+            List.of(viewInput),
+            null,
+            ViewExportFormat.PARQUET,
+            true,
+            Collections.emptySet(),
+            null);
+
+    assertThatThrownBy(() -> executor.execute(request, UUID.randomUUID().toString()))
+        .isInstanceOf(InvalidUserInputError.class)
+        .hasMessageContaining("'nothing'")
+        .hasMessageContaining("CAST")
+        .hasMessageContaining("output format");
+
+    // No Parquet output should have been written for the rejected request.
+    assertThat(parquetFilesUnder(uniqueTempDir)).isEmpty();
+  }
+
+  @Test
+  void ndjsonExportWithVoidColumnIsUnaffected() {
+    // The new validation applies only to Parquet; NDJSON export of the same view is unaffected.
+    final Patient patient = createPatient("test-1", "Smith");
+    executor = createExecutor(patient);
+
+    final ViewInput viewInput = new ViewInput("patients", createVoidColumnView());
+    final ViewDefinitionExportRequest request =
+        new ViewDefinitionExportRequest(
+            "http://example.org/$viewdefinition-export",
+            "http://example.org/fhir",
+            List.of(viewInput),
+            null,
+            ViewExportFormat.NDJSON,
+            true,
+            Collections.emptySet(),
+            null);
+
+    assertThatCode(() -> executor.execute(request, UUID.randomUUID().toString()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void csvExportWithVoidColumnIsUnaffectedByNewValidation() {
+    // CSV export of the same view must not be touched by the new Parquet validation; it retains
+    // its pre-existing behaviour (it does not throw the new InvalidUserInputError).
+    final Patient patient = createPatient("test-1", "Smith");
+    executor = createExecutor(patient);
+
+    final ViewInput viewInput = new ViewInput("patients", createVoidColumnView());
+    final ViewDefinitionExportRequest request =
+        new ViewDefinitionExportRequest(
+            "http://example.org/$viewdefinition-export",
+            "http://example.org/fhir",
+            List.of(viewInput),
+            null,
+            ViewExportFormat.CSV,
+            true,
+            Collections.emptySet(),
+            null);
+
+    // The pre-existing behaviour may accept or reject the column, but it must never be the new
+    // Parquet-specific InvalidUserInputError.
+    try {
+      executor.execute(request, UUID.randomUUID().toString());
+    } catch (final InvalidUserInputError e) {
+      throw new AssertionError("CSV export must not be affected by the new Parquet validation", e);
+    } catch (final RuntimeException ignored) {
+      // Any pre-existing failure mode is acceptable; only the new validation is under test.
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Multiple views tests
   // -------------------------------------------------------------------------
@@ -410,5 +494,22 @@ class ViewDefinitionExportExecutorTest {
             FhirView.columns(
                 FhirView.column("id", "id"), FhirView.column("family_name", "name.first().family")))
         .build();
+  }
+
+  private FhirView createVoidColumnView() {
+    // The empty FHIRPath literal "{}" resolves to an empty collection whose Spark type is NullType
+    // (VOID), reproducing the unresolved-column failure mode.
+    return FhirView.ofResource("Patient")
+        .select(FhirView.columns(FhirView.column("id", "id"), FhirView.column("nothing", "{}")))
+        .build();
+  }
+
+  /** Returns every Parquet output file found beneath the given directory. */
+  private List<Path> parquetFilesUnder(final Path root) throws IOException {
+    try (final java.util.stream.Stream<Path> paths = Files.walk(root)) {
+      return paths
+          .filter(p -> p.getFileName().toString().endsWith(".parquet"))
+          .collect(java.util.stream.Collectors.toList());
+    }
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionExportExecutorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/view/ViewDefinitionExportExecutorTest.java
@@ -43,6 +43,8 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.spark.sql.SparkSession;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Patient;
@@ -506,10 +508,10 @@ class ViewDefinitionExportExecutorTest {
 
   /** Returns every Parquet output file found beneath the given directory. */
   private List<Path> parquetFilesUnder(final Path root) throws IOException {
-    try (final java.util.stream.Stream<Path> paths = Files.walk(root)) {
+    try (final Stream<Path> paths = Files.walk(root)) {
       return paths
           .filter(p -> p.getFileName().toString().endsWith(".parquet"))
-          .collect(java.util.stream.Collectors.toList());
+          .collect(Collectors.toList());
     }
   }
 }

--- a/site/docs/server/operations/sql-run.md
+++ b/site/docs/server/operations/sql-run.md
@@ -219,6 +219,15 @@ When `_format` is `json`, the response is a single JSON array of row objects.
 
 When `_format` is `parquet`, the response is a binary Parquet file.
 
+Parquet cannot represent a column whose type is unresolved (Spark `NullType`,
+displayed as "VOID"). This typically arises when a query projects a literal
+`NULL` without a cast (for example `SELECT NULL AS foo`). If the result
+contains such a column, the request is rejected with an HTTP 400 and an
+`OperationOutcome` that names every offending column and suggests two
+remediations: add an explicit `CAST` (for example `CAST(foo AS STRING)`), or
+choose a different output format. Other formats (`ndjson`, `csv`, `json`,
+`fhir`) accept these columns without error.
+
 ### FHIR Parameters
 
 When `_format` is `fhir`, the response is a FHIR Parameters resource

--- a/site/docs/server/operations/view-export.md
+++ b/site/docs/server/operations/view-export.md
@@ -195,6 +195,14 @@ part per file.
 | CSV     | `csv`           | `text/csv`                       | Comma-separated values. Use `header=false` to exclude headers. |
 | Parquet | `parquet`       | `application/vnd.apache.parquet` | Apache Parquet columnar format. Efficient for large datasets.  |
 
+Parquet cannot represent a column whose type is unresolved (Spark `NullType`,
+displayed as "VOID"), such as a column that resolves to an empty collection. If
+a view's result contains such a column and Parquet output is requested, the
+export job fails and the polled status carries an `OperationOutcome` that names
+every offending column and suggests two remediations: add an explicit cast in
+the view, or choose a different output format. The NDJSON and CSV formats are
+unaffected.
+
 ## Multiple views
 
 Export multiple views in a single request by including multiple `view`


### PR DESCRIPTION
Closes #2657.

Parquet output of SQL on FHIR results previously failed with an opaque 500 when a view produced an unresolved (VOID) column, for example a column whose FHIRPath expression resolves to an empty collection. Spark's Parquet writer cannot represent `NullType`, so the job failed deep inside Spark with an error that gave the user no way to understand or fix the problem.

This adds a schema validator that detects VOID columns before writing Parquet and fails fast with a clear, user-facing error. The error names every offending column and suggests two remediations: add an explicit cast in the view, or choose a different output format. Both the synchronous `$sqlquery-run` path and the asynchronous `$viewdefinition-export` path are covered, with the async job surfacing the diagnostic in its polled status as an OperationOutcome. NDJSON and CSV output are unaffected.

The limitation and the resulting error are documented for both the run and export operations.
