### PR TITLE
Unauthenticated requests return 401 instead of 500

### DIFF
--- a/.github/actions/setup-r/action.yml
+++ b/.github/actions/setup-r/action.yml
@@ -40,7 +40,22 @@ runs:
     - name: Set up TinyTeX
       uses: r-lib/actions/setup-tinytex@v2
 
-    # libcurl is required for building the R package documentation.
-    - name: Install libcurl
+    # Native libraries required to build the R package and its documentation
+    # toolchain from source. When the R package cache misses, devtools and
+    # pkgdown are compiled from source, which pulls in systemfonts, textshaping
+    # and ragg. Those packages need the font (fontconfig, freetype, harfbuzz,
+    # fribidi) and image (png, tiff, jpeg) development headers, and libcurl is
+    # needed for the documentation build.
+    - name: Install system libraries
       shell: bash
-      run: sudo apt-get install -y libcurl4-openssl-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libcurl4-openssl-dev \
+          libfontconfig1-dev \
+          libfreetype-dev \
+          libharfbuzz-dev \
+          libfribidi-dev \
+          libpng-dev \
+          libtiff-dev \
+          libjpeg-dev

--- a/library-runtime/pom.xml
+++ b/library-runtime/pom.xml
@@ -123,12 +123,17 @@
             </filter>
             <!-- Servlet API classes belong to the runtime environment (server, Spark
                  distribution); bundling them shadows the environment's own version and
-                 causes NoSuchMethodError on newer servlet API methods. -->
+                 causes NoSuchMethodError on newer servlet API methods. The only classes
+                 retained are the ones that were removed in Servlet 6.0 - they cannot
+                 shadow anything in a Servlet 6 environment, and Spark's shaded Jetty
+                 still links against them when starting the Spark UI. -->
             <filter>
               <artifact>jakarta.servlet:jakarta.servlet-api</artifact>
-              <excludes>
-                <exclude>**</exclude>
-              </excludes>
+              <includes>
+                <include>jakarta/servlet/SingleThreadModel.class</include>
+                <include>jakarta/servlet/http/HttpSessionContext.class</include>
+                <include>jakarta/servlet/http/HttpUtils.class</include>
+              </includes>
             </filter>
           </filters>
           <transformers>

--- a/library-runtime/pom.xml
+++ b/library-runtime/pom.xml
@@ -121,6 +121,15 @@
                 <exclude>**</exclude>
               </excludes>
             </filter>
+            <!-- Servlet API classes belong to the runtime environment (server, Spark
+                 distribution); bundling them shadows the environment's own version and
+                 causes NoSuchMethodError on newer servlet API methods. -->
+            <filter>
+              <artifact>jakarta.servlet:jakarta.servlet-api</artifact>
+              <excludes>
+                <exclude>**</exclude>
+              </excludes>
+            </filter>
           </filters>
           <transformers>
             <transformer

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -421,11 +421,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>jakarta.servlet</groupId>
-        <artifactId>jakarta.servlet-api</artifactId>
-        <version>6.0.0</version>
-      </dependency>
       <!-- Override Spark's Avro version to fix CVE-2025-33042. -->
       <dependency>
         <groupId>org.apache.avro</groupId>

--- a/server/src/main/java/au/csiro/pathling/config/SecurityConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/SecurityConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
@@ -113,6 +114,12 @@ public class SecurityConfiguration {
                       .authenticated())
           // Enable CORS as per the configuration.
           .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+          // This is a stateless bearer-token API: every request carries its own credentials, so
