### PR TITLE
Make a .tsv path mean tab-separated, and rename the CLI context to pc

### DIFF
--- a/lib/python/pathling/cli/__init__.py
+++ b/lib/python/pathling/cli/__init__.py
@@ -25,3 +25,5 @@ command needs it.
 
 Author: John Grimes.
 """
+
+from __future__ import annotations

--- a/lib/python/pathling/cli/config.py
+++ b/lib/python/pathling/cli/config.py
@@ -30,6 +30,8 @@ reference, or via an environment variable.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 from dataclasses import dataclass, field

--- a/lib/python/pathling/cli/console.py
+++ b/lib/python/pathling/cli/console.py
@@ -17,13 +17,15 @@
 
 """The ``pathling console`` command.
 
-Opens an interactive IPython session with ``spark`` (the Spark session),
-``pathling`` (the configured Pathling context), and the Pathling package's
-public API pre-imported into the user namespace, after a banner identifying the
-version and the variables in scope. The terminology display function is bound as
-``tx_display`` rather than ``display`` so that IPython's built-in ``display``
-remains reachable at the prompt. IPython is imported inside the command body so
-that ``--help`` stays fast.
+Opens an interactive IPython session with ``spark`` (the Spark session), ``pc``
+(the configured Pathling context), and the Pathling package's public API
+pre-imported into the user namespace, after a banner identifying the version and
+the variables in scope. The ``pathling`` name is bound to the package module
+itself, so typing ``import pathling`` at the prompt cannot clobber the context.
+The terminology display function is bound as ``tx_display`` rather than
+``display`` so that IPython's built-in ``display`` remains reachable at the
+prompt. IPython is imported inside the command body so that ``--help`` stays
+fast.
 
 Author: John Grimes.
 """
@@ -40,7 +42,8 @@ def build_banner() -> str:
     """Builds the banner shown before the console's first prompt.
 
     The banner identifies the Pathling and Python versions, lists the
-    variables in scope, notes that the Pathling public functions are
+    variables in scope - naming the context ``pc``, the name a user copies into
+    their next command - notes that the Pathling public functions are
     pre-imported (with the terminology display available as ``tx_display``),
     and explains how to exit.
 
@@ -49,7 +52,7 @@ def build_banner() -> str:
     return (
         f"Pathling console (version {__version__}, "
         f"Python {platform.python_version()})\n"
-        "Variables in scope: spark (SparkSession), pathling (PathlingContext)\n"
+        "Variables in scope: spark (SparkSession), pc (PathlingContext)\n"
         "Pathling public functions are pre-imported (member_of, translate, "
         "to_coding, ...); see https://pathling.csiro.au/docs/python/pathling.html\n"
         "The terminology display function is available as tx_display "
@@ -63,7 +66,7 @@ def build_banner() -> str:
 def console(obj):
     """Open an interactive console with the Pathling environment ready.
 
-    Starts an IPython session with spark (the Spark session) and pathling
+    Starts an IPython session with spark (the Spark session) and pc
     (the configured Pathling context) in scope. The Pathling public functions
     (member_of, translate, to_coding, and so on) are pre-imported, so no
     "from pathling import ..." is needed; the terminology display is available
@@ -88,7 +91,7 @@ def console(obj):
     user_ns = session.public_namespace()
     user_ns["tx_display"] = user_ns.pop("display")
     user_ns["spark"] = pc.spark
-    user_ns["pathling"] = pc
+    user_ns["pc"] = pc
 
     import IPython
     from traitlets.config import Config

--- a/lib/python/pathling/cli/console.py
+++ b/lib/python/pathling/cli/console.py
@@ -30,12 +30,18 @@ fast.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 import platform
+from typing import TYPE_CHECKING
 
 import click
 
 from pathling._version import __version__
 from pathling.cli import session
+
+if TYPE_CHECKING:
+    from pathling.cli.main import CliContext
 
 
 def build_banner() -> str:
@@ -63,7 +69,7 @@ def build_banner() -> str:
 
 @click.command(name="console")
 @click.pass_obj
-def console(obj):
+def console(obj: CliContext) -> None:
     """Open an interactive console with the Pathling environment ready.
 
     Starts an IPython session with spark (the Spark session) and pc

--- a/lib/python/pathling/cli/convert.py
+++ b/lib/python/pathling/cli/convert.py
@@ -24,15 +24,23 @@ counts written.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import click
+from rich.console import Console
 from rich.table import Table
 
 from pathling.cli import session
 from pathling.cli.errors import EXIT_USAGE, CliError
 from pathling.cli.io import FROM_CHOICES, read_source, resolve_source
 from pathling.cli.render import check_overwrite, progress_status
+
+if TYPE_CHECKING:
+    from pathling.cli.main import CliContext
+    from pathling.datasource import DataSource
 
 # The output formats convert can write.
 TO_CHOICES = ("ndjson", "parquet", "delta")
@@ -83,7 +91,16 @@ MODE_CHOICES = ("overwrite", "error", "append", "merge")
     help="Replace an existing output path (equivalent to --mode overwrite).",
 )
 @click.pass_obj
-def convert(obj, source, from_format, to_format, output, mode, types, overwrite):
+def convert(
+    obj: CliContext,
+    source: str,
+    from_format: Optional[str],
+    to_format: str,
+    output: str,
+    mode: str,
+    types: Tuple[str, ...],
+    overwrite: bool,
+) -> None:
     """Convert FHIR data between formats.
 
     Examples:
@@ -134,7 +151,9 @@ def convert(obj, source, from_format, to_format, output, mode, types, overwrite)
     _print_summary(console, data_source, output_path)
 
 
-def _print_summary(console, data_source, output_path) -> None:
+def _print_summary(
+    console: Console, data_source: DataSource, output_path: Path
+) -> None:
     """Prints a table of the resource types written and the output location.
 
     Row counts are deliberately omitted: counting each type would trigger an

--- a/lib/python/pathling/cli/departition.py
+++ b/lib/python/pathling/cli/departition.py
@@ -28,15 +28,22 @@ keeping the move on a single filesystem.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Union
+from typing import TYPE_CHECKING, Tuple, Union
 
 from py4j.java_gateway import is_instance_of
 
 from pathling.cli.errors import CliError
 
+if TYPE_CHECKING:
+    from pyspark.sql import SparkSession
 
-def _filesystem(spark, reference_path: Union[str, Path]):
+
+def _filesystem(
+    spark: SparkSession, reference_path: Union[str, Path]
+) -> Tuple[object, object]:
     """Resolves the Hadoop ``FileSystem`` for a path, unwrapping checksums.
 
     The filesystem is resolved from ``reference_path`` so that operations stay
@@ -63,7 +70,7 @@ def _filesystem(spark, reference_path: Union[str, Path]):
     return fs, path_class
 
 
-def remove_path(spark, path: Union[str, Path]) -> None:
+def remove_path(spark: SparkSession, path: Union[str, Path]) -> None:
     """Removes a file or directory over its Hadoop ``FileSystem``, if it exists.
 
     Used to clear an existing target before an overwrite and to clean up the
@@ -81,7 +88,7 @@ def remove_path(spark, path: Union[str, Path]) -> None:
 
 
 def departition(
-    spark,
+    spark: SparkSession,
     source_dir: Union[str, Path],
     target_path: Union[str, Path],
     part_extension: str,

--- a/lib/python/pathling/cli/errors.py
+++ b/lib/python/pathling/cli/errors.py
@@ -25,6 +25,8 @@ are shown only when the user passes ``--verbose``.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 import re
 import traceback
 from typing import Optional

--- a/lib/python/pathling/cli/export.py
+++ b/lib/python/pathling/cli/export.py
@@ -25,10 +25,14 @@ counts.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import click
+from rich.console import Console
 from rich.table import Table
 
 from pathling.cli import session
@@ -41,8 +45,13 @@ from pathling.cli.errors import (
 )
 from pathling.cli.render import check_overwrite, progress_status
 
+if TYPE_CHECKING:
+    from pathling.cli.config import BulkAuth
+    from pathling.cli.main import CliContext
+    from pathling.datasource import DataSource
 
-def _parse_since(since):
+
+def _parse_since(since: Optional[str]) -> Optional[datetime]:
     """Parses a ``--since`` ISO 8601 timestamp with a timezone offset.
 
     :param since: the raw ``--since`` value, or None.
@@ -70,7 +79,7 @@ def _parse_since(since):
     return parsed
 
 
-def _build_auth_config(bulk_auth) -> dict:
+def _build_auth_config(bulk_auth: BulkAuth) -> dict:
     """Builds the library's auth config dict from resolved bulk auth.
 
     :param bulk_auth: the resolved :class:`BulkAuth`.
@@ -144,25 +153,25 @@ def _build_auth_config(bulk_auth) -> dict:
 @click.option("--overwrite", is_flag=True, help="Replace an existing output directory.")
 @click.pass_obj
 def export(
-    obj,
-    endpoint,
-    output,
-    group,
-    patients,
-    types,
-    elements,
-    type_filters,
-    include_associated_data,
-    since,
-    timeout,
-    max_downloads,
-    client_id,
-    token_endpoint,
-    scope,
-    private_key_jwk,
-    client_secret,
-    overwrite,
-):
+    obj: CliContext,
+    endpoint: str,
+    output: str,
+    group: Optional[str],
+    patients: Tuple[str, ...],
+    types: Tuple[str, ...],
+    elements: Tuple[str, ...],
+    type_filters: Tuple[str, ...],
+    include_associated_data: Tuple[str, ...],
+    since: Optional[str],
+    timeout: Optional[int],
+    max_downloads: int,
+    client_id: Optional[str],
+    token_endpoint: Optional[str],
+    scope: Optional[str],
+    private_key_jwk: Optional[str],
+    client_secret: Optional[str],
+    overwrite: bool,
+) -> None:
     """Bulk export data from a FHIR server.
 
     Examples:
@@ -234,7 +243,9 @@ def export(
     _print_summary(console, data_source, output_path)
 
 
-def _print_summary(console, data_source, output_path) -> None:
+def _print_summary(
+    console: Console, data_source: DataSource, output_path: Path
+) -> None:
     """Prints a summary of the resource types, file count, and output path.
 
     Row counts are deliberately omitted: counting each type would trigger an

--- a/lib/python/pathling/cli/fhirpath.py
+++ b/lib/python/pathling/cli/fhirpath.py
@@ -25,26 +25,37 @@ named variables, and a FHIR search ``--filter`` in data source mode.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Tuple
+
 import click
+from rich.console import Console
 
 from pathling.cli import session
 from pathling.cli.errors import EXIT_USAGE, CliError
 from pathling.cli.io import (
     FROM_CHOICES,
     SourceFormat,
+    SourceSpec,
     read_single_resource,
     read_source,
     resolve_source,
 )
 from pathling.cli.render import (
+    OutputSpec,
     output_options,
     progress_status,
     resolve_output,
     write_output,
 )
 
+if TYPE_CHECKING:
+    from pathling import PathlingContext
+    from pathling.cli.main import CliContext
 
-def _parse_variables(var_specs) -> dict:
+
+def _parse_variables(var_specs: Tuple[str, ...]) -> dict:
     """Parses repeated ``name=value`` variable specifications.
 
     :param var_specs: the raw ``--var`` values.
@@ -87,22 +98,22 @@ def _parse_variables(var_specs) -> dict:
 @output_options
 @click.pass_obj
 def fhirpath(
-    obj,
-    source,
-    from_format,
-    expression,
-    resource_type,
-    context_expression,
-    variables,
-    filter_expr,
-    output_format,
-    output,
-    limit,
-    overwrite,
-    departition,
-    delimiter,
-    header,
-):
+    obj: CliContext,
+    source: str,
+    from_format: Optional[str],
+    expression: str,
+    resource_type: Optional[str],
+    context_expression: Optional[str],
+    variables: Tuple[str, ...],
+    filter_expr: Optional[str],
+    output_format: Optional[str],
+    output: Optional[str],
+    limit: int,
+    overwrite: bool,
+    departition: bool,
+    delimiter: Optional[str],
+    header: bool,
+) -> None:
     """Evaluate a FHIRPath expression against FHIR data.
 
     \b
@@ -164,7 +175,14 @@ def fhirpath(
 
 
 def _run_data_source(
-    pc, spec, expression, resource_type, filter_expr, output_spec, console, verbose
+    pc: PathlingContext,
+    spec: SourceSpec,
+    expression: str,
+    resource_type: Optional[str],
+    filter_expr: Optional[str],
+    output_spec: OutputSpec,
+    console: Console,
+    verbose: bool,
 ) -> None:
     """Evaluates an expression over every resource in a data source.
 
@@ -201,15 +219,15 @@ def _run_data_source(
 
 
 def _run_single_resource(
-    pc,
-    spec,
-    expression,
-    resource_type,
-    context_expression,
-    variables,
-    output_spec,
-    console,
-    verbose,
+    pc: PathlingContext,
+    spec: SourceSpec,
+    expression: str,
+    resource_type: Optional[str],
+    context_expression: Optional[str],
+    variables: dict,
+    output_spec: OutputSpec,
+    console: Console,
+    verbose: bool,
 ) -> None:
     """Evaluates an expression against a single FHIR resource file.
 

--- a/lib/python/pathling/cli/import_terminology.py
+++ b/lib/python/pathling/cli/import_terminology.py
@@ -25,16 +25,25 @@ mode, streamed to stderr.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 import dataclasses
+from typing import TYPE_CHECKING, Optional
 
 import click
+from rich.console import Console
 
 from pathling.cli import session
+from pathling.cli.config import CliConfig
 from pathling.cli.errors import EXIT_USAGE, CliError
 from pathling.cli.render import progress_status
 
+if TYPE_CHECKING:
+    from pathling import PathlingContext
+    from pathling.cli.main import CliContext
 
-def _import_context(config, console):
+
+def _import_context(config: CliConfig, console: Console) -> PathlingContext:
     """Creates a context for importing into a store.
 
     The import commands populate a store rather than query terminology, so the
@@ -51,7 +60,7 @@ def _import_context(config, console):
     return session.create_context(dataclasses.replace(config, tx_store=None), console)
 
 
-def _resolve_storage_path(config, storage_path):
+def _resolve_storage_path(config: CliConfig, storage_path: Optional[str]) -> str:
     """Resolves the target store path, falling back to the configured store.
 
     The explicit ``STORAGE_PATH`` positional wins; otherwise the configured
@@ -82,7 +91,12 @@ def _resolve_storage_path(config, storage_path):
     "--edition-uri", "edition_uri", help="Override the SNOMED edition/version URI."
 )
 @click.pass_obj
