### PR TITLE
Remove hardcoded JVM debug port from library test fixtures

### DIFF
--- a/lib/R/tests/testthat/helper_default.R
+++ b/lib/R/tests/testthat/helper_default.R
@@ -7,7 +7,6 @@ def_spark <- function() {
     master = "local[1]",
     config = list(
       "sparklyr.shell.driver-memory" = "4G",
-      "sparklyr.shell.driver-java-options" = '"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=7896"',
       "sparklyr.shell.conf" = c(
         "spark.sql.mapKeyDedupPolicy=LAST_WIN",
         "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension",

--- a/lib/python/tests/conftest.py
+++ b/lib/python/tests/conftest.py
@@ -71,10 +71,6 @@ def pathling_ctx(request, temp_warehouse_dir):
         .config("spark.driver.memory", "4g")
         .config("spark.sql.mapKeyDedupPolicy", "LAST_WIN")
         .config(
-            "spark.driver.extraJavaOptions",
-            "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=7896",
-        )
-        .config(
             "spark.jars.packages",
             f"au.csiro.pathling:library-runtime:{__java_version__},"
             f"io.delta:delta-spark_{__scala_version__}:{__delta_version__}",


### PR DESCRIPTION
The Python and R test fixtures opened a JDWP debug socket on a fixed port (7896), which caused a bind collision and JVM startup failure whenever two test sessions ran concurrently on the same machine.

This removes the debug agent from both fixtures. It is not needed for normal test runs, and developers who need JVM debugging can use the opt-in `enable_remote_debugging` and `debug_port` options on `PathlingContext.create()`.

Closes #2653