### PR TITLE
Make silently dropped RF2 rows visible on import

### DIFF
--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -352,12 +352,22 @@ edition/version. `import-fhir-terminology` accepts a JSON file, a directory of
 JSON files, or a FHIR NPM package (`.tgz`), and imports CodeSystems of any size
 with bounded memory (for example, the multi-gigabyte OMOP vocabulary CodeSystem).
 
+An RF2 source given to `import-snomed` must be
+[self-contained](terminology#rf2-sources-must-be-self-contained): rows
+referencing concepts the source does not itself ship are dropped, which is the
+ordinary shape of a derived or extension package supplied without the release it
+depends on. Under `--verbose` the import reports, for each file, how many of its
+active rows resolved, which is how a shortfall is detected. The same section
+gives a
+[recipe for combining a package with its dependency](terminology#combining-a-derived-package-with-its-dependency).
+
 Large imports run for many minutes. With `--verbose`, the command streams a
-running count of parsed concepts and stage-transition messages so progress is
-visible; without it, the startup spinner covers the wait. If an import fails
-partway through writing a CodeSystem, it reports that the store may hold a
-partial version and advises re-running; because content is keyed by system
-version, re-running with a corrected source repairs the store.
+running count of parsed concepts, the per-file resolution counts, and
+stage-transition messages so progress is visible; without it, the startup spinner
+covers the wait. If an import fails partway through writing a CodeSystem, it
+reports that the store may hold a partial version and advises re-running; because
+content is keyed by system version, re-running with a corrected source repairs
+the store.
 
 Peak memory does not grow with the number of concepts, but the largest
 vocabularies still need more driver heap than the 1 GB default to hold the

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -356,18 +356,16 @@ An RF2 source given to `import-snomed` must be
 [self-contained](terminology#rf2-sources-must-be-self-contained): rows
 referencing concepts the source does not itself ship are dropped, which is the
 ordinary shape of a derived or extension package supplied without the release it
-depends on. Under `--verbose` the import reports, for each file, how many of its
-active rows resolved, which is how a shortfall is detected. The same section
-gives a
+depends on. The import reports, for each file, how many of its active rows
+resolved, which is how a shortfall is detected. The same section gives a
 [recipe for combining a package with its dependency](terminology#combining-a-derived-package-with-its-dependency).
 
 Large imports run for many minutes. With `--verbose`, the command streams a
-running count of parsed concepts, the per-file resolution counts, and
-stage-transition messages so progress is visible; without it, the startup spinner
-covers the wait. If an import fails partway through writing a CodeSystem, it
-reports that the store may hold a partial version and advises re-running; because
-content is keyed by system version, re-running with a corrected source repairs
-the store.
+running count of parsed concepts and stage-transition messages so progress is
+visible; without it, the startup spinner covers the wait. If an import fails
+partway through writing a CodeSystem, it reports that the store may hold a
+partial version and advises re-running; because content is keyed by system
+version, re-running with a corrected source repairs the store.
 
 Peak memory does not grow with the number of concepts, but the largest
 vocabularies still need more driver heap than the 1 GB default to hold the

--- a/site/docs/libraries/terminology.md
+++ b/site/docs/libraries/terminology.md
@@ -1017,7 +1017,8 @@ produce no line, since none of them is resolved against the concept dictionary.
 
 Unresolved rows are reported informationally and never fail the import:
 importing a package whose references are mostly external is a legitimate thing to
-do if that is what you intend. The CLI surfaces these lines under `--verbose`.
+do if that is what you intend. The lines are logged at `INFO` by the importer, so
+they appear wherever logging for `au.csiro.pathling` is enabled at that level.
 
 #### Combining a derived package with its dependency
 

--- a/site/docs/libraries/terminology.md
+++ b/site/docs/libraries/terminology.md
@@ -984,6 +984,108 @@ pathling import-fhir-terminology /data/hl7.terminology.tgz /data/tx-store
 </TabItem>
 </Tabs>
 
+#### RF2 sources must be self-contained
+
+An RF2 source is imported on its own terms: the concepts it ships are the
+dictionary that every other file is resolved against. A description,
+relationship or reference set row referencing a concept the source does not ship
+has nothing to attach to, so it is dropped. A relationship needs both its source
+and its destination concept, so one missing destination drops the row.
+
+This is the ordinary shape of a **derived** or **extension** package. Such a
+package declares its dependency on another edition through the Module Dependency
+reference set and ships only its own modules' components, so most of what it
+references lives in the edition it extends. Imported alone, it succeeds while
+carrying almost none of the content you expected. Two published examples: the
+SNOMED CT International Patient Summary ships no concepts of its own at all, and
+the SNOMED CT Netherlands Patient Friendly Extension ships two bookkeeping
+concepts alongside 1,287 active descriptions, of which 7 resolve.
+
+To tell whether this has happened, read the per-file resolution counts in the
+import log. Every file resolved against the concept dictionary reports one line:
+
+```text
+.../sct2_Description_Snapshot-en_NL_20200930.txt: 7 of 1287 active rows resolved against the concept dictionary.
+```
+
+A line is reported for every such file, including the files that resolve
+completely, so a file whose two figures are equal is never confused with one that
+was absent. Both figures count active rows only, because rows excluded for being
+inactive are excluded by design rather than for want of a concept. The concept
+file itself, the language reference sets and the Module Dependency reference set
+produce no line, since none of them is resolved against the concept dictionary.
+
+Unresolved rows are reported informationally and never fail the import:
+importing a package whose references are mostly external is a legitimate thing to
+do if that is what you intend. The CLI surfaces these lines under `--verbose`.
+
+#### Combining a derived package with its dependency
+
+To import a derived package's content in full, combine it with the release it
+declares a dependency on and import the combination as a single source.
+
+Three roles are single-valued, so their files must be **concatenated** into one
+file each, keeping only the first file's header row:
+
+- the concept file (`sct2_Concept_Snapshot_*`)
+- the relationship file (`sct2_Relationship_Snapshot_*`)
+- the Module Dependency reference set (`der2_ssRefset_ModuleDependencySnapshot_*`)
+
+Every other role is multi-valued, so those files are **left as they are**, each
+keeping its own header, in the directory layout the import expects:
+
+- descriptions and text definitions (`sct2_Description_*`, `sct2_TextDefinition_*`)
+- language reference sets (`der2_cRefset_Language*`)
+- all other reference sets (`der2_*Refset*`)
+
+```bash
+INT=/data/SnomedCT_InternationalRF2_PRODUCTION_20250601T120000Z/Snapshot
+EXT=/data/SnomedCT_ExtensionRF2_PRODUCTION_20250930T120000Z/Snapshot
+OUT=/data/merged/Snapshot
+
+mkdir -p "$OUT/Terminology" "$OUT/Refset/Language" "$OUT/Refset/Content" \
+         "$OUT/Refset/Metadata"
+
+# Single-valued roles: concatenate, keeping only the first file's header row.
+concat() {
+  cat "$1" > "$3"
+  tail -n +2 "$2" >> "$3"
+}
+concat "$INT"/Terminology/sct2_Concept_Snapshot_*.txt \
+       "$EXT"/Terminology/sct2_Concept_Snapshot_*.txt \
+       "$OUT/Terminology/sct2_Concept_Snapshot_MERGED.txt"
+concat "$INT"/Terminology/sct2_Relationship_Snapshot_*.txt \
+       "$EXT"/Terminology/sct2_Relationship_Snapshot_*.txt \
+       "$OUT/Terminology/sct2_Relationship_Snapshot_MERGED.txt"
+concat "$INT"/Refset/Metadata/der2_ssRefset_ModuleDependencySnapshot_*.txt \
+       "$EXT"/Refset/Metadata/der2_ssRefset_ModuleDependencySnapshot_*.txt \
+       "$OUT/Refset/Metadata/der2_ssRefset_ModuleDependencySnapshot_MERGED.txt"
+
+# Multi-valued roles: copy every file as it is. The two releases name their files
+# by edition and date, so nothing is overwritten.
+cp "$INT"/Terminology/sct2_Description_*.txt \
+   "$INT"/Terminology/sct2_TextDefinition_*.txt \
+   "$EXT"/Terminology/sct2_Description_*.txt "$OUT/Terminology/"
+cp "$INT"/Refset/Language/*.txt "$EXT"/Refset/Language/*.txt "$OUT/Refset/Language/"
+cp "$INT"/Refset/Content/*.txt "$EXT"/Refset/Content/*.txt "$OUT/Refset/Content/"
+
+pathling import-snomed /data/merged /data/tx-store
+```
+
+Adjust the copies for the roles a given package actually ships; an extension
+without text definitions, for instance, contributes none.
+
+Do not simply extract both releases side by side into one directory. The import
+rejects a source in which more than one file fills a single-valued role, naming
+the role and every candidate path, because it cannot tell which tree's content
+you meant and would otherwise proceed against one and silently ignore the other.
+
+Combine a package only with the release it declares a dependency on. An
+extension ships only its own modules' components, so a package and its
+dependency do not overlap. Two overlapping editions do: the same concept code
+would arrive twice, be given two internal identifiers, and fan out every join
+built on it. Nothing detects that, so it is yours to avoid.
+
 #### Large CodeSystems
 
 CodeSystems are imported with bounded memory regardless of their size. The

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
@@ -136,9 +136,10 @@ public class SnomedRf2Importer {
   private static final String OBSERVED_ROWS = "rows";
 
   /**
-   * How long to wait for an observed row count to arrive before abandoning its line. Spark delivers
-   * observed metrics through the asynchronous listener bus, whose events may be dropped under load,
-   * so waiting indefinitely would risk stalling an otherwise complete import for a diagnostic.
+   * How long to wait, in total, for a batch of observed row counts to arrive before abandoning
+   * their lines. Spark delivers observed metrics through the asynchronous listener bus, whose
+   * events may be dropped under load, so waiting indefinitely would risk stalling an otherwise
+   * complete import for the sake of a diagnostic.
    */
   private static final long METRIC_TIMEOUT_SECONDS = 60;
 
@@ -303,9 +304,13 @@ public class SnomedRf2Importer {
    * @param resolutions the resolution metrics to report, one per file
    */
   private static void logResolutions(@Nonnull final List<Resolution> resolutions) {
+    // Every metric of a batch is fulfilled by the same query's completion, so they all arrive
+    // together or not at all. One deadline therefore bounds the whole batch, rather than a release
+    // with dozens of reference set files being able to wait once per file.
+    final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(METRIC_TIMEOUT_SECONDS);
     for (final Resolution resolution : resolutions) {
-      final Long input = rowCount(resolution.input);
-      final Long resolved = rowCount(resolution.resolved);
+      final Long input = rowCount(resolution.input, deadline);
+      final Long resolved = input == null ? null : rowCount(resolution.resolved, deadline);
       if (input != null && resolved != null) {
         log.info(
             "{}: {} of {} active rows resolved against the concept dictionary.",
@@ -317,17 +322,19 @@ public class SnomedRf2Importer {
   }
 
   /**
-   * Reads an observed row count, waiting a bounded time for it to arrive.
+   * Reads an observed row count, waiting no later than a deadline for it to arrive.
    *
    * @param observation the observation to read
+   * @param deadline the {@link System#nanoTime()} value to stop waiting at
    * @return the row count, or null if it did not arrive
    */
   @Nullable
-  private static Long rowCount(@Nonnull final Observation observation) {
+  private static Long rowCount(@Nonnull final Observation observation, final long deadline) {
     try {
       final scala.collection.immutable.Map<String, Object> metrics =
           Await.result(
-              observation.future(), Duration.create(METRIC_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+              observation.future(),
+              Duration.create(Math.max(0, deadline - System.nanoTime()), TimeUnit.NANOSECONDS));
       final Option<Object> rows = metrics.get(OBSERVED_ROWS);
       return rows.isDefined() ? (Long) rows.get() : null;
     } catch (final TimeoutException e) {

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
@@ -446,11 +446,11 @@ public class SnomedRf2Importer {
   @Nonnull
   private Rf2Files locateFiles(@Nonnull final String source) {
     final Path root = new Path(source);
-    String concept = null;
+    final List<String> concepts = new ArrayList<>();
     final List<String> descriptions = new ArrayList<>();
-    String relationship = null;
+    final List<String> relationships = new ArrayList<>();
     final List<String> languages = new ArrayList<>();
-    String moduleDependency = null;
+    final List<String> moduleDependencies = new ArrayList<>();
     final List<String> otherRefsets = new ArrayList<>();
     boolean sawNonSnapshotRelease = false;
 
@@ -471,16 +471,16 @@ public class SnomedRf2Importer {
           continue;
         }
         if (name.startsWith("sct2_Concept_")) {
-          concept = path;
+          concepts.add(path);
         } else if (name.startsWith("sct2_Description_")
             || name.startsWith("sct2_TextDefinition_")) {
           descriptions.add(path);
         } else if (name.startsWith("sct2_Relationship_")) {
-          relationship = path;
+          relationships.add(path);
         } else if (name.contains("Refset_Language")) {
           languages.add(path);
         } else if (name.contains("Refset_ModuleDependency")) {
-          moduleDependency = path;
+          moduleDependencies.add(path);
         } else if (name.startsWith("der2_") && name.contains("Refset")) {
           otherRefsets.add(path);
         }
@@ -489,7 +489,7 @@ public class SnomedRf2Importer {
       throw new TerminologyImportException("Unable to read the RF2 source at " + source, e);
     }
 
-    if (concept == null) {
+    if (concepts.isEmpty()) {
       final String detail =
           sawNonSnapshotRelease
               ? " Only snapshot releases are supported; this appears to be a full or delta release."
@@ -497,8 +497,51 @@ public class SnomedRf2Importer {
       throw new TerminologyImportException(
           "No SNOMED CT snapshot concept file was found under " + source + "." + detail);
     }
+    // The concept, relationship and module dependency roles are single-valued. More than one file
+    // filling one of them means two release trees have been placed in the same directory, in which
+    // case the import would otherwise proceed against one tree's content and silently ignore the
+    // other's.
+    requireSingle("concept", concepts, source);
+    requireSingle("relationship", relationships, source);
+    requireSingle("module dependency", moduleDependencies, source);
     return new Rf2Files(
-        concept, descriptions, relationship, languages, moduleDependency, otherRefsets);
+        concepts.get(0),
+        descriptions,
+        relationships.isEmpty() ? null : relationships.get(0),
+        languages,
+        moduleDependencies.isEmpty() ? null : moduleDependencies.get(0),
+        otherRefsets);
+  }
+
+  /**
+   * Rejects a source in which more than one file fills a single-valued role, naming every candidate
+   * in a stable order so the offending files can be found. No file content has been read at this
+   * point, so the store is untouched.
+   *
+   * @param role the name of the role, as it appears in the failure message
+   * @param candidates the paths of the files found for the role
+   * @param source the source path the release was discovered under
+   * @throws TerminologyImportException if more than one candidate was found
+   */
+  private static void requireSingle(
+      @Nonnull final String role,
+      @Nonnull final List<String> candidates,
+      @Nonnull final String source) {
+    if (candidates.size() > 1) {
+      final List<String> sorted = new ArrayList<>(candidates);
+      sorted.sort(Comparator.naturalOrder());
+      throw new TerminologyImportException(
+          "Multiple SNOMED CT snapshot "
+              + role
+              + " files were found under "
+              + source
+              + ": "
+              + String.join(", ", sorted)
+              + ". A single "
+              + role
+              + " file is expected. If you are combining releases, concatenate them into one file"
+              + " rather than placing both release trees in the same directory.");
+    }
   }
 
   // --- RF2 parsing. ---

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
@@ -52,6 +52,7 @@ import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.RELATIO
 import static org.apache.spark.sql.functions.coalesce;
 import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.functions.collect_list;
+import static org.apache.spark.sql.functions.count;
 import static org.apache.spark.sql.functions.lit;
 import static org.apache.spark.sql.functions.map_from_entries;
 import static org.apache.spark.sql.functions.min;
@@ -76,6 +77,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -91,12 +94,16 @@ import org.apache.spark.api.java.function.FilterFunction;
 import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Observation;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.expressions.Window;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
+import scala.Option;
+import scala.concurrent.Await;
+import scala.concurrent.duration.Duration;
 
 /**
  * Imports a SNOMED CT RF2 snapshot release into the terminology store. The release is read through
@@ -123,6 +130,17 @@ public class SnomedRf2Importer {
   private static final String DEFINED_STATUS = "900000000000073002";
   private static final String TARGET_COMPONENT_ID = "targetComponentId";
   private static final String ACCEPTABILITY_ID = "acceptabilityId";
+  private static final String DESCRIPTION_ID = "descriptionId";
+
+  /** The name of the row count metric carried by every resolution observation. */
+  private static final String OBSERVED_ROWS = "rows";
+
+  /**
+   * How long to wait for an observed row count to arrive before abandoning its line. Spark delivers
+   * observed metrics through the asynchronous listener bus, whose events may be dropped under load,
+   * so waiting indefinitely would risk stalling an otherwise complete import for a diagnostic.
+   */
+  private static final long METRIC_TIMEOUT_SECONDS = 60;
 
   private static final Pattern SNOMED_VERSION =
       Pattern.compile("http://snomed.info/x?sct/(?<edition>\\d+)/version/(?<time>\\d{8})");
@@ -215,7 +233,7 @@ public class SnomedRf2Importer {
     final Relationships relationships = readRelationships(files, denseByCode, systemVersionId);
 
     // Reference set membership.
-    final Dataset<Row> refsetMembers = readRefsets(files, denseByCode, systemVersionId);
+    final Refsets refsets = readRefsets(files, denseByCode, systemVersionId);
 
     final Dataset<Row> codeSystemRow =
         codeSystemRow(systemVersionId, version, parsed, conceptCount);
@@ -226,16 +244,99 @@ public class SnomedRf2Importer {
     writer.writePartitionedBySystemVersion(codeSystemRow, CODE_SYSTEM, systemVersionId);
     writer.writePartitionedBySystemVersion(conceptTable, CONCEPT, systemVersionId);
     writer.writePartitionedBySystemVersion(descriptions.table, DESCRIPTION, systemVersionId);
+    logResolutions(descriptions.resolutions);
     writer.writePartitionedBySystemVersion(relationships.attributes, RELATIONSHIP, systemVersionId);
+    logResolutions(relationships.resolutions);
     log.info("Computing the transitive closure");
     final Dataset<Row> closure = new TransitiveClosureBuilder().build(relationships.isa);
     writer.writePartitionedBySystemVersion(closure, CLOSURE, systemVersionId);
     closure.unpersist();
-    writer.writePartitionedBySystemVersion(refsetMembers, REFSET_MEMBER, systemVersionId);
+    writer.writePartitionedBySystemVersion(refsets.members, REFSET_MEMBER, systemVersionId);
+    logResolutions(refsets.resolutions);
     writeManifest(writer, version, source);
     descriptions.cached.forEach(Dataset::unpersist);
     concepts.unpersist();
     log.info("Import complete for {} version {} ({} concepts)", SNOMED_URI, version, conceptCount);
+  }
+
+  // --- Resolution reporting. ---
+
+  /**
+   * The row count metrics of one RF2 file: how many active rows it contributed, and how many of
+   * them resolved against the concept dictionary. Each metric is named from the file's path,
+   * because Spark requires the collected metric names within a query plan to be unique.
+   */
+  private static final class Resolution {
+    @Nonnull final String path;
+    @Nonnull final Observation input;
+    @Nonnull final Observation resolved;
+
+    Resolution(@Nonnull final String path) {
+      this.path = path;
+      this.input = new Observation("input: " + path);
+      this.resolved = new Observation("resolved: " + path);
+    }
+  }
+
+  /**
+   * Attaches a row count metric to a data frame. The rows are unchanged and no action is added: the
+   * count is aggregated as the rows pass through the write the import already performs, so no
+   * further pass is made over any RF2 file.
+   *
+   * @param data the rows to count
+   * @param observation the observation that will hold the count
+   * @return the same rows, with the metric attached
+   */
+  @Nonnull
+  private static Dataset<Row> observeRowCount(
+      @Nonnull final Dataset<Row> data, @Nonnull final Observation observation) {
+    return data.observe(observation, count(lit(1)).alias(OBSERVED_ROWS));
+  }
+
+  /**
+   * Reports, for each file, how many of its active rows resolved against the concept dictionary.
+   * This is called once the write that materialises the corresponding table has completed, so the
+   * counts are available. A source that is not self-contained, such as a derived package imported
+   * without its declared dependency, is a legitimate thing to import, so the shortfall is reported
+   * informationally and the import's outcome is unchanged.
+   *
+   * @param resolutions the resolution metrics to report, one per file
+   */
+  private static void logResolutions(@Nonnull final List<Resolution> resolutions) {
+    for (final Resolution resolution : resolutions) {
+      final Long input = rowCount(resolution.input);
+      final Long resolved = rowCount(resolution.resolved);
+      if (input != null && resolved != null) {
+        log.info(
+            "{}: {} of {} active rows resolved against the concept dictionary.",
+            resolution.path,
+            resolved,
+            input);
+      }
+    }
+  }
+
+  /**
+   * Reads an observed row count, waiting a bounded time for it to arrive.
+   *
+   * @param observation the observation to read
+   * @return the row count, or null if it did not arrive
+   */
+  @Nullable
+  private static Long rowCount(@Nonnull final Observation observation) {
+    try {
+      final scala.collection.immutable.Map<String, Object> metrics =
+          Await.result(
+              observation.future(), Duration.create(METRIC_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+      final Option<Object> rows = metrics.get(OBSERVED_ROWS);
+      return rows.isDefined() ? (Long) rows.get() : null;
+    } catch (final TimeoutException e) {
+      log.debug("Row count metric '{}' was not reported.", observation.name());
+      return null;
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return null;
+    }
   }
 
   // --- Archive extraction. ---
@@ -482,13 +583,18 @@ public class SnomedRf2Importer {
      */
     @Nonnull final List<Dataset<Row>> cached;
 
+    /** The resolution metrics of each description and text definition file read. */
+    @Nonnull final List<Resolution> resolutions;
+
     Descriptions(
         @Nonnull final Dataset<Row> table,
         @Nonnull final Dataset<Row> display,
-        @Nonnull final List<Dataset<Row>> cached) {
+        @Nonnull final List<Dataset<Row>> cached,
+        @Nonnull final List<Resolution> resolutions) {
       this.table = table;
       this.display = display;
       this.cached = cached;
+      this.resolutions = resolutions;
     }
   }
 
@@ -504,7 +610,7 @@ public class SnomedRf2Importer {
           concepts
               .select(col(COLUMN_CODE), lit(null).cast("string").alias(COLUMN_DISPLAY))
               .limit(0);
-      return new Descriptions(emptyTable, emptyDisplay, List.of());
+      return new Descriptions(emptyTable, emptyDisplay, List.of(), List.of());
     }
 
     // The description and language reference set files are each consumed several times below (the
@@ -513,13 +619,41 @@ public class SnomedRf2Importer {
     // files in a release, so the parsed rows are cached to read and parse each file only once. A
     // release may ship several files of each kind (descriptions plus text definitions, one language
     // file per dialect), so all of them are combined.
+    //
+    // Each file is carried separately through the join to the concept dictionary so that its own
+    // share of the rows that resolved can be reported, and the joined results are then combined. An
+    // inner join distributes over a union, so the same rows pass through the same join as they
+    // would
+    // have had the files been combined first and joined once.
+    final List<Dataset<Row>> descriptionFiles = new ArrayList<>();
+    final List<Dataset<Row>> resolvedFiles = new ArrayList<>();
+    final List<Resolution> resolutions = new ArrayList<>();
+    for (final String path : files.descriptions) {
+      final Dataset<Row> active =
+          readRf2(path, "id", "conceptId", "typeId", COLUMN_TERM)
+              .filter(col(COLUMN_ACTIVE).equalTo("1"))
+              .persist();
+      descriptionFiles.add(active);
+      final Resolution resolution = new Resolution(path);
+      resolutions.add(resolution);
+      // The metrics are attached above the cache boundary, so that they are collected by the write
+      // of the description table rather than by whichever action first populates the cache.
+      final Dataset<Row> observed = observeRowCount(active, resolution.input);
+      final Dataset<Row> resolved =
+          observed
+              .join(denseByCode, observed.col("conceptId").equalTo(denseByCode.col(COLUMN_CODE)))
+              .select(
+                  observed.col("id").alias(DESCRIPTION_ID),
+                  col(COLUMN_DENSE_ID),
+                  observed.col(COLUMN_TERM),
+                  observed.col("languageCode").alias(COLUMN_LANGUAGE),
+                  observed.col("typeId").alias(COLUMN_TYPE_CODE));
+      resolvedFiles.add(observeRowCount(resolved, resolution.resolved));
+    }
     final Dataset<Row> descRaw =
-        files.descriptions.stream()
-            .map(path -> readRf2(path, "id", "conceptId", "typeId", COLUMN_TERM))
-            .reduce(Dataset::unionByName)
-            .orElseThrow()
-            .filter(col(COLUMN_ACTIVE).equalTo("1"))
-            .persist();
+        descriptionFiles.stream().reduce(Dataset::unionByName).orElseThrow();
+    final Dataset<Row> resolvedDescriptions =
+        resolvedFiles.stream().reduce(Dataset::unionByName).orElseThrow();
 
     // Active language reference set rows: description id -> (refset, acceptability).
     final Dataset<Row> langActive =
@@ -545,17 +679,20 @@ public class SnomedRf2Importer {
                 map_from_entries(collect_list(struct(col("refsetId"), col(ACCEPTABILITY_ID))))
                     .alias(COLUMN_ACCEPTABILITY));
 
+    // The acceptability map is a left join keyed on the description, so it neither adds nor drops
+    // rows and the resolved count above remains the count written to the table.
     final Dataset<Row> table =
-        descRaw
-            .join(denseByCode, descRaw.col("conceptId").equalTo(denseByCode.col(COLUMN_CODE)))
+        resolvedDescriptions
             .join(
-                acceptability, descRaw.col("id").equalTo(acceptability.col("descId")), "left_outer")
+                acceptability,
+                resolvedDescriptions.col(DESCRIPTION_ID).equalTo(acceptability.col("descId")),
+                "left_outer")
             .select(
                 lit(systemVersionId).alias(COLUMN_SYSTEM_VERSION_ID),
                 col(COLUMN_DENSE_ID).alias(COLUMN_CONCEPT_DENSE_ID),
                 col(COLUMN_TERM),
-                col("languageCode").alias(COLUMN_LANGUAGE),
-                col("typeId").alias(COLUMN_TYPE_CODE),
+                col(COLUMN_LANGUAGE),
+                col(COLUMN_TYPE_CODE),
                 lit(SNOMED_URI).alias(COLUMN_TYPE_SYSTEM),
                 col(COLUMN_ACCEPTABILITY));
 
@@ -585,7 +722,9 @@ public class SnomedRf2Importer {
                 coalesce(col("preferredTerm"), col("fsnTerm"), col(COLUMN_CODE))
                     .alias(COLUMN_DISPLAY));
 
-    return new Descriptions(table, display, List.of(descRaw, langActive));
+    final List<Dataset<Row>> cached = new ArrayList<>(descriptionFiles);
+    cached.add(langActive);
+    return new Descriptions(table, display, cached, resolutions);
   }
 
   @Nonnull
@@ -613,9 +752,16 @@ public class SnomedRf2Importer {
     @Nonnull final Dataset<Row> isa;
     @Nonnull final Dataset<Row> attributes;
 
-    Relationships(@Nonnull final Dataset<Row> isa, @Nonnull final Dataset<Row> attributes) {
+    /** The resolution metrics of the relationship file, empty when the release ships none. */
+    @Nonnull final List<Resolution> resolutions;
+
+    Relationships(
+        @Nonnull final Dataset<Row> isa,
+        @Nonnull final Dataset<Row> attributes,
+        @Nonnull final List<Resolution> resolutions) {
       this.isa = isa;
       this.attributes = attributes;
+      this.resolutions = resolutions;
     }
   }
 
@@ -625,26 +771,36 @@ public class SnomedRf2Importer {
       @Nonnull final Dataset<Row> denseByCode,
       @Nonnull final String systemVersionId) {
     if (files.relationship == null) {
-      return new Relationships(emptyIsa(), emptyRelationshipTable());
+      return new Relationships(emptyIsa(), emptyRelationshipTable(), List.of());
     }
+    final Resolution resolution = new Resolution(files.relationship);
     final Dataset<Row> relRaw =
-        readRf2(files.relationship, "sourceId", "destinationId", "typeId")
-            .filter(col(COLUMN_ACTIVE).equalTo("1"));
+        observeRowCount(
+            readRf2(files.relationship, "sourceId", "destinationId", "typeId")
+                .filter(col(COLUMN_ACTIVE).equalTo("1")),
+            resolution.input);
 
     final Dataset<Row> sourceDense =
         denseByCode.withColumnRenamed(COLUMN_DENSE_ID, COLUMN_SOURCE_DENSE_ID);
     final Dataset<Row> targetDense =
         denseByCode.withColumnRenamed(COLUMN_DENSE_ID, COLUMN_TARGET_DENSE_ID);
 
+    // A relationship resolves only when both its source and its destination concepts are present,
+    // so
+    // the resolved count is taken after both joins.
     final Dataset<Row> mapped =
-        relRaw
-            .join(sourceDense, relRaw.col("sourceId").equalTo(sourceDense.col(COLUMN_CODE)))
-            .join(targetDense, relRaw.col("destinationId").equalTo(targetDense.col(COLUMN_CODE)))
-            .select(
-                col("typeId"),
-                col("relationshipGroup"),
-                col(COLUMN_SOURCE_DENSE_ID),
-                col(COLUMN_TARGET_DENSE_ID))
+        observeRowCount(
+                relRaw
+                    .join(sourceDense, relRaw.col("sourceId").equalTo(sourceDense.col(COLUMN_CODE)))
+                    .join(
+                        targetDense,
+                        relRaw.col("destinationId").equalTo(targetDense.col(COLUMN_CODE)))
+                    .select(
+                        col("typeId"),
+                        col("relationshipGroup"),
+                        col(COLUMN_SOURCE_DENSE_ID),
+                        col(COLUMN_TARGET_DENSE_ID)),
+                resolution.resolved)
             .persist();
 
     final Dataset<Row> isa =
@@ -663,39 +819,59 @@ public class SnomedRf2Importer {
                 col("typeId").alias(COLUMN_TYPE_CODE),
                 col(COLUMN_TARGET_DENSE_ID),
                 col("relationshipGroup").cast(DataTypes.IntegerType).alias(COLUMN_ROLE_GROUP));
-    return new Relationships(isa, attributes);
+    return new Relationships(isa, attributes, List.of(resolution));
   }
 
   // --- Reference sets. ---
 
+  /** The reference set membership rows, and the resolution metrics of each file read. */
+  private static final class Refsets {
+    @Nonnull final Dataset<Row> members;
+    @Nonnull final List<Resolution> resolutions;
+
+    Refsets(@Nonnull final Dataset<Row> members, @Nonnull final List<Resolution> resolutions) {
+      this.members = members;
+      this.resolutions = resolutions;
+    }
+  }
+
   @Nonnull
-  private Dataset<Row> readRefsets(
+  private Refsets readRefsets(
       @Nonnull final Rf2Files files,
       @Nonnull final Dataset<Row> denseByCode,
       @Nonnull final String systemVersionId) {
     Dataset<Row> members = null;
+    final List<Resolution> resolutions = new ArrayList<>();
     for (final String path : files.otherRefsets) {
+      final Resolution resolution = new Resolution(path);
+      resolutions.add(resolution);
       final Dataset<Row> raw =
-          readRf2(path, "refsetId", "referencedComponentId")
-              .filter(col(COLUMN_ACTIVE).equalTo("1"));
+          observeRowCount(
+              readRf2(path, "refsetId", "referencedComponentId")
+                  .filter(col(COLUMN_ACTIVE).equalTo("1")),
+              resolution.input);
       final boolean hasTarget = raw.schema().getFieldIndex(TARGET_COMPONENT_ID).isDefined();
       final Dataset<Row> targetColumn =
           hasTarget
               ? raw.withColumn(COLUMN_TARGET_CODE, col(TARGET_COMPONENT_ID))
               : raw.withColumn(COLUMN_TARGET_CODE, lit(null).cast(DataTypes.StringType));
       final Dataset<Row> mapped =
-          targetColumn
-              .join(
-                  denseByCode,
-                  targetColumn.col("referencedComponentId").equalTo(denseByCode.col(COLUMN_CODE)))
-              .select(
-                  lit(systemVersionId).alias(COLUMN_SYSTEM_VERSION_ID),
-                  col("refsetId").alias(COLUMN_REFSET_CODE),
-                  col(COLUMN_DENSE_ID).alias(COLUMN_REFERENCED_DENSE_ID),
-                  col(COLUMN_TARGET_CODE));
+          observeRowCount(
+              targetColumn
+                  .join(
+                      denseByCode,
+                      targetColumn
+                          .col("referencedComponentId")
+                          .equalTo(denseByCode.col(COLUMN_CODE)))
+                  .select(
+                      lit(systemVersionId).alias(COLUMN_SYSTEM_VERSION_ID),
+                      col("refsetId").alias(COLUMN_REFSET_CODE),
+                      col(COLUMN_DENSE_ID).alias(COLUMN_REFERENCED_DENSE_ID),
+                      col(COLUMN_TARGET_CODE)),
+              resolution.resolved);
       members = members == null ? mapped : members.unionByName(mapped);
     }
-    return members == null ? emptyRefsetTable(systemVersionId) : members;
+    return new Refsets(members == null ? emptyRefsetTable(systemVersionId) : members, resolutions);
   }
 
   // --- Metadata rows. ---

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
@@ -671,10 +671,9 @@ public class SnomedRf2Importer {
     // file per dialect), so all of them are combined.
     //
     // Each file is carried separately through the join to the concept dictionary so that its own
-    // share of the rows that resolved can be reported, and the joined results are then combined. An
-    // inner join distributes over a union, so the same rows pass through the same join as they
-    // would
-    // have had the files been combined first and joined once.
+    // share of the rows that resolved can be reported, and the joined results are then combined.
+    // An inner join distributes over a union, so the same rows pass through the same join as they
+    // would have done had the files been combined first and joined once.
     final List<Dataset<Row>> descriptionFiles = new ArrayList<>();
     final List<Dataset<Row>> resolvedFiles = new ArrayList<>();
     final List<Resolution> resolutions = new ArrayList<>();
@@ -835,9 +834,8 @@ public class SnomedRf2Importer {
     final Dataset<Row> targetDense =
         denseByCode.withColumnRenamed(COLUMN_DENSE_ID, COLUMN_TARGET_DENSE_ID);
 
-    // A relationship resolves only when both its source and its destination concepts are present,
-    // so
-    // the resolved count is taken after both joins.
+    // A relationship resolves only when both its source and its destination concept are present,
+    // so the resolved count is taken after both joins.
     final Dataset<Row> mapped =
         observeRowCount(
                 relRaw

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterTest.java
@@ -49,36 +49,85 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import au.csiro.pathling.test.Rf2Mini;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import org.apache.spark.scheduler.SparkListener;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
 
 /**
  * Verifies the SNOMED CT RF2 importer against the rf2-mini fixture: the store tables carry the
  * expected content, dense identifiers are contiguous, edition and version are detected (and
- * overridable), and a source that is not a snapshot release is rejected without touching the store.
+ * overridable), every file joined against the concept dictionary reports how much of it resolved,
+ * and a source that is not a snapshot release is rejected without touching the store.
  *
  * @author John Grimes
  */
 class SnomedRf2ImporterTest {
+
+  // File names within the rf2-mini base release, and the prefixes that identify their roles.
+  private static final String CONCEPT_FILE = "sct2_Concept_Snapshot_INT_20230601.txt";
+  private static final String DESCRIPTION_FILE = "sct2_Description_Snapshot-en_INT_20230601.txt";
+  private static final String RELATIONSHIP_FILE = "sct2_Relationship_Snapshot_INT_20230601.txt";
+  private static final String SIMPLE_REFSET_FILE = "der2_Refset_SimpleSnapshot_INT_20230601.txt";
+  private static final String ASSOCIATION_REFSET_FILE =
+      "der2_cRefset_AssociationSnapshot_INT_20230601.txt";
+  private static final String LANGUAGE_REFSET_FILE =
+      "der2_cRefset_LanguageSnapshot-en_INT_20230601.txt";
+  private static final String CONCEPT_PREFIX = "sct2_Concept_";
+  private static final String DESCRIPTION_PREFIX = "sct2_Description_";
+  private static final String RELATIONSHIP_PREFIX = "sct2_Relationship_";
+  private static final String LANGUAGE_PREFIX = "der2_cRefset_Language";
+
+  private static final String MODULE_DEPENDENCY_REFSET = "900000000000534007";
+  private static final String MODEL_MODULE = "900000000000012004";
+  private static final String SYNONYM_TYPE = "900000000000013009";
+  private static final String CASE_INSENSITIVE = "900000000000448009";
+  private static final String STATED_RELATIONSHIP = "900000000000011006";
+  private static final String SOME_MODIFIER = "900000000000451002";
+
+  /** A concept code the fixture does not ship, used to make a reference dangle deliberately. */
+  private static final String ABSENT_CODE = "9999999999";
+
+  /**
+   * The number of Spark jobs one import of the base release into a fresh store runs. Measured three
+   * times on the importer as it stood before the per-file resolution reporting was added, and
+   * asserted exactly so that any additional pass over an RF2 file fails the build.
+   */
+  private static final int BASELINE_SPARK_JOBS = 79;
+
+  /** The per-file resolution line specified in {@code contracts/import-diagnostics.md}. */
+  private static final Pattern RESOLUTION_LINE =
+      Pattern.compile(
+          "^(?<path>.+?): (?<resolved>\\d+) of (?<input>\\d+)"
+              + " active rows resolved against the concept dictionary\\.$");
 
   private static SparkSession spark;
   private static TerminologyStoreReader reader;
@@ -278,44 +327,20 @@ class SnomedRf2ImporterTest {
     // also at the top of the dependency graph, so detection must select the concept-bearing module
     // that depends on the other concept-bearing modules.
     final String extensionModule = "32506021000036107";
-    final String modelModule = "900000000000012004";
     final String mappingModule = "449080006";
-    final String moduleDependencyRefset = "900000000000534007";
     final Path release = work.resolve("release");
     copyDirectory(Rf2Mini.baseRelease(), release);
     reassignConceptModules(release, extensionModule, 5);
-    final Path metadata = release.resolve("Snapshot").resolve("Refset").resolve("Metadata");
-    Files.createDirectories(metadata);
-    final String header =
-        "id\teffectiveTime\tactive\tmoduleId\trefsetId\treferencedComponentId"
-            + "\tsourceEffectiveTime\ttargetEffectiveTime\n";
-    final StringBuilder refset = new StringBuilder(header);
-    int member = 0;
-    for (final String[] edge :
+    writeModuleDependencyRefset(
+        release,
+        "der2_ssRefset_ModuleDependencySnapshot_AU1000036_20230601.txt",
         new String[][] {
           {extensionModule, Rf2Mini.CORE_MODULE},
-          {extensionModule, modelModule},
-          {Rf2Mini.CORE_MODULE, modelModule},
+          {extensionModule, MODEL_MODULE},
+          {Rf2Mini.CORE_MODULE, MODEL_MODULE},
           {mappingModule, Rf2Mini.CORE_MODULE},
-          {mappingModule, modelModule}
-        }) {
-      refset
-          .append(
-              String.join(
-                  "\t",
-                  "m" + ++member,
-                  "20230601",
-                  "1",
-                  edge[0],
-                  moduleDependencyRefset,
-                  edge[1],
-                  "20230601",
-                  "20230601"))
-          .append("\n");
-    }
-    Files.writeString(
-        metadata.resolve("der2_ssRefset_ModuleDependencySnapshot_AU1000036_20230601.txt"),
-        refset.toString());
+          {mappingModule, MODEL_MODULE}
+        });
 
     // Act: import with detection (no override).
     final String store = work.resolve("store").toString();
@@ -345,12 +370,12 @@ class SnomedRf2ImporterTest {
     final Path release = work.resolve("release");
     copyDirectory(Rf2Mini.baseRelease(), release);
     splitFile(
-        release.resolve("Snapshot").resolve("Terminology"),
-        "sct2_Description_",
+        terminologyDirectory(release),
+        DESCRIPTION_PREFIX,
         "sct2_TextDefinition_Snapshot-en_INT_20230601.txt");
     splitFile(
-        release.resolve("Snapshot").resolve("Refset").resolve("Language"),
-        "der2_cRefset_Language",
+        languageRefsetDirectory(release),
+        LANGUAGE_PREFIX,
         "der2_cRefset_LanguageSnapshot-en-XX_INT_20230601.txt");
 
     // Act: import the split release.
@@ -370,31 +395,6 @@ class SnomedRf2ImporterTest {
         CONCEPT, row -> display.put(row.getString(COLUMN_CODE), row.getString(COLUMN_DISPLAY)));
     assertEquals("Diabetes mellitus", display.get(Rf2Mini.DIABETES));
     assertEquals("Type 2 diabetes mellitus", display.get(Rf2Mini.TYPE2_DIABETES));
-  }
-
-  /**
-   * Moves the second half of the data rows of the single file in {@code directory} whose name
-   * starts with {@code prefix} into a new sibling file named {@code newName}, preserving the header
-   * in both.
-   */
-  private static void splitFile(final Path directory, final String prefix, final String newName)
-      throws Exception {
-    final Path original;
-    try (final Stream<Path> files = Files.list(directory)) {
-      original =
-          files
-              .filter(f -> f.getFileName().toString().startsWith(prefix))
-              .findFirst()
-              .orElseThrow();
-    }
-    final List<String> lines = Files.readAllLines(original);
-    final int splitPoint = 1 + (lines.size() - 1) / 2;
-    final List<String> first = new ArrayList<>(lines.subList(0, splitPoint));
-    final List<String> second = new ArrayList<>();
-    second.add(lines.get(0));
-    second.addAll(lines.subList(splitPoint, lines.size()));
-    Files.write(original, first);
-    Files.write(directory.resolve(newName), second);
   }
 
   @Test
@@ -434,31 +434,442 @@ class SnomedRf2ImporterTest {
     assertEquals(denseByCode.size(), conceptCount.get());
   }
 
+  // --- Per-file resolution reporting (User Story 1). ---
+
+  @Test
+  void reportsResolutionCountsForEveryResolvedFile(@TempDir final Path work) throws Throwable {
+    // Every file joined against the concept dictionary reports its active input row count and the
+    // count that resolved. The base release resolves fully except for four is-a rows whose
+    // destination is 138875005 ("SNOMED CT Concept"), a concept the fixture does not ship.
+    final List<ILoggingEvent> events = new ArrayList<>();
+    captureImportLog(
+        events,
+        () ->
+            new SnomedRf2Importer(spark, work.resolve("store").toString())
+                .importFrom(Rf2Mini.baseRelease().toString(), null));
+
+    assertEquals(
+        Map.of(
+            DESCRIPTION_FILE, "401 of 401",
+            RELATIONSHIP_FILE, "199 of 203",
+            SIMPLE_REFSET_FILE, "3 of 3",
+            ASSOCIATION_REFSET_FILE, "1 of 1"),
+        resolutionCounts(events));
+
+    // Each line names the source file path, not merely its name, and is reported informationally.
+    final String releaseRoot = Rf2Mini.baseRelease().toString();
+    assertEquals(4, resolutionLines(events).size());
+    assertTrue(resolutionLines(events).stream().allMatch(line -> line.contains(releaseRoot)));
+    assertEquals(List.of(), eventsAbove(events, Level.INFO));
+  }
+
+  @Test
+  void reportsNoResolutionCountForFilesNotJoinedToConcepts(@TempDir final Path work)
+      throws Throwable {
+    // The concept file, the language reference sets and the Module Dependency reference set are not
+    // resolved against the concept dictionary, so none of them produces a line.
+    final String moduleDependencyFile = "der2_ssRefset_ModuleDependencySnapshot_INT_20230601.txt";
+    final Path release = work.resolve("release");
+    copyDirectory(Rf2Mini.baseRelease(), release);
+    writeModuleDependencyRefset(
+        release, moduleDependencyFile, new String[][] {{Rf2Mini.CORE_MODULE, MODEL_MODULE}});
+
+    final List<ILoggingEvent> events = new ArrayList<>();
+    captureImportLog(
+        events,
+        () ->
+            new SnomedRf2Importer(spark, work.resolve("store").toString())
+                .importFrom(release.toString(), null));
+
+    final Set<String> reported = resolutionCounts(events).keySet();
+    assertFalse(reported.contains(CONCEPT_FILE));
+    assertFalse(reported.contains(LANGUAGE_REFSET_FILE));
+    assertFalse(reported.contains(moduleDependencyFile));
+    assertEquals(
+        Set.of(DESCRIPTION_FILE, RELATIONSHIP_FILE, SIMPLE_REFSET_FILE, ASSOCIATION_REFSET_FILE),
+        reported);
+  }
+
+  @Test
+  void reportsTheShortfallOfADerivedPackageWithoutFailing(@TempDir final Path work)
+      throws Throwable {
+    // The shape of a derived package imported without its declared dependency: two bookkeeping
+    // concepts, and a full complement of descriptions, relationships and reference set members
+    // referencing concepts the package does not ship. The import must still succeed, and the
+    // shortfall must be readable straight off the log.
+    final Path release = work.resolve("release");
+    copyDirectory(Rf2Mini.baseRelease(), release);
+    truncateFile(terminologyDirectory(release), CONCEPT_PREFIX, 2);
+
+    final List<ILoggingEvent> events = new ArrayList<>();
+    captureImportLog(
+        events,
+        () ->
+            new SnomedRf2Importer(spark, work.resolve("store").toString())
+                .importFrom(release.toString(), null));
+
+    // The import succeeded, on the two concepts that remain.
+    assertTrue(
+        events.stream()
+            .anyMatch(
+                event -> "Writing 2 concepts to the store".equals(event.getFormattedMessage())));
+    // Unresolved rows are information, not an alarm: nothing above informational severity.
+    assertEquals(List.of(), eventsAbove(events, Level.INFO));
+
+    // Every affected file resolves less than it took in, and the reference sets resolve nothing.
+    final Map<String, String> reported = resolutionCounts(events);
+    assertEquals("0 of 3", reported.get(SIMPLE_REFSET_FILE));
+    assertEquals("0 of 1", reported.get(ASSOCIATION_REFSET_FILE));
+    assertResolvedBelowInput(reported, DESCRIPTION_FILE, 401);
+    assertResolvedBelowInput(reported, RELATIONSHIP_FILE, 203);
+  }
+
+  @Test
+  void excludesInactiveRowsFromTheInputCount(@TempDir final Path work) throws Throwable {
+    // Inactive rows are excluded by design rather than by failure, so counting them as input would
+    // report a permanent shortfall on every healthy release.
+    final Path release = work.resolve("release");
+    copyDirectory(Rf2Mini.baseRelease(), release);
+    appendRows(
+        terminologyDirectory(release),
+        DESCRIPTION_PREFIX,
+        List.of(
+            descriptionRow("5900001", "0", Rf2Mini.DIABETES, "Retired synonym"),
+            descriptionRow("5900002", "0", Rf2Mini.DIABETES, "Another retired synonym")));
+
+    final List<ILoggingEvent> events = new ArrayList<>();
+    captureImportLog(
+        events,
+        () ->
+            new SnomedRf2Importer(spark, work.resolve("store").toString())
+                .importFrom(release.toString(), null));
+
+    // The two added rows are inactive, so the input figure does not grow beyond the base release's.
+    assertEquals("401 of 401", resolutionCounts(events).get(DESCRIPTION_FILE));
+  }
+
+  @Test
+  void reportsEachDescriptionFileSeparately(@TempDir final Path work) throws Throwable {
+    // A release shipping several description files must let the offending file be identified, so
+    // the figures are reported per file rather than aggregated into one line for the table.
+    final String secondDescriptionFile = "sct2_Description_Snapshot-en-XX_INT_20230601.txt";
+    final Path release = work.resolve("release");
+    copyDirectory(Rf2Mini.baseRelease(), release);
+    splitFile(terminologyDirectory(release), DESCRIPTION_PREFIX, secondDescriptionFile);
+
+    final List<ILoggingEvent> events = new ArrayList<>();
+    captureImportLog(
+        events,
+        () ->
+            new SnomedRf2Importer(spark, work.resolve("store").toString())
+                .importFrom(release.toString(), null));
+
+    // The 401 active rows are split across the two files, each reported on its own line.
+    final Map<String, String> reported = resolutionCounts(events);
+    assertEquals("200 of 200", reported.get(DESCRIPTION_FILE));
+    assertEquals("201 of 201", reported.get(secondDescriptionFile));
+  }
+
+  @Test
+  void dropsRelationshipRowsWhoseDestinationIsAbsent(@TempDir final Path work) throws Throwable {
+    // A relationship resolves only when both its source and its destination are present, so a row
+    // with a present source and an absent destination is dropped.
+    final Path release = work.resolve("release");
+    copyDirectory(Rf2Mini.baseRelease(), release);
+    appendRows(
+        terminologyDirectory(release),
+        RELATIONSHIP_PREFIX,
+        List.of(relationshipRow("r900001", Rf2Mini.DIABETES, ABSENT_CODE)));
+
+    final List<ILoggingEvent> events = new ArrayList<>();
+    captureImportLog(
+        events,
+        () ->
+            new SnomedRf2Importer(spark, work.resolve("store").toString())
+                .importFrom(release.toString(), null));
+
+    // One more active row went in, and the resolved figure is unchanged.
+    assertEquals("199 of 204", resolutionCounts(events).get(RELATIONSHIP_FILE));
+  }
+
+  @Test
+  void rejectsReleaseWithNoActiveConceptsBeforeCounting(@TempDir final Path work) throws Exception {
+    // The existing guard still fires, and it fires before any resolution counting happens.
+    final Path release = work.resolve("release");
+    copyDirectory(Rf2Mini.baseRelease(), release);
+    deactivateRows(terminologyDirectory(release), CONCEPT_PREFIX);
+
+    final SnomedRf2Importer importer =
+        new SnomedRf2Importer(spark, work.resolve("store").toString());
+    final List<ILoggingEvent> events = new ArrayList<>();
+    final TerminologyImportException e =
+        assertThrows(
+            TerminologyImportException.class,
+            () -> captureImportLog(events, () -> importer.importFrom(release.toString(), null)));
+    assertEquals(
+        "The release contains no active concepts, so no edition can be detected.", e.getMessage());
+    assertEquals(Map.of(), resolutionCounts(events));
+  }
+
+  @Test
+  void importAddsNoSparkJobs(@TempDir final Path work) throws Exception {
+    // The counts are collected by metric aggregation attached to the write actions the import
+    // already runs, so no action, and therefore no Spark job, is added.
+    final AtomicInteger jobs = new AtomicInteger();
+    final SparkListener listener =
+        new SparkListener() {
+          @Override
+          public void onJobEnd(final SparkListenerJobEnd jobEnd) {
+            jobs.incrementAndGet();
+          }
+        };
+    spark.sparkContext().addSparkListener(listener);
+    try {
+      new SnomedRf2Importer(spark, work.resolve("store").toString())
+          .importFrom(Rf2Mini.baseRelease().toString(), null);
+      spark.sparkContext().listenerBus().waitUntilEmpty();
+    } finally {
+      spark.sparkContext().removeSparkListener(listener);
+    }
+    assertEquals(BASELINE_SPARK_JOBS, jobs.get());
+  }
+
+  // --- Log capture. ---
+
+  /**
+   * Runs {@code action} with the importer's log events captured at {@code INFO} into {@code
+   * events}, restoring the logger's previous level and detaching the appender whether or not the
+   * action throws. Events are collected even on failure, so a test can assert what was logged
+   * before an expected exception.
+   */
+  private static void captureImportLog(final List<ILoggingEvent> events, final Executable action)
+      throws Throwable {
+    final Logger logger = (Logger) LoggerFactory.getLogger(SnomedRf2Importer.class);
+    final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    final Level previousLevel = logger.getLevel();
+    logger.setLevel(Level.INFO);
+    logger.addAppender(appender);
+    try {
+      action.execute();
+    } finally {
+      events.addAll(appender.list);
+      logger.detachAppender(appender);
+      logger.setLevel(previousLevel);
+      appender.stop();
+    }
+  }
+
+  /** Returns the formatted per-file resolution lines among {@code events}, in the order logged. */
+  private static List<String> resolutionLines(final List<ILoggingEvent> events) {
+    return events.stream()
+        .map(ILoggingEvent::getFormattedMessage)
+        .filter(message -> RESOLUTION_LINE.matcher(message).matches())
+        .toList();
+  }
+
+  /**
+   * Returns the per-file resolution figures among {@code events}, keyed by the reported file's name
+   * and valued as {@code "{resolved} of {input}"}.
+   */
+  private static Map<String, String> resolutionCounts(final List<ILoggingEvent> events) {
+    final Map<String, String> counts = new LinkedHashMap<>();
+    for (final String line : resolutionLines(events)) {
+      final Matcher matcher = RESOLUTION_LINE.matcher(line);
+      assertTrue(matcher.matches());
+      final String path = matcher.group("path");
+      final String name = path.substring(path.lastIndexOf('/') + 1);
+      counts.put(name, matcher.group("resolved") + " of " + matcher.group("input"));
+    }
+    return counts;
+  }
+
+  /** Returns the formatted messages of {@code events} logged above {@code level}. */
+  private static List<String> eventsAbove(final List<ILoggingEvent> events, final Level level) {
+    return events.stream()
+        .filter(event -> event.getLevel().toInt() > level.toInt())
+        .map(ILoggingEvent::getFormattedMessage)
+        .toList();
+  }
+
+  /**
+   * Asserts that {@code file} took in {@code expectedInput} active rows and resolved fewer than
+   * that.
+   */
+  private static void assertResolvedBelowInput(
+      final Map<String, String> counts, final String file, final int expectedInput) {
+    final String reported = counts.get(file);
+    assertTrue(reported != null, () -> "No resolution line was reported for " + file);
+    final String[] figures = reported.split(" of ");
+    assertEquals(expectedInput, Integer.parseInt(figures[1]));
+    assertTrue(
+        Integer.parseInt(figures[0]) < expectedInput,
+        () -> file + " reported " + reported + ", expecting a shortfall");
+  }
+
+  // --- Fixture shaping. ---
+
+  /** Returns the Snapshot Terminology directory of a release. */
+  private static Path terminologyDirectory(final Path release) {
+    return release.resolve("Snapshot").resolve("Terminology");
+  }
+
+  /** Returns the Snapshot language reference set directory of a release. */
+  private static Path languageRefsetDirectory(final Path release) {
+    return release.resolve("Snapshot").resolve("Refset").resolve("Language");
+  }
+
+  /** Returns the Snapshot content reference set directory of a release. */
+  private static Path contentRefsetDirectory(final Path release) {
+    return release.resolve("Snapshot").resolve("Refset").resolve("Content");
+  }
+
+  /** Returns the single file in {@code directory} whose name starts with {@code prefix}. */
+  private static Path fileStartingWith(final Path directory, final String prefix) throws Exception {
+    try (final Stream<Path> files = Files.list(directory)) {
+      return files
+          .filter(file -> file.getFileName().toString().startsWith(prefix))
+          .findFirst()
+          .orElseThrow();
+    }
+  }
+
+  /**
+   * Moves the second half of the data rows of the single file in {@code directory} whose name
+   * starts with {@code prefix} into a new sibling file named {@code newName}, preserving the header
+   * in both.
+   */
+  private static void splitFile(final Path directory, final String prefix, final String newName)
+      throws Exception {
+    final Path original = fileStartingWith(directory, prefix);
+    final List<String> lines = Files.readAllLines(original);
+    final int splitPoint = 1 + (lines.size() - 1) / 2;
+    final List<String> first = new ArrayList<>(lines.subList(0, splitPoint));
+    final List<String> second = new ArrayList<>();
+    second.add(lines.get(0));
+    second.addAll(lines.subList(splitPoint, lines.size()));
+    Files.write(original, first);
+    Files.write(directory.resolve(newName), second);
+  }
+
+  /**
+   * Truncates the single file in {@code directory} whose name starts with {@code prefix} to its
+   * header plus its first {@code dataRows} data rows, so that the rows of other files referencing
+   * the rest have nothing to resolve against.
+   */
+  private static void truncateFile(final Path directory, final String prefix, final int dataRows)
+      throws Exception {
+    final Path file = fileStartingWith(directory, prefix);
+    final List<String> lines = Files.readAllLines(file);
+    Files.write(file, lines.subList(0, Math.min(lines.size(), dataRows + 1)));
+  }
+
+  /** Appends {@code rows} to the single file in {@code directory} starting with {@code prefix}. */
+  private static void appendRows(final Path directory, final String prefix, final List<String> rows)
+      throws Exception {
+    final Path file = fileStartingWith(directory, prefix);
+    final List<String> lines = new ArrayList<>(Files.readAllLines(file));
+    lines.addAll(rows);
+    Files.write(file, lines);
+  }
+
+  /**
+   * Marks every data row of the single file in {@code directory} starting with {@code prefix} as
+   * inactive, giving a release with no active content of that kind.
+   */
+  private static void deactivateRows(final Path directory, final String prefix) throws Exception {
+    final Path file = fileStartingWith(directory, prefix);
+    final List<String> lines = new ArrayList<>(Files.readAllLines(file));
+    for (int i = 1; i < lines.size(); i++) {
+      final String[] fields = lines.get(i).split("\t", -1);
+      fields[2] = "0";
+      lines.set(i, String.join("\t", fields));
+    }
+    Files.write(file, lines);
+  }
+
+  /**
+   * Writes a Module Dependency reference set into {@code release} under {@code fileName}, declaring
+   * each {@code {module, dependency}} pair in {@code edges} as an active member.
+   */
+  private static void writeModuleDependencyRefset(
+      final Path release, final String fileName, final String[][] edges) throws Exception {
+    final Path metadata = release.resolve("Snapshot").resolve("Refset").resolve("Metadata");
+    Files.createDirectories(metadata);
+    final StringBuilder refset =
+        new StringBuilder(
+            "id\teffectiveTime\tactive\tmoduleId\trefsetId\treferencedComponentId"
+                + "\tsourceEffectiveTime\ttargetEffectiveTime\n");
+    int member = 0;
+    for (final String[] edge : edges) {
+      refset
+          .append(
+              String.join(
+                  "\t",
+                  "m" + ++member,
+                  "20230601",
+                  "1",
+                  edge[0],
+                  MODULE_DEPENDENCY_REFSET,
+                  edge[1],
+                  "20230601",
+                  "20230601"))
+          .append("\n");
+    }
+    Files.writeString(metadata.resolve(fileName), refset.toString());
+  }
+
+  /** Builds an RF2 description row for the fixture's column layout. */
+  private static String descriptionRow(
+      final String id, final String active, final String conceptId, final String term) {
+    return String.join(
+        "\t",
+        id,
+        "20230601",
+        active,
+        Rf2Mini.CORE_MODULE,
+        conceptId,
+        "en",
+        SYNONYM_TYPE,
+        term,
+        CASE_INSENSITIVE);
+  }
+
+  /** Builds an active RF2 is-a relationship row for the fixture's column layout. */
+  private static String relationshipRow(
+      final String id, final String sourceId, final String destinationId) {
+    return String.join(
+        "\t",
+        id,
+        "20230601",
+        "1",
+        Rf2Mini.CORE_MODULE,
+        sourceId,
+        destinationId,
+        "0",
+        Rf2Mini.IS_A,
+        STATED_RELATIONSHIP,
+        SOME_MODIFIER);
+  }
+
   /**
    * Rewrites the module of the first {@code count} active concepts in the release's concept file to
    * {@code module}, giving a derived edition module some content of its own.
    */
   private static void reassignConceptModules(
       final Path release, final String module, final int count) throws Exception {
-    final Path terminology = release.resolve("Snapshot").resolve("Terminology");
-    try (final Stream<Path> files = Files.list(terminology)) {
-      final Path conceptFile =
-          files
-              .filter(f -> f.getFileName().toString().startsWith("sct2_Concept_"))
-              .findFirst()
-              .orElseThrow();
-      final List<String> lines = Files.readAllLines(conceptFile);
-      int reassigned = 0;
-      for (int i = 1; i < lines.size() && reassigned < count; i++) {
-        final String[] fields = lines.get(i).split("\t", -1);
-        if ("1".equals(fields[2])) {
-          fields[3] = module;
-          lines.set(i, String.join("\t", fields));
-          reassigned++;
-        }
+    final Path conceptFile = fileStartingWith(terminologyDirectory(release), CONCEPT_PREFIX);
+    final List<String> lines = Files.readAllLines(conceptFile);
+    int reassigned = 0;
+    for (int i = 1; i < lines.size() && reassigned < count; i++) {
+      final String[] fields = lines.get(i).split("\t", -1);
+      if ("1".equals(fields[2])) {
+        fields[3] = module;
+        lines.set(i, String.join("\t", fields));
+        reassigned++;
       }
-      Files.write(conceptFile, lines);
     }
+    Files.write(conceptFile, lines);
   }
 
   /** Copies every regular file beneath {@code source} into {@code target}, preserving layout. */

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterTest.java
@@ -86,7 +86,8 @@ import org.slf4j.LoggerFactory;
  * Verifies the SNOMED CT RF2 importer against the rf2-mini fixture: the store tables carry the
  * expected content, dense identifiers are contiguous, edition and version are detected (and
  * overridable), every file joined against the concept dictionary reports how much of it resolved,
- * and a source that is not a snapshot release is rejected without touching the store.
+ * more than one file matching a single-valued role is rejected, and a source that is not a snapshot
+ * release is rejected without touching the store.
  *
  * @author John Grimes
  */
@@ -105,6 +106,7 @@ class SnomedRf2ImporterTest {
   private static final String DESCRIPTION_PREFIX = "sct2_Description_";
   private static final String RELATIONSHIP_PREFIX = "sct2_Relationship_";
   private static final String LANGUAGE_PREFIX = "der2_cRefset_Language";
+  private static final String SIMPLE_REFSET_PREFIX = "der2_Refset_Simple";
 
   private static final String MODULE_DEPENDENCY_REFSET = "900000000000534007";
   private static final String MODEL_MODULE = "900000000000012004";
@@ -634,6 +636,127 @@ class SnomedRf2ImporterTest {
     assertEquals(BASELINE_SPARK_JOBS, jobs.get());
   }
 
+  // --- Ambiguous file discovery (User Story 2). ---
+
+  @Test
+  void rejectsTwoConceptFiles(@TempDir final Path work) throws Exception {
+    // Two release trees dropped into one directory: the concept role is single-valued, so the
+    // import must fail rather than silently keep one tree's content.
+    final Path release = work.resolve("release");
+    copyDirectory(Rf2Mini.baseRelease(), release);
+    final String duplicate = "sct2_Concept_Snapshot_INT_20240601.txt";
+    duplicateFile(terminologyDirectory(release), CONCEPT_PREFIX, duplicate);
+
+    final String store = work.resolve("store").toString();
+    final SnomedRf2Importer importer = new SnomedRf2Importer(spark, store);
+    final TerminologyImportException e =
+        assertThrows(
+            TerminologyImportException.class, () -> importer.importFrom(release.toString(), null));
+    assertAmbiguousDiscovery(e, "concept", release, CONCEPT_FILE, duplicate);
+    // Nothing was written to the store, because the failure precedes any content being read.
+    assertThrows(
+        TerminologyStoreException.class, () -> TerminologyStoreReader.open(store, Map.of()));
+  }
+
+  @Test
+  void rejectsTwoRelationshipFiles(@TempDir final Path work) throws Exception {
+    final Path release = work.resolve("release");
+    copyDirectory(Rf2Mini.baseRelease(), release);
+    final String duplicate = "sct2_Relationship_Snapshot_INT_20240601.txt";
+    duplicateFile(terminologyDirectory(release), RELATIONSHIP_PREFIX, duplicate);
+
+    final String store = work.resolve("store").toString();
+    final SnomedRf2Importer importer = new SnomedRf2Importer(spark, store);
+    final TerminologyImportException e =
+        assertThrows(
+            TerminologyImportException.class, () -> importer.importFrom(release.toString(), null));
+    assertAmbiguousDiscovery(e, "relationship", release, RELATIONSHIP_FILE, duplicate);
+    assertThrows(
+        TerminologyStoreException.class, () -> TerminologyStoreReader.open(store, Map.of()));
+  }
+
+  @Test
+  void rejectsTwoModuleDependencyFiles(@TempDir final Path work) throws Exception {
+    final Path release = work.resolve("release");
+    copyDirectory(Rf2Mini.baseRelease(), release);
+    final String first = "der2_ssRefset_ModuleDependencySnapshot_INT_20230601.txt";
+    final String second = "der2_ssRefset_ModuleDependencySnapshot_INT_20240601.txt";
+    final String[][] edges = {{Rf2Mini.CORE_MODULE, MODEL_MODULE}};
+    writeModuleDependencyRefset(release, first, edges);
+    writeModuleDependencyRefset(release, second, edges);
+
+    final String store = work.resolve("store").toString();
+    final SnomedRf2Importer importer = new SnomedRf2Importer(spark, store);
+    final TerminologyImportException e =
+        assertThrows(
+            TerminologyImportException.class, () -> importer.importFrom(release.toString(), null));
+    assertAmbiguousDiscovery(e, "module dependency", release, first, second);
+    assertThrows(
+        TerminologyStoreException.class, () -> TerminologyStoreReader.open(store, Map.of()));
+  }
+
+  @Test
+  void acceptsSeveralFilesForMultiValuedRoles(@TempDir final Path work) throws Exception {
+    // Descriptions, text definitions, language reference sets and other reference sets are all
+    // legitimately multi-valued, so several files of each must continue to import.
+    final Path release = work.resolve("release");
+    copyDirectory(Rf2Mini.baseRelease(), release);
+    splitFile(
+        terminologyDirectory(release),
+        DESCRIPTION_PREFIX,
+        "sct2_TextDefinition_Snapshot-en_INT_20230601.txt");
+    splitFile(
+        languageRefsetDirectory(release),
+        LANGUAGE_PREFIX,
+        "der2_cRefset_LanguageSnapshot-en-XX_INT_20230601.txt");
+    splitFile(
+        contentRefsetDirectory(release),
+        SIMPLE_REFSET_PREFIX,
+        "der2_Refset_SimpleSnapshot-XX_INT_20230601.txt");
+
+    final String store = work.resolve("store").toString();
+    new SnomedRf2Importer(spark, store).importFrom(release.toString(), null);
+
+    // Discovery accepted every multi-valued role, and the whole concept set landed.
+    final TerminologyStoreReader multiReader = TerminologyStoreReader.open(store, Map.of());
+    final AtomicInteger concepts = new AtomicInteger();
+    multiReader.readTable(CONCEPT, row -> concepts.incrementAndGet());
+    assertEquals(Rf2Mini.CONCEPT_COUNT_20230601, concepts.get());
+  }
+
+  @Test
+  void reportsAMissingConceptFileUnchanged(@TempDir final Path work) throws Exception {
+    // The existing error for a source with no snapshot concept file, and its full or delta release
+    // hint, are both untouched by the ambiguity checks.
+    final Path emptySource = work.resolve("empty");
+    Files.createDirectories(emptySource);
+    final SnomedRf2Importer importer =
+        new SnomedRf2Importer(spark, work.resolve("store").toString());
+    final TerminologyImportException missing =
+        assertThrows(
+            TerminologyImportException.class,
+            () -> importer.importFrom(emptySource.toString(), null));
+    assertEquals(
+        "No SNOMED CT snapshot concept file was found under " + emptySource + ".",
+        missing.getMessage());
+
+    final Path fullSource = work.resolve("full");
+    final Path fullTerminology = fullSource.resolve("Full").resolve("Terminology");
+    Files.createDirectories(fullTerminology);
+    Files.writeString(
+        fullTerminology.resolve("sct2_Concept_Full_INT_20230601.txt"),
+        "id\teffectiveTime\tactive\tmoduleId\tdefinitionStatusId\n");
+    final TerminologyImportException full =
+        assertThrows(
+            TerminologyImportException.class,
+            () -> importer.importFrom(fullSource.toString(), null));
+    assertEquals(
+        "No SNOMED CT snapshot concept file was found under "
+            + fullSource
+            + ". Only snapshot releases are supported; this appears to be a full or delta release.",
+        full.getMessage());
+  }
+
   // --- Log capture. ---
 
   /**
@@ -705,6 +828,35 @@ class SnomedRf2ImporterTest {
     assertTrue(
         Integer.parseInt(figures[0]) < expectedInput,
         () -> file + " reported " + reported + ", expecting a shortfall");
+  }
+
+  /**
+   * Asserts that {@code e} is the ambiguous discovery failure for {@code role}, naming {@code
+   * source}, both candidate file names in a stable order, and the advice to concatenate.
+   */
+  private static void assertAmbiguousDiscovery(
+      final TerminologyImportException e,
+      final String role,
+      final Path source,
+      final String firstFile,
+      final String secondFile) {
+    final String message = e.getMessage();
+    assertTrue(
+        message.startsWith(
+            "Multiple SNOMED CT snapshot " + role + " files were found under " + source + ": "),
+        () -> "Unexpected message: " + message);
+    assertTrue(message.contains("A single " + role + " file is expected."), message);
+    assertTrue(
+        message.endsWith(
+            "If you are combining releases, concatenate them into one file rather than placing"
+                + " both release trees in the same directory."),
+        message);
+    // Both candidates are named, in a stable order.
+    final String earlier = firstFile.compareTo(secondFile) <= 0 ? firstFile : secondFile;
+    final String later = firstFile.compareTo(secondFile) <= 0 ? secondFile : firstFile;
+    assertTrue(message.contains(earlier), message);
+    assertTrue(message.contains(later), message);
+    assertTrue(message.indexOf(earlier) < message.indexOf(later), message);
   }
 
   // --- Fixture shaping. ---
@@ -786,6 +938,15 @@ class SnomedRf2ImporterTest {
       lines.set(i, String.join("\t", fields));
     }
     Files.write(file, lines);
+  }
+
+  /**
+   * Copies the single file in {@code directory} starting with {@code prefix} to a sibling named
+   * {@code newName}, producing two files filling the same role.
+   */
+  private static void duplicateFile(final Path directory, final String prefix, final String newName)
+      throws Exception {
+    Files.copy(fileStartingWith(directory, prefix), directory.resolve(newName));
   }
 
   /**

--- a/terminology/src/test/resources/rf2-mini/README.md
+++ b/terminology/src/test/resources/rf2-mini/README.md
@@ -93,6 +93,31 @@ TYPE2_DIABETES → TYPE2_WITH_COMPLICATION` is five levels below the root.
   implicit value set membership but remains resolvable for lookup.
 - **Designations**: `TYPE2_DIABETES` carries an extra acceptable synonym so
   designation filtering by acceptability can be tested.
+- **Rows that do not resolve**: `138875005` is the is-a parent of the four
+  top-level concepts but is not itself shipped in the concept file, so four
+  relationship rows have no destination concept to attach to. This is what the
+  base release's resolution figures below reflect.
+
+## Resolution figures of the base release
+
+The importer reports, per file, how many of its active rows resolved against the
+concept dictionary. `SnomedRf2ImporterTest` asserts these figures for
+`international-20230601`, so a regeneration that changes the fixture's shape
+means updating that test:
+
+| File                                     | Resolved | Active rows |
+| ---------------------------------------- | -------- | ----------- |
+| `sct2_Description_Snapshot-en_INT_*`     | 401      | 401         |
+| `sct2_Relationship_Snapshot_INT_*`       | 199      | 203         |
+| `der2_Refset_SimpleSnapshot_INT_*`       | 3        | 3           |
+| `der2_cRefset_AssociationSnapshot_INT_*` | 1        | 1           |
+
+The concept file, the language reference set and (where a test adds one) the
+Module Dependency reference set produce no figures, because none of them is
+resolved against the concept dictionary. Tests derive further shapes from these
+releases at run time rather than checking in more trees; `SnomedRf2ImporterTest`
+carries the helpers that copy a release and then truncate, split, append to,
+deactivate or duplicate one of its files.
 
 ## Well-known codes
 


### PR DESCRIPTION
Follow-up to the two items of feedback on local terminology evaluation raised in #2665.

A SNOMED CT RF2 import silently discards any description, relationship or reference set row whose referenced concept is absent from the same source. This is the normal shape of a derived or extension package - one that declares a dependency on another edition through the Module Dependency reference set and ships without it - and it was completely invisible: no log line, no warning, exit code zero. The SNOMED CT Netherlands Patient Friendly Extension, for instance, ships two bookkeeping concepts alongside 1,287 active descriptions of which 7 resolve, and the import reported only `Writing 2 concepts to the store`.

Every RF2 file that is resolved against the concept dictionary now reports how many active rows it contained and how many resolved, one line per file so the offending file can be identified:

```
.../sct2_Description_Snapshot-en_INT_20230601.txt: 4 of 401 active rows resolved against the concept dictionary.
```

The counts are collected by metric aggregation attached to the writes the import already performs, so no additional pass is made over any RF2 file and no Spark job is added - there is a regression test asserting the job count against a figure measured on the unchanged importer. Unresolved rows stay at informational severity with the outcome unchanged, because a package whose references are mostly external is a legitimate thing to import if that is what the user intends. The existing rejection of a release with no active concepts is untouched.

Separately, file discovery treated the concept file, the relationship file and the Module Dependency reference set as single-valued but kept whichever it encountered last. A user combining a derived package with its dependency by extracting both release trees into one directory therefore got an import that proceeded against one tree's content and silently ignored the other's. More than one file matching any of those three roles now fails before any content is read, naming the role and every candidate path and advising concatenation. The multi-valued roles - descriptions, text definitions, language reference sets and other reference sets - continue to accept many files, and the errors for a missing concept file and for a full or delta release are unchanged.

The terminology documentation now states that a source must be self-contained, how the per-file counts reveal a shortfall, and gives a recipe for combining a package with the release it declares a dependency on: which files to concatenate, which to leave alone, why co-locating two release trees fails, and why only a package and its declared dependency should be combined.

A guard against duplicate concept codes in a concatenated source was considered and deliberately left out of scope. Two packages contributing the same code would each receive a distinct internal identifier and fan out every join built on it, and nothing detects that; the recipe constrains itself to non-overlapping sources instead. It is worth raising separately rather than folding in here.

One thing worth knowing beyond this change: the CLI's `--verbose` flag only stops the CLI suppressing JVM logging, and Spark's default configuration still reports WARN and above, so the importer's informational messages - these counts, and the pre-existing running concept count - do not appear from `--verbose` alone. The documentation here describes the severity and logger rather than naming a flag that does not by itself reveal them. Making `--verbose` raise Pathling's own logger to INFO would be a small change to the CLI, but it belongs with the CLI work rather than here.

Verified with the full terminology module build and test suite, and end to end through the CLI against the `rf2-mini` fixture for a self-contained source, a derived package, a pair of co-located release trees, and both unchanged failure cases.