-def import_snomed(obj, source, storage_path, edition_uri):
+def import_snomed(
+    obj: CliContext,
+    source: str,
+    storage_path: Optional[str],
+    edition_uri: Optional[str],
+) -> None:
     """Import a SNOMED CT RF2 snapshot release into a local terminology store.
 
     STORAGE_PATH may be omitted when 'tx-store.path' (or --tx-store) is set.
@@ -104,7 +118,9 @@ def import_snomed(obj, source, storage_path, edition_uri):
 @click.argument("source")
 @click.argument("storage_path", required=False)
 @click.pass_obj
-def import_fhir_terminology(obj, source, storage_path):
+def import_fhir_terminology(
+    obj: CliContext, source: str, storage_path: Optional[str]
+) -> None:
     """Import FHIR CodeSystem, ValueSet, and ConceptMap resources into a store.
 
     The source may be a JSON file, a directory of JSON files, or a FHIR NPM

--- a/lib/python/pathling/cli/io.py
+++ b/lib/python/pathling/cli/io.py
@@ -25,13 +25,19 @@ directory) fail quickly with an actionable message.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from pathling.cli.errors import EXIT_USAGE, CliError
+
+if TYPE_CHECKING:
+    from pathling import PathlingContext
+    from pathling.datasource import DataSource
 
 # The number of leading characters of a candidate file inspected during format
 # detection. A FHIR resource names its ``resourceType`` near the start of the
@@ -234,7 +240,9 @@ def read_single_resource(path: Path) -> tuple:
     return resource_type, text
 
 
-def read_source(pc, spec: SourceSpec, types: Optional[List[str]] = None):
+def read_source(
+    pc: PathlingContext, spec: SourceSpec, types: Optional[List[str]] = None
+) -> DataSource:
     """Reads a :class:`SourceSpec` into a Pathling ``DataSource``.
 
     :param pc: the :class:`PathlingContext` to read with.

--- a/lib/python/pathling/cli/main.py
+++ b/lib/python/pathling/cli/main.py
@@ -26,10 +26,12 @@ execution so that ``--help`` and ``--version`` stay fast.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 import click
 from rich.console import Console
@@ -120,7 +122,7 @@ def _store_path_from(ctx: click.Context) -> Optional[str]:
 class PathlingCli(click.Group):
     """The root group with centralised error handling and exit codes."""
 
-    def invoke(self, ctx: click.Context):
+    def invoke(self, ctx: click.Context) -> object:
         """Invokes a command, mapping errors to friendly messages and codes.
 
         :param ctx: the Click context.
@@ -191,17 +193,17 @@ class PathlingCli(click.Group):
 @click.pass_context
 def cli(
     ctx: click.Context,
-    tx_server,
-    tx_store,
-    tx_client_id,
-    tx_client_secret,
-    tx_token_endpoint,
-    tx_scope,
-    fhir_version,
-    spark_conf,
-    config_path,
-    verbose,
-):
+    tx_server: Optional[str],
+    tx_store: Optional[str],
+    tx_client_id: Optional[str],
+    tx_client_secret: Optional[str],
+    tx_token_endpoint: Optional[str],
+    tx_scope: Optional[str],
+    fhir_version: Optional[str],
+    spark_conf: Tuple[str, ...],
+    config_path: Optional[Path],
+    verbose: bool,
+) -> None:
     """Pathling: a command line interface for FHIR analytics.
 
     Run a SQL on FHIR view, evaluate FHIRPath, convert FHIR data between

--- a/lib/python/pathling/cli/render.py
+++ b/lib/python/pathling/cli/render.py
@@ -123,16 +123,64 @@ def decode_delimiter(value: str) -> str:
     return decoded
 
 
-def _delimiter_callback(ctx, param, value: str) -> str:
+def default_delimiter_for_path(path: Optional[Path]) -> str:
+    """Resolves the default field separator implied by a path's extension.
+
+    A ``.tsv`` path means tab-separated, matched case-insensitively as format
+    inference is; every other path, and the absence of a path (stdout), takes the
+    base comma default. This is consulted only when ``--delimiter`` was not
+    supplied, and independently for the input and the output side, so each side's
+    default comes from its own path.
+
+    :param path: the path for the side being resolved, or None when there is no
+           path (CSV to stdout).
+    :return: the default single-character field separator for that side.
+    :example:
+        >>> default_delimiter_for_path(Path("codes.tsv"))
+        '\\t'
+        >>> default_delimiter_for_path(Path("codes.csv"))
+        ','
+        >>> default_delimiter_for_path(None)
+        ','
+    """
+    if path is not None and path.suffix.lower() == ".tsv":
+        return "\t"
+    return ","
+
+
+def tab_inference_notice(action: str, path) -> str:
+    """Builds the notice announcing a tab delimiter derived from a path.
+
+    A default the user did not type, derived from their filename, is announced
+    rather than assumed. Both sides share this wording so they cannot drift; only
+    the leading verb differs.
+
+    :param action: the leading verb, ``Reading`` for the input side or
+           ``Writing`` for the output side.
+    :param path: the path the delimiter was inferred from, as the user gave it.
+    :return: the notice text, for printing on standard error.
+    :example:
+        >>> tab_inference_notice("Reading", "codes.tsv")
+        'Reading codes.tsv as tab-separated CSV, inferred from the .tsv extension.'
+    """
+    return f"{action} {path} as tab-separated CSV, inferred from the .tsv extension."
+
+
+def _delimiter_callback(ctx, param, value: Optional[str]) -> Optional[str]:
     """Click callback that decodes and validates the ``--delimiter`` value.
+
+    An absent value is passed through untouched, meaning "not supplied - infer
+    each side from its own path" (see :func:`default_delimiter_for_path`).
 
     :param ctx: the Click context (unused).
     :param param: the Click parameter (unused).
