### PR TITLE
Schema introspection through $sqlquery-run (DESCRIBE)

### DIFF
--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
@@ -28,14 +28,18 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.FunctionIdentifier;
 import org.apache.spark.sql.catalyst.analysis.UnresolvedFunction;
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation;
+import org.apache.spark.sql.catalyst.analysis.UnresolvedTableOrView;
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo;
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression;
 import org.apache.spark.sql.catalyst.plans.logical.Command;
+import org.apache.spark.sql.catalyst.plans.logical.DescribeRelation;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
 import org.apache.spark.sql.catalyst.plans.logical.UnresolvedWith;
+import org.apache.spark.sql.execution.command.DescribeQueryCommand;
+import org.apache.spark.sql.execution.command.DescribeTableCommand;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -147,6 +151,16 @@ public class SqlValidator {
           "org.apache.spark.sql.catalyst.analysis.UnresolvedRelation",
           "org.apache.spark.sql.catalyst.analysis.UnresolvedInlineTable",
           "org.apache.spark.sql.catalyst.analysis.UnresolvedSubqueryColumnAliases");
+
+  // Fully-qualified names of the Catalyst command classes carved out of the blanket Command
+  // rejection to support schema introspection (spec 029). These are matched via instanceof against
+  // the imported types; the names are held here only so the build-time integrity test can confirm
+  // they still resolve on the classpath and catch a Spark rename.
+  private static final Set<String> DESCRIBE_COMMAND_NAMES =
+      Set.of(
+          "org.apache.spark.sql.catalyst.plans.logical.DescribeRelation",
+          "org.apache.spark.sql.execution.command.DescribeTableCommand",
+          "org.apache.spark.sql.execution.command.DescribeQueryCommand");
 
   // Function names rejected outright because they enable arbitrary code execution.
   private static final Set<String> REJECTED_FUNCTION_NAMES =