+          // no HTTP session or session cookie is ever needed. This also prevents the security
+          // layer from attempting to save unauthenticated requests to a session during 401
+          // handling.
+          .sessionManagement(
+              session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
           // Use the provided JWT decoder and authentication converter.
           .oauth2ResourceServer(
               oauth2 ->

--- a/server/src/test/java/au/csiro/pathling/test/integration/AuthenticationChallengeTest.java
+++ b/server/src/test/java/au/csiro/pathling/test/integration/AuthenticationChallengeTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.test.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import au.csiro.pathling.security.OidcConfiguration;
+import au.csiro.pathling.security.OidcConfiguration.ConfigItem;
+import jakarta.servlet.http.HttpSessionEvent;
+import jakarta.servlet.http.HttpSessionListener;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Verifies that an auth-enabled server issues a clean HTTP 401 challenge for unauthenticated
+ * requests, never creates HTTP sessions or emits session cookies, and leaves public endpoints
+ * accessible.
+ *
+ * @author John Grimes
+ */
+@TestPropertySource(
+    properties = {
+      "pathling.auth.enabled=true",
+      "pathling.auth.issuer=https://auth.ontoserver.csiro.au/auth/realms/aehrc",
+      "pathling.auth.audience=https://pathling.acme.com/fhir"
+    })
+@Tag("Tranche2")
+class AuthenticationChallengeTest extends IntegrationTest {
+
+  @LocalServerPort int port;
+
+  TestRestTemplate restTemplate;
+
+  @MockitoBean private JwtDecoder jwtDecoder;
+
+  @MockitoBean private JwtAuthenticationConverter jwtAuthenticationConverter;
+
+  @Autowired private SessionCreationRecorder sessionCreationRecorder;
+
+  @BeforeEach
+  void setup() {
+    // The JDK request factory is used so that response headers are reported faithfully.
+    restTemplate =
+        new TestRestTemplate(
+            new RestTemplateBuilder().requestFactory(JdkClientHttpRequestFactory.class));
+    // Any token offered to the decoder is rejected as invalid.
+    when(jwtDecoder.decode(anyString())).thenThrow(new BadJwtException("Invalid token"));
+    sessionCreationRecorder.reset();
+  }
+
+  @Test
+  void tokenlessRequestReceivesChallengeWithoutSession() {
+    // A request with no Authorization header to a protected endpoint must be challenged. The
+    // browser-like Accept header matters: it is what makes Spring Security's request cache
+    // attempt to save the request in an HTTP session, which is the code path that must never
+    // create a session on a stateless bearer-token API.
+    final HttpHeaders headers = new HttpHeaders();
+    headers.set(HttpHeaders.ACCEPT, "text/html,application/xhtml+xml");
+    final ResponseEntity<String> response =
+        restTemplate.exchange(
+            "http://localhost:" + port + "/fhir/Patient",
+            HttpMethod.GET,
+            new HttpEntity<String>(headers),
+            String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE)).startsWith("Bearer");
+    // No session may be created and no session cookie may be emitted.
+    assertThat(response.getHeaders().get(HttpHeaders.SET_COOKIE)).isNull();
+    assertThat(sessionCreationRecorder.getCount()).isZero();
+  }
+
+  @Test
+  void invalidTokenReceivesChallengeWithErrorDetailAndWithoutSession() {
+    // A request bearing a token the decoder rejects must be challenged with error detail.
+    final HttpHeaders headers = new HttpHeaders();
+    headers.set(HttpHeaders.ACCEPT, "text/html,application/xhtml+xml");
+    headers.setBearerAuth("not-a-valid-token");
+    final ResponseEntity<String> response =
+        restTemplate.exchange(
+            "http://localhost:" + port + "/fhir/Patient",
+            HttpMethod.GET,
+            new HttpEntity<String>(headers),
+            String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE))
+        .startsWith("Bearer")
+        .contains("error=\"invalid_token\"");
+    // No session may be created and no session cookie may be emitted.
+    assertThat(response.getHeaders().get(HttpHeaders.SET_COOKIE)).isNull();
+    assertThat(sessionCreationRecorder.getCount()).isZero();
+  }
+
+  @Test
+  void publicEndpointRemainsAccessibleWithoutToken() {
+    // The capability statement is a public endpoint and must not require authentication.
+    final ResponseEntity<String> response =
+        restTemplate.exchange(
+            "http://localhost:" + port + "/fhir/metadata",
+            HttpMethod.GET,
+            new HttpEntity<String>(new HttpHeaders()),
+            String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    // Public endpoints must be session-free as well.
+    assertThat(response.getHeaders().get(HttpHeaders.SET_COOKIE)).isNull();
+    assertThat(sessionCreationRecorder.getCount()).isZero();
+  }
+
+  /**
+   * Records HTTP session creations so tests can assert that the server never creates a session. The
+   * client-visible {@code Set-Cookie} header alone is not a sufficient signal, because a session
+   * created after the response has been committed (as happens during the error dispatch of a 401)
+   * produces no cookie yet still exercises the session-cookie code path that failed in production.
+   */
+  static class SessionCreationRecorder implements HttpSessionListener {
+
+    private final AtomicInteger count = new AtomicInteger();
+
+    @Override
+    public void sessionCreated(final HttpSessionEvent event) {
+      count.incrementAndGet();
+    }
+
+    int getCount() {
+      return count.get();
+    }
+
+    void reset() {
+      count.set(0);
+    }
+  }
+
+  @TestConfiguration
+  public static class AuthenticationChallengeTestDependencies {
+
+    @Bean
+    SessionCreationRecorder sessionCreationRecorder() {
+      return new SessionCreationRecorder();
+    }
+
+    @Bean
+    ServletListenerRegistrationBean<HttpSessionListener> sessionListenerRegistration(
+        final SessionCreationRecorder recorder) {
+      return new ServletListenerRegistrationBean<>(recorder);
+    }
+
+    @Bean
+    @Primary
+    OidcConfiguration oidcConfiguration() {
+      // A canned OIDC configuration avoids network access to the issuer during startup.
+      final Map<String, Object> oidcConfiguration = new HashMap<>();
+      oidcConfiguration.put(
+          ConfigItem.AUTH_URL.getKey(),
+          "https://auth.ontoserver.csiro.au/auth/realms/aehrc/protocol/openid-connect/auth");
+      oidcConfiguration.put(
+          ConfigItem.TOKEN_URL.getKey(),
+          "https://auth.ontoserver.csiro.au/auth/realms/aehrc/protocol/openid-connect/token");
+      oidcConfiguration.put(
+          ConfigItem.REVOKE_URL.getKey(),
+          "https://auth.ontoserver.csiro.au/auth/realms/aehrc/protocol/openid-connect/revoke");
+      return new OidcConfiguration(oidcConfiguration);
+    }
+  }
+}


### PR DESCRIPTION
On an auth-enabled server, any request without a valid bearer token was failing with a 500 (`NoSuchMethodError: jakarta.servlet.http.Cookie.setAttribute`) instead of a clean 401 challenge. This fixes it at both levels:

- The `library-runtime` fat jar no longer bundles Spark's transitive Servlet 5.0 API classes, which were shadowing the server's Servlet 6.0 API on the image classpath. The only classes retained are the three that were removed in Servlet 6.0 (`SingleThreadModel`, `HttpSessionContext`, `HttpUtils`) - Spark's shaded Jetty still links against them when starting the Spark UI, and they cannot shadow a Servlet 6 environment.
- The auth-enabled security filter chain now uses a stateless session policy, so Spring Security never attempts to save unauthenticated requests to an HTTP session or emit session cookies. A new integration test pins the 401 challenge behaviour and asserts via a session listener that no session is ever created.
- The now-redundant `jakarta.servlet-api` version pin has been removed from the server POM; Spring Boot's dependency management resolves the correct version on its own.