-    :param value: the raw option value.
-    :return: the decoded single-character delimiter.
-    :raises click.BadParameter: when the value is invalid (see
+    :param value: the raw option value, or None when the option was omitted.
+    :return: the decoded single-character delimiter, or None when omitted.
+    :raises click.BadParameter: when a supplied value is invalid (see
             :func:`decode_delimiter`).
     """
+    if value is None:
+        return None
     return decode_delimiter(value)
 
 
@@ -145,6 +193,9 @@ def output_options(func):
     ``--header/--no-header`` - and are resolved together by
     :func:`resolve_output` and consumed by :func:`write_output`. The delimiter
     and header apply to CSV output only and are no-ops for other formats.
+    ``--delimiter`` has no fixed default: when it is omitted each side resolves
+    its own separator from its own path (see
+    :func:`default_delimiter_for_path`), and a supplied value applies to both.
 
     :param func: the command callback to decorate.
     :return: the decorated callback.
@@ -177,9 +228,9 @@ def output_options(func):
         click.option(
             "--delimiter",
             "delimiter",
-            default=",",
             callback=_delimiter_callback,
-            help="Field separator for CSV input and output (default: ',').",
+            help="Field separator for CSV input and output (default: a tab for "
+            "a .tsv path, otherwise ',').",
         ),
         click.option(
             "--header/--no-header",
@@ -197,7 +248,8 @@ def output_options(func):
 # Maps file extensions to output formats for inference.
 _EXTENSION_FORMATS = {
     ".csv": OutputFormat.CSV,
-    # A .tsv file is CSV output; tab separation is selected with --delimiter.
+    # A .tsv file is CSV output; the extension governs the delimiter rather than
+    # the format, defaulting it to a tab (see default_delimiter_for_path).
     ".tsv": OutputFormat.CSV,
     ".ndjson": OutputFormat.NDJSON,
     ".jsonl": OutputFormat.NDJSON,
@@ -215,8 +267,12 @@ class OutputSpec:
     :param overwrite: whether an existing output path may be replaced.
     :param departition: whether file output is departitioned to a single file
            (the default) rather than left as a Spark directory of part files.
-    :param delimiter: the field separator for CSV output (stdout and file);
-           applies to CSV only, a no-op for other formats.
+    :param delimiter: the resolved field separator for CSV output (stdout and
+           file), always a concrete character; applies to CSV only, a no-op for
+           other formats.
+    :param delimiter_inferred: whether the delimiter was resolved from the output
+           path rather than supplied as a flag. Only an inference is announced to
+           the user, since an explicit value needs no announcement.
     :param header: whether CSV output includes a header row; applies to CSV
            only, a no-op for other formats.
     """
@@ -227,6 +283,7 @@ class OutputSpec:
     overwrite: bool = False
     departition: bool = True
     delimiter: str = ","
+    delimiter_inferred: bool = False
     header: bool = True
 
 
@@ -245,7 +302,7 @@ def resolve_output(
     limit: int = DEFAULT_LIMIT,
     overwrite: bool = False,
     departition: bool = True,
-    delimiter: str = ",",
+    delimiter: Optional[str] = None,
     header: bool = True,
 ) -> OutputSpec:
     """Resolves and validates output options.
@@ -256,7 +313,8 @@ def resolve_output(
     :param overwrite: whether replacing an existing output path is allowed.
     :param departition: whether file output is departitioned to a single file.
     :param delimiter: the CSV field separator, already decoded and validated by
-           the option callback; a no-op for non-CSV formats.
+           the option callback, or None to derive the output-side default from
+           the output path; a no-op for non-CSV formats.
     :param header: whether CSV output includes a header row; a no-op for non-CSV
            formats.
     :return: the resolved :class:`OutputSpec`.
@@ -298,13 +356,22 @@ def resolve_output(
             exit_code=EXIT_USAGE,
         )
 
+    # An omitted delimiter takes its default from the output path, so a .tsv
+    # target is tab-separated without the user naming the separator. Recording
+    # that it was inferred lets the impure layer announce it.
+    delimiter_inferred = delimiter is None
+    resolved_delimiter = (
+        default_delimiter_for_path(path) if delimiter_inferred else delimiter
+    )
+
     return OutputSpec(
         path=path,
         format=fmt,
         limit=limit,
         overwrite=overwrite,
         departition=departition,
-        delimiter=delimiter,
+        delimiter=resolved_delimiter,
+        delimiter_inferred=delimiter_inferred,
         header=header,
     )
 
@@ -461,11 +528,12 @@ def write_output(df, spec: OutputSpec, console: Console) -> None:
     For stdout, the table format is capped at ``spec.limit`` rows; other
     formats stream the full result. File output is produced by Spark's native
     writers (see :func:`_write_file`) and confirmed with a single stderr line
-    naming the format and path.
+    naming the format and path. A tab delimiter derived from a ``.tsv`` target is
+    announced on stderr before the write begins, since the user did not name it.
 
     :param df: the result Spark DataFrame.
     :param spec: the resolved output specification.
-    :param console: the stderr console for the confirmation message.
+    :param console: the stderr console for the notice and confirmation messages.
     :raises CliError: when the output path exists without ``--overwrite``.
     """
     columns = list(df.columns)
@@ -482,6 +550,15 @@ def write_output(df, spec: OutputSpec, console: Console) -> None:
         return
 
     check_overwrite(spec.path, spec.overwrite)
+    # Announce an inferred tab before writing, and only where the delimiter is
+    # actually consulted: a non-CSV format ignores it entirely, and an explicit
+    # value was the user's own choice.
+    if (
+        spec.format == OutputFormat.CSV
+        and spec.delimiter_inferred
+        and spec.delimiter == "\t"
+    ):
+        console.print(tab_inference_notice("Writing", spec.path))
     _write_file(df, spec)
     console.print(f"Wrote {spec.format} output to {spec.path}.")
 

--- a/lib/python/pathling/cli/render.py
+++ b/lib/python/pathling/cli/render.py
@@ -27,6 +27,8 @@ piped output stays clean.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 import codecs
 import csv
 import io
@@ -35,7 +37,7 @@ import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Sequence
+from typing import TYPE_CHECKING, Callable, Iterator, List, Optional, Sequence, Union
 
 import click
 from rich.console import Console
@@ -43,6 +45,9 @@ from rich.table import Table
 
 from pathling.cli.departition import departition, remove_path
 from pathling.cli.errors import EXIT_USAGE, CliError
+
+if TYPE_CHECKING:
+    from pyspark.sql import DataFrame
 
 # The default cap on rows collected for stdout table rendering.
 DEFAULT_LIMIT = 50
@@ -148,7 +153,7 @@ def default_delimiter_for_path(path: Optional[Path]) -> str:
     return ","
 
 
-def tab_inference_notice(action: str, path) -> str:
+def tab_inference_notice(action: str, path: Union[str, Path]) -> str:
     """Builds the notice announcing a tab delimiter derived from a path.
 
     A default the user did not type, derived from their filename, is announced
@@ -166,7 +171,9 @@ def tab_inference_notice(action: str, path) -> str:
     return f"{action} {path} as tab-separated CSV, inferred from the .tsv extension."
 
 
-def _delimiter_callback(ctx, param, value: Optional[str]) -> Optional[str]:
+def _delimiter_callback(
+    ctx: click.Context, param: click.Parameter, value: Optional[str]
+) -> Optional[str]:
     """Click callback that decodes and validates the ``--delimiter`` value.
 
     An absent value is passed through untouched, meaning "not supplied - infer
@@ -184,7 +191,7 @@ def _delimiter_callback(ctx, param, value: Optional[str]) -> Optional[str]:
     return decode_delimiter(value)
 
 
-def output_options(func):
+def output_options(func: Callable) -> Callable:
     """Applies the shared output options to a command callback.
 
     These options form the common output surface of every command that emits a
@@ -506,7 +513,9 @@ def stderr_console() -> Console:
 
 
 @contextmanager
-def progress_status(console: Console, message: str, verbose: bool = False):
+def progress_status(
+    console: Console, message: str, verbose: bool = False
+) -> Iterator[None]:
     """Shows a status spinner on stderr for a long-running stage.
 
     :param console: the stderr console.
@@ -522,7 +531,7 @@ def progress_status(console: Console, message: str, verbose: bool = False):
         yield
 
 
-def write_output(df, spec: OutputSpec, console: Console) -> None:
+def write_output(df: DataFrame, spec: OutputSpec, console: Console) -> None:
     """Writes a result DataFrame to stdout or a file per the output spec.
 
     For stdout, the table format is capped at ``spec.limit`` rows; other
@@ -563,7 +572,7 @@ def write_output(df, spec: OutputSpec, console: Console) -> None:
     console.print(f"Wrote {spec.format} output to {spec.path}.")
 
 
-def _write_file(df, spec: OutputSpec) -> None:
+def _write_file(df: DataFrame, spec: OutputSpec) -> None:
     """Writes a result DataFrame to a file using Spark's native writers.
 
     CSV, NDJSON, and Parquet are written by Spark rather than collected onto
@@ -620,7 +629,11 @@ def _write_file(df, spec: OutputSpec) -> None:
 
 
 def _write_spark_directory(
-    frame, fmt: str, target_dir, delimiter: str = ",", header: bool = True
+    frame: DataFrame,
+    fmt: str,
+    target_dir: Union[str, Path],
+    delimiter: str = ",",
+    header: bool = True,
 ) -> None:
     """Writes a frame to a Spark directory of part files in the given format.
 

--- a/lib/python/pathling/cli/ruff.toml
+++ b/lib/python/pathling/cli/ruff.toml
@@ -1,0 +1,17 @@
+# Ruff configuration for the command line interface package.
+#
+# A nested configuration applies to the files beneath its own directory only, so
+# this adds the missing-annotation rules (ANN) to the CLI package without
+# imposing them on the rest of the library or on the test suite. The CLI is the
+# extension point other commands compose against, so its signatures must state
+# what each parameter is; the project's own lint invocation
+# (`ruff check .` from lib/python) picks this up with no change.
+#
+# Author: John Grimes.
+
+extend = "../../pyproject.toml"
+
+[lint]
+extend-select = [
+    "ANN", # flake8-annotations - require parameter and return type hints
+]

--- a/lib/python/pathling/cli/run.py
+++ b/lib/python/pathling/cli/run.py
@@ -18,14 +18,15 @@
 """The ``pathling run`` command.
 
 Executes user-supplied Python code - from a script file, standard input, or an
-inline ``-c`` option - with ``spark`` (the Spark session) and ``pathling`` (the
+inline ``-c`` option - with ``spark`` (the Spark session) and ``pc`` (the
 configured Pathling context) bound in the code's global scope, along with the
 Pathling package's public API (its terminology and coding functions, argument
 helper types, and API types) so scripts need no explicit ``from pathling import
-...``. The terminology display function is bound as both ``display`` and
-``tx_display``. Python interpreter script semantics (``sys.argv``, ``__main__``,
-``__file__``, ``sys.path``, traceback fidelity, and ``SystemExit`` propagation)
-are reproduced.
+...``. The ``pathling`` name is bound to the package module itself, so a bare
+``import pathling`` cannot clobber the context. The terminology display function
+is bound as both ``display`` and ``tx_display``. Python interpreter script
+semantics (``sys.argv``, ``__main__``, ``__file__``, ``sys.path``, traceback
+fidelity, and ``SystemExit`` propagation) are reproduced.
 
 Author: John Grimes.
 """
@@ -185,7 +186,8 @@ def _execute(source: CodeSource, program_args, namespace) -> None:
 
     :param source: the resolved code source.
     :param program_args: the program's arguments (``sys.argv[1:]``).
-    :param namespace: the extra globals to bind (``spark`` and ``pathling``).
+    :param namespace: the extra globals to bind (``spark``, ``pc``, and the
+           pre-imported public API).
     """
     try:
         code_object = compile(source.text, source.filename, "exec")
@@ -237,7 +239,7 @@ def run(ctx, script, code, args):
     """Run Python code with the Pathling environment ready.
 
     Executes a script file (or '-' for standard input, or inline code via
-    -c) with spark (the Spark session) and pathling (the configured Pathling
+    -c) with spark (the Spark session) and pc (the configured Pathling
     context) already in scope. The Pathling public functions (to_coding,
     to_snomed_coding, member_of, translate, subsumes, display, and so on) are
     pre-imported too, so no "from pathling import ..." is needed; the
@@ -253,7 +255,7 @@ def run(ctx, script, code, args):
     SQL. Save this as summary.py and run "pathling run summary.py":
 
     \b
-        patients = pathling.read.ndjson("data").view(
+        patients = pc.read.ndjson("data").view(
             "Patient",
             select=[{"column": [{"path": "gender", "name": "gender"}]}],
         )
@@ -273,6 +275,6 @@ def run(ctx, script, code, args):
     namespace = session.public_namespace()
     namespace["tx_display"] = namespace["display"]
     namespace["spark"] = pc.spark
-    namespace["pathling"] = pc
+    namespace["pc"] = pc
 
     _execute(source, program_args, namespace)

--- a/lib/python/pathling/cli/run.py
+++ b/lib/python/pathling/cli/run.py
@@ -31,11 +31,13 @@ fidelity, and ``SystemExit`` propagation) are reproduced.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import traceback
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 import click
 
@@ -77,7 +79,7 @@ class RunCommand(click.Command):
     with trailing arguments), which parse to the same option values.
     """
 
-    def parse_args(self, ctx, args):
+    def parse_args(self, ctx: click.Context, args: Tuple[str, ...]) -> List[str]:
         """Stores the raw arguments on the context, then parses as normal.
 
         :param ctx: the Click context.
@@ -88,7 +90,7 @@ class RunCommand(click.Command):
         return super().parse_args(ctx, args)
 
 
-def _positional_precedes_code_flag(raw_args) -> bool:
+def _positional_precedes_code_flag(raw_args: Sequence[str]) -> bool:
     """Determines whether a positional argument appears before ``-c``.
 
     A positional (a script path or ``-``) before the inline-code flag means
@@ -108,7 +110,12 @@ def _positional_precedes_code_flag(raw_args) -> bool:
     return False
 
 
-def _resolve_source(ctx, script, code, args) -> Tuple[CodeSource, list]:
+def _resolve_source(
+    ctx: click.Context,
+    script: Optional[str],
+    code: Optional[str],
+    args: Tuple[str, ...],
+) -> Tuple[CodeSource, list]:
     """Validates the code-source rules and reads the program text.
 
     Exactly one source is required: a script path, ``-`` (stdin), or
@@ -176,7 +183,7 @@ def _resolve_source(ctx, script, code, args) -> Tuple[CodeSource, list]:
     )
 
 
-def _execute(source: CodeSource, program_args, namespace) -> None:
+def _execute(source: CodeSource, program_args: Sequence[str], namespace: dict) -> None:
     """Compiles and executes the program with interpreter semantics.
 
     ``sys.argv`` and ``sys.path`` are set for the duration of execution and
@@ -235,7 +242,12 @@ def _execute(source: CodeSource, program_args, namespace) -> None:
 @click.option("-c", "--code", "code", help="Inline Python code to execute.")
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
-def run(ctx, script, code, args):
+def run(
+    ctx: click.Context,
+    script: Optional[str],
+    code: Optional[str],
+    args: Tuple[str, ...],
+) -> None:
     """Run Python code with the Pathling environment ready.
 
     Executes a script file (or '-' for standard input, or inline code via

--- a/lib/python/pathling/cli/run.py
+++ b/lib/python/pathling/cli/run.py
@@ -79,7 +79,7 @@ class RunCommand(click.Command):
     with trailing arguments), which parse to the same option values.
     """
 
-    def parse_args(self, ctx: click.Context, args: Tuple[str, ...]) -> List[str]:
+    def parse_args(self, ctx: click.Context, args: List[str]) -> List[str]:
         """Stores the raw arguments on the context, then parses as normal.
 
         :param ctx: the Click context.

--- a/lib/python/pathling/cli/session.py
+++ b/lib/python/pathling/cli/session.py
@@ -58,17 +58,24 @@ def public_namespace() -> dict:
 
     The set of names is derived from the ``pathling`` package's public API list
     (``pathling.__all__``) so that it stays in sync automatically and no second,
-    hand-maintained list exists. The ``pathling`` package is imported inside the
-    function so that the ``--help`` and ``--version`` fast paths are not slowed
-    and do not trigger the JVM-backed imports; resolving the names here forces
-    those imports, which is only appropriate after a command has decided to
-    start the environment.
+    hand-maintained list exists. The package module itself is included under the
+    name ``pathling``, so a reflexive ``import pathling`` in a script or at the
+    console rebinds that name to the object it already holds and is therefore a
+    genuine no-op. Both commands consume this function, so they are identical by
+    construction rather than by convention. The ``pathling`` package is imported
+    inside the function so that the ``--help`` and ``--version`` fast paths are
+    not slowed and do not trigger the JVM-backed imports; resolving the names
+    here forces those imports, which is only appropriate after a command has
+    decided to start the environment.
 
-    :return: a mapping of each public name to the object it exports.
+    :return: a mapping of each public name to the object it exports, together
+             with the ``pathling`` module under its own name.
     """
     import pathling
 
-    return {name: getattr(pathling, name) for name in pathling.__all__}
+    namespace = {name: getattr(pathling, name) for name in pathling.__all__}
+    namespace["pathling"] = pathling
+    return namespace
 
 
 def quiet_log4j2_path() -> str:

--- a/lib/python/pathling/cli/session.py
+++ b/lib/python/pathling/cli/session.py
@@ -26,17 +26,24 @@ its defaults.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 import atexit
 import os
 import sys
 from contextlib import ExitStack
 from importlib.resources import as_file, files
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from rich.console import Console
 
 from pathling.cli.config import CliConfig
 from pathling.cli.render import progress_status, stderr_console
+
+if TYPE_CHECKING:
+    from pyspark.sql import SparkSession
+
+    from pathling import PathlingContext
 
 # The packaged log4j2 configuration that silences Spark and JVM logging. It is
 # supplied to the driver JVM before launch so that startup noise, and
@@ -92,7 +99,7 @@ def quiet_log4j2_path() -> str:
     return str(path)
 
 
-def _build_quiet_spark(config: CliConfig):
+def _build_quiet_spark(config: CliConfig) -> SparkSession:
     """Builds a Spark session with logging suppressed before JVM launch.
 
     The Pathling and Delta package configuration is shared with
@@ -133,7 +140,7 @@ def _build_quiet_spark(config: CliConfig):
     return _build_spark_session(extra_configs)
 
 
-def _create_pathling_context(config: CliConfig):
+def _create_pathling_context(config: CliConfig) -> PathlingContext:
     """Builds the Spark session and Pathling context from the configuration.
 
     :param config: the resolved CLI configuration.
@@ -177,7 +184,9 @@ def _create_pathling_context(config: CliConfig):
     )
 
 
-def create_context(config: CliConfig, console: Optional[Console] = None):
+def create_context(
+    config: CliConfig, console: Optional[Console] = None
+) -> PathlingContext:
     """Creates a :class:`PathlingContext` configured from the CLI settings.
 
     In the default (non-verbose) mode the JVM launcher's startup banner and Ivy

--- a/lib/python/pathling/cli/sparkconf.py
+++ b/lib/python/pathling/cli/sparkconf.py
@@ -31,7 +31,9 @@ Spark session starts.
 Author: John Grimes.
 """
 