@@ -416,6 +430,13 @@ public class SqlValidator {
   /** Recursively validates a parsed plan in strict mode. */
   private void walkPlanStrict(
       @Nonnull final LogicalPlan plan, @Nonnull final Set<String> allowedLabels) {
+    if (validateDescribeStrict(plan, allowedLabels)) {
+      // The node is one of the two allowed DESCRIBE forms and has been fully validated above. Its
+      // relation reference and inner query plan are checked there, so the generic strict walk must
+      // not descend into them (the relation node and the command itself are not in the plan-node
+      // allow-list).
+      return;
+    }
     validatePlanNodeStrict(plan, allowedLabels);
     final List<Expression> expressions = CollectionConverters.asJava(plan.expressions());
     for (final Expression expr : expressions) {
@@ -437,6 +458,56 @@ public class SqlValidator {
     for (final LogicalPlan child : children) {
       walkPlanStrict(child, allowedLabels);
     }
+  }
+
+  /**
+   * Recognises and validates the two allowed {@code DESCRIBE} forms at parse time, before the
+   * blanket {@link Command} rejection in {@link #validatePlanNodeStrict}. This is the complete
+   * security gate for describe statements: Spark executes {@link Command} plans eagerly when the
+   * statement is submitted, so the later analysed-mode walk is only defence in depth.
+   *
+   * <ul>
+   *   <li>{@link DescribeRelation} ({@code DESCRIBE [TABLE] <label>}) is accepted only when it is
+   *       not extended and carries no partition specification, and its target is a single-part
+   *       declared label. {@code EXTENDED}/{@code FORMATTED} and partition forms are rejected here;
+   *       the column form ({@link org.apache.spark.sql.catalyst.plans.logical.DescribeColumn}) and
+   *       {@code AS JSON} form are left to the blanket {@link Command} rejection.
+   *   <li>{@link DescribeQueryCommand} ({@code DESCRIBE [QUERY] <query>}) is accepted after its
+   *       inner query plan is strictly validated with the same allowed-label set (extended with any
+   *       CTEs the inner query defines). The inner plan is a constructor argument rather than a
+   *       tree child, so it must be walked explicitly.
+   * </ul>
+   *
+   * @return {@code true} when the node is a recognised, validated DESCRIBE form and the caller
+   *     should not descend into it; {@code false} when the node is not a DESCRIBE form at all
+   */
+  private boolean validateDescribeStrict(
+      @Nonnull final LogicalPlan plan, @Nonnull final Set<String> allowedLabels) {
+    if (plan instanceof final DescribeRelation describe) {
+      if (describe.isExtended()) {
+        throw new InvalidRequestException(
+            "SQL contains a disallowed operation: DESCRIBE EXTENDED / FORMATTED");
+      }
+      if (!describe.partitionSpec().isEmpty()) {
+        throw new InvalidRequestException(
+            "SQL contains a disallowed operation: DESCRIBE with a partition specification");
+      }
+      if (describe.child() instanceof final UnresolvedTableOrView target) {
+        validateSinglePartLabel(
+            CollectionConverters.asJava(target.multipartIdentifier()), allowedLabels);
+        return true;
+      }
+      // An unexpected target shape falls through to the generic Command rejection.
+      return false;
+    }
+    if (plan instanceof final DescribeQueryCommand describeQuery) {
+      final LogicalPlan innerPlan = describeQuery.plan();
+      final Set<String> innerLabels = new HashSet<>(allowedLabels);
+      collectCteNames(innerPlan, innerLabels);
+      walkPlanStrict(innerPlan, innerLabels);
+      return true;
+    }
+    return false;
   }
 
   /** Recursively validates an analyzed plan, tracking whether we are inside a trusted alias. */
@@ -541,6 +612,12 @@ public class SqlValidator {
       @Nonnull final LogicalPlan plan,
       @Nonnull final Set<String> registeredViewNames,
       final boolean inTrustedAlias) {
+    if (isAllowedDescribeAnalyzed(plan, registeredViewNames)) {
+      // A DESCRIBE command already fully vetted at parse time. Spark rewrites the parsed
+      // DescribeRelation into a DescribeTableCommand during analysis, so it is recognised here by
+      // its analysed form. This is defence in depth only; the parse-time gate is authoritative.
+      return;
+    }
     if (plan instanceof Command) {
       throw new InvalidRequestException(
           "SQL contains a disallowed operation: " + plan.getClass().getSimpleName());
@@ -556,13 +633,61 @@ public class SqlValidator {
   }
 
   /**
+   * Recognises the analysed form of the two allowed {@code DESCRIBE} statements. Spark's {@code
+   * ResolveSessionCatalog} rewrites a parsed {@link DescribeRelation} over a (temp) view into a
+   * {@link DescribeTableCommand}, so the table form is matched by that class here rather than by
+   * {@link DescribeRelation}.
+   *
+   * <ul>
+   *   <li>{@link DescribeTableCommand} is accepted only when it is not extended, carries no
+   *       partition specification, and its table name matches one of the request-scoped temp views
+   *       (case-insensitively, matching {@link #isTrustedAlias} for the same catalog-normalisation
+   *       reason). Any other target would indicate the parse-time label check was bypassed.
+   *   <li>{@link DescribeQueryCommand} is accepted unconditionally: its inner query plan was
+   *       strictly validated at parse time and is only ever analysed - never executed - by the
+   *       command, so no analysed-plan re-check is required.
+   * </ul>
+   *
+   * @return {@code true} when the node is an allowed analysed DESCRIBE form; {@code false}
+   *     otherwise, so a disallowed describe falls through to the blanket {@link Command} rejection
+   */
+  private static boolean isAllowedDescribeAnalyzed(
+      @Nonnull final LogicalPlan plan, @Nonnull final Set<String> registeredViewNames) {
+    if (plan instanceof DescribeQueryCommand) {
+      return true;
+    }
+    if (plan instanceof final DescribeTableCommand describe) {
+      if (describe.isExtended() || !describe.partitionSpec().isEmpty()) {
+        return false;
+      }
+      final String tableName = describe.table().table();
+      for (final String registered : registeredViewNames) {
+        if (registered.equalsIgnoreCase(tableName)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
    * Enforces that an unresolved relation is a single-part identifier matching {@link
    * #LABEL_PATTERN} and present in the allowed-label set. Rejects two-part datasource short-name
    * references such as {@code parquet.`/etc/passwd`}.
    */
   private static void validateRelationReference(
       @Nonnull final UnresolvedRelation relation, @Nonnull final Set<String> allowedLabels) {
-    final List<String> parts = CollectionConverters.asJava(relation.multipartIdentifier());
+    validateSinglePartLabel(
+        CollectionConverters.asJava(relation.multipartIdentifier()), allowedLabels);
+  }
+
+  /**
+   * Enforces that a relation identifier is a single-part identifier matching {@link #LABEL_PATTERN}
+   * and present in the allowed-label set. Shared by ordinary relation references and the {@code
+   * DESCRIBE [TABLE] <label>} target check.
+   */
+  private static void validateSinglePartLabel(
+      @Nonnull final List<String> parts, @Nonnull final Set<String> allowedLabels) {
     if (parts.size() != 1) {
       throw new InvalidRequestException(
           "SQL references an undeclared table: " + String.join(".", parts));
@@ -699,5 +824,11 @@ public class SqlValidator {
   @Nonnull
   static Set<String> rejectedExpressionNames() {
     return REJECTED_EXPRESSION_NAMES;
+  }
+
+  /** DESCRIBE carve-out class names, exposed for build-time integrity tests. */
+  @Nonnull
+  static Set<String> describeCommandNames() {
+    return DESCRIBE_COMMAND_NAMES;
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
@@ -86,6 +86,17 @@ import scala.jdk.javaapi.CollectionConverters;
  *       walks.
  * </ol>
  *
+ * <p>Two schema-introspection statements are carved out of the blanket {@link Command} rejection:
+ * {@code DESCRIBE [TABLE] <label>} and {@code DESCRIBE [QUERY] <query>}. Because Spark executes
+ * {@link Command} plans eagerly when {@code sparkSession.sql(...)} builds the Dataset - before the
+ * analysed-plan walk runs - the parse-time carve-out ({@code validateDescribeStrict}) is the
+ * complete security gate for these forms: it accepts only the non-extended, partition-free table
+ * form over a declared label, and the query form whose inner query passes the full strict walk. The
+ * analysed-mode carve-out ({@code isAllowedDescribeAnalyzed}) is defence in depth only; it
+ * re-recognises the rewritten {@code DescribeTableCommand} / {@code DescribeQueryCommand} and
+ * confirms the resolved target is one of the registered temp views. Every other DESCRIBE / SHOW
+ * variant remains rejected.
+ *
  * @see <a
  *     href="https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/OperationDefinition-SQLQueryRun.html">SQLQueryRun</a>
  */

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutorTest.java
@@ -25,6 +25,7 @@ import au.csiro.pathling.config.SqlQueryConfiguration;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import jakarta.annotation.Nonnull;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.spark.sql.Dataset;
@@ -86,6 +87,36 @@ class SqlQueryExecutorTest {
     assertThat(rows).hasSize(1);
   }
 
+  @Test
+  void describeQueryReturnsProjectedColumnTypes() {
+    final Dataset<Row> backing =
+        sparkSession.sql("SELECT CAST(1 AS INT) AS id, CAST('x' AS STRING) AS name");
+    final List<Row> rows =
+        runDescribe(
+            "DESCRIBE QUERY SELECT id, count(*) AS n FROM " + VIEW_NAME + " GROUP BY id",
+            backing,
+            null);
+
+    final var typesByColumn =
+        rows.stream().collect(Collectors.toMap(row -> row.getString(0), row -> row.getString(1)));
+    // count(*) projects a bigint; the passed-through id keeps its int type.
+    assertThat(typesByColumn).containsEntry("id", "int").containsEntry("n", "bigint");
+  }
+
+  @Test
+  void describeQueryBindsParameterMarker() {
+    final Dataset<Row> backing = sparkSession.sql("SELECT 1 AS id");
+    final List<Row> rows =
+        runDescribe(
+            "DESCRIBE QUERY SELECT :threshold AS v FROM " + VIEW_NAME,
+            backing,
+            null,
+            Map.of("threshold", 5));
+    // The bound parameter yields a single projected column, described without scanning the view.
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).getString(0)).isEqualTo("v");
+  }
+
   /**
    * Reproduces the executor's describe pipeline in the JVM: register the backing dataset as the
    * label-named temp view, run the parse-time gate, execute through {@code sparkSession.sql}, run
@@ -94,10 +125,20 @@ class SqlQueryExecutorTest {
   @Nonnull
   private List<Row> runDescribe(
       @Nonnull final String sql, @Nonnull final Dataset<Row> backing, final Integer limit) {
+    return runDescribe(sql, backing, limit, Map.of());
+  }
+
+  @Nonnull
+  private List<Row> runDescribe(
+      @Nonnull final String sql,
+      @Nonnull final Dataset<Row> backing,
+      final Integer limit,
+      @Nonnull final Map<String, Object> parameters) {
     backing.createOrReplaceTempView(VIEW_NAME);
     try {
       sqlValidator.validate(sql, Set.of(VIEW_NAME));
-      Dataset<Row> result = sparkSession.sql(sql);
+      Dataset<Row> result =
+          parameters.isEmpty() ? sparkSession.sql(sql) : sparkSession.sql(sql, parameters);
       sqlValidator.validateAnalyzed(result.queryExecution().analyzed(), Set.of(VIEW_NAME));
       if (limit != null) {
         result = result.limit(limit);

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutorTest.java
@@ -22,18 +22,95 @@ import static org.mockito.Mockito.mock;
 
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.config.SqlQueryConfiguration;
+import au.csiro.pathling.test.SpringBootUnitTest;
 import jakarta.annotation.Nonnull;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 
 /**
- * Unit tests for the row-cap clamp logic in {@link SqlQueryExecutor#effectiveLimit(Integer,
- * String)}. These verify that the server-configured cap is always honoured and that a
- * caller-supplied {@code _limit} can only narrow, never widen, the result set.
+ * Tests for {@link SqlQueryExecutor}. Two concerns are covered:
+ *
+ * <ul>
+ *   <li>The row-cap clamp logic in {@link SqlQueryExecutor#effectiveLimit(Integer, String)}, which
+ *       verifies that the server-configured cap is always honoured and that a caller-supplied
+ *       {@code _limit} can only narrow, never widen, the result set.
+ *   <li>That a {@code DESCRIBE <label>} statement flows through the same validate → execute →
+ *       {@code validateAnalyzed} sequence the executor uses and yields the engine's describe rows.
+ *       This exercises the analysed-mode carve-out end to end in the JVM, since the executor calls
+ *       {@link SqlValidator#validateAnalyzed} on the eagerly-executed command plan (spec 029 US1).
+ * </ul>
  */
+@Import(SqlValidator.class)
+@SpringBootUnitTest
 class SqlQueryExecutorTest {
 
   private static final String REQUEST_ID = "test-request";
+
+  private static final String VIEW_NAME = "patients";
+
+  @Autowired private SqlValidator sqlValidator;
+
+  @Autowired private SparkSession sparkSession;
+
+  // -------------------------------------------------------------------------
+  // DESCRIBE <label> flows through the executor's validate/execute/analyse
+  // sequence and returns the engine's describe rows.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void describeReturnsColumnRowsMatchingSchema() {
+    final Dataset<Row> backing =
+        sparkSession.sql("SELECT CAST(1 AS INT) AS id, CAST('x' AS STRING) AS name");
+    final List<Row> rows = runDescribe("DESCRIBE " + VIEW_NAME, backing, null);
+
+    // One row per column of the backing dataset, carrying the three describe fields.
+    final var typesByColumn =
+        rows.stream().collect(Collectors.toMap(row -> row.getString(0), row -> row.getString(1)));
+    assertThat(typesByColumn).containsEntry("id", "int").containsEntry("name", "string");
+    // The describe result schema is always col_name, data_type, comment.
+    assertThat(rows.get(0).schema().fieldNames())
+        .containsExactly("col_name", "data_type", "comment");
+  }
+
+  @Test
+  void limitAppliesToDescribeRows() {
+    final Dataset<Row> backing = sparkSession.sql("SELECT 1 AS a, 2 AS b, 3 AS c");
+    final List<Row> rows = runDescribe("DESCRIBE " + VIEW_NAME, backing, 1);
+    assertThat(rows).hasSize(1);
+  }
+
+  /**
+   * Reproduces the executor's describe pipeline in the JVM: register the backing dataset as the
+   * label-named temp view, run the parse-time gate, execute through {@code sparkSession.sql}, run
+   * the analysed-mode gate on the eagerly-executed plan, apply any limit, and collect.
+   */
+  @Nonnull
+  private List<Row> runDescribe(
+      @Nonnull final String sql, @Nonnull final Dataset<Row> backing, final Integer limit) {
+    backing.createOrReplaceTempView(VIEW_NAME);
+    try {
+      sqlValidator.validate(sql, Set.of(VIEW_NAME));
+      Dataset<Row> result = sparkSession.sql(sql);
+      sqlValidator.validateAnalyzed(result.queryExecution().analyzed(), Set.of(VIEW_NAME));
+      if (limit != null) {
+        result = result.limit(limit);
+      }
+      return result.collectAsList();
+    } finally {
+      sparkSession.catalog().dropTempView(VIEW_NAME);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Row-cap clamp logic.
+  // -------------------------------------------------------------------------
 
   @Test
   void appliesServerCapWhenCallerHasNoLimit() {

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunProviderIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunProviderIT.java
@@ -150,6 +150,27 @@ class SqlQueryRunProviderIT {
   }
 
   @Test
+  void describeQueryReturnsProjectedSchema() {
+    // DESCRIBE QUERY returns the schema of an arbitrary query without executing it (spec 029 US2).
+    final String sql = "DESCRIBE QUERY SELECT id, name FROM (VALUES (1, 'alice')) AS t(id, name)";
+    final String body =
+        postOk(
+            "/fhir/$sqlquery-run",
+            parametersJson(sqlQueryLibrary(sql), SqlQueryOutputFormat.NDJSON),
+            SqlQueryOutputFormat.NDJSON);
+
+    final String[] lines = body.trim().split("\n");
+    assertThat(lines).hasSize(2);
+    assertThat(body)
+        .contains("\"col_name\":\"id\"")
+        .contains("\"col_name\":\"name\"")
+        .contains("\"data_type\":\"int\"")
+        .contains("\"data_type\":\"string\"");
+    // The query is not executed, so no data values appear.
+    assertThat(body).doesNotContain("alice");
+  }
+
+  @Test
   void rejectsRequestWithNeitherQueryResourceNorQueryReference() {
     final Map<String, Object> parameters = new LinkedHashMap<>();
     parameters.put("resourceType", "Parameters");

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunSecurityIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunSecurityIT.java
@@ -120,6 +120,40 @@ class SqlQueryRunSecurityIT {
     assertThat(body).contains("alice").contains("bob");
   }
 
+  /**
+   * The complete DESCRIBE / SHOW rejection matrix from the feature contract. Every unsafe
+   * introspection form must be rejected at the API boundary with a 400 and an {@code
+   * OperationOutcome} (spec 029 US3 / FR-006 to FR-010). If any of these succeeds, a carve-out in
+   * {@code SqlValidator} is too wide.
+   */
+  @org.junit.jupiter.params.ParameterizedTest(name = "rejects: {0}")
+  @org.junit.jupiter.params.provider.ValueSource(
+      strings = {
+        // Extended / formatted describe leaks storage and catalogue metadata.
+        "DESCRIBE EXTENDED patients",
+        "DESCRIBE FORMATTED patients",
+        // AS JSON form.
+        "DESCRIBE EXTENDED patients AS JSON",
+        // Column and partition forms.
+        "DESCRIBE patients id",
+        "DESCRIBE patients PARTITION (x = 1)",
+        // Undeclared, multi-part, and other-request temp-view targets.
+        "DESCRIBE some_delta_table",
+        "DESCRIBE db.patients",
+        "DESCRIBE sqlquery_abc123_patients",
+        // DESCRIBE QUERY with a forbidden inner query.
+        "DESCRIBE QUERY SELECT * FROM undeclared_table",
+        "DESCRIBE QUERY SELECT reflect('java.lang.System', 'getenv')",
+        // Other catalogue / metadata commands remain rejected.
+        "SHOW COLUMNS FROM patients",
+        "SHOW TABLES",
+        "DESCRIBE FUNCTION abs"
+      })
+  void rejectsUnsafeIntrospectionForms(final String sql) {
+    final String body = postExpect4xx(parametersJson(sqlQueryLibrary(sql)));
+    assertThat(body).contains("OperationOutcome");
+  }
+
   @Test
   void rejectsTvfDosAttack() {
     // The literal exploit recorded in the threat model: a Cartesian product over two range TVFs.

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunWithViewDefinitionsIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunWithViewDefinitionsIT.java
@@ -272,6 +272,26 @@ class SqlQueryRunWithViewDefinitionsIT {
   }
 
   @Test
+  void describeQueryOverRegisteredView() {
+    // DESCRIBE QUERY over a declared view returns the projected column schema through the endpoint
+    // without scanning the view's data (spec 029 US2).
+    final Library library =
+        sqlQueryLibrary(
+            "DESCRIBE QUERY SELECT id, family_name FROM patients", "patients", VIEW_REFERENCE);
+
+    final String body =
+        postOk(
+            "/fhir/$sqlquery-run",
+            parametersJson(library, SqlQueryOutputFormat.NDJSON),
+            SqlQueryOutputFormat.NDJSON);
+
+    final String[] lines = body.trim().split("\n");
+    assertThat(lines).hasSize(2);
+    assertThat(body).contains("\"col_name\":\"id\"").contains("\"col_name\":\"family_name\"");
+    assertThat(body).doesNotContain("Smith");
+  }
+
+  @Test
   void returnsErrorWhenReferencedViewDefinitionDoesNotExist() {
     final Library library =
         sqlQueryLibrary(

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunWithViewDefinitionsIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRunWithViewDefinitionsIT.java
@@ -185,6 +185,92 @@ class SqlQueryRunWithViewDefinitionsIT {
         .contains("\"weight_kg\":\"65\"");
   }
 
+  // -------------------------------------------------------------------------
+  // DESCRIBE <label> against a registered ViewDefinition-backed view returns
+  // the view's column schema through the endpoint (spec 029 US1). The patient
+  // view projects two string columns: id and family_name.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void describesRegisteredViewNdjson() {
+    final Library library = sqlQueryLibrary("DESCRIBE patients", "patients", VIEW_REFERENCE);
+
+    final String body =
+        postOk(
+            "/fhir/$sqlquery-run",
+            parametersJson(library, SqlQueryOutputFormat.NDJSON),
+            SqlQueryOutputFormat.NDJSON);
+
+    final String[] lines = body.trim().split("\n");
+    assertThat(lines).hasSize(2);
+    assertThat(body)
+        .contains("\"col_name\":\"id\"")
+        .contains("\"col_name\":\"family_name\"")
+        .contains("\"data_type\":\"string\"");
+    // No data rows from the view itself leak through.
+    assertThat(body).doesNotContain("Smith").doesNotContain("Johnson");
+  }
+
+  @Test
+  void describeTableFormMatchesPlainForm() {
+    final Library library = sqlQueryLibrary("DESCRIBE TABLE patients", "patients", VIEW_REFERENCE);
+
+    final String body =
+        postOk(
+            "/fhir/$sqlquery-run",
+            parametersJson(library, SqlQueryOutputFormat.NDJSON),
+            SqlQueryOutputFormat.NDJSON);
+
+    assertThat(body.trim().split("\n")).hasSize(2);
+    assertThat(body).contains("\"col_name\":\"id\"").contains("\"col_name\":\"family_name\"");
+  }
+
+  @Test
+  void describeSynonymMatchesPlainForm() {
+    final Library library = sqlQueryLibrary("DESC patients", "patients", VIEW_REFERENCE);
+
+    final String body =
+        postOk(
+            "/fhir/$sqlquery-run",
+            parametersJson(library, SqlQueryOutputFormat.NDJSON),
+            SqlQueryOutputFormat.NDJSON);
+
+    assertThat(body).contains("\"col_name\":\"id\"").contains("\"col_name\":\"family_name\"");
+  }
+
+  @Test
+  void describesRegisteredViewCsvWithHeader() {
+    final Library library = sqlQueryLibrary("DESCRIBE patients", "patients", VIEW_REFERENCE);
+
+    final String body =
+        postOk(
+            "/fhir/$sqlquery-run",
+            parametersJson(library, SqlQueryOutputFormat.CSV, true),
+            SqlQueryOutputFormat.CSV);
+
+    final String[] lines = body.trim().split("\n");
+    assertThat(lines[0].trim()).isEqualTo("col_name,data_type,comment");
+    assertThat(body).contains("id,string").contains("family_name,string");
+  }
+
+  @Test
+  void describesRegisteredViewFhir() {
+    final Library library = sqlQueryLibrary("DESCRIBE patients", "patients", VIEW_REFERENCE);
+
+    final String body =
+        postOk(
+            "/fhir/$sqlquery-run",
+            parametersJson(library, SqlQueryOutputFormat.FHIR),
+            SqlQueryOutputFormat.FHIR);
+
+    // The describe result columns are all strings, so the FHIR complex-type rejection never fires.
+    assertThat(body)
+        .contains("Parameters")
+        .contains("col_name")
+        .contains("id")
+        .contains("family_name");
+  }
+
   @Test
   void returnsErrorWhenReferencedViewDefinitionDoesNotExist() {
     final Library library =
@@ -251,7 +337,24 @@ class SqlQueryRunWithViewDefinitionsIT {
   @Nonnull
   private String parametersJson(
       @Nonnull final Library library, @Nonnull final SqlQueryOutputFormat format) {
-    return parametersJson(library, format, null);
+    return parametersJson(library, format, (Integer) null);
+  }
+
+  @Nonnull
+  private String parametersJson(
+      @Nonnull final Library library,
+      @Nonnull final SqlQueryOutputFormat format,
+      final boolean includeHeader) {
+    final String base = parametersJson(library, format, (Integer) null);
+    final Map<String, Object> parameters = GSON.fromJson(base, Map.class);
+    @SuppressWarnings("unchecked")
+    final List<Map<String, Object>> parameterList =
+        (List<Map<String, Object>>) parameters.get("parameter");
+    final Map<String, Object> headerParam = new LinkedHashMap<>();
+    headerParam.put("name", "header");
+    headerParam.put("valueBoolean", includeHeader);
+    parameterList.add(headerParam);
+    return GSON.toJson(parameters);
   }
 
   @Nonnull

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorIntegrityTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorIntegrityTest.java
@@ -55,6 +55,13 @@ class SqlValidatorIntegrityTest {
     assertThat(resolves(fqn)).as("FQN '%s' did not resolve on the classpath", fqn).isTrue();
   }
 
+  @ParameterizedTest(name = "describe command: {0}")
+  @MethodSource("describeCommandFqns")
+  @DisplayName("Every DESCRIBE carve-out FQN resolves to a class on the classpath")
+  void describeCommandFqnResolves(final String fqn) {
+    assertThat(resolves(fqn)).as("FQN '%s' did not resolve on the classpath", fqn).isTrue();
+  }
+
   static Stream<String> planNodeFqns() {
     return SqlValidator.allowedPlanNodes().stream();
   }
@@ -65,6 +72,10 @@ class SqlValidatorIntegrityTest {
 
   static Stream<String> rejectedExpressionFqns() {
     return SqlValidator.rejectedExpressionNames().stream();
+  }
+
+  static Stream<String> describeCommandFqns() {
+    return SqlValidator.describeCommandNames().stream();
   }
 
   /**

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
@@ -658,6 +658,76 @@ class SqlValidatorTest {
   }
 
   // -------------------------------------------------------------------------
+  // DESCRIBE [QUERY] <query> — the query-introspection form is allowed and its
+  // inner query is validated exactly like a directly submitted query (spec 029
+  // US2). The QUERY keyword is optional in the Spark grammar.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void acceptsDescribeQueryOverDeclaredLabel() {
+    assertThatCode(() -> validate("DESCRIBE QUERY SELECT id FROM patients", "patients"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsDescQueryForm() {
+    assertThatCode(() -> validate("DESC QUERY SELECT id FROM patients", "patients"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsKeywordlessDescribeQuery() {
+    // The QUERY keyword is optional; DESCRIBE SELECT ... parses to the same command.
+    assertThatCode(() -> validate("DESCRIBE SELECT id FROM patients", "patients"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsDescribeQueryWithCte() {
+    assertThatCode(
+            () ->
+                validate(
+                    "DESCRIBE QUERY WITH x AS (SELECT id FROM patients) SELECT * FROM x",
+                    "patients"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void rejectsDescribeQueryOverUndeclaredTable() {
+    assertThatThrownBy(() -> validate("DESCRIBE QUERY SELECT * FROM undeclared", "patients"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("undeclared table");
+  }
+
+  @Test
+  void rejectsDescribeQueryWithReflectFunction() {
+    assertThatThrownBy(
+            () -> validate("DESCRIBE QUERY SELECT reflect('java.lang.System', 'getenv')"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed function");
+  }
+
+  @Test
+  void rejectsDescribeQueryWithNonBuiltInFunction() {
+    assertThatThrownBy(
+            () ->
+                validate(
+                    "DESCRIBE QUERY SELECT member_of(coding, 'http://snomed.info/sct?fhir_vs')"
+                        + " FROM patients",
+                    "patients"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("non-built-in function");
+  }
+
+  @Test
+  void rejectsDescribeQueryWithDisallowedPlanNode() {
+    // The range TVF is a disallowed plan node in the inner query, just as in a submitted query.
+    assertThatThrownBy(() -> validate("DESCRIBE QUERY SELECT * FROM range(0, 100)"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed plan node");
+  }
+
+  // -------------------------------------------------------------------------
   // Invalid SQL syntax.
   // -------------------------------------------------------------------------
 

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
@@ -570,6 +570,94 @@ class SqlValidatorTest {
   }
 
   // -------------------------------------------------------------------------
+  // DESCRIBE [TABLE] <label> — the plain named-view introspection form is
+  // allowed for declared labels; every unsafe variant is rejected at parse
+  // time (issue #2651, spec 029 US1/US3).
+  // -------------------------------------------------------------------------
+
+  @Test
+  void acceptsDescribeOfDeclaredLabel() {
+    assertThatCode(() -> validate("DESCRIBE patients", "patients")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsDescribeTableOfDeclaredLabel() {
+    assertThatCode(() -> validate("DESCRIBE TABLE patients", "patients"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsDescSynonymOfDeclaredLabel() {
+    assertThatCode(() -> validate("DESC patients", "patients")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsLowerCaseDescribeOfDeclaredLabel() {
+    assertThatCode(() -> validate("describe patients", "patients")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void rejectsDescribeExtended() {
+    assertThatThrownBy(() -> validate("DESCRIBE EXTENDED patients", "patients"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed operation")
+        .hasMessageContaining("EXTENDED");
+  }
+
+  @Test
+  void rejectsDescribeFormatted() {
+    assertThatThrownBy(() -> validate("DESCRIBE FORMATTED patients", "patients"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed operation")
+        .hasMessageContaining("EXTENDED");
+  }
+
+  @Test
+  void rejectsDescribeWithPartitionSpec() {
+    assertThatThrownBy(() -> validate("DESCRIBE patients PARTITION (x = 1)", "patients"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed operation")
+        .hasMessageContaining("partition");
+  }
+
+  @Test
+  void rejectsDescribeColumnForm() {
+    assertThatThrownBy(() -> validate("DESCRIBE patients id", "patients"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed operation");
+  }
+
+  @Test
+  void rejectsDescribeExtendedAsJson() {
+    assertThatThrownBy(() -> validate("DESCRIBE EXTENDED patients AS JSON", "patients"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed operation");
+  }
+
+  @Test
+  void rejectsDescribeOfUndeclaredLabel() {
+    assertThatThrownBy(() -> validate("DESCRIBE undeclared", "patients"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("undeclared table");
+  }
+
+  @Test
+  void rejectsDescribeOfMultiPartIdentifier() {
+    assertThatThrownBy(() -> validate("DESCRIBE db.patients", "patients"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("undeclared table");
+  }
+
+  @Test
+  void rejectsDescribeOfTempViewShapedNameNotInLabelSet() {
+    // A name shaped like a request-scoped temp view but not a declared label must be rejected,
+    // so one request cannot introspect another request's views.
+    assertThatThrownBy(() -> validate("DESCRIBE sqlquery_abc123_patients", "patients"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("undeclared table");
+  }
+
+  // -------------------------------------------------------------------------
   // Invalid SQL syntax.
   // -------------------------------------------------------------------------
 

--- a/site/docs/server/operations/sql-run.md
+++ b/site/docs/server/operations/sql-run.md
@@ -252,6 +252,54 @@ User SQL is validated before execution. The following are rejected:
 The query may use standard Spark SQL functions, joins, aggregates, and
 subqueries against the views referenced by the Library.
 
+## Schema introspection
+
+The operation accepts the `DESCRIBE` statement in two read-only, metadata-only
+forms, so consumers can discover the columns and types of a view or query ahead
+of execution without hard-coding that knowledge. Both forms perform no data
+scan and stream their results through the same output formats as an ordinary
+query.
+
+- `DESCRIBE [TABLE] <label>` returns the columns of a view declared as a
+  `relatedArtifact` label in the request. `DESC` is an accepted synonym, and the
+  `TABLE` keyword is optional.
+- `DESCRIBE [QUERY] <query>` returns the columns of an arbitrary query without
+  executing it. The `QUERY` keyword is optional, so `DESCRIBE SELECT ...` is
+  equivalent. The inner query is validated with exactly the same rules as a
+  directly submitted query.
+
+The result has one row per column, with three string columns:
+
+| Column      | Description                                        |
+| ----------- | -------------------------------------------------- |
+| `col_name`  | The column name.                                   |
+| `data_type` | The Spark SQL type (e.g. `string`, `date`, `int`). |
+| `comment`   | The column comment, or null when none is set.      |
+
+For example, submitting `DESCRIBE patients` (with `patients` declared as a
+`relatedArtifact` label) and `Accept: application/x-ndjson` returns:
+
+```
+{"col_name":"id","data_type":"string","comment":null}
+{"col_name":"gender","data_type":"string","comment":null}
+{"col_name":"birth_date","data_type":"date","comment":null}
+```
+
+`DESCRIBE QUERY` returns the schema of the query without reading any of the
+underlying view data.
+
+All other introspection variants remain rejected with a `400`:
+
+- `DESCRIBE EXTENDED` and `DESCRIBE FORMATTED` (they expose storage and
+  catalogue metadata).
+- `DESCRIBE ... AS JSON`.
+- The column form (`DESCRIBE <label> <column>`) and partition form
+  (`DESCRIBE <label> PARTITION (...)`).
+- A target that is not a declared label, including multi-part identifiers,
+  backing tables, and another request's temporary view name.
+- `SHOW COLUMNS` and every other catalogue command (`SHOW TABLES`,
+  `DESCRIBE FUNCTION`, `DESCRIBE DATABASE`, and so on).
+
 ## Runtime parameters
 
 A Library may declare named parameters, which are then bound at execution


### PR DESCRIPTION
Adds schema introspection to the `$sqlquery-run` operation so consumers can discover the columns and types of a registered view or an arbitrary query before running it (closes #2651).

Two read-only, metadata-only `DESCRIBE` forms are now accepted by the SQL validator:

- `DESCRIBE [TABLE] <label>` returns the columns of a view declared as a `relatedArtifact` label.
- `DESCRIBE [QUERY] <query>` returns the columns of an arbitrary query without executing it; the inner query is validated with exactly the same rules as a directly submitted query.

Each result row carries `col_name`, `data_type`, and `comment`, streamed through the existing output formats. Validation is complete at parse time (Spark executes command plans eagerly), with a defence-in-depth check on the analysed plan. Every other `DESCRIBE`/`SHOW` variant - extended, formatted, `AS JSON`, column, partition, undeclared or multi-part targets, another request's temp view, and all other catalogue commands - remains rejected with a 400 `OperationOutcome`.

Coverage: unit tests for the accepted and rejected parse forms and the in-JVM describe pipeline, endpoint integration tests across NDJSON, CSV-with-header, and FHIR formats, and a full rejection matrix at the API boundary. Server documentation for `$sqlquery-run` gains a schema-introspection section.
