### PR TITLE
Accept window functions and frames in $sqlquery-run

### DIFF
--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
@@ -288,6 +288,15 @@ public class SqlValidator {
           "org.apache.spark.sql.catalyst.expressions.WindowSpecDefinition",
           "org.apache.spark.sql.catalyst.expressions.SpecifiedWindowFrame",
           "org.apache.spark.sql.catalyst.expressions.UnspecifiedFrame",
+          // The SpecialFrameBoundary markers for an explicit frame (CURRENT ROW,
+          // UNBOUNDED PRECEDING, UNBOUNDED FOLLOWING). These are leaf, unevaluable
+          // objects describing a frame edge and carry no code-execution risk.
+          "org.apache.spark.sql.catalyst.expressions.CurrentRow",
+          "org.apache.spark.sql.catalyst.expressions.UnboundedPreceding",
+          "org.apache.spark.sql.catalyst.expressions.UnboundedFollowing",
+          // The named-window reference (OVER w) resolved during analysis into the
+          // already-permitted WindowExpression; it is an unevaluable placeholder.
+          "org.apache.spark.sql.catalyst.expressions.UnresolvedWindowExpression",
           // Struct, array, and map expressions.
           "org.apache.spark.sql.catalyst.expressions.CreateNamedStruct",
           "org.apache.spark.sql.catalyst.expressions.CreateArray",

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
@@ -33,11 +33,13 @@ import org.apache.spark.sql.catalyst.catalog.HiveTableRelation;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo;
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression;
+import org.apache.spark.sql.catalyst.expressions.WindowSpecDefinition;
 import org.apache.spark.sql.catalyst.plans.logical.Command;
 import org.apache.spark.sql.catalyst.plans.logical.DescribeRelation;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
 import org.apache.spark.sql.catalyst.plans.logical.UnresolvedWith;
+import org.apache.spark.sql.catalyst.plans.logical.WithWindowDefinition;
 import org.apache.spark.sql.execution.command.DescribeQueryCommand;
 import org.apache.spark.sql.execution.command.DescribeTableCommand;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
@@ -474,6 +476,17 @@ public class SqlValidator {
         walkPlanStrict(cte._2(), allowedLabels);
       }
     }