-from typing import Callable, Optional
+from __future__ import annotations
+
+from typing import Callable, Iterable, Optional
 
 from pathling._spark_defaults import (
     CATALOG_KEY,
@@ -43,7 +45,7 @@ from pathling._spark_defaults import (
 from pathling.cli.errors import EXIT_USAGE, CliError
 
 
-def parse_spark_conf_flags(flags) -> dict:
+def parse_spark_conf_flags(flags: Optional[Iterable[str]]) -> dict:
     """Parses repeatable ``--spark-conf KEY=VALUE`` flags into a mapping.
 
     Each flag is split on the first ``=`` only, so a value may itself contain
@@ -66,7 +68,7 @@ def parse_spark_conf_flags(flags) -> dict:
     return result
 
 
-def validate_and_coerce(key: str, value) -> str:
+def validate_and_coerce(key: str, value: object) -> str:
     """Validates a Spark configuration key and coerces its value to a string.
 
     The key must begin with ``spark.``. Scalar values (string, integer, float,

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -26,7 +26,10 @@ options.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Optional, Sequence, Tuple
 
 import click
 
@@ -46,8 +49,14 @@ from pathling.cli.render import (
     write_output,
 )
 
+if TYPE_CHECKING:
+    from pyspark.sql import Column, DataFrame
 
-def _common_options(func):
+    from pathling import PathlingContext
+    from pathling.cli.main import CliContext
+
+
+def _common_options(func: Callable) -> Callable:
     """Applies the dataset argument, coding options, and output options.
 
     :param func: the command callback to decorate.
@@ -88,7 +97,7 @@ def _common_options(func):
     return func
 
 
-def _detect_tabular_format(path):
+def _detect_tabular_format(path: Path) -> str:
     """Detects the tabular format of a dataset from its name and layout.
 
     Detection inspects only the path's suffix and, for directories, the names
@@ -130,7 +139,13 @@ def _detect_tabular_format(path):
     )
 
 
-def _read_dataset(pc, dataset, from_format, delimiter=",", input_header=True):
+def _read_dataset(
+    pc: PathlingContext,
+    dataset: str,
+    from_format: Optional[str],
+    delimiter: str = ",",
+    input_header: bool = True,
+) -> DataFrame:
     """Reads a tabular dataset into a Spark DataFrame using a resolved format.
 
     The format and the delimiter are both resolved earlier, before the Spark
@@ -160,7 +175,9 @@ def _read_dataset(pc, dataset, from_format, delimiter=",", input_header=True):
     return pc.spark.read.format("delta").load(path)
 
 
-def _validate_columns(df, required, dataset):
+def _validate_columns(
+    df: DataFrame, required: Sequence[Optional[str]], dataset: str
+) -> None:
     """Validates that the named columns exist, listing the actual columns.
 
     :param df: the dataset DataFrame.
@@ -183,7 +200,15 @@ def _validate_columns(df, required, dataset):
         )
 
 
-def _coding_column(pc, code_column, system, system_column, version, *, code=None):
+def _coding_column(
+    pc: PathlingContext,
+    code_column: str,
+    system: Optional[str],
+    system_column: Optional[str],
+    version: Optional[str],
+    *,
+    code: Optional[str] = None,
+) -> Column:
     """Builds a Coding struct column from a code source and a system source.
 
     The struct's field names and order are derived from the library's own Coding
@@ -223,7 +248,13 @@ def _coding_column(pc, code_column, system, system_column, version, *, code=None
     return struct(*[overrides.get(name, lit(None)).alias(name) for name in field_names])
 
 
-def _require_exactly_one(first, first_name, second, second_name, neither_message):
+def _require_exactly_one(
+    first: Optional[str],
+    first_name: str,
+    second: Optional[str],
+    second_name: str,
+    neither_message: str,
+) -> None:
     """Validates that exactly one of a pair of options is provided.
 
     :param first: the first option's value, falsey when the option is absent.
@@ -243,7 +274,9 @@ def _require_exactly_one(first, first_name, second, second_name, neither_message
         raise CliError(neither_message, exit_code=EXIT_USAGE)
 
 
-def _validate_coding_source(dataset, system, system_column):
+def _validate_coding_source(
+    dataset: str, system: Optional[str], system_column: Optional[str]
+) -> None:
     """Validates the dataset path and code system options before Spark starts.
 
     :param dataset: the dataset path.
@@ -267,21 +300,21 @@ def _validate_coding_source(dataset, system, system_column):
 
 
 def _execute(
-    obj,
-    dataset,
-    from_format,
-    system,
-    system_column,
-    output_format,
-    output,
-    limit,
-    overwrite,
-    departition,
-    delimiter,
-    header,
-    input_header,
-    build,
-):
+    obj: CliContext,
+    dataset: str,
+    from_format: Optional[str],
+    system: Optional[str],
+    system_column: Optional[str],
+    output_format: Optional[str],
+    output: Optional[str],
+    limit: int,
+    overwrite: bool,
+    departition: bool,
+    delimiter: Optional[str],
+    header: bool,
+    input_header: bool,
+    build: Callable[[PathlingContext, DataFrame], DataFrame],
+) -> None:
     """Runs a terminology operation and emits the augmented dataset.
 
     :param obj: the CLI context object.
@@ -358,24 +391,24 @@ def _execute(
 @click.option("--value-set", "value_set", required=True, help="Value set URI.")
 @click.pass_obj
 def member_of(
-    obj,
-    dataset,
-    from_format,
-    code_column,
-    system,
-    system_column,
-    system_version,
-    result_column,
-    output_format,
-    output,
-    limit,
-    overwrite,
-    departition,
-    delimiter,
-    header,
-    input_header,
-    value_set,
-):
+    obj: CliContext,
+    dataset: str,
+    from_format: Optional[str],
+    code_column: str,
+    system: Optional[str],
+    system_column: Optional[str],
+    system_version: Optional[str],
+    result_column: Optional[str],
+    output_format: Optional[str],
+    output: Optional[str],
+    limit: int,
+    overwrite: bool,
+    departition: bool,
+    delimiter: Optional[str],
+    header: bool,
+    input_header: bool,
+    value_set: str,
+) -> None:
     """Test codes for membership of a value set.
 
     Example:
@@ -385,7 +418,7 @@ def member_of(
     """
     name = result_column or "member_of"
 
-    def build(pc, df):
+    def build(pc: PathlingContext, df: DataFrame) -> DataFrame:
         from pathling import udfs
 
         _validate_columns(df, [code_column, system_column], dataset)
@@ -422,26 +455,26 @@ def member_of(
 )
 @click.pass_obj
 def translate(
-    obj,
-    dataset,
-    from_format,
-    code_column,
-    system,
-    system_column,
-    system_version,
-    result_column,
-    output_format,
-    output,
-    limit,
-    overwrite,
-    departition,
-    delimiter,
-    header,
-    input_header,
-    concept_map,
-    reverse,
-    equivalences,
-):
+    obj: CliContext,
+    dataset: str,
+    from_format: Optional[str],
+    code_column: str,
+    system: Optional[str],
+    system_column: Optional[str],
+    system_version: Optional[str],
+    result_column: Optional[str],
+    output_format: Optional[str],
+    output: Optional[str],
+    limit: int,
+    overwrite: bool,
+    departition: bool,
+    delimiter: Optional[str],
+    header: bool,
+    input_header: bool,
+    concept_map: str,
+    reverse: bool,
+    equivalences: Tuple[str, ...],
+) -> None:
     """Translate codes using a concept map.
 
     Example:
@@ -453,7 +486,7 @@ def translate(
     system_name = f"{base}_system"
     code_name = f"{base}_code"
 
-    def build(pc, df):
+    def build(pc: PathlingContext, df: DataFrame) -> DataFrame:
         from pyspark.sql.functions import col, explode_outer
 
         from pathling import udfs
@@ -494,7 +527,7 @@ def translate(
 # ========== subsumes / subsumed-by ==========
 
 
-def _second_coding_options(func):
+def _second_coding_options(func: Callable) -> Callable:
     """Adds the second coding options used by subsumes and subsumed-by.
 
     :param func: the command callback to decorate.
@@ -524,29 +557,29 @@ def _second_coding_options(func):
 
 
 def _run_subsumption(
-    obj,
-    operation,
-    default_name,
-    dataset,
-    from_format,
-    code_column,
-    system,
-    system_column,
-    system_version,
-    result_column,
-    output_format,
-    output,
-    limit,
-    overwrite,
-    departition,
-    delimiter,
-    header,
-    input_header,
-    other_code,
-    other_code_column,
-    other_system,
-    other_system_column,
-):
+    obj: CliContext,
+    operation: str,
+    default_name: str,
+    dataset: str,
+    from_format: Optional[str],
+    code_column: str,
+    system: Optional[str],
+    system_column: Optional[str],
+    system_version: Optional[str],
+    result_column: Optional[str],
+    output_format: Optional[str],
+    output: Optional[str],
+    limit: int,
+    overwrite: bool,
+    departition: bool,
+    delimiter: Optional[str],
+    header: bool,
+    input_header: bool,
+    other_code: Optional[str],
+    other_code_column: Optional[str],
+    other_system: Optional[str],
+    other_system_column: Optional[str],
+) -> None:
     """Shared implementation for subsumes and subsumed-by.
 
     :param obj: the CLI context object.
@@ -596,7 +629,7 @@ def _run_subsumption(
 
     name = result_column or default_name
 
-    def build(pc, df):
+    def build(pc: PathlingContext, df: DataFrame) -> DataFrame:
         from pathling import udfs
 
         _validate_columns(
@@ -638,27 +671,27 @@ def _run_subsumption(
 @_second_coding_options
 @click.pass_obj
 def subsumes(
-    obj,
-    dataset,
-    from_format,
-    code_column,
-    system,
-    system_column,
-    system_version,
-    result_column,
-    output_format,
-    output,
-    limit,
-    overwrite,
-    departition,
-    delimiter,
-    header,
-    input_header,
-    other_code,
-    other_code_column,
-    other_system,
-    other_system_column,
-):
+    obj: CliContext,
+    dataset: str,
+    from_format: Optional[str],
+    code_column: str,
+    system: Optional[str],
+    system_column: Optional[str],
+    system_version: Optional[str],
+    result_column: Optional[str],
+    output_format: Optional[str],
+    output: Optional[str],
+    limit: int,
+    overwrite: bool,
+    departition: bool,
+    delimiter: Optional[str],
+    header: bool,
+    input_header: bool,
+    other_code: Optional[str],
+    other_code_column: Optional[str],
+    other_system: Optional[str],
+    other_system_column: Optional[str],
+) -> None:
     """Test subsumption against another code column or a fixed target coding.
 
     Compare a column of codes against either a second code column or a single
@@ -703,27 +736,27 @@ def subsumes(
 @_second_coding_options
 @click.pass_obj
 def subsumed_by(
-    obj,
-    dataset,
-    from_format,
-    code_column,
-    system,
-    system_column,
-    system_version,
-    result_column,
-    output_format,
-    output,
-    limit,
-    overwrite,
-    departition,
-    delimiter,
-    header,
-    input_header,
-    other_code,
-    other_code_column,
-    other_system,
-    other_system_column,
-):
+    obj: CliContext,
+    dataset: str,
+    from_format: Optional[str],
+    code_column: str,
+    system: Optional[str],
+    system_column: Optional[str],
+    system_version: Optional[str],
+    result_column: Optional[str],
+    output_format: Optional[str],
+    output: Optional[str],
+    limit: int,
+    overwrite: bool,
+    departition: bool,
+    delimiter: Optional[str],
+    header: bool,
+    input_header: bool,
+    other_code: Optional[str],
+    other_code_column: Optional[str],
+    other_system: Optional[str],
+    other_system_column: Optional[str],
+) -> None:
     """Test reverse subsumption against another code column or a fixed target.
 
     Compare a column of codes against either a second code column or a single
@@ -771,24 +804,24 @@ def subsumed_by(
 @click.option("--accept-language", "accept_language", help="Preferred language(s).")
 @click.pass_obj
 def display(
-    obj,
-    dataset,
-    from_format,
-    code_column,
-    system,
-    system_column,
-    system_version,
-    result_column,
-    output_format,
-    output,
-    limit,
-    overwrite,
-    departition,
-    delimiter,
-    header,
-    input_header,
-    accept_language,
-):
+    obj: CliContext,
+    dataset: str,
+    from_format: Optional[str],
+    code_column: str,
+    system: Optional[str],
+    system_column: Optional[str],
+    system_version: Optional[str],
+    result_column: Optional[str],
+    output_format: Optional[str],
+    output: Optional[str],
+    limit: int,
+    overwrite: bool,
+    departition: bool,
+    delimiter: Optional[str],
+    header: bool,
+    input_header: bool,
+    accept_language: Optional[str],
+) -> None:
     """Look up display names for codes.
 
     Example:
