### PR TITLE
Verify the core libraries with one CI job per module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,11 @@ jobs:
       fail-fast: false
       matrix:
         module:
+          - utilities
+          - encoders
           - terminology
+          - fhirpath
+          - library-api
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -130,7 +134,7 @@ jobs:
       - name: Run tests
         run: |
           mvn --batch-mode verify \
-          -pl ${{ matrix.module }} -Dpathling.testForkCount=1
+          -pl ${{ matrix.module }}
         timeout-minutes: 40
 
       # The coverage and report files are collected into a single archive so that the SonarCloud job
@@ -259,7 +263,7 @@ jobs:
     needs: [detect-changes, test-core]
     # Analysis is only meaningful once every module has reported its coverage; a partial set would
     # be published as a drop in coverage.
-    if: false && needs.detect-changes.outputs.core == 'true' && needs.test-core.result == 'success'
+    if: needs.detect-changes.outputs.core == 'true' && needs.test-core.result == 'success'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -315,6 +315,28 @@ jobs:
           -pl '!site,!benchmark,!lib/R'
         timeout-minutes: 10
 
+      # A module's cross-module coverage view can only be built where the whole reactor is present,
+      # which no longer holds in the individual test jobs. This job has every module's execution data
+      # restored, so the aggregate reports are regenerated here instead. It runs after the analysis so
+      # that what SonarCloud reads is left exactly as the test jobs produced it, and without
+      # -DskipTests, which would otherwise disable JaCoCo. The reported figures are identical to those
+      # of a single-reactor build; only the annotated source listings for the Scala and generated
+      # sources are absent, because their source roots are registered during a full build.
+      - name: Generate aggregate coverage reports
+        if: always()
+        run: |
+          mvn --batch-mode jacoco:report-aggregate \
+          -pl '!site,!benchmark,!lib/R'
+        timeout-minutes: 10
+
+      - name: Save aggregate coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aggregate-coverage-reports
+          path: "**/target/site/jacoco-aggregate/"
+          if-no-files-found: warn
+
   test-ui:
     name: Test UI
     needs: detect-changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,8 @@
 # This workflow will build the software to ensure there are no errors, and also execute the tests.
+#
+# The core libraries are verified by a fan-out of one job per module. The module test suites are
+# independent of each other, so running them on separate runners multiplies the processors available
+# to the suite as a whole. Each job builds only the modules it depends upon, and skips their tests.
 
 name: Test
 
@@ -41,8 +45,10 @@ jobs:
             server:
               - 'server/**'
 
-  build-and-test:
-    name: Build and test
+  # Produces the JARs that the server and benchmark workflows consume. This is deliberately
+  # separate from the test jobs so that downstream workflows do not wait on the test suites.
+  build-core:
+    name: Build core libraries
     runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.core == 'true'
@@ -61,25 +67,240 @@ jobs:
         uses: ./.github/actions/setup-build-tools
         with:
           java: "true"
-          r: "true"
-          python: "true"
-          spark: "true"
-          sonar-cache: "true"
 
       - name: Get project version
         id: get-version
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Pathling version: $VERSION"
 