+    // A WithWindowDefinition node (a WINDOW w AS (...) clause) holds its named-window
+    // specifications in a windowDefinitions map that is neither a tree child nor reported
+    // by plan.expressions(), so the generic walk never reaches it. Walk each definition
+    // explicitly so that a disallowed function hidden in a named window's PARTITION BY,
+    // ORDER BY, or frame bound is rejected just as it is in the inline OVER (...) form.
+    if (plan instanceof final WithWindowDefinition withWindow) {
+      for (final WindowSpecDefinition spec :
+          CollectionConverters.asJava(withWindow.windowDefinitions()).values()) {
+        walkExpressionStrict(spec, allowedLabels);
+      }
+    }
     final List<LogicalPlan> children = CollectionConverters.asJava(plan.children());
     for (final LogicalPlan child : children) {
       walkPlanStrict(child, allowedLabels);
@@ -539,6 +552,16 @@ public class SqlValidator {
     final List<Expression> expressions = CollectionConverters.asJava(plan.expressions());
     for (final Expression expr : expressions) {
       walkExpressionAnalyzed(expr, registeredViewNames);
+    }
+    // Defence in depth: mirror the strict-walk carve-out for any WithWindowDefinition that
+    // survives analysis (for example a pipe-SQL WINDOW clause), whose windowDefinitions map
+    // is not reached by plan.expressions(). The authoritative gate is the strict walk in
+    // validate; ordinary SQL substitutes named windows into Window nodes before this runs.
+    if (plan instanceof final WithWindowDefinition withWindow) {
+      for (final WindowSpecDefinition spec :
+          CollectionConverters.asJava(withWindow.windowDefinitions()).values()) {
+        walkExpressionAnalyzed(spec, registeredViewNames);
+      }
     }
     final boolean childTrust = inTrustedAlias || isTrustedAlias(plan, registeredViewNames);
     final List<LogicalPlan> children = CollectionConverters.asJava(plan.children());

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
@@ -243,6 +243,54 @@ class SqlValidatorTest {
   }
 
   @Test
+  void rejectsReflectionInsideNamedWindowDefinition() {
+    // A named-window definition body is a plan sub-structure the strict walk must
+    // descend into: a reflection-style function hidden in its PARTITION BY must
+    // still be rejected, exactly as it is in the inline form.
+    assertThatThrownBy(
+            () ->
+                validate(
+                    "SELECT sum(x) OVER w FROM t"
+                        + " WINDOW w AS (PARTITION BY java_method('java.lang.Math', 'random')"
+                        + " ORDER BY id)",
+                    "t"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed function");
+  }
+
+  @Test
+  void rejectsUdfInsideNamedWindowDefinitionOrderBy() {
+    // A non-built-in (terminology UDF) function in the ORDER BY of a named window
+    // must also be rejected.
+    assertThatThrownBy(
+            () ->
+                validate(
+                    "SELECT sum(x) OVER w FROM t"
+                        + " WINDOW w AS (PARTITION BY id"
+                        + " ORDER BY member_of(coding, 'http://snomed.info/sct?fhir_vs'))",
+                    "t"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("non-built-in function");
+  }
+
+  @Test
+  void rejectsNonLiteralFunctionInNamedWindowFrameBound() {
+    // A frame bound cannot smuggle a function: Spark's grammar requires the bound
+    // to be a literal, so a function-valued bound is rejected at parse time. This
+    // guards the frame-bound position of a named window's definition body.
+    assertThatThrownBy(
+            () ->
+                validate(
+                    "SELECT sum(x) OVER w FROM t"
+                        + " WINDOW w AS (ORDER BY id"
+                        + " ROWS BETWEEN CAST(java_method('java.lang.Math', 'random') AS INT)"
+                        + " PRECEDING AND CURRENT ROW)",
+                    "t"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("Invalid SQL syntax");
+  }
+
+  @Test
   void acceptsNamedWindowWithRangeFrame() {
     // The reporter's ten-column case reduced to two aggregates that share one
     // named window carrying a RANGE frame with a CURRENT ROW boundary.

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
@@ -25,6 +25,9 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import jakarta.annotation.Nonnull;
 import java.util.Set;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.WithWindowDefinition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -308,6 +311,55 @@ class SqlValidatorTest {
                         + ")",
                     "t"))
         .doesNotThrowAnyException();
+  }
+
+  // -------------------------------------------------------------------------
+  // Analysed-plan defence in depth for named windows (US2, #2649). Ordinary SQL
+  // substitutes named windows into Window nodes before analysis, so a
+  // WithWindowDefinition normally never reaches the analysed-plan walk, and its
+  // windowDefinitions map is not reachable through plan.expressions(). The walk
+  // nonetheless descends into any WithWindowDefinition that survives, so that a
+  // definition body cannot become a blind spot. These tests force that branch
+  // by wrapping a real named-window definition map around an already-validated
+  // child.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void walksCleanBodyOfSurvivingWithWindowDefinition() throws ParseException {
+    // A clean named-window body passes: the walk reaches into the definition and
+    // finds nothing disallowed.
+    final WithWindowDefinition node =
+        withWindowNode("SELECT 1 FROM t WINDOW w AS (PARTITION BY id ORDER BY ts)");
+    assertThatCode(() -> sqlValidator.validateAnalyzed(node, Set.of())).doesNotThrowAnyException();
+  }
+
+  @Test
+  void rejectsReflectionInBodyOfSurvivingWithWindowDefinition() throws ParseException {
+    // A reflection-style function hidden in a surviving named-window definition
+    // must still be rejected by the analysed-plan walk, mirroring the strict-walk
+    // carve-out.
+    final WithWindowDefinition node =
+        withWindowNode(
+            "SELECT 1 FROM t WINDOW w AS ("
+                + "PARTITION BY java_method('java.lang.Math', 'random') ORDER BY id)");
+    assertThatThrownBy(() -> sqlValidator.validateAnalyzed(node, Set.of()))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed function");
+  }
+
+  /**
+   * Builds a {@link WithWindowDefinition} that carries a real named-window definition map (parsed
+   * from the given WINDOW-clause SQL) but a trivial, already-validated child. This forces the
+   * analysed-plan walk through the WithWindowDefinition branch that ordinary SQL elides during
+   * analysis, where named windows are substituted into Window nodes before the walk runs.
+   */
+  @Nonnull
+  private WithWindowDefinition withWindowNode(@Nonnull final String windowSql)
+      throws ParseException {
+    final LogicalPlan source = sparkSession.sessionState().sqlParser().parsePlan(windowSql);
+    final WithWindowDefinition parsed = (WithWindowDefinition) source;
+    final LogicalPlan cleanChild = sparkSession.sql("SELECT 1 AS id").queryExecution().analyzed();
+    return new WithWindowDefinition(parsed.windowDefinitions(), cleanChild, false);
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
@@ -160,6 +160,108 @@ class SqlValidatorTest {
         .doesNotThrowAnyException();
   }
 
+  // -------------------------------------------------------------------------
+  // Explicit window frames (US1, #2650). An inline frame with the CURRENT ROW,
+  // UNBOUNDED PRECEDING, and UNBOUNDED FOLLOWING boundary markers must be
+  // accepted. Before the fix, the CURRENT ROW boundary was rejected as
+  // "CurrentRow$" (the Scala case-object runtime name). Value-based bounds
+  // (N PRECEDING / N FOLLOWING) were already permitted and are covered here as
+  // a non-regression guard.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void acceptsWindowFrameWithCurrentRow() {
+    // The reporter's "rolling worst value over the prior 24 hours per patient"
+    // form, reduced to the window construct over a declared label.
+    assertThatCode(
+            () ->
+                validate(
+                    "SELECT patient_id, min(value) OVER ("
+                        + "  PARTITION BY patient_id"
+                        + "  ORDER BY obs_time"
+                        + "  RANGE BETWEEN INTERVAL '24' HOUR PRECEDING AND CURRENT ROW"
+                        + ") AS worst_value FROM t",
+                    "t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsWindowFrameWithUnboundedPrecedingToCurrentRow() {
+    assertThatCode(
+            () ->
+                validate(
+                    "SELECT sum(x) OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT"
+                        + " ROW) FROM t",
+                    "t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsWindowFrameWithUnboundedBounds() {
+    assertThatCode(
+            () ->
+                validate(
+                    "SELECT sum(x) OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED"
+                        + " FOLLOWING) FROM t",
+                    "t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsValueBoundedWindowFrame() {
+    // Value bounds parse to ordinary arithmetic expressions (UnaryMinus over a
+    // Literal), which are already permitted, so this needs no new allow-list
+    // entry; it guards against a regression in that reasoning.
+    assertThatCode(
+            () ->
+                validate(
+                    "SELECT avg(x) OVER (ORDER BY id ROWS BETWEEN 3 PRECEDING AND 1 FOLLOWING)"
+                        + " FROM t",
+                    "t"))
+        .doesNotThrowAnyException();
+  }
+
+  // -------------------------------------------------------------------------
+  // Named window definitions (US2, #2649). A SELECT that references a named
+  // window via OVER w with a matching WINDOW w AS (...) clause must be
+  // accepted. Before the fix, the named-window reference was rejected as
+  // "UnresolvedWindowExpression". The frameless form isolates that gate; the
+  // frame-bearing form additionally relies on US1's boundary additions.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void acceptsFramelessNamedWindow() {
+    // No explicit frame, so this fails only on UnresolvedWindowExpression and
+    // remains red until US2, isolating that gate from US1's frame boundaries.
+    assertThatCode(
+            () ->
+                validate(
+                    "SELECT patient_id, min(value) OVER w AS worst_value FROM t"
+                        + " WINDOW w AS (PARTITION BY patient_id ORDER BY obs_time)",
+                    "t"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsNamedWindowWithRangeFrame() {
+    // The reporter's ten-column case reduced to two aggregates that share one
+    // named window carrying a RANGE frame with a CURRENT ROW boundary.
+    assertThatCode(
+            () ->
+                validate(
+                    "SELECT patient_id,"
+                        + "  min(value) OVER w AS worst_min,"
+                        + "  max(value) OVER w AS worst_max"
+                        + " FROM t"
+                        + " WINDOW w AS ("
+                        + "  PARTITION BY patient_id"
+                        + "  ORDER BY obs_time"
+                        + "  RANGE BETWEEN INTERVAL '24' HOUR PRECEDING AND CURRENT ROW"
+                        + ")",
+                    "t"))
+        .doesNotThrowAnyException();
+  }
+
   @Test
   void acceptsSelectWithDistinct() {
     assertThatCode(() -> validate("SELECT DISTINCT name FROM t", "t")).doesNotThrowAnyException();


### PR DESCRIPTION
Window functions are a standard, spec-valid part of Spark SQL and are a natural fit for the kind of read-only analytic queries `$sqlquery-run` is meant to serve (for example, computing a rolling "worst value over the prior 24 hours" per patient). Until now the SqlValidator allow-list rejected them before the query could run, in two different ways depending on how the window was written.

A named window (`WINDOW w AS (...)` referenced via `OVER w`) failed as `UnresolvedWindowExpression`, and an inline frame (`OVER (... RANGE BETWEEN INTERVAL '24' HOUR PRECEDING AND CURRENT ROW)`) failed as `CurrentRow$`. Both forms are now accepted: the allow-list permits window expressions, window spec definitions, named-window references, and window frame boundary nodes. These are all planning-only, pure read expressions that perform no writes.

Resolves #2649 and #2650.