@@ -797,7 +830,7 @@ def display(
     """
     name = result_column or "display"
 
-    def build(pc, df):
+    def build(pc: PathlingContext, df: DataFrame) -> DataFrame:
         from pathling import udfs
 
         _validate_columns(df, [code_column, system_column], dataset)
@@ -838,26 +871,26 @@ def display(
 @click.option("--accept-language", "accept_language", help="Preferred language(s).")
 @click.pass_obj
 def property_of(
-    obj,
-    dataset,
-    from_format,
-    code_column,
-    system,
-    system_column,
-    system_version,
-    result_column,
-    output_format,
-    output,
-    limit,
-    overwrite,
-    departition,
-    delimiter,
-    header,
-    input_header,
-    property_code,
-    property_type,
-    accept_language,
-):
+    obj: CliContext,
+    dataset: str,
+    from_format: Optional[str],
+    code_column: str,
+    system: Optional[str],
+    system_column: Optional[str],
+    system_version: Optional[str],
+    result_column: Optional[str],
+    output_format: Optional[str],
+    output: Optional[str],
+    limit: int,
+    overwrite: bool,
+    departition: bool,
+    delimiter: Optional[str],
+    header: bool,
+    input_header: bool,
+    property_code: str,
+    property_type: str,
+    accept_language: Optional[str],
+) -> None:
     """Look up properties for codes.
 
     Example:
@@ -867,7 +900,7 @@ def property_of(
     """
     name = result_column or "property"
 
-    def build(pc, df):
+    def build(pc: PathlingContext, df: DataFrame) -> DataFrame:
         from pathling import udfs
 
         _validate_columns(df, [code_column, system_column], dataset)
@@ -904,25 +937,25 @@ def property_of(
 @click.option("--language", "language", help="Designation language.")
 @click.pass_obj
 def designation(
-    obj,
-    dataset,
-    from_format,
-    code_column,
-    system,
-    system_column,
-    system_version,
-    result_column,
-    output_format,
-    output,
-    limit,
-    overwrite,
-    departition,
-    delimiter,
-    header,
-    input_header,
-    use,
-    language,
-):
+    obj: CliContext,
+    dataset: str,
+    from_format: Optional[str],
+    code_column: str,
+    system: Optional[str],
+    system_column: Optional[str],
+    system_version: Optional[str],
+    result_column: Optional[str],
+    output_format: Optional[str],
+    output: Optional[str],
+    limit: int,
+    overwrite: bool,
+    departition: bool,
+    delimiter: Optional[str],
+    header: bool,
+    input_header: bool,
+    use: Optional[str],
+    language: Optional[str],
+) -> None:
     """Look up designations for codes.
 
     Example:
@@ -932,7 +965,7 @@ def designation(
     """
     name = result_column or "designation"
 
-    def build(pc, df):
+    def build(pc: PathlingContext, df: DataFrame) -> DataFrame:
         from pathling import udfs
         from pathling.coding import Coding
 

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -38,9 +38,11 @@ from pathling.cli.errors import (
     unwrap_java_exception,
 )
 from pathling.cli.render import (
+    default_delimiter_for_path,
     output_options,
     progress_status,
     resolve_output,
+    tab_inference_notice,
     write_output,
 )
 
@@ -115,7 +117,8 @@ def _detect_tabular_format(path):
             exit_code=EXIT_USAGE,
         )
     suffix = path.suffix.lower()
-    # A .tsv file is treated as CSV; the tab separator is supplied via --delimiter.
+    # A .tsv file is treated as CSV; its extension governs the delimiter rather
+    # than the format, defaulting it to a tab (see default_delimiter_for_path).
     if suffix in (".csv", ".tsv"):
         return "csv"
     if suffix == ".parquet":
@@ -130,17 +133,18 @@ def _detect_tabular_format(path):
 def _read_dataset(pc, dataset, from_format, delimiter=",", input_header=True):
     """Reads a tabular dataset into a Spark DataFrame using a resolved format.
 
-    The format is resolved earlier, before the Spark session starts (see
-    :func:`_execute`), so this function only dispatches to the matching reader.
-    CSV is read with no schema inference; the delimiter and header options apply
-    to CSV inputs only, since Parquet and Delta carry their own schema. Parquet
-    and Delta accept both single-file and directory inputs.
+    The format and the delimiter are both resolved earlier, before the Spark
+    session starts (see :func:`_execute`), so this function only dispatches to
+    the matching reader. CSV is read with no schema inference; the delimiter and
+    header options apply to CSV inputs only, since Parquet and Delta carry their
+    own schema. Parquet and Delta accept both single-file and directory inputs.
 
     :param pc: the Pathling context.
     :param dataset: the path to the dataset file or directory.
     :param from_format: the resolved format, one of ``csv``, ``parquet``, or
            ``delta``.
-    :param delimiter: the CSV field separator; applied to ``csv`` inputs only.
+    :param delimiter: the resolved CSV field separator, a concrete character;
+           applied to ``csv`` inputs only.
     :param input_header: whether the first line of a CSV input is a header row;
            applied to ``csv`` inputs only. When False, Spark assigns positional
            column names ``_c0``, ``_c1``, ... referenced via ``--code-column``.
@@ -290,8 +294,9 @@ def _execute(
     :param limit: the table row cap.
     :param overwrite: whether to replace an existing output path.
     :param departition: whether file output is departitioned to a single file.
-    :param delimiter: the CSV field separator for both the input read and the
-           output write.
+    :param delimiter: the CSV field separator applied to both the input read and
+           the output write, or None to resolve each side independently from its
+           own path.
     :param header: whether CSV output includes a header row.
     :param input_header: whether the first line of a CSV input is a header row.
     :param build: a callback ``(pc, df) -> result_df`` performing the operation.
@@ -306,11 +311,23 @@ def _execute(
     # wins; otherwise the format is detected from the path (FR-002/FR-003).
     _validate_coding_source(dataset, system, system_column)
     resolved_format = from_format or _detect_tabular_format(Path(dataset))
+    # An omitted --delimiter takes its input-side default from the dataset path,
+    # independently of the output side, so a .tsv input is read as tab-separated
+    # without the user naming the separator. Resolved here, alongside the other
+    # pre-Spark steps, so the notice appears before the cold start rather than
+    # after a multi-second pause.
+    input_delimiter = (
+        default_delimiter_for_path(Path(dataset)) if delimiter is None else delimiter
+    )
+    # Announce an inferred tab only where the delimiter is actually consulted:
+    # Parquet and Delta inputs carry their own schema and ignore it entirely.
+    if delimiter is None and resolved_format == "csv" and input_delimiter == "\t":
+        console.print(tab_inference_notice("Reading", dataset))
     output_spec = resolve_output(
         output, output_format, limit, overwrite, departition, delimiter, header
     )
     pc = session.create_context(config, console)
-    df = _read_dataset(pc, dataset, resolved_format, delimiter, input_header)
+    df = _read_dataset(pc, dataset, resolved_format, input_delimiter, input_header)
 
     try:
         with progress_status(
@@ -547,7 +564,8 @@ def _run_subsumption(
     :param limit: the table row cap.
     :param overwrite: whether to replace an existing output path.
     :param departition: whether file output is departitioned to a single file.
-    :param delimiter: the CSV field separator for the input read and output write.
+    :param delimiter: the CSV field separator for the input read and output
+           write, or None to resolve each side from its own path.
     :param header: whether CSV output includes a header row.
     :param input_header: whether the first line of a CSV input is a header row.
     :param other_code: a fixed target code applied to every row, or None.

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -142,7 +142,7 @@ def _detect_tabular_format(path: Path) -> str:
 def _read_dataset(
     pc: PathlingContext,
     dataset: str,
-    from_format: Optional[str],
+    from_format: str,
     delimiter: str = ",",
     input_header: bool = True,
 ) -> DataFrame:

--- a/lib/python/pathling/cli/terminology.py
+++ b/lib/python/pathling/cli/terminology.py
@@ -346,19 +346,20 @@ def _execute(
     resolved_format = from_format or _detect_tabular_format(Path(dataset))
     # An omitted --delimiter takes its input-side default from the dataset path,
     # independently of the output side, so a .tsv input is read as tab-separated
-    # without the user naming the separator. Resolved here, alongside the other
-    # pre-Spark steps, so the notice appears before the cold start rather than
-    # after a multi-second pause.
+    # without the user naming the separator.
     input_delimiter = (
         default_delimiter_for_path(Path(dataset)) if delimiter is None else delimiter
     )
-    # Announce an inferred tab only where the delimiter is actually consulted:
-    # Parquet and Delta inputs carry their own schema and ignore it entirely.
-    if delimiter is None and resolved_format == "csv" and input_delimiter == "\t":
-        console.print(tab_inference_notice("Reading", dataset))
     output_spec = resolve_output(
         output, output_format, limit, overwrite, departition, delimiter, header
     )
+    # Announce an inferred tab only where the delimiter is actually consulted:
+    # Parquet and Delta inputs carry their own schema and ignore it entirely. This
+    # comes after the output options are resolved, so an invalid combination fails
+    # rather than announcing a read that never happens - and still before the
+    # multi-second Spark cold start, rather than after it.
+    if delimiter is None and resolved_format == "csv" and input_delimiter == "\t":
+        console.print(tab_inference_notice("Reading", dataset))
     pc = session.create_context(config, console)
     df = _read_dataset(pc, dataset, resolved_format, input_delimiter, input_header)
 

--- a/lib/python/pathling/cli/view.py
+++ b/lib/python/pathling/cli/view.py
@@ -24,8 +24,11 @@ restricting the resources processed with a FHIR search ``--filter``.
 Author: John Grimes.
 """
 
+from __future__ import annotations
+
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING, Optional
 
 import click
 
@@ -39,8 +42,11 @@ from pathling.cli.render import (
     write_output,
 )
 
+if TYPE_CHECKING:
+    from pathling.cli.main import CliContext
 
-def _load_view(view_path, view_json) -> tuple:
+
+def _load_view(view_path: Optional[str], view_json: Optional[str]) -> tuple:
     """Loads and minimally validates a ViewDefinition.
 
     :param view_path: the ``--view`` file path, or None.
@@ -104,20 +110,20 @@ def _load_view(view_path, view_json) -> tuple:
 @output_options
 @click.pass_obj
 def view(
-    obj,
-    source,
-    from_format,
-    view_path,
-    view_json,
-    filter_expr,
-    output_format,
-    output,
-    limit,
-    overwrite,
-    departition,
-    delimiter,
-    header,
-):
+    obj: CliContext,
+    source: str,
+    from_format: Optional[str],
+    view_path: Optional[str],
+    view_json: Optional[str],
+    filter_expr: Optional[str],
+    output_format: Optional[str],
+    output: Optional[str],
+    limit: int,
+    overwrite: bool,
+    departition: bool,
+    delimiter: Optional[str],
+    header: bool,
+) -> None:
     """Run a SQL on FHIR ViewDefinition against a data source.
 
     \b

--- a/lib/python/tests/cli/conftest.py
+++ b/lib/python/tests/cli/conftest.py
@@ -102,6 +102,20 @@ def runner():
 
 
 @fixture
+def wide_stderr(monkeypatch):
+    """Widens the CLI's stderr console so status messages are not wrapped.
+
+    Rich sizes a console from the ``COLUMNS`` environment variable, and hard-folds
+    a long unbroken run of characters - such as a temporary directory path - onto
+    the next line. Widening the console keeps each message on one line so tests
+    can assert on its content rather than on Rich's display-width wrapping.
+
+    :param monkeypatch: the pytest monkeypatch fixture.
+    """
+    monkeypatch.setenv("COLUMNS", "10000")
+
+
+@fixture
 def patched_context(monkeypatch, pathling_ctx):
     """Makes commands reuse the shared mock-backed ``PathlingContext``.
 

--- a/lib/python/tests/cli/test_console.py
+++ b/lib/python/tests/cli/test_console.py
@@ -41,8 +41,20 @@ def test_banner_contains_version_variables_and_exit_hint():
 
     assert __version__ in banner
     assert "spark" in banner
-    assert "pathling" in banner
+    assert "pc" in banner
     assert "exit" in banner.lower()
+
+
+def test_banner_names_pc_as_the_context_not_pathling():
+    """The banner names pc as the context and does not call pathling one (FR-015).
+
+    The name in scope is what a user copies into their next command, so the
+    banner must not point them at a name that holds the module.
+    """
+    banner = build_banner()
+
+    assert "pc (PathlingContext)" in banner
+    assert "pathling (PathlingContext)" not in banner
 
 
 def test_banner_mentions_preimported_functions_and_tx_display():
@@ -76,19 +88,47 @@ def test_console_starts_ipython_with_namespace(runner, patched_context, monkeypa
     # IPython must not consume the process's own argv.
     assert captured["argv"] == []
     user_ns = captured["user_ns"]
-    # spark and pathling remain correctly bound.
+    # spark and pc remain correctly bound.
     assert user_ns["spark"] is patched_context.spark
-    assert user_ns["pathling"] is patched_context
-    # The namespace is the public API minus display, plus spark, pathling, and
-    # tx_display (INV-2), derived from __all__ rather than a hard-coded list.
+    assert user_ns["pc"] is patched_context
+    # The namespace is the public API minus display, plus spark, pc, the pathling
+    # module, and tx_display (INV-2), derived from __all__ rather than a
+    # hard-coded list.
     expected = (set(pathling.__all__) - {"display"}) | {
         "spark",
+        "pc",
         "pathling",
         "tx_display",
     }
     assert set(user_ns) == expected
     # The configuration carries the banner.
     assert captured["config"].TerminalInteractiveShell.banner1 == build_banner()
+
+
+def test_console_binds_the_module_not_the_context_to_pathling(
+    runner, patched_context, monkeypatch
+):
+    """``pathling`` is the module, so typing ``import pathling`` leaves pc intact.
+
+    The context is reachable only as ``pc`` (FR-012, FR-013, FR-014).
+    """
+    captured = {}
+
+    def fake_start_ipython(argv=None, user_ns=None, config=None, **kwargs):
+        captured["user_ns"] = user_ns
+
+    monkeypatch.setattr(IPython, "start_ipython", fake_start_ipython)
+
+    result = runner.invoke(cli, ["console"])
+
+    assert result.exit_code == 0, result.stderr
+    user_ns = captured["user_ns"]
+    assert user_ns["pathling"] is pathling
+    assert user_ns["pathling"] is not patched_context
+    # Rebinding the name to the module - what `import pathling` does - leaves the
+    # context reachable, which is the whole point of the rename.
+    user_ns["pathling"] = pathling
+    assert user_ns["pc"] is patched_context
 
 
 def test_console_namespace_display_split(runner, patched_context, monkeypatch):

--- a/lib/python/tests/cli/test_fhirpath.py
+++ b/lib/python/tests/cli/test_fhirpath.py
@@ -111,6 +111,61 @@ def test_fhirpath_accepts_delimiter_and_header_options(
     assert "Krajcik437" in result.stdout
 
 
+def test_fhirpath_to_tsv_file_is_tab_separated(
+    runner, patched_context, ndjson_source, tmp_path, wide_stderr
+):
+    """``fhirpath -o out.tsv`` writes tab-separated output with no --delimiter (T008)."""
+    out = tmp_path / "results.tsv"
+
+    result = runner.invoke(
+        cli,
+        [
+            "fhirpath",
+            ndjson_source,
+            "-t",
+            "Patient",
+            "-e",
+            "name.first().family",
+            "-o",
+            str(out),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = list(csv.reader(io.StringIO(out.read_text()), delimiter="\t"))
+    assert rows[0] == ["id", "result"]
+    assert (
+        f"Writing {out} as tab-separated CSV, inferred from the .tsv extension."
+        in result.stderr
+    )
+
+
+def test_fhirpath_to_csv_file_stays_comma_separated(
+    runner, patched_context, ndjson_source, tmp_path
+):
+    """``fhirpath -o out.csv`` still writes commas and announces nothing (T008)."""
+    out = tmp_path / "results.csv"
+
+    result = runner.invoke(
+        cli,
+        [
+            "fhirpath",
+            ndjson_source,
+            "-t",
+            "Patient",
+            "-e",
+            "name.first().family",
+            "-o",
+            str(out),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = list(csv.reader(io.StringIO(out.read_text())))
+    assert rows[0] == ["id", "result"]
+    assert "tab-separated" not in result.stderr
+
+
 def test_data_source_mode_requires_type(runner, patched_context, ndjson_source):
     """Omitting -t in data source mode is a usage error."""
     result = runner.invoke(cli, ["fhirpath", ndjson_source, "-e", "name.family"])

--- a/lib/python/tests/cli/test_help.py
+++ b/lib/python/tests/cli/test_help.py
@@ -72,7 +72,7 @@ def test_run_help_mentions_sources_and_arguments(runner):
     assert "SCRIPT" in result.output
     assert "-c" in result.output
     assert "spark" in result.output
-    assert "pathling" in result.output
+    assert "pc" in result.output
     assert "sys.argv" in result.output
 
 
@@ -82,8 +82,23 @@ def test_console_help_mentions_variables(runner):
 
     assert result.exit_code == 0
     assert "spark" in result.output
-    assert "pathling" in result.output
+    assert "pc" in result.output
     assert "exit" in result.output.lower()
+
+
+@pytest.mark.parametrize("command_name", ["run", "console"])
+def test_help_names_the_context_pc(runner, command_name):
+    """Both commands' help refer to the context as pc, in prose and examples.
+
+    A snippet copied out of the help must work at the prompt, so the help cannot
+    describe the context under the name that holds the module (FR-016).
+    """
+    result = runner.invoke(cli, [command_name, "--help"])
+
+    assert result.exit_code == 0
+    collapsed = " ".join(result.output.split())
+    assert "pc (the configured Pathling context)" in collapsed
+    assert "pathling (the configured Pathling context)" not in collapsed
 
 
 @pytest.mark.parametrize(

--- a/lib/python/tests/cli/test_lint_gate.py
+++ b/lib/python/tests/cli/test_lint_gate.py
@@ -1,0 +1,107 @@
+#
+# Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for the scope of the missing-annotation lint gate.
+
+Every signature in ``pathling/cli/`` must carry type annotations, enforced by a
+nested ``ruff.toml`` that adds the ``ANN`` rules for that directory only. These
+tests prove the gate both bites inside the CLI package and stays out of the rest
+of the library and the test suite - a gate that fired everywhere would have to be
+suppressed everywhere, and one that fired nowhere would not be a gate at all.
+
+Ruff is run over standard input with a substituted filename, so the scoping is
+exercised without creating files that a failed run could leave behind.
+
+Author: John Grimes.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# An unannotated parameter and return type: two ANN findings wherever the gate
+# applies, and none where it does not.
+UNANNOTATED_SOURCE = "def scratch(value):\n    return value\n"
+
+# The library root, which is the working directory the project's own lint check
+# runs from and the directory holding the root configuration.
+LIBRARY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _check(relative_path: str) -> subprocess.CompletedProcess:
+    """Runs ruff over the unannotated source, attributed to the given path.
+
+    :param relative_path: the path, relative to the library root, that the
+           source is attributed to; this is what ruff matches configuration
+           against.
+    :return: the completed ruff process, with its output captured.
+    """
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ruff",
+            "check",
+            "--no-cache",
+            "--stdin-filename",
+            relative_path,
+            "-",
+        ],
+        cwd=LIBRARY_ROOT,
+        input=UNANNOTATED_SOURCE,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_gate_rejects_an_unannotated_signature_in_the_cli_package():
+    """An unannotated function inside the CLI package fails the check (FR-020)."""
+    result = _check("pathling/cli/scratch.py")
+
+    assert result.returncode != 0, result.stdout
+    # Both the parameter and the return type are named.
+    assert "ANN001" in result.stdout
+    assert "ANN201" in result.stdout
+    assert "value" in result.stdout
+
+
+def test_gate_covers_a_nested_module_in_the_cli_package():
+    """The gate applies throughout the package, not only at its top level."""
+    result = _check("pathling/cli/nested/scratch.py")
+
+    assert result.returncode != 0, result.stdout
+    assert "ANN001" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        # The rest of the library, outside the CLI package.
+        "pathling/scratch.py",
+        # The test suite, which is deliberately left unannotated.
+        "tests/scratch.py",
+        "tests/cli/scratch.py",
+    ],
+)
+def test_gate_does_not_apply_outside_the_cli_package(relative_path):
+    """The same unannotated source passes everywhere else (FR-020)."""
+    result = _check(relative_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ANN" not in result.stdout

--- a/lib/python/tests/cli/test_render.py
+++ b/lib/python/tests/cli/test_render.py
@@ -34,6 +34,7 @@ from pathling.cli.render import (
     OutputFormat,
     check_overwrite,
     decode_delimiter,
+    default_delimiter_for_path,
     infer_format_from_extension,
     output_options,
     render_csv,
@@ -41,6 +42,7 @@ from pathling.cli.render import (
     render_rows,
     render_table,
     resolve_output,
+    tab_inference_notice,
 )
 
 COLUMNS = ["id", "family"]
@@ -341,6 +343,121 @@ def test_delimiter_and_header_flags_appear_in_command_help():
 
     assert "--delimiter" in result.output
     assert "--no-header" in result.output
+
+
+# ========== Extension-derived delimiter defaults (T004) ==========
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("codes.tsv", "\t"),
+        # The suffix is matched case-insensitively, as format inference is.
+        ("codes.TSV", "\t"),
+        ("codes.Tsv", "\t"),
+        ("codes.csv", ","),
+        # An unrecognised or absent suffix falls back to the base default.
+        ("codes.dat", ","),
+        ("codes", ","),
+    ],
+)
+def test_default_delimiter_for_path(name, expected):
+    """Only a .tsv suffix, in any case, defaults to a tab."""
+    from pathlib import Path
+
+    assert default_delimiter_for_path(Path(name)) == expected
+
+
+def test_default_delimiter_for_absent_path_is_a_comma():
+    """With no path (stdout) there is nothing to infer from, so a comma applies."""
+    assert default_delimiter_for_path(None) == ","
+
+
+def test_tab_inference_notice_wording():
+    """Both sides share one wording, differing only in the leading verb."""
+    assert tab_inference_notice("Reading", "/tmp/codes.tsv") == (
+        "Reading /tmp/codes.tsv as tab-separated CSV, inferred from the .tsv extension."
+    )
+    assert tab_inference_notice("Writing", "/tmp/out.tsv") == (
+        "Writing /tmp/out.tsv as tab-separated CSV, inferred from the .tsv extension."
+    )
+
+
+def test_resolve_output_infers_tab_from_tsv_path():
+    """An omitted delimiter with a .tsv output path resolves to a tab."""
+    spec = resolve_output("out.tsv", None)
+
+    assert spec.delimiter == "\t"
+    assert spec.delimiter_inferred is True
+
+
+def test_resolve_output_infers_comma_from_csv_path():
+    """An omitted delimiter with a .csv output path resolves to a comma."""
+    spec = resolve_output("out.csv", None)
+
+    assert spec.delimiter == ","
+    assert spec.delimiter_inferred is True
+
+
+def test_resolve_output_infers_comma_for_stdout():
+    """CSV to stdout has no path to infer from, so it resolves to a comma."""
+    spec = resolve_output(None, OutputFormat.CSV)
+
+    assert spec.delimiter == ","
+    assert spec.delimiter_inferred is True
+
+
+@pytest.mark.parametrize("supplied", [",", "\t", ";"])
+def test_resolve_output_explicit_delimiter_is_not_inferred(supplied):
+    """An explicitly supplied delimiter wins over the path and is not inferred.
+
+    A .tsv path with an explicit comma yields a comma - the flag is authoritative
+    - and the spec records that no inference took place, so no notice is printed.
+    """
+    spec = resolve_output("out.tsv", None, delimiter=supplied)
+
+    assert spec.delimiter == supplied
+    assert spec.delimiter_inferred is False
+
+
+def test_resolve_output_infers_tab_for_uppercase_tsv_path():
+    """The output-side inference is case-insensitive, matching format inference."""
+    spec = resolve_output("OUT.TSV", None)
+
+    assert spec.delimiter == "\t"
+    assert spec.delimiter_inferred is True
+
+
+def test_delimiter_help_states_the_extension_derived_default():
+    """The --delimiter help text documents the per-path default."""
+    from click.testing import CliRunner
+
+    @click.command()
+    @output_options
+    def cmd(**kwargs):
+        pass
+
+    result = CliRunner().invoke(cmd, ["--help"])
+
+    # Rich/Click may wrap the help text, so the words are asserted rather than
+    # the exact line breaks.
+    collapsed = " ".join(result.output.split())
+    assert "a tab for a .tsv path, otherwise ','" in collapsed
+
+
+def test_format_offers_no_tsv_value():
+    """--format gains no tsv value; the extension governs the delimiter only."""
+    from click.testing import CliRunner
+
+    @click.command()
+    @output_options
+    def cmd(**kwargs):
+        pass
+
+    result = CliRunner().invoke(cmd, ["--format", "tsv", "-o", "out.tsv"])
+
+    assert result.exit_code != 0
+    assert "is not one of" in result.output
 
 
 # ========== Overwrite handling ==========

--- a/lib/python/tests/cli/test_run.py
+++ b/lib/python/tests/cli/test_run.py
@@ -64,11 +64,11 @@ def _write_script(tmp_path, body, name="script.py"):
 # ========== Namespace binding ==========
 
 
-def test_spark_and_pathling_are_bound(runner, patched_context, tmp_path):
+def test_spark_and_pc_are_bound(runner, patched_context, tmp_path):
     """The script sees the context's Spark session and the context itself."""
     script = _write_script(
         tmp_path,
-        "print(id(spark))\nprint(id(pathling))\n",
+        "print(id(spark))\nprint(id(pc))\n",
     )
 
     result = runner.invoke(cli, ["run", script])
@@ -191,7 +191,7 @@ def test_sys_exit_message_prints_and_exits_1(runner, patched_context, tmp_path):
 
 def test_inline_code_executes_with_namespace(runner, patched_context):
     """-c code executes with both variables bound."""
-    result = runner.invoke(cli, ["run", "-c", "print(id(spark)); print(id(pathling))"])
+    result = runner.invoke(cli, ["run", "-c", "print(id(spark)); print(id(pc))"])
 
     assert result.exit_code == 0, result.stderr
     lines = result.stdout.splitlines()
@@ -223,7 +223,7 @@ def test_inline_syntax_error_names_string(runner, patched_context):
 
 def test_stdin_code_executes_with_namespace(runner, patched_context):
     """Code piped on stdin via '-' executes with both variables bound."""
-    result = runner.invoke(cli, ["run", "-"], input="print(type(pathling).__name__)\n")
+    result = runner.invoke(cli, ["run", "-"], input="print(type(pc).__name__)\n")
 
     assert result.exit_code == 0, result.stderr
     assert "PathlingContext" in result.stdout
@@ -409,3 +409,49 @@ def test_every_public_name_is_in_program_globals(runner, patched_context):
 
     assert result.exit_code == 0, result.stderr
     assert result.stdout.splitlines()[0] == "[]"
+
+
+def test_pathling_is_bound_to_the_module(runner, patched_context):
+    """``pathling`` is the package module, not the context (FR-013, FR-014)."""
+    result = runner.invoke(
+        cli,
+        ["run", "-c", "import types\nprint(isinstance(pathling, types.ModuleType))"],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout.splitlines()[0] == "True"
+
+
+def test_import_pathling_leaves_the_context_usable(runner, patched_context, tmp_path):
+    """A bare ``import pathling`` is a no-op and pc still works afterwards (SC-003).
+
+    This is the failure this rename removes: with the context bound to
+    ``pathling``, the import silently rebound the name and the break surfaced
+    later as an AttributeError far from its cause.
+    """
+    script = _write_script(
+        tmp_path,
+        "import pathling\n"
+        "print(type(pathling).__name__)\n"
+        "print(type(pc).__name__)\n"
+        "print(pc.spark is spark)\n",
+    )
+
+    result = runner.invoke(cli, ["run", script])
+
+    assert result.exit_code == 0, result.stderr
+    lines = result.stdout.splitlines()
+    assert lines[0] == "module"
+    assert lines[1] == "PathlingContext"
+    assert lines[2] == "True"
+
+
+def test_module_attribute_resolves_without_an_import(runner, patched_context):
+    """``pathling.PathlingContext`` resolves with no import, since the module is
+    bound under its own name."""
+    result = runner.invoke(
+        cli, ["run", "-c", "print(pathling.PathlingContext.__name__)"]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout.splitlines()[0] == "PathlingContext"

--- a/lib/python/tests/cli/test_session.py
+++ b/lib/python/tests/cli/test_session.py
@@ -280,11 +280,22 @@ def test_remote_mode_passes_existing_parameters_unchanged(monkeypatch):
 # ========== Public namespace helper ==========
 
 
-def test_public_namespace_keys_equal_all():
-    """The helper's keys are exactly the package's public API list (FR-003)."""
+def test_public_namespace_keys_equal_all_plus_the_module():
+    """The keys are the public API list plus the package module itself (FR-014)."""
     namespace = public_namespace()
 
-    assert set(namespace) == set(pathling.__all__)
+    assert set(namespace) == set(pathling.__all__) | {"pathling"}
+
+
+def test_public_namespace_binds_the_pathling_module():
+    """``pathling`` is bound to the module, so a bare import cannot clobber it.
+
+    Binding the module makes ``import pathling`` in a script or at the console a
+    genuine no-op: it rebinds the name to the object it already holds (FR-014).
+    """
+    namespace = public_namespace()
+
+    assert namespace["pathling"] is pathling
 
 
 def test_public_namespace_values_are_the_resolved_objects():
@@ -311,12 +322,12 @@ def test_public_namespace_covers_every_public_name():
 
 def test_run_namespace_is_superset_of_public_api():
     """The run namespace is derived from __all__ plus the run-only extras (INV-1)."""
-    expected = set(pathling.__all__) | {"spark", "pathling", "tx_display"}
+    expected = set(pathling.__all__) | {"spark", "pc", "pathling", "tx_display"}
 
     namespace = dict(public_namespace())
     namespace["tx_display"] = namespace["display"]
     namespace["spark"] = object()
-    namespace["pathling"] = object()
+    namespace["pc"] = object()
 
     assert set(namespace) >= expected
 
@@ -326,6 +337,7 @@ def test_console_namespace_equals_public_api_minus_display():
     (INV-2)."""
     expected = (set(pathling.__all__) - {"display"}) | {
         "spark",
+        "pc",
         "pathling",
         "tx_display",
     }
@@ -333,6 +345,6 @@ def test_console_namespace_equals_public_api_minus_display():
     namespace = dict(public_namespace())
     namespace["tx_display"] = namespace.pop("display")
     namespace["spark"] = object()
-    namespace["pathling"] = object()
+    namespace["pc"] = object()
 
     assert set(namespace) == expected

--- a/lib/python/tests/cli/test_terminology.py
+++ b/lib/python/tests/cli/test_terminology.py
@@ -263,6 +263,241 @@ def test_member_of_tab_separated_round_trip(
     assert file_rows[0] == ["code", "system", "member_of"]
 
 
+# ========== Extension-derived delimiter inference (T006) ==========
+
+
+def _member_of_args(dataset):
+    """Builds the common member-of argument list for a dataset path.
+
+    :param dataset: the dataset path to read.
+    :return: the argument list, ready for further options to be appended.
+    """
+    return [
+        "member-of",
+        str(dataset),
+        "--code-column",
+        "code",
+        "--system",
+        SNOMED,
+        "--value-set",
+        VALUE_SET,
+    ]
+
+
+def test_tsv_input_parses_without_a_delimiter_flag(
+    runner, patched_context, delimited_csv
+):
+    """A .tsv input parses into its columns with no --delimiter (FR-002)."""
+    dataset = delimited_csv(
+        [["368529001", SNOMED]],
+        header=["code", "system"],
+        delimiter="\t",
+        name="codes.tsv",
+    )
+
+    result = runner.invoke(cli, _member_of_args(dataset) + ["--format", "csv"])
+
+    # Without the inference the whole tabbed line would collapse into one
+    # column and the --code-column lookup would fail.
+    assert result.exit_code == 0, result.stderr
+    assert _stdout_rows(result)[0] == ["code", "system", "member_of"]
+
+
+def test_tsv_input_prints_the_input_side_notice(
+    runner, patched_context, delimited_csv, wide_stderr
+):
+    """The inferred tab on the input side is announced on stderr (FR-007)."""
+    dataset = delimited_csv(
+        [["368529001", SNOMED]],
+        header=["code", "system"],
+        delimiter="\t",
+        name="codes.tsv",
+    )
+
+    result = runner.invoke(cli, _member_of_args(dataset) + ["--format", "csv"])
+
+    assert result.exit_code == 0, result.stderr
+    assert (
+        f"Reading {dataset} as tab-separated CSV, inferred from the .tsv extension."
+        in result.stderr
+    )
+
+
+def test_csv_input_reads_with_a_comma_and_no_notice(runner, patched_context, codes_csv):
+    """A .csv input keeps the comma default and prints no notice (FR-008)."""
+    result = runner.invoke(cli, _member_of_args(codes_csv) + ["--format", "csv"])
+
+    assert result.exit_code == 0, result.stderr
+    assert _stdout_rows(result)[0] == ["code", "system", "member_of"]
+    assert "tab-separated" not in result.stderr
+
+
+def test_explicit_delimiter_overrides_the_extension_on_both_sides(
+    runner, patched_context, delimited_csv, tmp_path
+):
+    """An explicit --delimiter wins over both path extensions (FR-003)."""
+    # A semicolon-separated file deliberately named .tsv: the explicit flag must
+    # win, otherwise the read would fail to find the code column.
+    dataset = delimited_csv(
+        [["368529001", SNOMED]],
+        header=["code", "system"],
+        delimiter=";",
+        name="codes.tsv",
+    )
+    out = tmp_path / "out.tsv"
+
+    result = runner.invoke(
+        cli, _member_of_args(dataset) + ["--delimiter", ";", "-o", str(out)]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    # Both sides used the semicolon; no inference occurred on either.
+    rows = list(csv.reader(io.StringIO(out.read_text()), delimiter=";"))
+    assert rows[0] == ["code", "system", "member_of"]
+    assert "tab-separated" not in result.stderr
+
+
+def test_explicit_comma_on_a_tsv_path_yields_a_comma(
+    runner, patched_context, codes_csv, tmp_path
+):
+    """An explicit comma on a .tsv output path is honoured with no notice."""
+    out = tmp_path / "out.tsv"
+
+    result = runner.invoke(
+        cli, _member_of_args(codes_csv) + ["--delimiter", ",", "-o", str(out)]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = list(csv.reader(io.StringIO(out.read_text())))
+    assert rows[0] == ["code", "system", "member_of"]
+    assert "tab-separated" not in result.stderr
+
+
+def test_tsv_path_with_from_parquet_involves_no_delimiter(
+    runner, patched_context, tmp_path, pathling_ctx
+):
+    """A .tsv path read as Parquet uses no delimiter and prints no notice (FR-005)."""
+    # A Parquet dataset directory deliberately named .tsv, read with an explicit
+    # --from, so the resolved format is not CSV.
+    dataset = _write_parquet(
+        pathling_ctx.spark,
+        tmp_path / "data.tsv",
+        "code string, system string",
+        [["368529001", SNOMED]],
+    )
+
+    result = runner.invoke(
+        cli, _member_of_args(dataset) + ["--from", "parquet", "--format", "csv"]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert _stdout_rows(result)[0] == ["code", "system", "member_of"]
+    assert "tab-separated" not in result.stderr
+
+
+def test_tsv_path_with_from_csv_still_infers_a_tab(
+    runner, patched_context, delimited_csv
+):
+    """Inference is independent of --from, so an explicit csv still infers a tab.
+
+    The extension governs the delimiter; ``--from`` governs only the format
+    (FR-006).
+    """
+    dataset = delimited_csv(
+        [["368529001", SNOMED]],
+        header=["code", "system"],
+        delimiter="\t",
+        name="codes.tsv",
+    )
+
+    result = runner.invoke(
+        cli, _member_of_args(dataset) + ["--from", "csv", "--format", "csv"]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert _stdout_rows(result)[0] == ["code", "system", "member_of"]
+    assert "tab-separated" in result.stderr
+
+
+def test_zero_flag_tsv_round_trip(
+    runner, patched_context, delimited_csv, tmp_path, wide_stderr
+):
+    """A .tsv in and .tsv out round trip needs no delimiter flag (SC-001).
+
+    This is quickstart Scenario 1: both sides infer a tab from their own path,
+    and both announce it.
+    """
+    dataset = delimited_csv(
+        [["368529001", SNOMED], ["439319006", SNOMED]],
+        header=["code", "system"],
+        delimiter="\t",
+        name="codes.tsv",
+    )
+    out = tmp_path / "out.tsv"
+
+    result = runner.invoke(cli, _member_of_args(dataset) + ["-o", str(out)])
+
+    assert result.exit_code == 0, result.stderr
+    rows = list(csv.reader(io.StringIO(out.read_text()), delimiter="\t"))
+    assert rows[0] == ["code", "system", "member_of"]
+    assert len(rows[0]) == 3
+    # Both sides announced their inference.
+    assert f"Reading {dataset} as tab-separated CSV" in result.stderr
+    assert f"Writing {out} as tab-separated CSV" in result.stderr
+
+
+def test_tsv_in_csv_out_resolves_each_side_independently(
+    runner, patched_context, delimited_csv, tmp_path, wide_stderr
+):
+    """A .tsv input and .csv output resolve separately (quickstart Scenario 2)."""
+    dataset = delimited_csv(
+        [["368529001", SNOMED]],
+        header=["code", "system"],
+        delimiter="\t",
+        name="codes.tsv",
+    )
+    out = tmp_path / "out.csv"
+
+    result = runner.invoke(cli, _member_of_args(dataset) + ["-o", str(out)])
+
+    assert result.exit_code == 0, result.stderr
+    # The input was read as tab-separated and the output written comma-separated.
+    rows = list(csv.reader(io.StringIO(out.read_text())))
+    assert rows[0] == ["code", "system", "member_of"]
+    # Only the input side announced an inference.
+    assert f"Reading {dataset} as tab-separated CSV" in result.stderr
+    assert "Writing" not in result.stderr
+
+
+def test_stdout_stays_comma_separated_for_a_tsv_input(
+    runner, patched_context, delimited_csv
+):
+    """With no -o there is no path to infer from, so stdout is comma-separated."""
+    dataset = delimited_csv(
+        [["368529001", SNOMED]],
+        header=["code", "system"],
+        delimiter="\t",
+        name="codes.tsv",
+    )
+
+    result = runner.invoke(cli, _member_of_args(dataset) + ["--format", "csv"])
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout.splitlines()[0] == "code,system,member_of"
+
+
+def test_from_offers_no_tsv_value(runner, patched_context, delimited_csv):
+    """--from gains no tsv value; the extension governs the delimiter only."""
+    dataset = delimited_csv(
+        [["368529001", SNOMED]], header=["code", "system"], name="codes.tsv"
+    )
+
+    result = runner.invoke(cli, _member_of_args(dataset) + ["--from", "tsv"])
+
+    assert result.exit_code == 2
+    assert "is not one of" in result.stderr
+
+
 # ========== Headerless CSV input (US3) ==========
 
 

--- a/lib/python/tests/cli/test_terminology.py
+++ b/lib/python/tests/cli/test_terminology.py
@@ -486,6 +486,31 @@ def test_stdout_stays_comma_separated_for_a_tsv_input(
     assert result.stdout.splitlines()[0] == "code,system,member_of"
 
 
+def test_invalid_output_path_fails_without_announcing_a_read(
+    runner, patched_context, delimited_csv, tmp_path
+):
+    """An unusable output path fails before the input-side notice is printed.
+
+    Announcing a read that the command then never performs would be misleading,
+    so the notice comes after the output options are resolved - while still
+    staying ahead of the Spark cold start.
+    """
+    dataset = delimited_csv(
+        [["368529001", SNOMED]],
+        header=["code", "system"],
+        delimiter="\t",
+        name="codes.tsv",
+    )
+
+    result = runner.invoke(
+        cli, _member_of_args(dataset) + ["-o", str(tmp_path / "out.json")]
+    )
+
+    assert result.exit_code == 2
+    assert "ndjson" in result.stderr.lower()
+    assert "tab-separated" not in result.stderr
+
+
 def test_from_offers_no_tsv_value(runner, patched_context, delimited_csv):
     """--from gains no tsv value; the extension governs the delimiter only."""
     dataset = delimited_csv(

--- a/lib/python/tests/cli/test_view.py
+++ b/lib/python/tests/cli/test_view.py
@@ -154,6 +154,48 @@ def test_view_to_csv_file(runner, patched_context, ndjson_source, view_file, tmp
     assert "rows" not in result.stderr
 
 
+def test_view_to_tsv_file_is_tab_separated(
+    runner, patched_context, ndjson_source, view_file, tmp_path, wide_stderr
+):
+    """``view -o out.tsv`` writes tab-separated output with no --delimiter (T007).
+
+    ``view`` reads FHIR data rather than CSV, so only the ``-o`` extension takes
+    part in delimiter resolution.
+    """
+    out = tmp_path / "results.tsv"
+
+    result = runner.invoke(
+        cli, ["view", ndjson_source, "--view", str(view_file), "-o", str(out)]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = list(csv.reader(io.StringIO(out.read_text()), delimiter="\t"))
+    # The header parses into its separate columns rather than one tabbed field.
+    assert len(rows[0]) > 1
+    assert "family_name" in rows[0]
+    assert (
+        f"Writing {out} as tab-separated CSV, inferred from the .tsv extension."
+        in result.stderr
+    )
+
+
+def test_view_to_csv_file_stays_comma_separated(
+    runner, patched_context, ndjson_source, view_file, tmp_path
+):
+    """``view -o out.csv`` still writes commas and announces nothing (T007)."""
+    out = tmp_path / "results.csv"
+
+    result = runner.invoke(
+        cli, ["view", ndjson_source, "--view", str(view_file), "-o", str(out)]
+    )
+
+    assert result.exit_code == 0, result.stderr
+    rows = list(csv.reader(io.StringIO(out.read_text())))
+    assert len(rows[0]) > 1
+    assert "family_name" in rows[0]
+    assert "tab-separated" not in result.stderr
+
+
 def test_view_to_parquet_file(
     runner, patched_context, ndjson_source, view_file, tmp_path
 ):

--- a/lib/python/tests/cli/test_write_file.py
+++ b/lib/python/tests/cli/test_write_file.py
@@ -60,6 +60,7 @@ def _spec(
     overwrite: bool = False,
     departition: bool = True,
     delimiter: str = ",",
+    delimiter_inferred: bool = False,
     header: bool = True,
 ) -> OutputSpec:
     """Builds an :class:`OutputSpec` for a file path and format.
@@ -69,6 +70,8 @@ def _spec(
     :param overwrite: whether an existing target may be replaced.
     :param departition: whether single-file departitioning is applied.
     :param delimiter: the CSV field separator.
+    :param delimiter_inferred: whether the delimiter was derived from the path
+           rather than supplied explicitly.
     :param header: whether CSV output includes a header row.
     :return: the output specification.
     """
@@ -78,6 +81,7 @@ def _spec(
         overwrite=overwrite,
         departition=departition,
         delimiter=delimiter,
+        delimiter_inferred=delimiter_inferred,
         header=header,
     )
 
@@ -382,3 +386,95 @@ def test_confirmation_names_format_and_path_without_row_count(spark, tmp_path):
     message = buffer.getvalue()
     assert message.strip() == f"Wrote csv output to {out}."
     assert "row" not in message.lower()
+
+
+# ========== Inferred-tab notice on the output side (T005) ==========
+
+
+def test_inferred_tab_prints_the_output_side_notice(spark, tmp_path):
+    """An inferred tab delimiter is announced on stderr before the confirmation."""
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    out = tmp_path / "out.tsv"
+    console, buffer = _capture_console()
+
+    write_output(
+        df,
+        _spec(out, OutputFormat.CSV, delimiter="\t", delimiter_inferred=True),
+        console,
+    )
+
+    lines = [line for line in buffer.getvalue().splitlines() if line]
+    assert lines == [
+        f"Writing {out} as tab-separated CSV, inferred from the .tsv extension.",
+        f"Wrote csv output to {out}.",
+    ]
+
+
+def test_inferred_comma_prints_no_notice(spark, tmp_path):
+    """An inferred comma is the base default and needs no announcement."""
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    out = tmp_path / "out.csv"
+    console, buffer = _capture_console()
+
+    write_output(
+        df,
+        _spec(out, OutputFormat.CSV, delimiter=",", delimiter_inferred=True),
+        console,
+    )
+
+    assert buffer.getvalue().strip() == f"Wrote csv output to {out}."
+
+
+def test_explicit_tab_prints_no_notice(spark, tmp_path):
+    """An explicitly requested tab was not inferred, so nothing is announced."""
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    out = tmp_path / "out.tsv"
+    console, buffer = _capture_console()
+
+    write_output(
+        df,
+        _spec(out, OutputFormat.CSV, delimiter="\t", delimiter_inferred=False),
+        console,
+    )
+
+    assert buffer.getvalue().strip() == f"Wrote csv output to {out}."
+
+
+def test_non_csv_format_prints_no_notice(spark, tmp_path):
+    """A non-CSV format never consults the delimiter, so nothing is announced.
+
+    ``--format ndjson -o out.tsv`` reaches this state: the explicit format wins
+    over the extension, so the inferred tab is irrelevant to the write.
+    """
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    out = tmp_path / "out.tsv"
+    console, buffer = _capture_console()
+
+    write_output(
+        df,
+        _spec(out, OutputFormat.NDJSON, delimiter="\t", delimiter_inferred=True),
+        console,
+    )
+
+    assert buffer.getvalue().strip() == f"Wrote ndjson output to {out}."
+
+
+def test_stdout_prints_no_notice(spark, capsys):
+    """CSV to stdout resolves to a comma, so no notice is printed."""
+    df = spark.createDataFrame([("1", "Smith")], "id string, family string")
+    console, buffer = _capture_console()
+
+    write_output(
+        df,
+        OutputSpec(
+            path=None,
+            format=OutputFormat.CSV,
+            delimiter=",",
+            delimiter_inferred=True,
+        ),
+        console,
+    )
+
+    # Nothing on the stderr console, and the stdout rows are comma-separated.
+    assert buffer.getvalue() == ""
+    assert "1,Smith" in capsys.readouterr().out

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -67,15 +67,15 @@ specify `--from`.
 Tabular results (from `view`, `fhirpath`, and the terminology commands) render
 as a human-readable table by default.
 
-| Option                           | Behaviour                                                                                                                     |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `--format`                       | `table` (default), `csv`, `ndjson`; with `-o` also `parquet`, `delta`.                                                        |
-| `-o PATH`                        | Write to a file instead of stdout; the format is inferred from the extension (`.csv`/`.tsv`, `.ndjson`/`.jsonl`, `.parquet`). |
-| `--limit N`                      | Row cap for stdout table output (default 50).                                                                                 |
-| `--overwrite`                    | Allow replacing an existing output path.                                                                                      |
-| `--departition/--no-departition` | Write file output as a single file (default) or as a Spark directory of part files. No effect on Delta.                       |
-| `--delimiter CHAR`               | Field separator for CSV input and output (default `,`). Accepts a backslash escape such as `\t` for a tab.                    |
-| `--header/--no-header`           | Include a header row in CSV output (default enabled).                                                                         |
+| Option                           | Behaviour                                                                                                                                                    |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--format`                       | `table` (default), `csv`, `ndjson`; with `-o` also `parquet`, `delta`.                                                                                       |
+| `-o PATH`                        | Write to a file instead of stdout; the format, and for `.tsv` the delimiter, is inferred from the extension (`.csv`/`.tsv`, `.ndjson`/`.jsonl`, `.parquet`). |
+| `--limit N`                      | Row cap for stdout table output (default 50).                                                                                                                |
+| `--overwrite`                    | Allow replacing an existing output path.                                                                                                                     |
+| `--departition/--no-departition` | Write file output as a single file (default) or as a Spark directory of part files. No effect on Delta.                                                      |
+| `--delimiter CHAR`               | Field separator for CSV input and output (default: a tab for a `.tsv` path, otherwise `,`). Accepts an escape such as `\t`.                                  |
+| `--header/--no-header`           | Include a header row in CSV output (default enabled).                                                                                                        |
 
 File output is produced by Spark's distributed writers, so results larger than
 driver memory can be written. By default the output is departitioned to a
@@ -88,13 +88,25 @@ full result.
 The `--delimiter` and `--header/--no-header` options apply to CSV output for
 `view`, `fhirpath`, and the terminology commands, and are ignored for non-CSV
 formats. The delimiter is also used to read CSV input in the terminology
-commands, so a tab-separated dataset round-trips in a single invocation:
+commands.
+
+`--delimiter` has no fixed default. When it is omitted, the input side and the
+output side each take their default from their own path: a `.tsv` extension (in
+any letter case) means a tab, and anything else means a comma. CSV written to
+standard output, where there is no path, is comma-separated. A tab-separated
+dataset therefore round-trips with no delimiter flag at all:
 
 ```bash
 pathling member-of codes.tsv --code-column code \
   --system http://snomed.info/sct --value-set <uri> \
-  --delimiter '\t' --format csv
+  -o out.tsv
 ```
+
+Because the two sides resolve independently, `codes.tsv -o out.csv` reads with a
+tab and writes with a comma. A delimiter given explicitly applies to both sides
+and overrides both extensions, so `--delimiter ','` on a `.tsv` path yields a
+comma. Whenever a tab is derived from an extension rather than typed, the CLI
+says so on standard error, naming the path.
 
 ## Commands
 
@@ -173,7 +185,7 @@ environment variables so that they need not appear in shell history.
 ### run
 
 Execute Python code with the Pathling environment ready. The code runs with
-two variables already in scope: `spark` (the Spark session) and `pathling`
+two variables already in scope: `spark` (the Spark session) and `pc`
 (the configured Pathling context), built with the same configuration
 resolution as every other command.
 
@@ -186,9 +198,11 @@ coding functions (`to_coding`, `to_snomed_coding`, `to_loinc_coding`,
 [Python API reference](https://pathling.csiro.au/docs/python/pathling.html) for
 the full list. The terminology
 display function is bound under both its natural name `display` and the alias
-`tx_display`. Any pre-imported name is only a default: assigning or defining the
-same name in your own code takes precedence, and an explicit
-`from pathling import ...` continues to work unchanged.
+`tx_display`. The name `pathling` is bound to the package module itself, so a
+bare `import pathling` is a harmless no-op that leaves `pc` intact. Any
+pre-imported name is only a default: assigning or defining the same name in your
+own code takes precedence, and an explicit `from pathling import ...` continues
+to work unchanged.
 
 ```bash
 # Run a script file.
@@ -208,7 +222,7 @@ For example, a script that projects a tabular view of patients and then
 summarises it with Spark SQL:
 
 ```python
-patients = pathling.read.ndjson("data").view(
+patients = pc.read.ndjson("data").view(
     "Patient",
     select=[{"column": [{"path": "gender", "name": "gender"}]}],
 )
@@ -235,7 +249,7 @@ passes through unmodified.
 ### console
 
 Open an interactive [IPython](https://ipython.org/) console with the same
-`spark` and `pathling` variables in scope, and the Pathling public functions
+`spark` and `pc` variables in scope, and the Pathling public functions
 pre-imported just as in [`run`](#run).
 
 ```bash
@@ -295,8 +309,9 @@ The default result column names (`member_of`, `translated_system` and
 `translated_code`, `subsumes`, `subsumed_by`, `display`, `property`,
 `designation`) can be overridden with `--result-column`.
 
-CSV input is read with the shared `--delimiter` (so a tab- or semicolon-separated
-dataset is read correctly); a `.tsv` file is read as CSV. Pass `--no-input-header`
+CSV input is read with the shared `--delimiter` (so a semicolon-separated
+dataset is read correctly); a `.tsv` file is read as CSV and, with no
+`--delimiter`, as tab-separated. Pass `--no-input-header`
 to read a headerless CSV; its columns are then addressable by the positional names
 Spark assigns (`_c0`, `_c1`, ...), which you reference via `--code-column`,
 `--system-column`, and the other column options.


### PR DESCRIPTION
Addresses the three pieces of review feedback raised on #2665 against the Python command line interface. Two are silent-failure footguns introduced by features landed earlier in this same release cycle; the third is a code quality gap in the extension points those features added. All three are only free to fix while 9.9.0 remains untagged.

**A `.tsv` path now means tab-separated.** `--delimiter` previously only ever defaulted to a comma, so a tab-separated `codes.tsv` was silently misread with every field collapsing into one column, and `-o out.tsv` silently wrote comma-delimited data into a file named `.tsv`. The option now has no fixed default: when it is omitted, the input side and the output side each resolve independently from their own path, so a `.tsv` suffix in any letter case means a tab and anything else means a comma. `codes.tsv -o out.csv` therefore reads with a tab and writes with a comma. An explicit value still applies to both sides and overrides both extensions. CSV to stdout, where there is no path, stays comma-separated. Because a delimiter derived from a filename is not one the user typed, an inferred tab is announced on stderr. No `tsv` value is added to `--format` or `--from` - the extension governs the delimiter only, not the format.

**The `run` and `console` context is now `pc`.** It was bound to the name `pathling`, so a reflexive `import pathling` silently rebound it to the module. Nothing failed at the import line; the break surfaced later as `AttributeError: module 'pathling' has no attribute 'read'`, disconnected from its cause. The context is now `pc`, matching every Python example in the documentation, and the `pathling` name is bound to the package module itself so the import is a genuine no-op.

**Every signature in `pathling/cli/` is annotated.** The delimiter and header plumbing added earlier in this cycle left 378 signatures without type hints, contrary to the project's Python conventions, and these are exactly the extension points other commands compose against. Spark and Pathling types are deferred behind `TYPE_CHECKING` so nothing eagerly imports PySpark or the JVM-backed modules, and a nested `pathling/cli/ruff.toml` adds the `ANN` rules for that directory only - so a future unannotated signature here fails the existing lint check, while the rest of the library and the test suite are unaffected.

Both delimiter and context changes are breaking the moment 9.9.0 ships, so they need to land before the tag. The annotation pass has no such deadline.

Verified with the full `lib/python` suite (537 passed), `ruff check`, `ruff format --check`, and the module build, plus a manual pass over each end-to-end scenario against a live terminology server.

Two notes for whoever reviews this. It supersedes the two documentation commits on #2665 (9c2c1d5f3c and 010b300216), which describe the behaviour being replaced - #2665 had not merged when this branch was cut, so if this lands first those commits may reintroduce the superseded passages. Separately, stdout CSV renders booleans as `True`/`False` while file output writes `true`/`false`; that is pre-existing and untouched here, but worth its own issue.