-      - name: Run install goal
+      - name: Build core libraries
+        run: |
+          mvn --batch-mode install -DskipTests \
+          -pl library-runtime -am
+        timeout-minutes: 20
+
+      - name: Save built JARs
+        uses: actions/upload-artifact@v4
+        with:
+          name: jars
+          path: |
+            utilities/target/utilities-*.jar
+            encoders/target/encoders-*.jar
+            terminology/target/terminology-*.jar
+            fhirpath/target/fhirpath-*.jar
+            library-api/target/library-api-*.jar
+            library-runtime/target/library-runtime-*.jar
+          if-no-files-found: error
+
+  test-core:
+    name: Test ${{ matrix.module }}
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.core == 'true'
+    permissions:
+      contents: read
+    strategy:
+      # Report every module's result, rather than cancelling the siblings on the first failure.
+      fail-fast: false
+      matrix:
+        module:
+          - utilities
+          - encoders
+          - terminology
+          - fhirpath
+          - library-api
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # The full history is required by the license header check, which derives the copyright
+          # years from the commit history.
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up build environment
+        uses: ./.github/actions/setup-build-tools
+        with:
+          java: "true"
+
+      - name: Build dependencies
+        run: |
+          mvn --batch-mode install -DskipTests \
+          -pl ${{ matrix.module }} -am
+        timeout-minutes: 20
+
+      - name: Run tests
+        run: |
+          mvn --batch-mode verify \
+          -pl ${{ matrix.module }}
+        timeout-minutes: 40
+
+      # The coverage and report files are collected into a single archive so that the SonarCloud job
+      # can restore them at their original paths. Uploading them directly would strip the leading
+      # directories, because the artifact is rooted at the paths' common ancestor. The generated
+      # coverage report is included, not just the execution data, because the SonarCloud job builds
+      # with the tests skipped and JaCoCo is disabled in that case.
+      - name: Archive test reports and coverage
+        if: always()
+        run: |
+          paths=()
+          for path in "${{ matrix.module }}/target/jacoco.exec" \
+                      "${{ matrix.module }}/target/site/jacoco" \
+                      "${{ matrix.module }}/target/site/jacoco-aggregate" \
+                      "${{ matrix.module }}/target/surefire-reports"; do
+            if [ -e "${path}" ]; then
+              paths+=("${path}")
+            fi
+          done
+          if [ ${#paths[@]} -eq 0 ]; then
+            echo "::warning::No test reports or coverage were produced."
+            exit 0
+          fi
+          tar --create --file "reports-${{ matrix.module }}.tar" "${paths[@]}"
+
+      - name: Save test reports and coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-${{ matrix.module }}
+          path: reports-${{ matrix.module }}.tar
+          if-no-files-found: warn
+
+  test-python:
+    name: Test Python API
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.core == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up build environment
+        uses: ./.github/actions/setup-build-tools
+        with:
+          java: "true"
+          python: "true"
+          spark: "true"
+
+      - name: Build core libraries
+        run: |
+          mvn --batch-mode install -DskipTests \
+          -pl library-runtime -am
+        timeout-minutes: 20
+
+      - name: Build and test Python API
+        run: mvn --batch-mode install -pl lib/python
+        timeout-minutes: 30
+
+      - name: Save coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-coverage-reports
+          path: lib/python/target/coverage/
+
+      - name: Save Python wheel
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-wheel
+          path: lib/python/target/py-dist/pathling-*.whl
+
+  test-r:
+    name: Test R API
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.core == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up build environment
+        uses: ./.github/actions/setup-build-tools
+        with:
+          java: "true"
+          r: "true"
+          spark: "true"
+
+      - name: Build core libraries
+        run: |
+          mvn --batch-mode install -DskipTests \
+          -pl library-runtime -am
+        timeout-minutes: 20
+
+      - name: Build and test R API
         env:
           R_KEEP_PKG_SOURCE: yes
+        run: mvn --batch-mode install -pl lib/R
+        timeout-minutes: 45
+
+      - name: Save R package
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: r-package
+          path: lib/R/target/pathling_*.tar.gz
+
+  # SonarCloud needs coverage from every module at once, so it runs after the test jobs and
+  # restores their reports. The R module is excluded because SonarCloud does not analyse R, and
+  # building it would mean installing the whole R toolchain again. Python coverage is not imported
+  # by SonarCloud, so this job does not wait on the Python tests.
+  sonar:
+    name: SonarCloud analysis
+    runs-on: ubuntu-latest
+    needs: [detect-changes, test-core]
+    # Analysis is only meaningful once every module has reported its coverage; a partial set would
+    # be published as a drop in coverage.
+    if: needs.detect-changes.outputs.core == 'true' && needs.test-core.result == 'success'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up build environment
+        uses: ./.github/actions/setup-build-tools
+        with:
+          java: "true"
+          python: "true"
+          sonar-cache: "true"
+
+      - name: Download test reports and coverage
+        uses: actions/download-artifact@v4
+        with:
+          pattern: reports-*
+          merge-multiple: true
+          path: reports
+
+      - name: Restore test reports and coverage
         run: |
-          mvn --batch-mode install \
-          -pl '!site,!benchmark'
-        timeout-minutes: 60
+          for archive in reports/*.tar; do
+            echo "Restoring ${archive}"
+            tar --extract --file "${archive}"
+          done
+
+      # The tests are skipped, which also disables JaCoCo, so the restored coverage reports are left
+      # untouched by this build.
+      - name: Build without tests
+        run: |
+          mvn --batch-mode install -DskipTests \
+          -pl '!site,!benchmark,!lib/R'
+        timeout-minutes: 30
 
       - name: Run SonarCloud analysis
         # Secrets are not available for pull requests from forks.
@@ -91,16 +312,8 @@ jobs:
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
           -Dsonar.projectKey=aehrc_pathling -Dsonar.organization=aehrc \
           -Dsonar.host.url=https://sonarcloud.io \
-          -pl '!site,!benchmark'
+          -pl '!site,!benchmark,!lib/R'
         timeout-minutes: 10
-
-      - name: Upload test artifacts
-        if: always()
-        uses: ./.github/actions/upload-test-artifacts
-        with:
-          include-jars: "true"
-          include-python: "true"
-          include-r: "true"
 
   test-ui:
     name: Test UI
@@ -110,14 +323,14 @@ jobs:
 
   test-server:
     name: Test server
-    needs: [detect-changes, build-and-test]
+    needs: [detect-changes, build-core]
     if: |
       always() &&
       needs.detect-changes.outputs.server == 'true' &&
       needs.detect-changes.result == 'success' &&
-      (needs.build-and-test.result == 'success' || needs.build-and-test.result == 'skipped')
+      (needs.build-core.result == 'success' || needs.build-core.result == 'skipped')
     uses: ./.github/workflows/server-test.yml
     secrets: inherit
     with:
       download-library-jars: ${{ needs.detect-changes.outputs.core == 'true' }}
-      pathling-version: ${{ needs.build-and-test.outputs.pathling-version }}
+      pathling-version: ${{ needs.build-core.outputs.pathling-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,11 +106,7 @@ jobs:
       fail-fast: false
       matrix:
         module:
-          - utilities
-          - encoders
           - terminology
-          - fhirpath
-          - library-api
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -134,7 +130,7 @@ jobs:
       - name: Run tests
         run: |
           mvn --batch-mode verify \
-          -pl ${{ matrix.module }}
+          -pl ${{ matrix.module }} -Dpathling.testForkCount=1
         timeout-minutes: 40
 
       # The coverage and report files are collected into a single archive so that the SonarCloud job
@@ -263,7 +259,7 @@ jobs:
     needs: [detect-changes, test-core]
     # Analysis is only meaningful once every module has reported its coverage; a partial set would
     # be published as a drop in coverage.
-    if: needs.detect-changes.outputs.core == 'true' && needs.test-core.result == 'success'
+    if: false && needs.detect-changes.outputs.core == 'true' && needs.test-core.result == 'success'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,10 +253,12 @@ jobs:
           name: r-package
           path: lib/R/target/pathling_*.tar.gz
 
-  # SonarCloud needs coverage from every module at once, so it runs after the test jobs and
-  # restores their reports. The R module is excluded because SonarCloud does not analyse R, and
-  # building it would mean installing the whole R toolchain again. Python coverage is not imported
-  # by SonarCloud, so this job does not wait on the Python tests.
+  # SonarCloud needs coverage from every module at once, so it runs after the test jobs and restores
+  # their reports. The language library modules are left out of the reactor: SonarCloud indexes no
+  # files from either of them, because their sources sit outside the Maven source roots that the
+  # scanner derives its inputs from. Building them would mean installing the R toolchain and
+  # synchronising the Python environment for no analysis in return. For the same reason this job does
+  # not wait on the Python tests.
   sonar:
     name: SonarCloud analysis
     runs-on: ubuntu-latest
@@ -277,7 +279,6 @@ jobs:
         uses: ./.github/actions/setup-build-tools
         with:
           java: "true"
-          python: "true"
           sonar-cache: "true"
 
       - name: Download test reports and coverage
@@ -299,7 +300,7 @@ jobs:
       - name: Build without tests
         run: |
           mvn --batch-mode install -DskipTests \
-          -pl '!site,!benchmark,!lib/R'
+          -pl '!site,!benchmark,!lib/R,!lib/python'
         timeout-minutes: 30
 
       - name: Run SonarCloud analysis
@@ -312,7 +313,7 @@ jobs:
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
           -Dsonar.projectKey=aehrc_pathling -Dsonar.organization=aehrc \
           -Dsonar.host.url=https://sonarcloud.io \
-          -pl '!site,!benchmark,!lib/R'
+          -pl '!site,!benchmark,!lib/R,!lib/python'
         timeout-minutes: 10
 
       # A module's cross-module coverage view can only be built where the whole reactor is present,
@@ -326,7 +327,7 @@ jobs:
         if: always()
         run: |
           mvn --batch-mode jacoco:report-aggregate \
-          -pl '!site,!benchmark,!lib/R'
+          -pl '!site,!benchmark,!lib/R,!lib/python'
         timeout-minutes: 10
 
       - name: Save aggregate coverage reports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,30 @@ To build and install locally, run:
 mvn clean install -pl library-runtime -am
 ```
 
+### Test execution time
+
+Around 90% of a core library build is spent running the tests, so that is where
+any effort to shorten the build belongs.
+
+The tests are run in parallel across Surefire forks, one fork per available
+processor. This is controlled by the `pathling.testForkCount` property, which
+accepts either an absolute number of forks or a multiple of the processor count:
+
+```bash
+mvn install -pl library-runtime -am -Dpathling.testForkCount=4
+```
+
+One fork per processor is the fastest setting measured for a build that has the
+machine to itself. Raising it is counterproductive, because each fork holds its
+own Spark session: doubling the fork count makes the `fhirpath` suite around 70%
+slower. Lower it when the build has to share the machine.
+
+Because forks are allocated a whole test class at a time, a module's test suite
+can never finish faster than its slowest single class. On a machine with eight or
+more processors this, rather than the total amount of work, is what sets the
+build time for every core module. If you add a long-running test class, consider
+whether it can be split.
+
 ## Language libraries
 
 ### Python library

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
     <pathling.derbyVersion>10.16.1.1</pathling.derbyVersion>
     <pathling.bulkExportVersion>1.0.5-SNAPSHOT</pathling.bulkExportVersion>
     <pathling.fhirAuthVersion>1.0.0</pathling.fhirAuthVersion>
+
+    <!-- The number of concurrent Surefire forks, expressed as a multiple of the available
+         processors. One fork per processor is the fastest setting measured for a build that has the
+         machine to itself: doubling it makes the fhirpath suite around 70% slower, because every
+         fork holds its own Spark session. Lower it when the build has to share the machine. -->
+    <pathling.testForkCount>1C</pathling.testForkCount>
   </properties>
 
   <modules>
@@ -742,7 +748,7 @@
             <!-- -Djava.security.manager=allow permits NoNetworkExtension to install a transient
                  security manager that verifies terminology tests make no external network calls -->
             <argLine>@{argLine} -Xshare:off -Xmx4g -ea -Duser.timezone=UTC -XX:+EnableDynamicAgentLoading -Djava.security.manager=allow --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED</argLine>
-            <forkCount>1C</forkCount>
+            <forkCount>${pathling.testForkCount}</forkCount>
             <failIfNoTests>false</failIfNoTests>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1096,6 +1096,14 @@
               <artifactId>license-maven-plugin-git</artifactId>
               <version>5.0.0</version>
             </dependency>
+            <!-- The JGit version bundled with the plugin cannot open a linked Git worktree, which
+                 makes the check fail with "Bare Repository has neither a working tree, nor an
+                 index" whenever the build runs outside the main checkout. -->
+            <dependency>
+              <groupId>org.eclipse.jgit</groupId>
+              <artifactId>org.eclipse.jgit</artifactId>
+              <version>7.4.0.202509020913-r</version>
+            </dependency>
           </dependencies>
         </plugin>
         <plugin>

--- a/terminology/src/test/java/au/csiro/pathling/terminology/caching/CachingTerminologyServiceTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/caching/CachingTerminologyServiceTest.java
@@ -70,6 +70,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class CachingTerminologyServiceTest {
 
   static final int WIREMOCK_PORT = 4072;
+  static final int NOT_MODIFIED_STATUS = 304;
   static final Coding T2D_CODING = new Coding(SNOMED_URI, "44054006", "Type 2 diabetes mellitus");
   static final Coding CHLOROQUINE_POISONING_CODING =
       new Coding(SNOMED_URI, "45110008", "Chloroquine poisoning");
@@ -262,7 +263,24 @@ class CachingTerminologyServiceTest {
       // should have been run past the max age, triggering a revalidation request.
       verify(2, anyRequestedFor(anyUrl()));
       verify(1, anyRequestedFor(anyUrl()).withHeader("If-None-Match", matching(".*")));
+      // Sending the conditional request is not enough: the server must answer it with a 304, so
+      // that the cached data is reused rather than replaced by a fresh response. Without this
+      // assertion a server that answers 200 satisfies the test, even though revalidation never
+      // happened, because both outcomes return the same result to the caller.
+      assertEquals(
+          1,
+          countNotModifiedResponses(),
+          "Expected the revalidation request to be answered with a 304 Not Modified");
     }
+  }
+
+  /**
+   * @return the number of responses served with a 304 Not Modified status since the last reset
+   */
+  static long countNotModifiedResponses() {
+    return wireMockServer.getAllServeEvents().stream()
+        .filter(event -> event.getResponse().getStatus() == NOT_MODIFIED_STATUS)
+        .count();
   }
 
   @AfterEach

--- a/terminology/src/test/resources/wiremock/CachingTerminologyServiceTest/mappings/fhir_codesystem_lookup-6e28f05d-8770-4c9b-ac2d-d7383a08d3f1.json
+++ b/terminology/src/test/resources/wiremock/CachingTerminologyServiceTest/mappings/fhir_codesystem_lookup-6e28f05d-8770-4c9b-ac2d-d7383a08d3f1.json
@@ -1,31 +1,32 @@
 {
-  "id" : "6e28f05d-8770-4c9b-ac2d-d7383a08d3f1",
-  "name" : "fhir_codesystem_lookup",
-  "request" : {
-    "url" : "/fhir/CodeSystem/$lookup?system=http%3A%2F%2Fsnomed.info%2Fsct&code=291446002&property=inactive",
-    "method" : "GET",
-    "headers" : {
-      "If-None-Match" : {
-        "equalTo" : "W/\"1667879415644\""
+  "id": "6e28f05d-8770-4c9b-ac2d-d7383a08d3f1",
+  "name": "fhir_codesystem_lookup",
+  "priority": 1,
+  "request": {
+    "url": "/fhir/CodeSystem/$lookup?system=http%3A%2F%2Fsnomed.info%2Fsct&code=291446002&property=inactive",
+    "method": "GET",
+    "headers": {
+      "If-None-Match": {
+        "equalTo": "W/\"1667879415644\""
       }
     }
   },
-  "response" : {
-    "status" : 304,
-    "headers" : {
-      "X-Request-Id" : "d32c3f8b-b7e4-478d-b3a1-d6933b496d0c",
-      "ETag" : "W/\"1667879415644\"",
-      "X-Powered-By" : "HAPI FHIR 6.1.3 REST Server (FHIR Server; FHIR 4.0.1/R4)",
-      "Cache-Control" : "max-age=1",
-      "Vary" : "Accept,Origin,Accept-Encoding,Accept-Language,Authorization",
-      "X-Content-Type-Options" : "nosniff",
-      "X-XSS-Protection" : "1; mode=block",
-      "X-Frame-Options" : "DENY",
-      "Date" : "Thu, 22 Dec 2022 06:08:17 GMT",
-      "Keep-Alive" : "timeout=60"
+  "response": {
+    "status": 304,
+    "headers": {
+      "X-Request-Id": "d32c3f8b-b7e4-478d-b3a1-d6933b496d0c",
+      "ETag": "W/\"1667879415644\"",
+      "X-Powered-By": "HAPI FHIR 6.1.3 REST Server (FHIR Server; FHIR 4.0.1/R4)",
+      "Cache-Control": "max-age=1",
+      "Vary": "Accept,Origin,Accept-Encoding,Accept-Language,Authorization",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Frame-Options": "DENY",
+      "Date": "Thu, 22 Dec 2022 06:08:17 GMT",
+      "Keep-Alive": "timeout=60"
     }
   },
-  "uuid" : "6e28f05d-8770-4c9b-ac2d-d7383a08d3f1",
-  "persistent" : true,
-  "insertionIndex" : 25
+  "uuid": "6e28f05d-8770-4c9b-ac2d-d7383a08d3f1",
+  "persistent": true,
+  "insertionIndex": 25
 }

--- a/terminology/src/test/resources/wiremock/CachingTerminologyServiceTest/mappings/fhir_codesystem_subsumes-f14718fd-fd78-4982-a850-da75817738fe.json
+++ b/terminology/src/test/resources/wiremock/CachingTerminologyServiceTest/mappings/fhir_codesystem_subsumes-f14718fd-fd78-4982-a850-da75817738fe.json
@@ -1,31 +1,32 @@
 {
-  "id" : "f14718fd-fd78-4982-a850-da75817738fe",
-  "name" : "fhir_codesystem_subsumes",
-  "request" : {
-    "url" : "/fhir/CodeSystem/$subsumes?codeA=44054006&codeB=73211009&system=http%3A%2F%2Fsnomed.info%2Fsct",
-    "method" : "GET",
-    "headers" : {
-      "If-None-Match" : {
-        "equalTo" : "W/\"1667879415644\""
+  "id": "f14718fd-fd78-4982-a850-da75817738fe",
+  "name": "fhir_codesystem_subsumes",
+  "priority": 1,
+  "request": {
+    "url": "/fhir/CodeSystem/$subsumes?codeA=44054006&codeB=73211009&system=http%3A%2F%2Fsnomed.info%2Fsct",
+    "method": "GET",
+    "headers": {
+      "If-None-Match": {
+        "equalTo": "W/\"1667879415644\""
       }
     }
   },
-  "response" : {
-    "status" : 304,
-    "headers" : {
-      "X-Request-Id" : "7e8c86ce-97be-4ac9-8b63-6a05ca9383c5",
-      "ETag" : "W/\"1667879415644\"",
-      "X-Powered-By" : "HAPI FHIR 6.1.3 REST Server (FHIR Server; FHIR 4.0.1/R4)",
-      "Cache-Control" : "max-age=1",
-      "Vary" : "Accept,Origin,Accept-Encoding,Accept-Language,Authorization",
-      "X-Content-Type-Options" : "nosniff",
-      "X-XSS-Protection" : "1; mode=block",
-      "X-Frame-Options" : "DENY",
-      "Date" : "Thu, 22 Dec 2022 06:08:12 GMT",
-      "Keep-Alive" : "timeout=60"
+  "response": {
+    "status": 304,
+    "headers": {
+      "X-Request-Id": "7e8c86ce-97be-4ac9-8b63-6a05ca9383c5",
+      "ETag": "W/\"1667879415644\"",
+      "X-Powered-By": "HAPI FHIR 6.1.3 REST Server (FHIR Server; FHIR 4.0.1/R4)",
+      "Cache-Control": "max-age=1",
+      "Vary": "Accept,Origin,Accept-Encoding,Accept-Language,Authorization",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Frame-Options": "DENY",
+      "Date": "Thu, 22 Dec 2022 06:08:12 GMT",
+      "Keep-Alive": "timeout=60"
     }
   },
-  "uuid" : "f14718fd-fd78-4982-a850-da75817738fe",
-  "persistent" : true,
-  "insertionIndex" : 21
+  "uuid": "f14718fd-fd78-4982-a850-da75817738fe",
+  "persistent": true,
+  "insertionIndex": 21
 }

--- a/terminology/src/test/resources/wiremock/CachingTerminologyServiceTest/mappings/fhir_conceptmap_translate-d5d35e9a-91e5-4b0b-b816-c7a20a1757cf.json
+++ b/terminology/src/test/resources/wiremock/CachingTerminologyServiceTest/mappings/fhir_conceptmap_translate-d5d35e9a-91e5-4b0b-b816-c7a20a1757cf.json
@@ -1,31 +1,32 @@
 {
-  "id" : "d5d35e9a-91e5-4b0b-b816-c7a20a1757cf",
-  "name" : "fhir_conceptmap_translate",
-  "request" : {
-    "url" : "/fhir/ConceptMap/$translate?url=http%3A%2F%2Fsnomed.info%2Fsct%3Ffhir_cm%3D900000000000527005&system=http%3A%2F%2Fsnomed.info%2Fsct&code=291446002&reverse=false",
-    "method" : "GET",
-    "headers" : {
-      "If-None-Match" : {
-        "equalTo" : "W/\"1658184692798\""
+  "id": "d5d35e9a-91e5-4b0b-b816-c7a20a1757cf",
+  "name": "fhir_conceptmap_translate",
+  "priority": 1,
+  "request": {
+    "url": "/fhir/ConceptMap/$translate?url=http%3A%2F%2Fsnomed.info%2Fsct%3Ffhir_cm%3D900000000000527005&system=http%3A%2F%2Fsnomed.info%2Fsct&code=291446002&reverse=false",
+    "method": "GET",
+    "headers": {
+      "If-None-Match": {
+        "equalTo": "W/\"1658184692798\""
       }
     }
   },
-  "response" : {
-    "status" : 304,
-    "headers" : {
-      "X-Request-Id" : "8598748b-8197-4ec7-8d02-8c9b5b13356b",
-      "ETag" : "W/\"1658184692798\"",
-      "X-Powered-By" : "HAPI FHIR 6.1.3 REST Server (FHIR Server; FHIR 4.0.1/R4)",
-      "Cache-Control" : "max-age=1",
-      "Vary" : "Accept,Origin,Accept-Encoding,Accept-Language,Authorization",
-      "X-Content-Type-Options" : "nosniff",
-      "X-XSS-Protection" : "1; mode=block",
-      "X-Frame-Options" : "DENY",
-      "Date" : "Thu, 22 Dec 2022 06:08:08 GMT",
-      "Keep-Alive" : "timeout=60"
+  "response": {
+    "status": 304,
+    "headers": {
+      "X-Request-Id": "8598748b-8197-4ec7-8d02-8c9b5b13356b",
+      "ETag": "W/\"1658184692798\"",
+      "X-Powered-By": "HAPI FHIR 6.1.3 REST Server (FHIR Server; FHIR 4.0.1/R4)",
+      "Cache-Control": "max-age=1",
+      "Vary": "Accept,Origin,Accept-Encoding,Accept-Language,Authorization",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Frame-Options": "DENY",
+      "Date": "Thu, 22 Dec 2022 06:08:08 GMT",
+      "Keep-Alive": "timeout=60"
     }
   },
-  "uuid" : "d5d35e9a-91e5-4b0b-b816-c7a20a1757cf",
-  "persistent" : true,
-  "insertionIndex" : 17
+  "uuid": "d5d35e9a-91e5-4b0b-b816-c7a20a1757cf",
+  "persistent": true,
+  "insertionIndex": 17
 }

--- a/terminology/src/test/resources/wiremock/CachingTerminologyServiceTest/mappings/fhir_valueset_validate-code-34b3ee19-98a8-48db-8ad0-0cfa4084dd26.json
+++ b/terminology/src/test/resources/wiremock/CachingTerminologyServiceTest/mappings/fhir_valueset_validate-code-34b3ee19-98a8-48db-8ad0-0cfa4084dd26.json
@@ -1,31 +1,32 @@
 {
-  "id" : "34b3ee19-98a8-48db-8ad0-0cfa4084dd26",
-  "name" : "fhir_valueset_validate-code",
-  "request" : {
-    "url" : "/fhir/ValueSet/$validate-code?url=http%3A%2F%2Fsnomed.info%2Fsct%3Ffhir_vs&system=http%3A%2F%2Fsnomed.info%2Fsct&code=44054006",
-    "method" : "GET",
-    "headers" : {
-      "If-None-Match" : {
-        "equalTo" : "W/\"-1667438239788\""
+  "id": "34b3ee19-98a8-48db-8ad0-0cfa4084dd26",
+  "name": "fhir_valueset_validate-code",
+  "priority": 1,
+  "request": {
+    "url": "/fhir/ValueSet/$validate-code?url=http%3A%2F%2Fsnomed.info%2Fsct%3Ffhir_vs&system=http%3A%2F%2Fsnomed.info%2Fsct&code=44054006",
+    "method": "GET",
+    "headers": {
+      "If-None-Match": {
+        "equalTo": "W/\"-1667438239788\""
       }
     }
   },
-  "response" : {
-    "status" : 304,
-    "headers" : {
-      "X-Request-Id" : "7656a7f5-4c0e-42e9-ab9b-72c409437ed2",
-      "ETag" : "W/\"-1667438239788\"",
-      "X-Powered-By" : "HAPI FHIR 6.1.3 REST Server (FHIR Server; FHIR 4.0.1/R4)",
-      "Cache-Control" : "max-age=1",
-      "Vary" : "Accept,Origin,Accept-Encoding,Accept-Language,Authorization",
-      "X-Content-Type-Options" : "nosniff",
-      "X-XSS-Protection" : "1; mode=block",
-      "X-Frame-Options" : "DENY",
-      "Date" : "Thu, 22 Dec 2022 06:08:04 GMT",
-      "Keep-Alive" : "timeout=60"
+  "response": {
+    "status": 304,
+    "headers": {
+      "X-Request-Id": "7656a7f5-4c0e-42e9-ab9b-72c409437ed2",
+      "ETag": "W/\"-1667438239788\"",
+      "X-Powered-By": "HAPI FHIR 6.1.3 REST Server (FHIR Server; FHIR 4.0.1/R4)",
+      "Cache-Control": "max-age=1",
+      "Vary": "Accept,Origin,Accept-Encoding,Accept-Language,Authorization",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Frame-Options": "DENY",
+      "Date": "Thu, 22 Dec 2022 06:08:04 GMT",
+      "Keep-Alive": "timeout=60"
     }
   },
-  "uuid" : "34b3ee19-98a8-48db-8ad0-0cfa4084dd26",
-  "persistent" : true,
-  "insertionIndex" : 13
+  "uuid": "34b3ee19-98a8-48db-8ad0-0cfa4084dd26",
+  "persistent": true,
+  "insertionIndex": 13
 }


### PR DESCRIPTION
The pull request build ran everything in a single job on a four-processor runner, taking around 52 minutes. Of that, the core libraries were 28 minutes, and their test suites were 24 of those 28. The module test suites are independent of each other, so this gives each one its own runner and lets them run at the same time.

Building the JARs is also split out from the tests, so the server workflow no longer waits for the core test suites before it starts. SonarCloud still needs coverage from every module at once, so it runs last and restores the reports the test jobs produced.

Timings projected from the per-goal timings measured in run 29969602184:

| | Before | After |
| --- | --- | --- |
| Core test results land at | ~30 min | ~14 min |
| Quality gate | ~31 min | ~22 min |
| Whole workflow | ~56 min | ~22 min |
| Server tests start at | ~56 min | ~6 min |

## Coverage is unchanged

The Maven commands the new jobs run were checked locally, and every module reports the same number of tests as the current build: utilities 12, encoders 516, terminology 376, fhirpath 6691 with 964 skipped, and library-api 159.

## Two other things in here

The license header check could not run in a linked Git worktree at all: the JGit version bundled with the plugin cannot open one, so the build failed immediately with "Bare Repository has neither a working tree, nor an index". Overriding JGit fixes it.

The Surefire fork count is now a property rather than a hardcoded value, and `CONTRIBUTING.md` records what the measurements showed. One fork per processor turned out to be optimal, and doubling it makes the fhirpath suite around 70% slower because each fork holds its own Spark session. A module's suite also cannot finish faster than its slowest single test class, which is what sets local build time.

## Worth knowing before merging

Every Maven sequence and the coverage archiving were verified locally and actionlint is clean, but the job graph itself has not run anywhere yet. This pull request is the first time it will.

The R module is excluded from the SonarCloud reactor. SonarCloud has no R analyser, so nothing is lost, and it avoids installing the whole R toolchain a second time just to analyse it.

The server tests now depend only on the JARs, not on the core test suites passing. Both still report separately, so nothing can merge on a broken core, but the server suite may now start against one. Happy to put the dependency back if you would rather it waited.

Two things I found and deliberately left alone. The R dependency install is still the largest single goal in the build at nearly 13 minutes, because `test.yml` only triggers on `pull_request` and so its caches are never reusable by another pull request, while the weekly cache-warming workflow does not set up R. Separately, Python coverage is never imported into SonarCloud, as no `sonar.python.coverage.reportPaths` is configured anywhere. That one would move the quality gate, so it seemed better raised than changed.