### PR TITLE
Assign dense identifiers in hierarchy order, behind an option

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -64,6 +64,33 @@
       <artifactId>jmh-generator-annprocess</artifactId>
       <version>${pathling.jmhVersion}</version>
     </dependency>
+    <!-- Java Object Layout, used to measure the true retained heap of an object graph. The bitmap
+         library's own size estimate is documented as unreliable for sparse data spanning a wide
+         range of values, which is exactly the shape the hierarchy index measurement examines. -->
+    <dependency>
+      <groupId>org.openjdk.jol</groupId>
+      <artifactId>jol-core</artifactId>
+      <version>${pathling.jolVersion}</version>
+    </dependency>
+    <!-- The module ships a logback configuration, so it needs an SLF4J binding for the harness to
+         report anything. Spark contributes only the API and the log4j bridges. -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/benchmark/src/main/java/au/csiro/pathling/benchmark/DenseIdOrdering.java
+++ b/benchmark/src/main/java/au/csiro/pathling/benchmark/DenseIdOrdering.java
@@ -103,8 +103,7 @@ public final class DenseIdOrdering {
     // popped, so the stack is sized by the number of edges, not the number of concepts.
     final int[] stack = new int[roots.size() + edgeCount(children)];
     int depth = 0;
-    // Push the roots in descending order so that the smallest is popped, and therefore visited,
-    // first.
+    // Push the roots in descending order so the smallest is popped, and visited, first.
     for (int index = roots.size() - 1; index >= 0; index--) {
       stack[depth++] = roots.get(index);
     }

--- a/benchmark/src/main/java/au/csiro/pathling/benchmark/DenseIdOrdering.java
+++ b/benchmark/src/main/java/au/csiro/pathling/benchmark/DenseIdOrdering.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.benchmark;
+
+import jakarta.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.roaringbitmap.IntIterator;
+import org.roaringbitmap.RoaringBitmap;
+
+/**
+ * Rules for assigning dense identifiers to concepts. A rule is expressed as a permutation, an array
+ * whose value at each existing dense identifier is that concept's replacement identifier.
+ *
+ * <p>Two rules are compared by the memory harness: the identity, which reproduces the assignment
+ * the importer makes today (concept code order), and a depth-first pre-order over the is-a graph,
+ * which places each subtree in a near-contiguous interval so that a descendant set can compress
+ * into a few runs rather than many scattered chunks.
+ *
+ * @author John Grimes
+ */
+public final class DenseIdOrdering {
+
+  private DenseIdOrdering() {
+    // Utility class.
+  }
+
+  /**
+   * Returns the permutation that leaves every identifier where it is, which is the assignment the
+   * importer makes today.
+   *
+   * @param conceptCount the number of concepts in the dictionary
+   * @return the identity permutation
+   */
+  @Nonnull
+  public static int[] identity(final int conceptCount) {
+    final int[] permutation = new int[conceptCount];
+    for (int dense = 0; dense < conceptCount; dense++) {
+      permutation[dense] = dense;
+    }
+    return permutation;
+  }
+
+  /**
+   * Computes a depth-first pre-order over the is-a graph held in a hierarchy index's direct-edge
+   * maps, and returns it as a permutation of dense identifiers.
+   *
+   * <p>Roots - concepts with no parent - are visited in ascending identifier order, and each
+   * concept's children likewise, so the result depends only on the graph and not on map iteration
+   * order. The traversal is iterative, because a real hierarchy is deep enough to make recursion a
+   * stack risk, and it marks concepts as it assigns them, so a concept reachable by more than one
+   * path is visited once and the traversal terminates on a directed acyclic graph.
+   *
+   * <p>Concepts the traversal never reaches - inactive concepts, and any concept with no is-a edge
+   * - keep their relative order and are appended after it. Dense identifiers address the whole
+   * concept dictionary rather than only the hierarchy, so a permutation that omitted them would not
+   * be a bijection and would corrupt every other index.
+   *
+   * @param maps the hierarchy index maps supplying the is-a graph
+   * @param conceptCount the number of concepts in the dictionary
+   * @return a permutation of {@code [0, conceptCount)} in depth-first pre-order
+   * @throws IllegalArgumentException if the graph refers to a concept outside the dictionary
+   */
+  @Nonnull
+  public static int[] preOrder(@Nonnull final HierarchyMaps maps, final int conceptCount) {
+    final Map<Integer, RoaringBitmap> children = maps.children();
+    final Map<Integer, RoaringBitmap> parents = maps.parents();
+    checkWithinDictionary(children, conceptCount);
+    checkWithinDictionary(parents, conceptCount);
+
+    // A concept that has children but no parent is a root of the is-a graph.
+    final List<Integer> roots = new ArrayList<>();
+    for (final Integer node : children.keySet()) {
+      if (!parents.containsKey(node)) {
+        roots.add(node);
+      }
+    }
+    Collections.sort(roots);
+
+    final int[] permutation = new int[conceptCount];
+    Arrays.fill(permutation, -1);
+    int next = 0;
+
+    // A concept with several parents can be pushed once per parent before it is first
+    // popped, so the stack is sized by the number of edges, not the number of concepts.
+    final int[] stack = new int[roots.size() + edgeCount(children)];
+    int depth = 0;
+    // Push the roots in descending order so that the smallest is popped, and therefore visited,
+    // first.
+    for (int index = roots.size() - 1; index >= 0; index--) {
+      stack[depth++] = roots.get(index);
+    }
+    while (depth > 0) {
+      final int node = stack[--depth];
+      if (permutation[node] != -1) {
+        continue;
+      }
+      permutation[node] = next++;
+      depth = pushChildren(children.get(node), stack, depth, permutation);
+    }
+
+    // Every concept the traversal did not reach keeps its existing relative order.
+    for (int dense = 0; dense < conceptCount; dense++) {
+      if (permutation[dense] == -1) {
+        permutation[dense] = next++;
+      }
+    }
+    return permutation;
+  }
+
+  /**
+   * Counts the edges in a direct-edge map, which bounds how many entries the traversal stack can
+   * hold at once.
+   *
+   * @param edges a map from concept to its directly related concepts
+   * @return the total number of edges
+   */
+  private static int edgeCount(@Nonnull final Map<Integer, RoaringBitmap> edges) {
+    long total = 0;
+    for (final RoaringBitmap targets : edges.values()) {
+      total += targets.getLongCardinality();
+    }
+    if (total > Integer.MAX_VALUE - 8) {
+      throw new IllegalArgumentException("Hierarchy has too many edges to traverse: " + total);
+    }
+    return (int) total;
+  }
+
+  /**
+   * Pushes a concept's not-yet-assigned children onto the stack in descending order, so that they
+   * are popped in ascending order.
+   *
+   * @param children the concept's children, or null if it has none
+   * @param stack the traversal stack
+   * @param depth the current stack depth
+   * @param permutation the assignment so far, used to skip concepts already visited
+   * @return the new stack depth
+   */
+  private static int pushChildren(
+      final RoaringBitmap children,
+      @Nonnull final int[] stack,
+      final int depth,
+      @Nonnull final int[] permutation) {
+    if (children == null) {
+      return depth;
+    }
+    // The bitmap iterates in ascending order, so collect first and push in reverse.
+    final int[] pending = new int[children.getCardinality()];
+    int count = 0;
+    final IntIterator iterator = children.getIntIterator();
+    while (iterator.hasNext()) {
+      final int child = iterator.next();
+      if (permutation[child] == -1) {
+        pending[count++] = child;
+      }
+    }
+    int newDepth = depth;
+    for (int index = count - 1; index >= 0; index--) {
+      stack[newDepth++] = pending[index];
+    }
+    return newDepth;
+  }
+
+  /**
+   * Checks that every identifier the graph mentions addresses a concept in the dictionary, so that
+   * the permutation it produces can be a bijection. The map is traversed with {@link Map#forEach}
+   * rather than through a view, because a map caches the view object it hands out and would then
+   * measure larger than one that was never traversed.
+   *
+   * @param map a map from concept to its directly related concepts
+   * @param conceptCount the number of concepts in the dictionary
+   * @throws IllegalArgumentException if the graph refers to a concept outside the dictionary
+   */
+  private static void checkWithinDictionary(
+      @Nonnull final Map<Integer, RoaringBitmap> map, final int conceptCount) {
+    map.forEach(
+        (key, targets) -> {
+          if (key < 0 || key >= conceptCount) {
+            throw new IllegalArgumentException(
+                "Hierarchy refers to dense identifier "
+                    + key
+                    + ", which is outside a dictionary of "
+                    + conceptCount
+                    + " concepts");
+          }
+          if (!targets.isEmpty() && (targets.first() < 0 || targets.last() >= conceptCount)) {
+            throw new IllegalArgumentException(
+                "Hierarchy relates concept "
+                    + key
+                    + " to a dense identifier outside a dictionary of "
+                    + conceptCount
+                    + " concepts");
+          }
+        });
+  }
+}

--- a/benchmark/src/main/java/au/csiro/pathling/benchmark/HierarchyIndexMemoryHarness.java
+++ b/benchmark/src/main/java/au/csiro/pathling/benchmark/HierarchyIndexMemoryHarness.java
@@ -237,23 +237,53 @@ public final class HierarchyIndexMemoryHarness {
       @Nonnull final Map<String, List<HierarchyVariantFootprint>> results) {
     final long baseline = total(results, MeasurementVariant.BASELINE);
     final long optimisedCodeOrder = total(results, MeasurementVariant.OPTIMISED_CODE_ORDER);
+    final long unoptimisedPreOrder = total(results, MeasurementVariant.UNOPTIMISED_PRE_ORDER);
     log.info("");
     log.info("Attribution (total retained bytes)");
     for (final MeasurementVariant variant : variants) {
       final long value = total(results, variant.getLabel());
-      final String against =
-          MeasurementVariant.BASELINE.equals(variant.getLabel())
-              ? "baseline"
-              : MeasurementVariant.PROPOSAL.equals(variant.getLabel())
-                  ? String.format(
-                      "%s vs A, %s vs B",
-                      percentChange(baseline, value), percentChange(optimisedCodeOrder, value))
-                  : String.format("%s vs A", percentChange(baseline, value));
       log.info(
           String.format(
               "  %-2s %-34s %18s   %s",
-              variant.getLabel(), variant.getDescription(), grouped(value), against));
+              variant.getLabel(),
+              variant.getDescription(),
+              grouped(value),
+              attribution(
+                  variant.getLabel(), baseline, optimisedCodeOrder, unoptimisedPreOrder, value)));
     }
+  }
+
+  /**
+   * Describes one variant's total against the comparisons that isolate a factor. The proposal is
+   * stated against both of the single-factor variants, so that what the reordering contributes over
+   * the change that costs nothing, and what optimisation contributes on top of the reordering, can
+   * each be read off directly.
+   *
+   * @param label the variant being described
+   * @param baseline variant A's total
+   * @param optimisedCodeOrder variant B's total
+   * @param unoptimisedPreOrder variant C's total
+   * @param value this variant's total
+   * @return the comparison text
+   */
+  @Nonnull
+  private static String attribution(
+      @Nonnull final String label,
+      final long baseline,
+      final long optimisedCodeOrder,
+      final long unoptimisedPreOrder,
+      final long value) {
+    if (MeasurementVariant.BASELINE.equals(label)) {
+      return "baseline";
+    }
+    if (MeasurementVariant.PROPOSAL.equals(label)) {
+      return String.format(
+          "%s vs A, %s vs B, %s vs C",
+          percentChange(baseline, value),
+          percentChange(optimisedCodeOrder, value),
+          percentChange(unoptimisedPreOrder, value));
+    }
+    return String.format("%s vs A", percentChange(baseline, value));
   }
 
   /**
@@ -348,15 +378,25 @@ public final class HierarchyIndexMemoryHarness {
               driverHeapRuleMet ? "met" : "not met", statusQuoHeap, winnerHeap);
     }
 
-    // Below the instrument's own spread two variants cannot be distinguished, so that is the floor
-    // for calling optimisation alone a benefit.
+    // Optimisation is worth adopting instead of the reordering only if it captures a material share
+    // of what the two factors together achieve. The share is measured against the same threshold
+    // the
+    // plan fixed for the reordering, because that is the only figure fixed before the measurement.
+    final long unoptimisedPreOrder = total(results, MeasurementVariant.UNOPTIMISED_PRE_ORDER);
     final double optimisationSaving = saving(baseline, optimisedCodeOrder);
+    final double combinedSaving = saving(baseline, proposal);
+    final double capturedShare = combinedSaving == 0 ? 0.0 : optimisationSaving / combinedSaving;
+    final boolean adoptOptimisationAlone = capturedShare >= REORDERING_THRESHOLD;
+
+    // Once the reordering is being made, optimisation costs nothing more, so any saving the
+    // instrument can resolve justifies it.
+    final double furtherSaving = saving(unoptimisedPreOrder, proposal);
     final double instrumentFloor =
         Math.max(
-                spread(results, MeasurementVariant.BASELINE),
-                spread(results, MeasurementVariant.OPTIMISED_CODE_ORDER))
+                spread(results, MeasurementVariant.UNOPTIMISED_PRE_ORDER),
+                spread(results, MeasurementVariant.PROPOSAL))
             / 100.0;
-    final boolean adoptOptimisation = optimisationSaving > instrumentFloor;
+    final boolean adoptOptimisationAsWell = furtherSaving > instrumentFloor;
 
     log.info("");
     log.info("Decision rule");
@@ -374,8 +414,14 @@ public final class HierarchyIndexMemoryHarness {
         adoptReordering(subRuleA, driverHeapRuleMet, statusQuoHeap != null));
     log.info(
         String.format(
-            "  Adopt runOptimize alone: %s (%+.1f%% vs A, instrument spread %.2f%%)",
-            adoptOptimisation ? "yes" : "no", -optimisationSaving * 100, instrumentFloor * 100));
+            "  Adopt runOptimize alone, in place of the reordering: %s"
+                + " (%+.1f%% vs A, which is %.1f%% of what A to D achieves)",
+            adoptOptimisationAlone ? "yes" : "no", -optimisationSaving * 100, capturedShare * 100));
+    log.info(
+        String.format(
+            "  Adopt runOptimize as well as the reordering: %s (%+.1f%% vs C, instrument spread"
+                + " %.2f%%)",
+            adoptOptimisationAsWell ? "yes" : "no", -furtherSaving * 100, instrumentFloor * 100));
     log.info("");
     log.info(
         "The four variants measured were: {}",

--- a/benchmark/src/main/java/au/csiro/pathling/benchmark/HierarchyIndexMemoryHarness.java
+++ b/benchmark/src/main/java/au/csiro/pathling/benchmark/HierarchyIndexMemoryHarness.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.benchmark;
+
+import au.csiro.pathling.terminology.local.index.ConceptDictionary;
+import au.csiro.pathling.terminology.store.TerminologyStoreReader;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Measures what a local terminology store's hierarchy index costs in retained heap, and attributes
+ * that cost between two independent factors: how dense identifiers are assigned, and whether the
+ * compressed bitmaps have been asked to adopt run-length encoding.
+ *
+ * <p>The harness changes no production code. It loads one store, derives a depth-first pre-order
+ * from the index's own direct-edge maps, and builds the reordered and optimised variants in memory
+ * alongside the original, so all four variants come from a single load and no variant store has to
+ * be imported.
+ *
+ * <p>Configured by system properties:
+ *
+ * <ul>
+ *   <li>{@code pathling.benchmark.terminology.storagePath} - the store to measure (required).
+ *   <li>{@code pathling.benchmark.terminology.systemVersionId} - the code system version within it
+ *       (required).
+ *   <li>{@code pathling.benchmark.hierarchy.repeats} - runs per variant, default 3.
+ *   <li>{@code pathling.benchmark.hierarchy.statusQuoDriverHeapGb} - optional. The minimum viable
+ *       driver heap measured for the status quo, in gigabytes. Supplying it and its counterpart
+ *       lets the harness evaluate the second sub-rule of the decision rule, which the fine-grained
+ *       measurement cannot reach on its own.
+ *   <li>{@code pathling.benchmark.hierarchy.winnerDriverHeapGb} - optional. The same figure for the
+ *       winning variant.
+ * </ul>
+ *
+ * @author John Grimes
+ */
+public final class HierarchyIndexMemoryHarness {
+
+  private static final Logger log = LoggerFactory.getLogger(HierarchyIndexMemoryHarness.class);
+
+  /** System property naming the terminology store to measure. */
+  static final String STORAGE_PATH_PROPERTY = TerminologyBenchmarkState.STORAGE_PATH_PROPERTY;
+
+  /** System property naming the code system version within the store. */
+  static final String SYSTEM_VERSION_ID_PROPERTY = "pathling.benchmark.terminology.systemVersionId";
+
+  /** System property naming the number of measurement runs per variant. */
+  static final String REPEATS_PROPERTY = "pathling.benchmark.hierarchy.repeats";
+
+  /** System property carrying the separately measured status quo driver heap, in gigabytes. */
+  static final String STATUS_QUO_DRIVER_HEAP_PROPERTY =
+      "pathling.benchmark.hierarchy.statusQuoDriverHeapGb";
+
+  /** System property carrying the separately measured winning variant driver heap, in gigabytes. */
+  static final String WINNER_DRIVER_HEAP_PROPERTY =
+      "pathling.benchmark.hierarchy.winnerDriverHeapGb";
+
+  /** The default number of measurement runs per variant. */
+  private static final int DEFAULT_REPEATS = 3;
+
+  /**
+   * The proportion of variant B's total retained heap that variant D must save to earn the loss of
+   * identifier stability across releases. Fixed in the plan before any figure was taken.
+   */
+  private static final double REORDERING_THRESHOLD = 0.25;
+
+  /** The granularity of the original driver heap measurement, in gigabytes. */
+  private static final double DRIVER_HEAP_STEP_GB = 0.5;
+
+  private HierarchyIndexMemoryHarness() {
+    // Runnable harness.
+  }
+
+  /**
+   * Runs the measurement and emits the report.
+   *
+   * @param args ignored; the harness is configured by system properties
+   */
+  public static void main(@Nonnull final String[] args) {
+    final String storagePath = requiredProperty(STORAGE_PATH_PROPERTY);
+    final String systemVersionId = requiredProperty(SYSTEM_VERSION_ID_PROPERTY);
+    final int repeats = repeats();
+
+    log.info("Opening terminology store at {}", storagePath);
+    final TerminologyStoreReader reader = TerminologyStoreReader.open(storagePath, Map.of());
+
+    log.info("Loading the concept dictionary for {}", systemVersionId);
+    final ConceptDictionary dictionary = ConceptDictionary.load(reader, systemVersionId);
+    final int conceptCount = dictionary.size();
+    log.info("Dictionary holds {} concepts", conceptCount);
+
+    log.info("Loading the hierarchy index");
+    final HierarchyMaps source = HierarchyMaps.load(reader, systemVersionId);
+
+    // Reported so that a reader can confirm the remapping introduces no size artefact of its own:
+    // variant A is built by remapping through the identity, and should match this figure.
+    final long asLoadedBytes = HierarchyVariantFootprint.measure(source).getTotalRetainedBytes();
+    log.info("Index as loaded from the store retains {} bytes", grouped(asLoadedBytes));
+
+    log.info("Deriving the depth-first pre-order from the index's direct edges");
+    final int[] identity = DenseIdOrdering.identity(conceptCount);
+    final int[] preOrder = DenseIdOrdering.preOrder(source, conceptCount);
+
+    final List<MeasurementVariant> variants = MeasurementVariant.all();
+    final Map<String, List<HierarchyVariantFootprint>> results = new LinkedHashMap<>();
+    for (final MeasurementVariant variant : variants) {
+      final List<HierarchyVariantFootprint> footprints = new ArrayList<>();
+      for (int repeat = 1; repeat <= repeats; repeat++) {
+        log.info(
+            "Measuring variant {} ({}), run {} of {}",
+            variant.getLabel(),
+            variant.getDescription(),
+            repeat,
+            repeats);
+        // The variant becomes unreachable at the end of each iteration, so the harness holds the
+        // source index and at most one variant at a time.
+        final HierarchyMaps materialised = variant.materialise(source, identity, preOrder);
+        footprints.add(HierarchyVariantFootprint.measure(materialised));
+      }
+      results.put(variant.getLabel(), footprints);
+    }
+
+    report(storagePath, systemVersionId, conceptCount, asLoadedBytes, repeats, variants, results);
+  }
+
+  /**
+   * Emits the whole report: a per-variant table, the attribution summary, the direction breakdown,
+   * the reproducibility statement, and the decision rule evaluated against the figures.
+   *
+   * @param storagePath the store measured
+   * @param systemVersionId the code system version measured
+   * @param conceptCount the size of the concept dictionary
+   * @param asLoadedBytes the retained heap of the index exactly as loaded
+   * @param repeats the number of runs per variant
+   * @param variants the variants measured, in report order
+   * @param results each variant's footprints, one per run
+   */
+  private static void report(
+      @Nonnull final String storagePath,
+      @Nonnull final String systemVersionId,
+      final int conceptCount,
+      final long asLoadedBytes,
+      final int repeats,
+      @Nonnull final List<MeasurementVariant> variants,
+      @Nonnull final Map<String, List<HierarchyVariantFootprint>> results) {
+    log.info("");
+    log.info("Hierarchy index memory measurement");
+    log.info("  store             {}", storagePath);
+    log.info("  code system       {}", systemVersionId);
+    log.info("  concepts          {}", grouped(conceptCount));
+    log.info("  runs per variant  {}", repeats);
+    log.info("  index as loaded   {} bytes retained", grouped(asLoadedBytes));
+
+    for (final MeasurementVariant variant : variants) {
+      reportVariant(variant, results.get(variant.getLabel()).get(0));
+    }
+    reportAttribution(variants, results);
+    reportDirections(variants, results);
+    reportReproducibility(repeats, variants, results);
+    reportDecision(variants, results);
+  }
+
+  /**
+   * Emits one variant's per-map table.
+   *
+   * @param variant the variant described
+   * @param footprint that variant's first run
+   */
+  private static void reportVariant(
+      @Nonnull final MeasurementVariant variant,
+      @Nonnull final HierarchyVariantFootprint footprint) {
+    log.info("");
+    log.info("Variant {} - {}", variant.getLabel(), variant.getDescription());
+    log.info(
+        String.format(
+            "  %-12s %14s %18s %12s %12s %12s",
+            "map", "entries", "retained bytes", "array", "bitmap", "run"));
+    for (final HierarchyMapFootprint map : footprint.getMaps()) {
+      log.info(
+          String.format(
+              "  %-12s %14s %18s %12s %12s %12s",
+              map.getName(),
+              grouped(map.getEntries()),
+              grouped(map.getRetainedBytes()),
+              grouped(map.getArrayContainers()),
+              grouped(map.getBitmapContainers()),
+              grouped(map.getRunContainers())));
+    }
+    log.info(
+        String.format(
+            "  %-12s %14s %18s %12s %12s %12s",
+            "total",
+            "-",
+            grouped(footprint.getTotalRetainedBytes()),
+            grouped(footprint.getTotalArrayContainers()),
+            grouped(footprint.getTotalBitmapContainers()),
+            grouped(footprint.getTotalRunContainers())));
+    if (!variant.isOptimised() && footprint.getTotalRunContainers() != 0) {
+      log.error(
+          "Variant {} did not request optimisation but holds {} run containers; the measurement is"
+              + " not measuring what it claims",
+          variant.getLabel(),
+          footprint.getTotalRunContainers());
+    }
+  }
+
+  /**
+   * Emits the attribution summary, stating each variant's total against the baseline and the
+   * proposal against the change that costs nothing.
+   *
+   * @param variants the variants measured
+   * @param results each variant's footprints
+   */
+  private static void reportAttribution(
+      @Nonnull final List<MeasurementVariant> variants,
+      @Nonnull final Map<String, List<HierarchyVariantFootprint>> results) {
+    final long baseline = total(results, MeasurementVariant.BASELINE);
+    final long optimisedCodeOrder = total(results, MeasurementVariant.OPTIMISED_CODE_ORDER);
+    log.info("");
+    log.info("Attribution (total retained bytes)");
+    for (final MeasurementVariant variant : variants) {
+      final long value = total(results, variant.getLabel());
+      final String against =
+          MeasurementVariant.BASELINE.equals(variant.getLabel())
+              ? "baseline"
+              : MeasurementVariant.PROPOSAL.equals(variant.getLabel())
+                  ? String.format(
+                      "%s vs A, %s vs B",
+                      percentChange(baseline, value), percentChange(optimisedCodeOrder, value))
+                  : String.format("%s vs A", percentChange(baseline, value));
+      log.info(
+          String.format(
+              "  %-2s %-34s %18s   %s",
+              variant.getLabel(), variant.getDescription(), grouped(value), against));
+    }
+  }
+
+  /**
+   * Emits the direction breakdown, which tests the proposal's own prediction that the descendant
+   * maps shrink sharply while the ancestor maps stay roughly flat. One linear order cannot make
+   * both directions contiguous, so a single total would hide a loss on one side behind a gain on
+   * the other.
+   *
+   * @param variants the variants measured
+   * @param results each variant's footprints
+   */
+  private static void reportDirections(
+      @Nonnull final List<MeasurementVariant> variants,
+      @Nonnull final Map<String, List<HierarchyVariantFootprint>> results) {
+    log.info("");
+    log.info("Direction breakdown (retained bytes, and change against variant A)");
+    for (final String direction : List.of(HierarchyMaps.DESCENDANTS, HierarchyMaps.ANCESTORS)) {
+      final long baseline =
+          results.get(MeasurementVariant.BASELINE).get(0).getMap(direction).getRetainedBytes();
+      final StringBuilder line = new StringBuilder(String.format("  %-12s", direction));
+      for (final MeasurementVariant variant : variants) {
+        final long value =
+            results.get(variant.getLabel()).get(0).getMap(direction).getRetainedBytes();
+        line.append(
+            String.format(
+                "  %s %18s (%s)",
+                variant.getLabel(), grouped(value), percentChange(baseline, value)));
+      }
+      log.info(line.toString());
+    }
+  }
+
+  /**
+   * Emits the reproducibility statement. A difference smaller than the instrument's own spread
+   * cannot be read as a result, so the report states both.
+   *
+   * @param repeats the number of runs per variant
+   * @param variants the variants measured
+   * @param results each variant's footprints
+   */
+  private static void reportReproducibility(
+      final int repeats,
+      @Nonnull final List<MeasurementVariant> variants,
+      @Nonnull final Map<String, List<HierarchyVariantFootprint>> results) {
+    log.info("");
+    log.info("Reproducibility over {} runs, per variant", repeats);
+    log.info(String.format("  %-8s %18s %18s %10s", "variant", "min bytes", "max bytes", "spread"));
+    for (final MeasurementVariant variant : variants) {
+      log.info(
+          String.format(
+              "  %-8s %18s %18s %9.2f%%",
+              variant.getLabel(),
+              grouped(minimum(results, variant.getLabel())),
+              grouped(maximum(results, variant.getLabel())),
+              spread(results, variant.getLabel())));
+    }
+  }
+
+  /**
+   * Emits the decision rule, restated and evaluated against the figures. Both sub-rules are
+   * reported even when the first settles the question, so the record is complete.
+   *
+   * @param variants the variants measured
+   * @param results each variant's footprints
+   */
+  private static void reportDecision(
+      @Nonnull final List<MeasurementVariant> variants,
+      @Nonnull final Map<String, List<HierarchyVariantFootprint>> results) {
+    final long baseline = total(results, MeasurementVariant.BASELINE);
+    final long optimisedCodeOrder = total(results, MeasurementVariant.OPTIMISED_CODE_ORDER);
+    final long proposal = total(results, MeasurementVariant.PROPOSAL);
+    final double reorderingSaving = saving(optimisedCodeOrder, proposal);
+    final boolean subRuleA = reorderingSaving >= REORDERING_THRESHOLD;
+
+    final Double statusQuoHeap = optionalDoubleProperty(STATUS_QUO_DRIVER_HEAP_PROPERTY);
+    final Double winnerHeap = optionalDoubleProperty(WINNER_DRIVER_HEAP_PROPERTY);
+    final String subRuleB;
+    final boolean driverHeapRuleMet;
+    if (statusQuoHeap == null || winnerHeap == null) {
+      subRuleB =
+          "not determined - supply -D"
+              + STATUS_QUO_DRIVER_HEAP_PROPERTY
+              + " and -D"
+              + WINNER_DRIVER_HEAP_PROPERTY
+              + " from the driver heap search";
+      driverHeapRuleMet = false;
+    } else {
+      driverHeapRuleMet = statusQuoHeap - winnerHeap >= DRIVER_HEAP_STEP_GB;
+      subRuleB =
+          String.format(
+              "%s (%.1f GB to %.1f GB)",
+              driverHeapRuleMet ? "met" : "not met", statusQuoHeap, winnerHeap);
+    }
+
+    // Below the instrument's own spread two variants cannot be distinguished, so that is the floor
+    // for calling optimisation alone a benefit.
+    final double optimisationSaving = saving(baseline, optimisedCodeOrder);
+    final double instrumentFloor =
+        Math.max(
+                spread(results, MeasurementVariant.BASELINE),
+                spread(results, MeasurementVariant.OPTIMISED_CODE_ORDER))
+            / 100.0;
+    final boolean adoptOptimisation = optimisationSaving > instrumentFloor;
+
+    log.info("");
+    log.info("Decision rule");
+    log.info(
+        String.format(
+            "  (a) D reduces total retained heap by >= %.0f%% against B      : %s (%+.1f%%)",
+            REORDERING_THRESHOLD * 100, subRuleA ? "met" : "not met", -reorderingSaving * 100));
+    log.info("  (b) D lowers the UK edition's minimum viable driver heap");
+    log.info(
+        String.format(
+            "      by >= one %.1f GB step against A                        : %s",
+            DRIVER_HEAP_STEP_GB, subRuleB));
+    log.info(
+        "  Adopt reordering: {}",
+        adoptReordering(subRuleA, driverHeapRuleMet, statusQuoHeap != null));
+    log.info(
+        String.format(
+            "  Adopt runOptimize alone: %s (%+.1f%% vs A, instrument spread %.2f%%)",
+            adoptOptimisation ? "yes" : "no", -optimisationSaving * 100, instrumentFloor * 100));
+    log.info("");
+    log.info(
+        "The four variants measured were: {}",
+        variants.stream()
+            .map(variant -> variant.getLabel() + " (" + variant.getDescription() + ")")
+            .toList());
+  }
+
+  @Nonnull
+  private static String adoptReordering(
+      final boolean subRuleA, final boolean driverHeapRuleMet, final boolean driverHeapKnown) {
+    if (subRuleA || driverHeapRuleMet) {
+      return "yes";
+    }
+    return driverHeapKnown
+        ? "no"
+        : "no on the measured evidence; sub-rule (b) is still to be determined";
+  }
+
+  private static long total(
+      @Nonnull final Map<String, List<HierarchyVariantFootprint>> results,
+      @Nonnull final String label) {
+    return results.get(label).get(0).getTotalRetainedBytes();
+  }
+
+  private static long minimum(
+      @Nonnull final Map<String, List<HierarchyVariantFootprint>> results,
+      @Nonnull final String label) {
+    return results.get(label).stream()
+        .mapToLong(HierarchyVariantFootprint::getTotalRetainedBytes)
+        .min()
+        .orElseThrow();
+  }
+
+  private static long maximum(
+      @Nonnull final Map<String, List<HierarchyVariantFootprint>> results,
+      @Nonnull final String label) {
+    return results.get(label).stream()
+        .mapToLong(HierarchyVariantFootprint::getTotalRetainedBytes)
+        .max()
+        .orElseThrow();
+  }
+
+  /**
+   * Returns a variant's spread across runs, as a percentage of its smallest run.
+   *
+   * @param results each variant's footprints
+   * @param label the variant to summarise
+   * @return the spread, as a percentage
+   */
+  private static double spread(
+      @Nonnull final Map<String, List<HierarchyVariantFootprint>> results,
+      @Nonnull final String label) {
+    final long min = minimum(results, label);
+    final long max = maximum(results, label);
+    return min == 0 ? 0.0 : (max - min) * 100.0 / min;
+  }
+
+  /**
+   * Returns the proportion of a baseline that a value saves, negative if it costs more.
+   *
+   * @param baseline the figure compared against
+   * @param value the figure compared
+   * @return the saving as a proportion of the baseline
+   */
+  private static double saving(final long baseline, final long value) {
+    return baseline == 0 ? 0.0 : (baseline - value) / (double) baseline;
+  }
+
+  @Nonnull
+  private static String percentChange(final long baseline, final long value) {
+    return baseline == 0 ? "n/a" : String.format("%+.1f%%", (value - baseline) * 100.0 / baseline);
+  }
+
+  @Nonnull
+  private static String grouped(final long value) {
+    return String.format("%,d", value);
+  }
+
+  private static int repeats() {
+    final String value = System.getProperty(REPEATS_PROPERTY);
+    if (value == null || value.isBlank()) {
+      return DEFAULT_REPEATS;
+    }
+    final int parsed = Integer.parseInt(value.trim());
+    if (parsed < 1) {
+      throw new IllegalArgumentException(
+          "Property " + REPEATS_PROPERTY + " must be at least 1, but was " + parsed);
+    }
+    return parsed;
+  }
+
+  @Nullable
+  private static Double optionalDoubleProperty(@Nonnull final String name) {
+    final String value = System.getProperty(name);
+    return value == null || value.isBlank() ? null : Double.valueOf(value.trim());
+  }
+
+  @Nonnull
+  private static String requiredProperty(@Nonnull final String name) {
+    final String value = System.getProperty(name);
+    if (value == null || value.isBlank()) {
+      throw new IllegalStateException(
+          "Required harness system property is not set: -D" + name + "=<value>");
+    }
+    return value;
+  }
+}

--- a/benchmark/src/main/java/au/csiro/pathling/benchmark/HierarchyIndexMemoryHarness.java
+++ b/benchmark/src/main/java/au/csiro/pathling/benchmark/HierarchyIndexMemoryHarness.java
@@ -378,10 +378,9 @@ public final class HierarchyIndexMemoryHarness {
               driverHeapRuleMet ? "met" : "not met", statusQuoHeap, winnerHeap);
     }
 
-    // Optimisation is worth adopting instead of the reordering only if it captures a material share
-    // of what the two factors together achieve. The share is measured against the same threshold
-    // the
-    // plan fixed for the reordering, because that is the only figure fixed before the measurement.
+    // Optimisation is worth adopting instead of the reordering only if it captures a material
+    // share of what the two factors together achieve. The share is measured against the same
+    // threshold the plan fixed for the reordering, that being the only figure fixed in advance.
     final long unoptimisedPreOrder = total(results, MeasurementVariant.UNOPTIMISED_PRE_ORDER);
     final double optimisationSaving = saving(baseline, optimisedCodeOrder);
     final double combinedSaving = saving(baseline, proposal);

--- a/benchmark/src/main/java/au/csiro/pathling/benchmark/HierarchyMapFootprint.java
+++ b/benchmark/src/main/java/au/csiro/pathling/benchmark/HierarchyMapFootprint.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.benchmark;
+
+import jakarta.annotation.Nonnull;
+import java.util.Map;
+import org.openjdk.jol.info.GraphLayout;
+import org.roaringbitmap.ContainerPointer;
+import org.roaringbitmap.RoaringBitmap;
+
+/**
+ * What one map of a hierarchy index occupies, and what it is built from: the true retained heap of
+ * its object graph, and a count of its compressed chunks by kind.
+ *
+ * <p>The retained figure comes from walking the object graph rather than from the bitmap library's
+ * own estimate, which its documentation rules out for sparse data spanning a wide range of values -
+ * exactly the shape a descendant set takes when identifiers are assigned in concept code order. The
+ * chunk counts test the mechanism rather than only the outcome: if reordering works, run counts
+ * rise and array and bitmap counts fall. Bytes falling with an unchanged histogram would mean
+ * something other than the stated hypothesis is responsible.
+ *
+ * @author John Grimes
+ */
+public final class HierarchyMapFootprint {
+
+  @Nonnull private final String name;
+  private final int entries;
+  private final long retainedBytes;
+  private final long arrayContainers;
+  private final long bitmapContainers;
+  private final long runContainers;
+
+  private HierarchyMapFootprint(
+      @Nonnull final String name,
+      final int entries,
+      final long retainedBytes,
+      final long arrayContainers,
+      final long bitmapContainers,
+      final long runContainers) {
+    this.name = name;
+    this.entries = entries;
+    this.retainedBytes = retainedBytes;
+    this.arrayContainers = arrayContainers;
+    this.bitmapContainers = bitmapContainers;
+    this.runContainers = runContainers;
+  }
+
+  /**
+   * Measures one map of a hierarchy index.
+   *
+   * @param name the map's name, for reporting
+   * @param map the map to measure
+   * @return the map's footprint
+   */
+  @Nonnull
+  public static HierarchyMapFootprint measure(
+      @Nonnull final String name, @Nonnull final Map<Integer, RoaringBitmap> map) {
+    long arrays = 0;
+    long bitmaps = 0;
+    long runs = 0;
+    for (final RoaringBitmap bitmap : map.values()) {
+      final ContainerPointer pointer = bitmap.getContainerPointer();
+      // The pointer returns a null container once it has passed the last one.
+      while (pointer.getContainer() != null) {
+        if (pointer.isRunContainer()) {
+          runs++;
+        } else if (pointer.isBitmapContainer()) {
+          bitmaps++;
+        } else {
+          arrays++;
+        }
+        pointer.advance();
+      }
+    }
+    return new HierarchyMapFootprint(
+        name, map.size(), GraphLayout.parseInstance(map).totalSize(), arrays, bitmaps, runs);
+  }
+
+  /**
+   * Returns the map's name.
+   *
+   * @return the name
+   */
+  @Nonnull
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Returns the number of keys in the map.
+   *
+   * @return the entry count
+   */
+  public int getEntries() {
+    return entries;
+  }
+
+  /**
+   * Returns the true retained heap of the map's object graph.
+   *
+   * @return the retained size in bytes
+   */
+  public long getRetainedBytes() {
+    return retainedBytes;
+  }
+
+  /**
+   * Returns the number of array containers across the map's bitmaps.
+   *
+   * @return the array container count
+   */
+  public long getArrayContainers() {
+    return arrayContainers;
+  }
+
+  /**
+   * Returns the number of bitmap containers across the map's bitmaps.
+   *
+   * @return the bitmap container count
+   */
+  public long getBitmapContainers() {
+    return bitmapContainers;
+  }
+
+  /**
+   * Returns the number of run-length-encoded containers across the map's bitmaps. This is zero for
+   * any map whose bitmaps have not been asked to optimise their representation.
+   *
+   * @return the run container count
+   */
+  public long getRunContainers() {
+    return runContainers;
+  }
+}

--- a/benchmark/src/main/java/au/csiro/pathling/benchmark/HierarchyMaps.java
+++ b/benchmark/src/main/java/au/csiro/pathling/benchmark/HierarchyMaps.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.benchmark;
+
+import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.CLOSURE;
+import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_ANCESTOR_DENSE_ID;
+import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_DESCENDANT_DENSE_ID;
+import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_DIRECT;
+import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_SYSTEM_VERSION_ID;
+
+import au.csiro.pathling.terminology.store.TerminologyStoreReader;
+import jakarta.annotation.Nonnull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.roaringbitmap.IntIterator;
+import org.roaringbitmap.RoaringBitmap;
+
+/**
+ * The four bitmap maps that make up a hierarchy index, held outside the production {@code
+ * HierarchyIndex} so that the memory harness can permute and optimise them without changing any
+ * production code.
+ *
+ * <p>The maps are built by exactly the construction the production index uses - a {@link HashMap}
+ * with default capacity, filled by repeated {@link RoaringBitmap#add(int)} - because retained heap
+ * depends on how a bitmap was grown as well as on what it contains. Building every variant the same
+ * way is what makes the variants comparable. {@code HierarchyIndexMemoryHarnessTest} pins this
+ * replica to the production index by asserting that the two answer every query identically over the
+ * {@code rf2-mini} fixture.
+ *
+ * @author John Grimes
+ */
+public final class HierarchyMaps {
+
+  /** The name of the map holding the transitive descendants of each concept. */
+  public static final String DESCENDANTS = "descendants";
+
+  /** The name of the map holding the transitive ancestors of each concept. */
+  public static final String ANCESTORS = "ancestors";
+
+  /** The name of the map holding the direct children of each concept. */
+  public static final String CHILDREN = "children";
+
+  /** The name of the map holding the direct parents of each concept. */
+  public static final String PARENTS = "parents";
+
+  @Nonnull private final Map<Integer, RoaringBitmap> descendants;
+  @Nonnull private final Map<Integer, RoaringBitmap> ancestors;
+  @Nonnull private final Map<Integer, RoaringBitmap> children;
+  @Nonnull private final Map<Integer, RoaringBitmap> parents;
+
+  private HierarchyMaps(
+      @Nonnull final Map<Integer, RoaringBitmap> descendants,
+      @Nonnull final Map<Integer, RoaringBitmap> ancestors,
+      @Nonnull final Map<Integer, RoaringBitmap> children,
+      @Nonnull final Map<Integer, RoaringBitmap> parents) {
+    this.descendants = descendants;
+    this.ancestors = ancestors;
+    this.children = children;
+    this.parents = parents;
+  }
+
+  /**
+   * Loads the four maps for a code system version from a store's closure table.
+   *
+   * @param reader the store reader
+   * @param systemVersionId the code system version to load
+   * @return the loaded maps
+   */
+  @Nonnull
+  public static HierarchyMaps load(
+      @Nonnull final TerminologyStoreReader reader, @Nonnull final String systemVersionId) {
+    final Map<Integer, RoaringBitmap> descendants = new HashMap<>();
+    final Map<Integer, RoaringBitmap> ancestors = new HashMap<>();
+    final Map<Integer, RoaringBitmap> children = new HashMap<>();
+    final Map<Integer, RoaringBitmap> parents = new HashMap<>();
+    reader.readTable(
+        CLOSURE,
+        row -> {
+          if (!systemVersionId.equals(row.getString(COLUMN_SYSTEM_VERSION_ID))) {
+            return;
+          }
+          final int ancestor = row.getInt(COLUMN_ANCESTOR_DENSE_ID);
+          final int descendant = row.getInt(COLUMN_DESCENDANT_DENSE_ID);
+          descendants.computeIfAbsent(ancestor, k -> new RoaringBitmap()).add(descendant);
+          ancestors.computeIfAbsent(descendant, k -> new RoaringBitmap()).add(ancestor);
+          if (row.getBoolean(COLUMN_DIRECT)) {
+            children.computeIfAbsent(ancestor, k -> new RoaringBitmap()).add(descendant);
+            parents.computeIfAbsent(descendant, k -> new RoaringBitmap()).add(ancestor);
+          }
+        });
+    return new HierarchyMaps(descendants, ancestors, children, parents);
+  }
+
+  /**
+   * Assembles the four maps directly, for tests that need a contrived hierarchy rather than a
+   * store.
+   *
+   * @param descendants the transitive descendants of each concept
+   * @param ancestors the transitive ancestors of each concept
+   * @param children the direct children of each concept
+   * @param parents the direct parents of each concept
+   * @return the assembled maps
+   */
+  @Nonnull
+  public static HierarchyMaps of(
+      @Nonnull final Map<Integer, RoaringBitmap> descendants,
+      @Nonnull final Map<Integer, RoaringBitmap> ancestors,
+      @Nonnull final Map<Integer, RoaringBitmap> children,
+      @Nonnull final Map<Integer, RoaringBitmap> parents) {
+    return new HierarchyMaps(descendants, ancestors, children, parents);
+  }
+
+  /**
+   * Returns the four maps in report order, keyed by name.
+   *
+   * @return an ordered, unmodifiable view of the four maps
+   */
+  @Nonnull
+  public Map<String, Map<Integer, RoaringBitmap>> byName() {
+    final Map<String, Map<Integer, RoaringBitmap>> named = new LinkedHashMap<>();
+    named.put(DESCENDANTS, descendants);
+    named.put(ANCESTORS, ancestors);
+    named.put(CHILDREN, children);
+    named.put(PARENTS, parents);
+    return Collections.unmodifiableMap(named);
+  }
+
+  /**
+   * Returns the direct children of each concept, which together with {@link #parents()} form the
+   * is-a graph the depth-first pre-order traverses.
+   *
+   * @return the children map
+   */
+  @Nonnull
+  public Map<Integer, RoaringBitmap> children() {
+    return children;
+  }
+
+  /**
+   * Returns the direct parents of each concept. A concept absent from this map has no parent and is
+   * therefore a root of the is-a graph.
+   *
+   * @return the parents map
+   */
+  @Nonnull
+  public Map<Integer, RoaringBitmap> parents() {
+    return parents;
+  }
+
+  /**
+   * Tests whether one concept subsumes another, by the same rule the production index applies: a
+   * concept subsumes itself, and otherwise subsumption is membership of the ancestor's descendant
+   * bitmap.
+   *
+   * @param ancestor the potential ancestor
+   * @param descendant the potential descendant
+   * @return true if {@code ancestor} subsumes {@code descendant}
+   */
+  public boolean subsumes(final int ancestor, final int descendant) {
+    if (ancestor == descendant) {
+      return true;
+    }
+    final RoaringBitmap bitmap = descendants.get(ancestor);
+    return bitmap != null && bitmap.contains(descendant);
+  }
+
+  /**
+   * Builds a new set of maps with every dense identifier, both key and member, replaced by its
+   * image under a permutation. Applying the identity permutation therefore yields a structurally
+   * identical copy, which is how the harness produces its baseline variant on the same footing as
+   * the reordered ones.
+   *
+   * @param permutation maps each existing dense identifier to its replacement
+   * @return the remapped maps
+   */
+  @Nonnull
+  public HierarchyMaps remap(@Nonnull final int[] permutation) {
+    return new HierarchyMaps(
+        remapOne(descendants, permutation),
+        remapOne(ancestors, permutation),
+        remapOne(children, permutation),
+        remapOne(parents, permutation));
+  }
+
+  /**
+   * Asks every bitmap in all four maps to adopt run-length encoding wherever that is more space
+   * efficient. The production index never does this, so no run container exists in it at any
+   * ordering.
+   *
+   * @return true if the representation of at least one bitmap changed
+   */
+  public boolean runOptimize() {
+    boolean changed = false;
+    for (final Map<Integer, RoaringBitmap> map : byName().values()) {
+      for (final RoaringBitmap bitmap : map.values()) {
+        changed |= bitmap.runOptimize();
+      }
+    }
+    return changed;
+  }
+
+  /**
+   * Remaps one map. The source is traversed with {@link Map#forEach}, and never through a view such
+   * as {@code entrySet()}, because a map caches the view object it hands out and a map carrying one
+   * measures larger than an otherwise identical map that does not. Measuring the source is part of
+   * the harness's job, so the harness must not leave a footprint on it.
+   *
+   * @param map the map to remap
+   * @param permutation maps each existing dense identifier to its replacement
+   * @return the remapped map
+   */
+  @Nonnull
+  private static Map<Integer, RoaringBitmap> remapOne(
+      @Nonnull final Map<Integer, RoaringBitmap> map, @Nonnull final int[] permutation) {
+    final Map<Integer, RoaringBitmap> remapped = new HashMap<>();
+    map.forEach(
+        (key, bitmap) -> {
+          final RoaringBitmap target =
+              remapped.computeIfAbsent(permutation[key], k -> new RoaringBitmap());
+          final IntIterator members = bitmap.getIntIterator();
+          while (members.hasNext()) {
+            target.add(permutation[members.next()]);
+          }
+        });
+    return remapped;
+  }
+}

--- a/benchmark/src/main/java/au/csiro/pathling/benchmark/HierarchyVariantFootprint.java
+++ b/benchmark/src/main/java/au/csiro/pathling/benchmark/HierarchyVariantFootprint.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.benchmark;
+
+import jakarta.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * What one measurement variant - a combination of an identifier ordering and a representation
+ * optimisation setting - occupies, broken down by map.
+ *
+ * @author John Grimes
+ */
+public final class HierarchyVariantFootprint {
+
+  @Nonnull private final List<HierarchyMapFootprint> maps;
+
+  private HierarchyVariantFootprint(@Nonnull final List<HierarchyMapFootprint> maps) {
+    this.maps = maps;
+  }
+
+  /**
+   * Measures every map of a variant.
+   *
+   * @param variant the four maps to measure
+   * @return the variant's footprint
+   */
+  @Nonnull
+  public static HierarchyVariantFootprint measure(@Nonnull final HierarchyMaps variant) {
+    final List<HierarchyMapFootprint> measured = new ArrayList<>();
+    variant.byName().forEach((name, map) -> measured.add(HierarchyMapFootprint.measure(name, map)));
+    return new HierarchyVariantFootprint(Collections.unmodifiableList(measured));
+  }
+
+  /**
+   * Returns the per-map footprints in report order.
+   *
+   * @return the map footprints
+   */
+  @Nonnull
+  public List<HierarchyMapFootprint> getMaps() {
+    return maps;
+  }
+
+  /**
+   * Returns the footprint of one named map.
+   *
+   * @param name the map name, one of the constants on {@link HierarchyMaps}
+   * @return that map's footprint
+   * @throws IllegalArgumentException if the variant has no map of that name
+   */
+  @Nonnull
+  public HierarchyMapFootprint getMap(@Nonnull final String name) {
+    return maps.stream()
+        .filter(map -> name.equals(map.getName()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("No such map in the measurement: " + name));
+  }
+
+  /**
+   * Returns the total retained heap of all four maps, which is the figure the decision rule is
+   * evaluated against.
+   *
+   * @return the total retained size in bytes
+   */
+  public long getTotalRetainedBytes() {
+    return maps.stream().mapToLong(HierarchyMapFootprint::getRetainedBytes).sum();
+  }
+
+  /**
+   * Returns the total number of array containers across all four maps.
+   *
+   * @return the array container count
+   */
+  public long getTotalArrayContainers() {
+    return maps.stream().mapToLong(HierarchyMapFootprint::getArrayContainers).sum();
+  }
+
+  /**
+   * Returns the total number of bitmap containers across all four maps.
+   *
+   * @return the bitmap container count
+   */
+  public long getTotalBitmapContainers() {
+    return maps.stream().mapToLong(HierarchyMapFootprint::getBitmapContainers).sum();
+  }
+
+  /**
+   * Returns the total number of run containers across all four maps.
+   *
+   * @return the run container count
+   */
+  public long getTotalRunContainers() {
+    return maps.stream().mapToLong(HierarchyMapFootprint::getRunContainers).sum();
+  }
+}

--- a/benchmark/src/main/java/au/csiro/pathling/benchmark/MeasurementVariant.java
+++ b/benchmark/src/main/java/au/csiro/pathling/benchmark/MeasurementVariant.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.benchmark;
+
+import jakarta.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * One combination of an identifier ordering and a representation optimisation setting. The two
+ * factors are crossed, giving four variants:
+ *
+ * <ul>
+ *   <li><b>A</b> - concept code order, representation not optimised. Today's behaviour, and the
+ *       baseline every other figure is stated against.
+ *   <li><b>B</b> - concept code order, representation optimised. A one-line change with no
+ *       trade-off, so if it captures most of the saving the reordering is unnecessary.
+ *   <li><b>C</b> - depth-first pre-order, representation not optimised. Expected to change nothing,
+ *       since run-length encoding only exists where it has been asked for; measured to prove that.
+ *   <li><b>D</b> - depth-first pre-order, representation optimised. The proposal.
+ * </ul>
+ *
+ * @author John Grimes
+ */
+public final class MeasurementVariant {
+
+  /** The label of the baseline variant, against which every saving is stated. */
+  public static final String BASELINE = "A";
+
+  /** The label of the variant isolating the effect of optimisation alone. */
+  public static final String OPTIMISED_CODE_ORDER = "B";
+
+  /** The label of the variant isolating the effect of reordering alone. */
+  public static final String UNOPTIMISED_PRE_ORDER = "C";
+
+  /** The label of the variant combining both factors, which is the proposal. */
+  public static final String PROPOSAL = "D";
+
+  @Nonnull private final String label;
+  @Nonnull private final String description;
+  private final boolean preOrder;
+  private final boolean optimised;
+
+  private MeasurementVariant(
+      @Nonnull final String label,
+      @Nonnull final String description,
+      final boolean preOrder,
+      final boolean optimised) {
+    this.label = label;
+    this.description = description;
+    this.preOrder = preOrder;
+    this.optimised = optimised;
+  }
+
+  /**
+   * Returns the four variants in report order.
+   *
+   * @return the variants
+   */
+  @Nonnull
+  public static List<MeasurementVariant> all() {
+    return List.of(
+        new MeasurementVariant(BASELINE, "code order, runOptimize not called", false, false),
+        new MeasurementVariant(OPTIMISED_CODE_ORDER, "code order, runOptimize called", false, true),
+        new MeasurementVariant(
+            UNOPTIMISED_PRE_ORDER, "pre-order, runOptimize not called", true, false),
+        new MeasurementVariant(PROPOSAL, "pre-order, runOptimize called", true, true));
+  }
+
+  /**
+   * Builds this variant from the loaded index. Every variant is built through the same remapping
+   * code path, differing only in which permutation it applies and whether it then asks for
+   * optimisation, so that no variant carries a construction artefact the others do not.
+   *
+   * @param source the index as loaded from the store
+   * @param identity the permutation that leaves every identifier where it is
+   * @param preOrderPermutation the depth-first pre-order permutation
+   * @return the materialised variant
+   */
+  @Nonnull
+  public HierarchyMaps materialise(
+      @Nonnull final HierarchyMaps source,
+      @Nonnull final int[] identity,
+      @Nonnull final int[] preOrderPermutation) {
+    final HierarchyMaps variant = source.remap(preOrder ? preOrderPermutation : identity);
+    if (optimised) {
+      variant.runOptimize();
+    }
+    return variant;
+  }
+
+  /**
+   * Returns the variant's single-letter label.
+   *
+   * @return the label
+   */
+  @Nonnull
+  public String getLabel() {
+    return label;
+  }
+
+  /**
+   * Returns a description of the variant's two factor settings.
+   *
+   * @return the description
+   */
+  @Nonnull
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Returns whether this variant asked its bitmaps to optimise their representation. Only these
+   * variants can contain run containers.
+   *
+   * @return true if optimisation was requested
+   */
+  public boolean isOptimised() {
+    return optimised;
+  }
+}

--- a/benchmark/src/test/java/au/csiro/pathling/benchmark/HierarchyIndexMemoryHarnessTest.java
+++ b/benchmark/src/test/java/au/csiro/pathling/benchmark/HierarchyIndexMemoryHarnessTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.benchmark;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import au.csiro.pathling.terminology.local.CodeSystemEntry;
+import au.csiro.pathling.terminology.local.index.ConceptDictionary;
+import au.csiro.pathling.terminology.local.index.HierarchyIndex;
+import au.csiro.pathling.terminology.store.SnomedRf2Importer;
+import au.csiro.pathling.terminology.store.TerminologyStoreReader;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.roaringbitmap.RoaringBitmap;
+
+/**
+ * Correctness tests for the hierarchy index memory harness. A memory figure taken with an incorrect
+ * permutation, or with a container histogram that does not measure what it claims, is worse than no
+ * figure at all, so everything the measurement rests on is asserted here against the {@code
+ * rf2-mini} fixture before the harness is pointed at a full SNOMED CT edition.
+ *
+ * @author John Grimes
+ */
+class HierarchyIndexMemoryHarnessTest {
+
+  private static SparkSession spark;
+  private static TerminologyStoreReader reader;
+  private static String systemVersionId;
+  private static ConceptDictionary dictionary;
+  private static HierarchyIndex index;
+  private static HierarchyMaps maps;
+
+  @BeforeAll
+  static void setUp() {
+    spark =
+        SparkSession.builder()
+            .appName("HierarchyIndexMemoryHarnessTest")
+            .master("local[2]")
+            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+            .config(
+                "spark.sql.catalog.spark_catalog",
+                "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+            .config("spark.sql.shuffle.partitions", "2")
+            .config("spark.driver.bindAddress", "localhost")
+            .config("spark.driver.host", "localhost")
+            .config("spark.ui.enabled", "false")
+            .getOrCreate();
+    final String storagePath;
+    try {
+      storagePath = Files.createTempDirectory("rf2-mini-harness").resolve("store").toString();
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    new SnomedRf2Importer(spark, storagePath).importFrom(fixturePath(), null);
+
+    reader = TerminologyStoreReader.open(storagePath, Map.of());
+    final List<CodeSystemEntry> catalogue = CodeSystemEntry.loadCatalogue(reader);
+    assertEquals(1, catalogue.size(), "The base fixture release holds one code system version");
+    systemVersionId = catalogue.get(0).getSystemVersionId();
+    dictionary = ConceptDictionary.load(reader, systemVersionId);
+    index = HierarchyIndex.load(reader, systemVersionId);
+    maps = HierarchyMaps.load(reader, systemVersionId);
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (spark != null) {
+      spark.stop();
+    }
+  }
+
+  /**
+   * Resolves the fixture from the sibling terminology module's source tree. The classpath resource
+   * is not usable here because it resides inside the terminology test-jar, from which Spark cannot
+   * read a directory.
+   */
+  private static String fixturePath() {
+    return Path.of(
+            "..", "terminology", "src", "test", "resources", "rf2-mini", "international-20230601")
+        .toAbsolutePath()
+        .normalize()
+        .toString();
+  }
+
+  // The harness works from its own copy of the four maps, because the production index keeps them
+  // private and the measurement is not allowed to change production code. These two tests pin that
+  // copy to the production index, so a figure taken from the copy is a figure about the real thing.
+
+  @Test
+  void replicaAnswersEveryLookupAsTheProductionIndexDoes() {
+    final Map<String, Map<Integer, RoaringBitmap>> named = maps.byName();
+    for (int dense = 0; dense < dictionary.size(); dense++) {
+      assertEquals(
+          index.descendantsOf(dense),
+          bitmapAt(named, HierarchyMaps.DESCENDANTS, dense),
+          "Descendants differ at dense identifier " + dense);
+      assertEquals(
+          index.ancestorsOf(dense),
+          bitmapAt(named, HierarchyMaps.ANCESTORS, dense),
+          "Ancestors differ at dense identifier " + dense);
+      assertEquals(
+          index.childrenOf(dense),
+          bitmapAt(named, HierarchyMaps.CHILDREN, dense),
+          "Children differ at dense identifier " + dense);
+      assertEquals(
+          index.parentsOf(dense),
+          bitmapAt(named, HierarchyMaps.PARENTS, dense),
+          "Parents differ at dense identifier " + dense);
+    }
+  }
+
+  @Test
+  void identityRemapCostsTheSameAsTheIndexAsLoaded() {
+    // Variant A is built by remapping through the identity, so that it carries the same
+    // construction
+    // artefacts as the reordered variants. That is only a fair baseline if the remap reproduces the
+    // loaded index's footprint exactly. The maps are reloaded rather than shared with the other
+    // tests,
+    // because measuring a map is only comparable between maps that have been traversed the same
+    // number
+    // of times.
+    final HierarchyMaps loaded = HierarchyMaps.load(reader, systemVersionId);
+    final long asLoaded = HierarchyVariantFootprint.measure(loaded).getTotalRetainedBytes();
+    final long identityRemapped =
+        HierarchyVariantFootprint.measure(loaded.remap(DenseIdOrdering.identity(dictionary.size())))
+            .getTotalRetainedBytes();
+    assertEquals(asLoaded, identityRemapped);
+  }
+
+  @Test
+  void preOrderPermutationIsABijectionOverTheWholeDictionary() {
+    final int conceptCount = dictionary.size();
+    final int[] permutation = DenseIdOrdering.preOrder(maps, conceptCount);
+
+    assertEquals(conceptCount, permutation.length);
+    final boolean[] seen = new boolean[conceptCount];
+    for (final int assigned : permutation) {
+      assertTrue(assigned >= 0 && assigned < conceptCount, "Assigned identifier out of range");
+      assertFalse(seen[assigned], "Identifier " + assigned + " was assigned twice");
+      seen[assigned] = true;
+    }
+    // The fixture's concept code order is not already a pre-order, so a permutation identical to
+    // the
+    // identity would mean the traversal did nothing.
+    assertFalse(
+        Arrays.equals(DenseIdOrdering.identity(conceptCount), permutation),
+        "The pre-order permutation is indistinguishable from the identity");
+  }
+
+  @Test
+  void conceptsWithNoIsARelationshipKeepCodeOrderAfterTheTraversal() {
+    final int conceptCount = dictionary.size();
+    final int[] permutation = DenseIdOrdering.preOrder(maps, conceptCount);
+
+    final List<Integer> unreached = new ArrayList<>();
+    for (int dense = 0; dense < conceptCount; dense++) {
+      if (!maps.children().containsKey(dense) && !maps.parents().containsKey(dense)) {
+        unreached.add(dense);
+      }
+    }
+    assertFalse(
+        unreached.isEmpty(),
+        "The fixture must contain concepts outside the is-a graph for this test to mean anything");
+
+    // Every concept outside the graph takes one of the highest identifiers, and they keep their
+    // existing relative order, which is concept code order.
+    final int firstUnreachedId = conceptCount - unreached.size();
+    for (int position = 0; position < unreached.size(); position++) {
+      assertEquals(
+          firstUnreachedId + position,
+          permutation[unreached.get(position)],
+          "Concept " + unreached.get(position) + " was not appended in code order");
+    }
+  }
+
+  @Test
+  void remappingPreservesEachMapsTotalCardinality() {
+    final int[] permutation = DenseIdOrdering.preOrder(maps, dictionary.size());
+    final HierarchyMaps remapped = maps.remap(permutation);
+
+    final Map<String, Map<Integer, RoaringBitmap>> before = maps.byName();
+    final Map<String, Map<Integer, RoaringBitmap>> after = remapped.byName();
+    assertEquals(before.keySet(), after.keySet());
+    for (final String name : before.keySet()) {
+      assertEquals(
+          before.get(name).size(), after.get(name).size(), "Entry count differs for map " + name);
+      assertEquals(
+          totalCardinality(before.get(name)),
+          totalCardinality(after.get(name)),
+          "Total cardinality differs for map " + name);
+    }
+  }
+
+  @Test
+  void subsumptionIsUnchangedByTheRemapping() {
+    final int conceptCount = dictionary.size();
+    final int[] permutation = DenseIdOrdering.preOrder(maps, conceptCount);
+    final HierarchyMaps remapped = maps.remap(permutation);
+
+    for (int ancestor = 0; ancestor < conceptCount; ancestor++) {
+      for (int descendant = 0; descendant < conceptCount; descendant++) {
+        assertEquals(
+            index.subsumes(ancestor, descendant),
+            remapped.subsumes(permutation[ancestor], permutation[descendant]),
+            "Subsumption differs for the pair (" + ancestor + ", " + descendant + ")");
+      }
+    }
+  }
+
+  @Test
+  void traversalTerminatesWhenAConceptIsReachableByMoreThanOnePath() {
+    // 0 is the root; 1 and 2 are its children; 3 is a child of both, so it is reachable by two
+    // paths.
+    // 4 has no is-a edge at all. The hierarchy is a directed acyclic graph, not a tree.
+    final HierarchyMaps diamond =
+        HierarchyMaps.of(
+            edges(Map.of(0, bitmapOf(1, 2, 3), 1, bitmapOf(3), 2, bitmapOf(3))),
+            edges(Map.of(1, bitmapOf(0), 2, bitmapOf(0), 3, bitmapOf(0, 1, 2))),
+            edges(Map.of(0, bitmapOf(1, 2), 1, bitmapOf(3), 2, bitmapOf(3))),
+            edges(Map.of(1, bitmapOf(0), 2, bitmapOf(0), 3, bitmapOf(1, 2))));
+
+    final int[] permutation = DenseIdOrdering.preOrder(diamond, 5);
+
+    // Pre-order from root 0: 0, then its smallest child 1, then 1's child 3, then 2. The isolated
+    // concept 4 is appended last. Concept 3 is visited once, despite having two parents.
+    assertArrayEquals(new int[] {0, 1, 3, 2, 4}, permutation);
+  }
+
+  @Test
+  void histogramCountsRunContainersOnlyWhereOptimisationWasRequested() {
+    // The production index builds every bitmap by repeated addition and never asks for
+    // optimisation,
+    // so no run container exists in it at any ordering.
+    for (final Map.Entry<String, Map<Integer, RoaringBitmap>> entry : maps.byName().entrySet()) {
+      final HierarchyMapFootprint footprint =
+          HierarchyMapFootprint.measure(entry.getKey(), entry.getValue());
+      assertEquals(
+          0,
+          footprint.getRunContainers(),
+          "Unoptimised map " + entry.getKey() + " holds run containers");
+      assertTrue(
+          footprint.getArrayContainers() + footprint.getBitmapContainers() > 0,
+          "Map " + entry.getKey() + " holds no containers at all");
+    }
+
+    // A contiguous range is the case run-length encoding exists for, so asking for optimisation
+    // must
+    // produce a run container and shrink the map.
+    final Map<Integer, RoaringBitmap> contiguous = new HashMap<>();
+    final RoaringBitmap range = new RoaringBitmap();
+    for (int value = 0; value < 20_000; value++) {
+      range.add(value);
+    }
+    contiguous.put(0, range);
+    final HierarchyMapFootprint before = HierarchyMapFootprint.measure("contiguous", contiguous);
+    assertEquals(0, before.getRunContainers());
+
+    assertTrue(range.runOptimize(), "A contiguous range must be worth run-length encoding");
+    final HierarchyMapFootprint after = HierarchyMapFootprint.measure("contiguous", contiguous);
+    assertTrue(after.getRunContainers() > 0, "Optimisation produced no run container");
+    assertTrue(
+        after.getRetainedBytes() < before.getRetainedBytes(),
+        "Run-length encoding a contiguous range did not reduce retained heap");
+  }
+
+  private static RoaringBitmap bitmapAt(
+      final Map<String, Map<Integer, RoaringBitmap>> named, final String name, final int dense) {
+    final RoaringBitmap bitmap = named.get(name).get(dense);
+    return bitmap == null ? new RoaringBitmap() : bitmap;
+  }
+
+  private static long totalCardinality(final Map<Integer, RoaringBitmap> map) {
+    return map.values().stream().mapToLong(RoaringBitmap::getLongCardinality).sum();
+  }
+
+  private static RoaringBitmap bitmapOf(final int... values) {
+    final RoaringBitmap bitmap = new RoaringBitmap();
+    for (final int value : values) {
+      bitmap.add(value);
+    }
+    return bitmap;
+  }
+
+  /** Copies a literal map into the mutable, default-capacity form the harness works with. */
+  private static Map<Integer, RoaringBitmap> edges(final Map<Integer, RoaringBitmap> literal) {
+    return new HashMap<>(literal);
+  }
+}

--- a/lib/R/R/terminology_import.R
+++ b/lib/R/R/terminology_import.R
@@ -25,6 +25,9 @@
 #' @param storage_path The terminology store location, created if absent.
 #' @param edition_uri An explicit SNOMED edition/version URI, overriding detection. Defaults to
 #'   NULL.
+#' @param dense_id_order How dense identifiers are assigned to concepts, either "code-order" (the
+#'   default) or "pre-order". The pre-order makes the runtime hierarchy index materially smaller, in
+#'   exchange for identifiers that shift more between releases. Defaults to NULL.
 #'
 #' @return The PathlingContext object, invisibly.
 #'
@@ -33,15 +36,25 @@
 #' @importFrom sparklyr j_invoke j_invoke_static spark_connection
 #'
 #' @export
-pathling_import_snomed <- function(pc, source, storage_path, edition_uri = NULL) {
+pathling_import_snomed <- function(pc, source, storage_path, edition_uri = NULL,
+                                   dense_id_order = NULL) {
   options <- NULL
-  if (!is.null(edition_uri)) {
-    options <- j_invoke_static(
+  if (!is.null(edition_uri) || !is.null(dense_id_order)) {
+    builder <- j_invoke_static(
       spark_connection(pc),
       "au.csiro.pathling.library.terminology.TerminologyImportOptions", "builder"
-    ) %>%
-      j_invoke("editionUri", edition_uri) %>%
-      j_invoke("build")
+    )
+    if (!is.null(edition_uri)) {
+      builder <- j_invoke(builder, "editionUri", edition_uri)
+    }
+    if (!is.null(dense_id_order)) {
+      order <- j_invoke_static(
+        spark_connection(pc),
+        "au.csiro.pathling.terminology.store.DenseIdOrder", "fromValue", dense_id_order
+      )
+      builder <- j_invoke(builder, "denseIdOrder", order)
+    }
+    options <- j_invoke(builder, "build")
   }
   j_invoke(pc, "importSnomed", source, storage_path, options)
   invisible(pc)

--- a/lib/python/pathling/cli/import_terminology.py
+++ b/lib/python/pathling/cli/import_terminology.py
@@ -81,8 +81,20 @@ def _resolve_storage_path(config, storage_path):
 @click.option(
     "--edition-uri", "edition_uri", help="Override the SNOMED edition/version URI."
 )
+@click.option(
+    "--dense-id-order",
+    "dense_id_order",
+    type=click.Choice(["code-order", "pre-order"]),
+    default="code-order",
+    show_default=True,
+    help=(
+        "How internal concept identifiers are assigned. 'pre-order' makes the "
+        "hierarchy index materially smaller, in exchange for identifiers that "
+        "shift more between releases."
+    ),
+)
 @click.pass_obj
-def import_snomed(obj, source, storage_path, edition_uri):
+def import_snomed(obj, source, storage_path, edition_uri, dense_id_order):
     """Import a SNOMED CT RF2 snapshot release into a local terminology store.
 
     STORAGE_PATH may be omitted when 'tx-store.path' (or --tx-store) is set.
@@ -96,7 +108,7 @@ def import_snomed(obj, source, storage_path, edition_uri):
     resolved_path = _resolve_storage_path(config, storage_path)
     pc = _import_context(config, console)
     with progress_status(console, "Importing SNOMED CT...", config.verbose):
-        pc.import_snomed(source, resolved_path, edition_uri)
+        pc.import_snomed(source, resolved_path, edition_uri, dense_id_order)
     click.echo(f"Imported SNOMED CT from {source} into {resolved_path}")
 
 

--- a/lib/python/pathling/context.py
+++ b/lib/python/pathling/context.py
@@ -405,6 +405,7 @@ class PathlingContext:
         source: str,
         storage_path: str,
         edition_uri: Optional[str] = None,
+        dense_id_order: Optional[str] = None,
     ) -> None:
         """
         Imports a SNOMED CT RF2 snapshot release into a local terminology store.
@@ -413,17 +414,26 @@ class PathlingContext:
                accessible through the Hadoop FileSystem API
         :param storage_path: the terminology store location, created if absent
         :param edition_uri: an explicit SNOMED edition/version URI, overriding detection
+        :param dense_id_order: how dense identifiers are assigned to concepts, either
+               ``"code-order"`` (the default) or ``"pre-order"``. The pre-order makes the runtime
+               hierarchy index materially smaller, in exchange for identifiers that shift more
+               between releases
         :raises: the mapped JVM ``TerminologyImportException`` if the source is not a valid RF2
                  snapshot release; the store is left unmodified
         """
         jvm = self._spark._jvm
         options = None
-        if edition_uri is not None:
-            options = (
-                jvm.au.csiro.pathling.library.terminology.TerminologyImportOptions.builder()
-                .editionUri(edition_uri)
-                .build()
-            )
+        if edition_uri is not None or dense_id_order is not None:
+            builder = jvm.au.csiro.pathling.library.terminology.TerminologyImportOptions.builder()
+            if edition_uri is not None:
+                builder = builder.editionUri(edition_uri)
+            if dense_id_order is not None:
+                builder = builder.denseIdOrder(
+                    jvm.au.csiro.pathling.terminology.store.DenseIdOrder.fromValue(
+                        dense_id_order
+                    )
+                )
+            options = builder.build()
         self._jpc.importSnomed(source, storage_path, options)
 
     def import_fhir_terminology(self, source: str, storage_path: str) -> None:

--- a/library-api/src/main/java/au/csiro/pathling/library/PathlingContext.java
+++ b/library-api/src/main/java/au/csiro/pathling/library/PathlingContext.java
@@ -38,6 +38,7 @@ import au.csiro.pathling.sql.udf.TerminologyUdfRegistrar;
 import au.csiro.pathling.terminology.DefaultTerminologyServiceFactory;
 import au.csiro.pathling.terminology.TerminologyServiceFactory;
 import au.csiro.pathling.terminology.local.LocalTerminologyServiceFactory;
+import au.csiro.pathling.terminology.store.DenseIdOrder;
 import au.csiro.pathling.terminology.store.FhirTerminologyImporter;
 import au.csiro.pathling.terminology.store.SnomedRf2Importer;
 import au.csiro.pathling.terminology.store.TerminologyStoreException;
@@ -636,7 +637,11 @@ public class PathlingContext {
       @Nonnull final String storagePath,
       @Nullable final TerminologyImportOptions options) {
     final String editionUri = options == null ? null : options.getEditionUri();
-    new SnomedRf2Importer(spark, storagePath).importFrom(source, editionUri);
+    final DenseIdOrder denseIdOrder =
+        options == null || options.getDenseIdOrder() == null
+            ? DenseIdOrder.CODE_ORDER
+            : options.getDenseIdOrder();
+    new SnomedRf2Importer(spark, storagePath).importFrom(source, editionUri, denseIdOrder);
     return this;
   }
 

--- a/library-api/src/main/java/au/csiro/pathling/library/terminology/TerminologyImportOptions.java
+++ b/library-api/src/main/java/au/csiro/pathling/library/terminology/TerminologyImportOptions.java
@@ -17,6 +17,7 @@
 
 package au.csiro.pathling.library.terminology;
 
+import au.csiro.pathling.terminology.store.DenseIdOrder;
 import jakarta.annotation.Nullable;
 import lombok.Builder;
 import lombok.Value;
@@ -36,4 +37,13 @@ public class TerminologyImportOptions {
    * null, the edition and version are detected from the release's module and effectiveTime content.
    */
   @Nullable String editionUri;
+
+  /**
+   * Selects how dense identifiers are assigned to concepts. When null, they follow concept code
+   * order, which is the behaviour of every release before this option existed. {@link
+   * DenseIdOrder#PRE_ORDER} instead assigns them by a depth-first traversal of the is-a hierarchy,
+   * which makes the runtime hierarchy index materially smaller but means identifiers shift whenever
+   * the hierarchy changes shape between releases.
+   */
+  @Nullable DenseIdOrder denseIdOrder;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,8 @@
     <pathling.logbackVersion>1.5.25</pathling.logbackVersion>
     <pathling.slf4jVersion>2.0.17</pathling.slf4jVersion>
     <pathling.derbyVersion>10.16.1.1</pathling.derbyVersion>
+    <!-- Java Object Layout, used by the benchmark module to measure retained heap. -->
+    <pathling.jolVersion>0.17</pathling.jolVersion>
     <pathling.bulkExportVersion>1.0.5-SNAPSHOT</pathling.bulkExportVersion>
     <pathling.fhirAuthVersion>1.0.0</pathling.fhirAuthVersion>
     <!-- Spark brings in a Netty version with published vulnerabilities, so the whole family is

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -348,9 +348,14 @@ pathling import-fhir-terminology /data/hl7.terminology.tgz /data/tx-store
 ```
 
 `import-snomed` accepts `--edition-uri` to override the detected SNOMED
-edition/version. `import-fhir-terminology` accepts a JSON file, a directory of
-JSON files, or a FHIR NPM package (`.tgz`), and imports CodeSystems of any size
-with bounded memory (for example, the multi-gigabyte OMOP vocabulary CodeSystem).
+edition/version, and `--dense-id-order pre-order` to assign internal concept
+identifiers by a depth-first traversal of the is-a hierarchy, which makes the
+hierarchy index materially smaller at query time in exchange for identifiers that
+shift more between releases - see
+[reducing the memory the hierarchy takes at query time](terminology#reducing-the-memory-the-hierarchy-takes-at-query-time).
+`import-fhir-terminology` accepts a JSON file, a directory of JSON files, or a
+FHIR NPM package (`.tgz`), and imports CodeSystems of any size with bounded
+memory (for example, the multi-gigabyte OMOP vocabulary CodeSystem).
 
 Large imports run for many minutes. With `--verbose`, the command streams a
 running count of parsed concepts and stage-transition messages so progress is

--- a/site/docs/libraries/terminology.md
+++ b/site/docs/libraries/terminology.md
@@ -984,6 +984,60 @@ pathling import-fhir-terminology /data/hl7.terminology.tgz /data/tx-store
 </TabItem>
 </Tabs>
 
+#### Reducing the memory the hierarchy takes at query time
+
+The largest structure a local store loads into memory is the hierarchy index,
+which holds the transitive closure of the is-a graph as compressed bitmaps
+addressed by an internal identifier per concept. By default those identifiers are
+assigned in concept code order, and a code's numeric value bears no relation to
+the concept's place in the hierarchy, so a concept's descendants scatter across
+the whole identifier range and compress poorly.
+
+The `pre-order` setting instead assigns identifiers by a depth-first traversal of
+the is-a hierarchy, so each subtree occupies a near-contiguous interval. Measured
+over a full SNOMED CT UK edition of 1,115,237 concepts, this reduces the
+hierarchy index from 738 MB to 536 MB of retained heap, a saving of 27%.
+
+The trade-off is identifier stability. Under the default ordering a concept keeps
+its identifier across re-imports of any release that contains it, and identifiers
+change only where codes are added or removed. Under the pre-order, a change
+anywhere in the shape of the hierarchy shifts the identifiers of everything that
+follows it, so identifiers vary much more between releases. Identifiers are
+internal to a store and never appear in query results, so this affects nothing a
+user can observe directly; it matters only if you compare or reuse the internal
+identifiers of two separately imported stores. Repeated imports of the same
+release remain reproducible under both orderings, and all seven terminology
+functions return identical results either way.
+
+<Tabs>
+<TabItem value="python" label="Python">
+
+```python
+pc.import_snomed(
+    "/data/rf2.zip",
+    "/data/tx-store",
+    dense_id_order="pre-order",
+)
+```
+
+</TabItem>
+<TabItem value="r" label="R">
+
+```r
+pathling_import_snomed(pc, "/data/rf2.zip", "/data/tx-store",
+  dense_id_order = "pre-order")
+```
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+```bash
+pathling import-snomed /data/rf2.zip /data/tx-store --dense-id-order pre-order
+```
+
+</TabItem>
+</Tabs>
+
 #### Large CodeSystems
 
 CodeSystems are imported with bounded memory regardless of their size. The

--- a/terminology/src/main/java/au/csiro/pathling/terminology/local/LocalTerminologyService.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/local/LocalTerminologyService.java
@@ -314,6 +314,30 @@ public class LocalTerminologyService implements TerminologyService, Closeable {
   }
 
   /**
+   * Emits one property per related concept, in ascending code order.
+   *
+   * <p>The order is taken from the codes rather than from the bitmap, whose order is that of the
+   * store's internal dense identifiers. Those identifiers are an implementation detail whose
+   * assignment depends on how the store was imported, so ordering by them would let an internal
+   * choice show through in a lookup result.
+   *
+   * @param propertyCode the property to emit, {@code parent} or {@code child}
+   * @param related the related concepts, by dense identifier
+   * @param dictionary the concept dictionary, for translating identifiers to codes
+   * @param result the list to append to
+   */
+  private static void addRelatedCodes(
+      @Nonnull final String propertyCode,
+      @Nonnull final RoaringBitmap related,
+      @Nonnull final ConceptDictionary dictionary,
+      @Nonnull final List<PropertyOrDesignation> result) {
+    final List<String> codes = new ArrayList<>(related.getCardinality());
+    related.forEach((IntConsumer) dense -> codes.add(dictionary.code(dense)));
+    Collections.sort(codes);
+    codes.forEach(code -> result.add(Property.of(propertyCode, new CodeType(code))));
+  }
+
+  /**
    * Builds the property and designation list for a resolved concept, honouring an optional property
    * filter and display language.
    */
@@ -337,24 +361,10 @@ public class LocalTerminologyService implements TerminologyService, Closeable {
       addDesignations(systemUrl, indexes, dense, result);
     }
     if (wants(propertyCode, PROPERTY_PARENT)) {
-      indexes
-          .hierarchy()
-          .parentsOf(dense)
-          .forEach(
-              (IntConsumer)
-                  parent ->
-                      result.add(
-                          Property.of(PROPERTY_PARENT, new CodeType(dictionary.code(parent)))));
+      addRelatedCodes(PROPERTY_PARENT, indexes.hierarchy().parentsOf(dense), dictionary, result);
     }
     if (wants(propertyCode, PROPERTY_CHILD)) {
-      indexes
-          .hierarchy()
-          .childrenOf(dense)
-          .forEach(
-              (IntConsumer)
-                  child ->
-                      result.add(
-                          Property.of(PROPERTY_CHILD, new CodeType(dictionary.code(child)))));
+      addRelatedCodes(PROPERTY_CHILD, indexes.hierarchy().childrenOf(dense), dictionary, result);
     }
     if (wants(propertyCode, PROPERTY_INACTIVE)) {
       result.add(Property.of(PROPERTY_INACTIVE, new BooleanType(!dictionary.isActive(dense))));

--- a/terminology/src/main/java/au/csiro/pathling/terminology/local/LocalTerminologyService.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/local/LocalTerminologyService.java
@@ -32,6 +32,7 @@ import jakarta.annotation.Nullable;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -314,12 +315,28 @@ public class LocalTerminologyService implements TerminologyService, Closeable {
   }
 
   /**
-   * Emits one property per related concept, in ascending code order.
+   * Returns the members of a bitmap ordered by their concept code.
    *
-   * <p>The order is taken from the codes rather than from the bitmap, whose order is that of the
-   * store's internal dense identifiers. Those identifiers are an implementation detail whose
-   * assignment depends on how the store was imported, so ordering by them would let an internal
-   * choice show through in a lookup result.
+   * <p>Every multi-valued lookup result must be ordered this way rather than by iterating the
+   * bitmap directly. A bitmap is ordered by the store's internal dense identifiers, which are an
+   * implementation detail whose assignment depends on how the store was imported, so emitting in
+   * bitmap order would let that internal choice show through in a result a caller can see.
+   *
+   * @param members the concepts, by dense identifier
+   * @param dictionary the concept dictionary, for translating identifiers to codes
+   * @return the members' dense identifiers, ordered by concept code
+   */
+  @Nonnull
+  private static List<Integer> byConceptCode(
+      @Nonnull final RoaringBitmap members, @Nonnull final ConceptDictionary dictionary) {
+    final List<Integer> ordered = new ArrayList<>(members.getCardinality());
+    members.forEach((IntConsumer) ordered::add);
+    ordered.sort(Comparator.comparing(dictionary::code));
+    return ordered;
+  }
+
+  /**
+   * Emits one property per related concept, in ascending code order.
    *
    * @param propertyCode the property to emit, {@code parent} or {@code child}
    * @param related the related concepts, by dense identifier
@@ -331,10 +348,9 @@ public class LocalTerminologyService implements TerminologyService, Closeable {
       @Nonnull final RoaringBitmap related,
       @Nonnull final ConceptDictionary dictionary,
       @Nonnull final List<PropertyOrDesignation> result) {
-    final List<String> codes = new ArrayList<>(related.getCardinality());
-    related.forEach((IntConsumer) dense -> codes.add(dictionary.code(dense)));
-    Collections.sort(codes);
-    codes.forEach(code -> result.add(Property.of(propertyCode, new CodeType(code))));
+    for (final int dense : byConceptCode(related, dictionary)) {
+      result.add(Property.of(propertyCode, new CodeType(dictionary.code(dense))));
+    }
   }
 
   /**
@@ -438,18 +454,15 @@ public class LocalTerminologyService implements TerminologyService, Closeable {
       if (!wants(propertyCode, type)) {
         continue;
       }
-      relationships
-          .targetsOf(type, source)
-          .forEach(
-              (IntConsumer)
-                  target ->
-                      result.add(
-                          Property.of(
-                              type,
-                              new Coding()
-                                  .setSystem(systemUrl)
-                                  .setCode(dictionary.code(target))
-                                  .setDisplay(dictionary.display(target)))));
+      for (final int target : byConceptCode(relationships.targetsOf(type, source), dictionary)) {
+        result.add(
+            Property.of(
+                type,
+                new Coding()
+                    .setSystem(systemUrl)
+                    .setCode(dictionary.code(target))
+                    .setDisplay(dictionary.display(target))));
+      }
     }
   }
 

--- a/terminology/src/main/java/au/csiro/pathling/terminology/local/index/HierarchyIndex.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/local/index/HierarchyIndex.java
@@ -83,7 +83,26 @@ public final class HierarchyIndex {
             parents.computeIfAbsent(descendant, k -> new RoaringBitmap()).add(ancestor);
           }
         });
+    // Building a bitmap by repeated addition never produces a run-length-encoded chunk, however
+    // contiguous the values are; the representation has to be asked for. Over a full SNOMED CT UK
+    // edition this saves a further 2.2% of the index's retained heap on top of what a hierarchy
+    // ordering of dense identifiers achieves, and nothing where the values are scattered, since
+    // run-length encoding is only chosen per chunk where it is the smaller representation.
+    optimiseRepresentation(descendants, ancestors, children, parents);
     return new HierarchyIndex(descendants, ancestors, children, parents);
+  }
+
+  /**
+   * Asks every bitmap to adopt run-length encoding wherever that is more space efficient. This
+   * changes only how each set is represented, never its membership, so no query answer changes.
+   *
+   * @param maps the maps to optimise
+   */
+  @SafeVarargs
+  private static void optimiseRepresentation(@Nonnull final Map<Integer, RoaringBitmap>... maps) {
+    for (final Map<Integer, RoaringBitmap> map : maps) {
+      map.values().forEach(RoaringBitmap::runOptimize);
+    }
   }
 
   /**

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/DenseIdOrder.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/DenseIdOrder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import jakarta.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * The rule an import uses to assign dense identifiers to concepts. Dense identifiers are internal
+ * to a store, so the choice affects only how compactly the runtime indexes represent themselves.
+ *
+ * @author John Grimes
+ */
+public enum DenseIdOrder {
+
+  /**
+   * Concept code order. The default, and the only ordering used before this option existed. A
+   * concept keeps the same identifier across re-imports of any release that contains it, but a
+   * concept's descendants are scattered across the whole identifier range, because a code's numeric
+   * value bears no relation to its position in the hierarchy.
+   */
+  CODE_ORDER("code-order"),
+
+  /**
+   * Depth-first pre-order over the active is-a hierarchy. Each subtree occupies a near-contiguous
+   * interval, which makes the hierarchy index materially smaller, at the cost of identifiers that
+   * shift whenever the hierarchy changes shape between releases.
+   */
+  PRE_ORDER("pre-order");
+
+  @Nonnull private final String value;
+
+  DenseIdOrder(@Nonnull final String value) {
+    this.value = value;
+  }
+
+  /**
+   * Returns the option's external name, as accepted on the command line and in the language
+   * libraries.
+   *
+   * @return the external name
+   */
+  @Nonnull
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Resolves an ordering from its external name.
+   *
+   * @param value the external name, for example {@code pre-order}
+   * @return the matching ordering
+   * @throws IllegalArgumentException if the name matches no ordering
+   */
+  @Nonnull
+  public static DenseIdOrder fromValue(@Nonnull final String value) {
+    return Arrays.stream(values())
+        .filter(order -> order.value.equals(value))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Unknown dense identifier order '"
+                        + value
+                        + "', expected one of: "
+                        + Arrays.stream(values())
+                            .map(DenseIdOrder::getValue)
+                            .collect(Collectors.joining(", "))));
+  }
+}

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/DenseIdPreOrder.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/DenseIdPreOrder.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import jakarta.annotation.Nonnull;
+import java.util.Arrays;
+
+/**
+ * Computes a depth-first pre-order over a concept hierarchy, expressed as a permutation of dense
+ * identifiers. Placing each subtree in a near-contiguous interval lets the runtime hierarchy index
+ * represent a descendant set as a few compressed chunks instead of many scattered ones.
+ *
+ * <p>The traversal runs on the driver over primitive arrays. A depth-first order is inherently
+ * sequential, so distributing it would buy nothing but shuffles, and the graph is small in absolute
+ * terms: the largest edition on hand has around 1.1 million concepts and 1.5 million active is-a
+ * edges, which is a few tens of megabytes against the several hundred the index itself occupies.
+ * The traversal is iterative rather than recursive, because a real hierarchy is deep enough to make
+ * recursion a stack risk.
+ *
+ * @author John Grimes
+ */
+public final class DenseIdPreOrder {
+
+  /** Marks a concept the traversal has not yet reached. */
+  private static final int UNASSIGNED = -1;
+
+  private DenseIdPreOrder() {
+    // Utility class.
+  }
+
+  /**
+   * Computes the pre-order permutation for a hierarchy.
+   *
+   * <p>Roots - concepts with no parent - are visited in ascending identifier order, and each
+   * concept's children likewise, so the result depends only on the hierarchy and not on the order
+   * the edges arrive in. Repeated imports of the same release therefore assign identical
+   * identifiers.
+   *
+   * <p>Every concept the traversal does not reach keeps its existing relative order and is appended
+   * after it. That covers inactive concepts, metadata concepts that are only ever referenced, and -
+   * should a malformed release contain one - a cyclic component, which has no root and so is never
+   * entered. Dense identifiers address the whole concept dictionary rather than only the hierarchy,
+   * so a permutation that omitted any concept would not be a bijection.
+   *
+   * @param children the child of each is-a edge, by existing dense identifier
+   * @param parents the parent of each is-a edge, by existing dense identifier, parallel to {@code
+   *     children}
+   * @param conceptCount the number of concepts in the dictionary
+   * @return a permutation of {@code [0, conceptCount)}, giving each concept's new identifier
+   * @throws IllegalArgumentException if the two edge arrays differ in length, or if an edge refers
+   *     to a concept outside the dictionary
+   */
+  @Nonnull
+  public static int[] compute(
+      @Nonnull final int[] children, @Nonnull final int[] parents, final int conceptCount) {
+    if (children.length != parents.length) {
+      throw new IllegalArgumentException(
+          "The is-a edge arrays must be the same length, but were "
+              + children.length
+              + " and "
+              + parents.length);
+    }
+    if (conceptCount < 0) {
+      throw new IllegalArgumentException("The concept count cannot be negative: " + conceptCount);
+    }
+
+    final boolean[] hasParent = new boolean[conceptCount];
+    final int[] childCounts = new int[conceptCount];
+    for (int edge = 0; edge < children.length; edge++) {
+      checkWithinDictionary(children[edge], conceptCount);
+      checkWithinDictionary(parents[edge], conceptCount);
+      hasParent[children[edge]] = true;
+      childCounts[parents[edge]]++;
+    }
+
+    // Adjacency in compressed form: childrenOf[start[n]] up to childrenOf[start[n + 1]] are the
+    // children of concept n. One pair of arrays for the whole graph keeps the traversal free of the
+    // per-concept collections a map of lists would allocate.
+    final int[] start = new int[conceptCount + 1];
+    for (int node = 0; node < conceptCount; node++) {
+      start[node + 1] = start[node] + childCounts[node];
+    }
+    final int[] childrenOf = new int[children.length];
+    final int[] cursor = Arrays.copyOf(start, conceptCount);
+    for (int edge = 0; edge < children.length; edge++) {
+      childrenOf[cursor[parents[edge]]++] = children[edge];
+    }
+    for (int node = 0; node < conceptCount; node++) {
+      Arrays.sort(childrenOf, start[node], start[node + 1]);
+    }
+
+    final int[] permutation = new int[conceptCount];
+    Arrays.fill(permutation, UNASSIGNED);
+    int next = 0;
+
+    // Each concept is pushed at most once per incoming edge, and each root once, which
+    // bounds the stack.
+    final int[] stack = new int[conceptCount + children.length];
+    int depth = 0;
+    // Push the roots in descending order, so that the smallest is popped, and visited, first.
+    for (int node = conceptCount - 1; node >= 0; node--) {
+      if (!hasParent[node] && start[node] < start[node + 1]) {
+        stack[depth++] = node;
+      }
+    }
+    while (depth > 0) {
+      final int node = stack[--depth];
+      if (permutation[node] != UNASSIGNED) {
+        continue;
+      }
+      permutation[node] = next++;
+      for (int index = start[node + 1] - 1; index >= start[node]; index--) {
+        if (permutation[childrenOf[index]] == UNASSIGNED) {
+          stack[depth++] = childrenOf[index];
+        }
+      }
+    }
+
+    for (int node = 0; node < conceptCount; node++) {
+      if (permutation[node] == UNASSIGNED) {
+        permutation[node] = next++;
+      }
+    }
+    return permutation;
+  }
+
+  private static void checkWithinDictionary(final int dense, final int conceptCount) {
+    if (dense < 0 || dense >= conceptCount) {
+      throw new IllegalArgumentException(
+          "An is-a edge refers to dense identifier "
+              + dense
+              + ", which is outside a dictionary of "
+              + conceptCount
+              + " concepts");
+    }
+  }
+}

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
@@ -57,6 +57,7 @@ import static org.apache.spark.sql.functions.map_from_entries;
 import static org.apache.spark.sql.functions.min;
 import static org.apache.spark.sql.functions.row_number;
 import static org.apache.spark.sql.functions.struct;
+import static org.apache.spark.sql.functions.udf;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -87,13 +88,17 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FilterFunction;
 import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.api.java.UDF1;
+import org.apache.spark.sql.expressions.UserDefinedFunction;
 import org.apache.spark.sql.expressions.Window;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
@@ -151,12 +156,27 @@ public class SnomedRf2Importer {
    * @throws TerminologyImportException if the source is not a valid RF2 snapshot release
    */
   public void importFrom(@Nonnull final String source, @Nullable final String editionUriOverride) {
+    importFrom(source, editionUriOverride, DenseIdOrder.CODE_ORDER);
+  }
+
+  /**
+   * Imports an RF2 snapshot release, choosing how dense identifiers are assigned.
+   *
+   * @param source the release directory or archive, on any Hadoop-accessible filesystem
+   * @param editionUriOverride an explicit edition/version URI, or null to detect it
+   * @param denseIdOrder the rule for assigning dense identifiers
+   * @throws TerminologyImportException if the source is not a valid RF2 snapshot release
+   */
+  public void importFrom(
+      @Nonnull final String source,
+      @Nullable final String editionUriOverride,
+      @Nonnull final DenseIdOrder denseIdOrder) {
     // A zip archive is extracted to a temporary directory first, since the file discovery and Spark
     // readers operate on the extracted release layout. A plain directory is read in place.
     final java.nio.file.Path extracted = isZipArchive(source) ? extractArchive(source) : null;
     try {
       final String releaseRoot = extracted != null ? extracted.toString() : source;
-      importFromRelease(releaseRoot, source, editionUriOverride);
+      importFromRelease(releaseRoot, source, editionUriOverride, denseIdOrder);
     } finally {
       if (extracted != null) {
         deleteRecursively(extracted);
@@ -170,11 +190,13 @@ public class SnomedRf2Importer {
    * @param releaseRoot the directory holding the extracted release, scanned for the Snapshot files
    * @param source the original source path, recorded in the manifest for provenance
    * @param editionUriOverride an explicit edition/version URI, or null to detect it
+   * @param denseIdOrder the rule for assigning dense identifiers
    */
   private void importFromRelease(
       @Nonnull final String releaseRoot,
       @Nonnull final String source,
-      @Nullable final String editionUriOverride) {
+      @Nullable final String editionUriOverride,
+      @Nonnull final DenseIdOrder denseIdOrder) {
     final Rf2Files files = locateFiles(releaseRoot);
 
     log.info("Reading concepts from {}", files.concept);
@@ -191,7 +213,7 @@ public class SnomedRf2Importer {
     log.info("Detected SNOMED CT edition {} version {}", parsed.edition, version);
 
     // Concept dictionary with dense identifiers, ordered by code for determinism.
-    final Dataset<Row> concepts =
+    final Dataset<Row> codeOrdered =
         conceptRaw
             .select(
                 col("id").alias(COLUMN_CODE),
@@ -201,7 +223,14 @@ public class SnomedRf2Importer {
                 col("definitionStatusId").equalTo(DEFINED_STATUS).alias(COLUMN_DEFINED))
             .withColumn(COLUMN_DENSE_ID, row_number().over(Window.orderBy(COLUMN_CODE)).minus(1))
             .persist();
-    final long conceptCount = concepts.count();
+    final long conceptCount = codeOrdered.count();
+
+    // The pre-order is derived by permuting the code-order identifiers, so the code ordering is
+    // computed either way. Only the permuting variant costs anything extra.
+    final Dataset<Row> concepts =
+        DenseIdOrder.PRE_ORDER == denseIdOrder
+            ? reorderDenseIds(codeOrdered, files, conceptCount)
+            : codeOrdered;
 
     final Dataset<Row> denseByCode = concepts.select(COLUMN_CODE, COLUMN_DENSE_ID);
 
@@ -235,7 +264,83 @@ public class SnomedRf2Importer {
     writeManifest(writer, version, source);
     descriptions.cached.forEach(Dataset::unpersist);
     concepts.unpersist();
+    codeOrdered.unpersist();
     log.info("Import complete for {} version {} ({} concepts)", SNOMED_URI, version, conceptCount);
+  }
+
+  // --- Dense identifier ordering. ---
+
+  /**
+   * Reassigns dense identifiers in depth-first pre-order over the active is-a hierarchy, so that
+   * each subtree occupies a near-contiguous interval and the runtime hierarchy index needs
+   * materially less memory to represent it.
+   *
+   * <p>The traversal is computed on the driver from the code-order identifiers already assigned,
+   * then broadcast and applied. Collecting the edges rather than distributing the traversal is
+   * deliberate: a depth-first order is inherently sequential, and the edge list is small enough to
+   * hold on the driver.
+   *
+   * @param codeOrdered the concept dictionary with code-order dense identifiers
+   * @param files the located release files, for the relationship file holding the is-a edges
+   * @param conceptCount the number of concepts in the dictionary
+   * @return the dictionary with pre-order dense identifiers
+   */
+  @Nonnull
+  private Dataset<Row> reorderDenseIds(
+      @Nonnull final Dataset<Row> codeOrdered,
+      @Nonnull final Rf2Files files,
+      final long conceptCount) {
+    if (conceptCount > Integer.MAX_VALUE) {
+      throw new TerminologyImportException(
+          "Pre-order dense identifiers are not supported for a release of "
+              + conceptCount
+              + " concepts");
+    }
+    log.info("Assigning dense identifiers in pre-order over the is-a hierarchy");
+    final List<Row> edges = collectIsaEdges(codeOrdered, files);
+    final int[] children = new int[edges.size()];
+    final int[] parents = new int[edges.size()];
+    for (int index = 0; index < edges.size(); index++) {
+      children[index] = edges.get(index).getInt(0);
+      parents[index] = edges.get(index).getInt(1);
+    }
+    log.info("Traversing {} active is-a edges", edges.size());
+    final int[] permutation = DenseIdPreOrder.compute(children, parents, (int) conceptCount);
+
+    final Broadcast<int[]> broadcast =
+        JavaSparkContext.fromSparkContext(spark.sparkContext()).broadcast(permutation);
+    final UDF1<Integer, Integer> lookup = dense -> broadcast.value()[dense];
+    final UserDefinedFunction reassign = udf(lookup, DataTypes.IntegerType);
+    return codeOrdered.withColumn(COLUMN_DENSE_ID, reassign.apply(col(COLUMN_DENSE_ID))).persist();
+  }
+
+  /**
+   * Collects the active is-a edges of a release, expressed in code-order dense identifiers.
+   *
+   * @param codeOrdered the concept dictionary with code-order dense identifiers
+   * @param files the located release files
+   * @return one row per edge, holding the child's identifier then the parent's
+   */
+  @Nonnull
+  private List<Row> collectIsaEdges(
+      @Nonnull final Dataset<Row> codeOrdered, @Nonnull final Rf2Files files) {
+    if (files.relationship == null) {
+      return List.of();
+    }
+    final Dataset<Row> denseByCode = codeOrdered.select(COLUMN_CODE, COLUMN_DENSE_ID);
+    final Dataset<Row> childDense =
+        denseByCode.withColumnRenamed(COLUMN_DENSE_ID, COLUMN_SOURCE_DENSE_ID);
+    final Dataset<Row> parentDense =
+        denseByCode.withColumnRenamed(COLUMN_DENSE_ID, COLUMN_TARGET_DENSE_ID);
+    final Dataset<Row> isaRaw =
+        readRf2(files.relationship, "sourceId", "destinationId", "typeId")
+            .filter(col(COLUMN_ACTIVE).equalTo("1"))
+            .filter(col("typeId").equalTo(IS_A));
+    return isaRaw
+        .join(childDense, isaRaw.col("sourceId").equalTo(childDense.col(COLUMN_CODE)))
+        .join(parentDense, isaRaw.col("destinationId").equalTo(parentDense.col(COLUMN_CODE)))
+        .select(col(COLUMN_SOURCE_DENSE_ID), col(COLUMN_TARGET_DENSE_ID))
+        .collectAsList();
   }
 
   // --- Archive extraction. ---

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/DenseIdPreOrderTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/DenseIdPreOrderTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the depth-first pre-order used to assign dense identifiers: it is a bijection over the
+ * whole concept dictionary, it is deterministic, and it terminates on a hierarchy that is a
+ * directed acyclic graph rather than a tree.
+ *
+ * @author John Grimes
+ */
+class DenseIdPreOrderTest {
+
+  @Test
+  void assignsIdentifiersInPreOrderFromEachRoot() {
+    // 0 is the root, with children 1 and 3; 1 has child 2; 3 has child 4. Edges are supplied out of
+    // order to show the result does not depend on the order they arrive in.
+    final int[] children = {2, 1, 4, 3};
+    final int[] parents = {1, 0, 3, 0};
+
+    final int[] permutation = DenseIdPreOrder.compute(children, parents, 5);
+
+    // Visiting 0, then 1, then 1's child 2, then 3, then 3's child 4 leaves every identifier
+    // where it already was, because this hierarchy is already in pre-order.
+    assertArrayEquals(new int[] {0, 1, 2, 3, 4}, permutation);
+  }
+
+  @Test
+  void placesEachSubtreeInAContiguousInterval() {
+    // 0 is the root; 1 and 2 are its children; 1's children are 3 and 4. In code order the subtree
+    // rooted at 1 is {1, 3, 4}, which is not contiguous. A pre-order makes it so.
+    final int[] children = {1, 2, 3, 4};
+    final int[] parents = {0, 0, 1, 1};
+
+    final int[] permutation = DenseIdPreOrder.compute(children, parents, 5);
+
+    assertArrayEquals(new int[] {0, 1, 4, 2, 3}, permutation);
+    // The subtree rooted at 1 now occupies the interval [1, 3].
+    assertEquals(1, permutation[1]);
+    assertEquals(2, permutation[3]);
+    assertEquals(3, permutation[4]);
+  }
+
+  @Test
+  void visitsAConceptOnceWhenItIsReachableByMoreThanOnePath() {
+    // 3 is a child of both 1 and 2, so the hierarchy is a directed acyclic graph, not a tree.
+    final int[] children = {1, 2, 3, 3};
+    final int[] parents = {0, 0, 1, 2};
+
+    final int[] permutation = DenseIdPreOrder.compute(children, parents, 4);
+
+    assertArrayEquals(new int[] {0, 1, 3, 2}, permutation);
+  }
+
+  @Test
+  void assignsAnIdentifierToEveryConceptOutsideTheHierarchy() {
+    // Only 0 and 1 take part in the hierarchy. Concepts 2, 3 and 4 have no is-a edge at all,
+    // which is the case for inactive concepts and for referenced-only metadata concepts.
+    final int[] children = {1};
+    final int[] parents = {0};
+
+    final int[] permutation = DenseIdPreOrder.compute(children, parents, 5);
+
+    assertBijection(permutation, 5);
+    // Concepts outside the hierarchy take the highest identifiers and keep their existing order.
+    assertArrayEquals(new int[] {0, 1, 2, 3, 4}, permutation);
+  }
+
+  @Test
+  void isABijectionWhenTheHierarchyHasSeveralRoots() {
+    // Two disjoint trees plus an isolated concept. Roots are visited in ascending order, so
+    // the tree rooted at 1 comes before the tree rooted at 4.
+    final int[] children = {2, 3, 5};
+    final int[] parents = {1, 1, 4};
+
+    final int[] permutation = DenseIdPreOrder.compute(children, parents, 7);
+
+    assertBijection(permutation, 7);
+    assertEquals(0, permutation[1]);
+    assertEquals(1, permutation[2]);
+    assertEquals(2, permutation[3]);
+    assertEquals(3, permutation[4]);
+    assertEquals(4, permutation[5]);
+    // 0 and 6 have no is-a edge, so they are appended in their existing order.
+    assertEquals(5, permutation[0]);
+    assertEquals(6, permutation[6]);
+  }
+
+  @Test
+  void isDeterministicAcrossRepeatedComputations() {
+    final int[] children = {3, 1, 4, 2, 5};
+    final int[] parents = {1, 0, 1, 0, 2};
+
+    final int[] first = DenseIdPreOrder.compute(children, parents, 8);
+    final int[] second = DenseIdPreOrder.compute(children, parents, 8);
+
+    assertArrayEquals(first, second);
+  }
+
+  @Test
+  void terminatesOnAHierarchyThatContainsACycle() {
+    // A cycle should never occur in a real release, but a malformed one must not hang the import. A
+    // cyclic component has no root, so it is never entered by the traversal and its members are
+    // appended with the other unreached concepts.
+    final int[] children = {1, 2, 0};
+    final int[] parents = {0, 1, 2};
+
+    final int[] permutation = DenseIdPreOrder.compute(children, parents, 3);
+
+    assertBijection(permutation, 3);
+  }
+
+  @Test
+  void handlesAnEmptyHierarchy() {
+    final int[] permutation = DenseIdPreOrder.compute(new int[0], new int[0], 3);
+
+    assertArrayEquals(new int[] {0, 1, 2}, permutation);
+  }
+
+  @Test
+  void rejectsMismatchedEdgeArrays() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DenseIdPreOrder.compute(new int[] {1, 2}, new int[] {0}, 3));
+  }
+
+  @Test
+  void rejectsAnEdgeOutsideTheDictionary() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DenseIdPreOrder.compute(new int[] {5}, new int[] {0}, 3));
+  }
+
+  /** Asserts that a permutation assigns each identifier in the range exactly once. */
+  private static void assertBijection(final int[] permutation, final int conceptCount) {
+    assertEquals(conceptCount, permutation.length);
+    final boolean[] seen = new boolean[conceptCount];
+    for (final int assigned : permutation) {
+      assertTrue(assigned >= 0 && assigned < conceptCount, "Assigned identifier out of range");
+      assertFalse(seen[assigned], "Identifier " + assigned + " was assigned twice");
+      seen[assigned] = true;
+    }
+  }
+}

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterDenseIdOrderTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterDenseIdOrderTest.java
@@ -79,7 +79,9 @@ class SnomedRf2ImporterDenseIdOrderTest {
   private static final String DIAMOND_DEEP_PARENT = "500000";
   private static final String DIAMOND_SHALLOW_PARENT = "600000";
   private static final String DIAMOND_CHILD = "900000";
+  private static final String DIAMOND_ATTRIBUTE = "700000";
   private static final String DIAMOND_TIME = "20240101";
+  private static final String IS_A = "116680003";
   private static final String DIAMOND_VERSION =
       "http://snomed.info/sct/900000000000207008/version/20240101";
 
@@ -320,9 +322,11 @@ class SnomedRf2ImporterDenseIdOrderTest {
           preOrderService.subsumes(coding, other),
           "subsumed_by differs for " + code);
 
-      // display, property_of and designation are all served by lookup. property_of is asked for the
-      // parent and child properties specifically, because those are the multi-valued ones derived
-      // from the hierarchy and so the only ones whose order could follow the dense identifiers.
+      // display, property_of and designation are all served by lookup, so each is asked for
+      // separately as well as together. This fixture is a tree with no repeated attribute type, so
+      // it
+      // cannot by itself prove the multi-valued properties are ordered independently of the dense
+      // identifiers - emitsEveryMultiValuedPropertyInTheSameOrderUnderBothOrderings does that.
       for (final String property :
           List.of("display", "parent", "child", "designation", "moduleId", "inactive")) {
         assertEquals(
@@ -338,13 +342,14 @@ class SnomedRf2ImporterDenseIdOrderTest {
   }
 
   @Test
-  void emitsMultiParentPropertiesInTheSameOrderUnderBothOrderings() {
-    // The rf2-mini hierarchy is a tree, so no concept there has two parents and the two orderings
-    // cannot disagree about the order a parent list comes back in. This uses a purpose-built
-    // release
-    // where a concept's two parents sit at different depths, so their pre-order positions bear no
-    // relation to their codes - which is the case a full edition is full of, and the case that once
-    // let the internal ordering show through in a lookup result.
+  void emitsEveryMultiValuedPropertyInTheSameOrderUnderBothOrderings() {
+    // The rf2-mini hierarchy is a tree, and no fixture concept has two attribute targets of one
+    // type, so neither can make the two orderings disagree about the order a property list comes
+    // back in. This uses a purpose-built release where a concept's two parents sit at different
+    // depths, and where the same two concepts are also the targets of two same-type attribute
+    // relationships - which is routine in a full edition, and is where an internal ordering can
+    // show
+    // through in a result a caller sees.
     final Path release = writeDiamondRelease();
     final String codeOrder = diamondStore.resolve("code-order").toString();
     final String preOrder = diamondStore.resolve("pre-order").toString();
@@ -370,18 +375,51 @@ class SnomedRf2ImporterDenseIdOrderTest {
           "The parent property list differs between the orderings");
       assertEquals(
           List.of(DIAMOND_DEEP_PARENT, DIAMOND_SHALLOW_PARENT),
-          codeOrderService.lookup(coding, "parent").stream()
-              .map(property -> ((Property) property).getValue().primitiveValue())
-              .toList(),
+          propertyValues(codeOrderService, coding, "parent"),
           "The parent property list is not in ascending code order");
+
+      // The same must hold for a defining relationship's targets, which reach the result by a
+      // different path from the hierarchy's parents and children.
+      assertEquals(
+          codeOrderService.lookup(coding, DIAMOND_ATTRIBUTE),
+          preOrderService.lookup(coding, DIAMOND_ATTRIBUTE),
+          "The attribute property list differs between the orderings");
+      assertEquals(
+          List.of(DIAMOND_DEEP_PARENT, DIAMOND_SHALLOW_PARENT),
+          propertyValues(codeOrderService, coding, DIAMOND_ATTRIBUTE),
+          "The attribute property list is not in ascending code order");
+
+      // An unfiltered lookup returns every property at once, so it catches anything the individual
+      // filters above miss.
+      assertEquals(
+          codeOrderService.lookup(coding, null),
+          preOrderService.lookup(coding, null),
+          "An unfiltered lookup differs between the orderings");
     }
   }
 
   /**
+   * Returns the codes carried by one property of a concept, in the order they are emitted. A
+   * hierarchy property carries a bare code, while an attribute property carries a whole Coding.
+   */
+  @Nonnull
+  private static List<String> propertyValues(
+      @Nonnull final LocalTerminologyService service,
+      @Nonnull final Coding coding,
+      @Nonnull final String propertyCode) {
+    return service.lookup(coding, propertyCode).stream()
+        .map(property -> ((Property) property).getValue())
+        .map(value -> value instanceof Coding target ? target.getCode() : value.primitiveValue())
+        .toList();
+  }
+
+  /**
    * Writes a minimal RF2 snapshot release whose hierarchy is not a tree. The root has two children,
-   * one of which has a child of its own, and a fifth concept is a child of both the shallow branch
-   * and the deep one. Codes are chosen so that the deep parent sorts before the shallow one, while
-   * a depth-first traversal reaches the shallow one first.
+   * a branch and a deep parent; the branch has the shallow parent beneath it; and a further concept
+   * is a child of both the shallow parent and the deep one, and also carries two attribute
+   * relationships of one type targeting the same pair. Codes are chosen so that the traversal
+   * reaches the shallow parent first while the deep parent's code sorts first, which is what makes
+   * the two orderings disagree about the order the pair comes back in.
    *
    * @return the release directory
    */
@@ -406,6 +444,7 @@ class SnomedRf2ImporterDenseIdOrderTest {
             DIAMOND_DEEP_PARENT,
             DIAMOND_SHALLOW_PARENT,
             DIAMOND_BRANCH,
+            DIAMOND_ATTRIBUTE,
             DIAMOND_CHILD)) {
       concepts.append(
           String.join("\t", code, DIAMOND_TIME, "1", module, "900000000000074008") + "\r\n");
@@ -427,11 +466,15 @@ class SnomedRf2ImporterDenseIdOrderTest {
     // parent hangs off the branch, and the child has both the shallow and the deep parent.
     for (final String[] edge :
         new String[][] {
-          {DIAMOND_BRANCH, DIAMOND_ROOT},
-          {DIAMOND_DEEP_PARENT, DIAMOND_ROOT},
-          {DIAMOND_SHALLOW_PARENT, DIAMOND_BRANCH},
-          {DIAMOND_CHILD, DIAMOND_SHALLOW_PARENT},
-          {DIAMOND_CHILD, DIAMOND_DEEP_PARENT}
+          {DIAMOND_BRANCH, DIAMOND_ROOT, IS_A},
+          {DIAMOND_DEEP_PARENT, DIAMOND_ROOT, IS_A},
+          {DIAMOND_SHALLOW_PARENT, DIAMOND_BRANCH, IS_A},
+          {DIAMOND_CHILD, DIAMOND_SHALLOW_PARENT, IS_A},
+          {DIAMOND_CHILD, DIAMOND_DEEP_PARENT, IS_A},
+          // Two targets of one attribute type, which is the other way a property list can be
+          // multi-valued.
+          {DIAMOND_CHILD, DIAMOND_SHALLOW_PARENT, DIAMOND_ATTRIBUTE},
+          {DIAMOND_CHILD, DIAMOND_DEEP_PARENT, DIAMOND_ATTRIBUTE}
         }) {
       relationships.append(
           String.join(
@@ -443,7 +486,7 @@ class SnomedRf2ImporterDenseIdOrderTest {
                   edge[0],
                   edge[1],
                   "0",
-                  "116680003",
+                  edge[2],
                   "900000000000011006",
                   "900000000000451002")
               + "\r\n");

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterDenseIdOrderTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterDenseIdOrderTest.java
@@ -324,9 +324,8 @@ class SnomedRf2ImporterDenseIdOrderTest {
 
       // display, property_of and designation are all served by lookup, so each is asked for
       // separately as well as together. This fixture is a tree with no repeated attribute type, so
-      // it
-      // cannot by itself prove the multi-valued properties are ordered independently of the dense
-      // identifiers - emitsEveryMultiValuedPropertyInTheSameOrderUnderBothOrderings does that.
+      // by itself it cannot prove the multi-valued properties are ordered independently of the
+      // dense identifiers - that is what the next test exists for.
       for (final String property :
           List.of("display", "parent", "child", "designation", "moduleId", "inactive")) {
         assertEquals(
@@ -347,8 +346,7 @@ class SnomedRf2ImporterDenseIdOrderTest {
     // type, so neither can make the two orderings disagree about the order a property list comes
     // back in. This uses a purpose-built release where a concept's two parents sit at different
     // depths, and where the same two concepts are also the targets of two same-type attribute
-    // relationships - which is routine in a full edition, and is where an internal ordering can
-    // show
+    // relationships - routine in a full edition, and where an internal ordering can otherwise show
     // through in a result a caller sees.
     final Path release = writeDiamondRelease();
     final String codeOrder = diamondStore.resolve("code-order").toString();

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterDenseIdOrderTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterDenseIdOrderTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_CODE;
+import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_DENSE_ID;
+import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.CONCEPT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import au.csiro.pathling.terminology.local.index.CodeSystemIndexes;
+import au.csiro.pathling.terminology.local.index.ConceptDictionary;
+import au.csiro.pathling.terminology.local.index.HierarchyIndex;
+import au.csiro.pathling.test.Rf2Mini;
+import jakarta.annotation.Nonnull;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.roaringbitmap.IntConsumer;
+import org.roaringbitmap.RoaringBitmap;
+
+/**
+ * Verifies the dense identifier ordering option: it is off by default, the pre-order variant
+ * assigns every concept exactly one identifier following a depth-first traversal of the is-a
+ * hierarchy, repeated imports of the same release assign identical identifiers, and the hierarchy
+ * answers every query identically under both orderings.
+ *
+ * <p>Three stores are imported once for the whole class, because an import is expensive: one under
+ * the default ordering, and two under the pre-order, so that reproducibility can be checked.
+ *
+ * @author John Grimes
+ */
+class SnomedRf2ImporterDenseIdOrderTest {
+
+  private static SparkSession spark;
+  private static Map<String, Integer> codeOrderIds;
+  private static Map<String, Integer> preOrderIds;
+  private static Map<String, Integer> repeatedPreOrderIds;
+  private static CodeSystemIndexes codeOrderIndexes;
+  private static CodeSystemIndexes preOrderIndexes;
+
+  @BeforeAll
+  static void setUp(@TempDir final Path warehouse, @TempDir final Path storeDir) {
+    spark =
+        SparkSession.builder()
+            .appName("SnomedRf2ImporterDenseIdOrderTest")
+            .master("local[2]")
+            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+            .config(
+                "spark.sql.catalog.spark_catalog",
+                "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+            .config("spark.sql.warehouse.dir", warehouse.toString())
+            .config("spark.sql.shuffle.partitions", "2")
+            .config("spark.driver.bindAddress", "localhost")
+            .config("spark.driver.host", "localhost")
+            .config("spark.ui.enabled", "false")
+            .getOrCreate();
+
+    final String release = Rf2Mini.baseRelease().toString();
+    final String codeOrderStore = storeDir.resolve("code-order").toString();
+    final String preOrderStore = storeDir.resolve("pre-order").toString();
+    final String repeatedStore = storeDir.resolve("pre-order-again").toString();
+
+    // The two-argument overload takes no ordering at all, which is how an existing caller reaches
+    // it.
+    new SnomedRf2Importer(spark, codeOrderStore).importFrom(release, null);
+    new SnomedRf2Importer(spark, preOrderStore).importFrom(release, null, DenseIdOrder.PRE_ORDER);
+    new SnomedRf2Importer(spark, repeatedStore).importFrom(release, null, DenseIdOrder.PRE_ORDER);
+
+    codeOrderIds = readDenseIds(codeOrderStore);
+    preOrderIds = readDenseIds(preOrderStore);
+    repeatedPreOrderIds = readDenseIds(repeatedStore);
+    codeOrderIndexes = loadIndexes(codeOrderStore);
+    preOrderIndexes = loadIndexes(preOrderStore);
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (spark != null) {
+      spark.stop();
+      spark = null;
+    }
+  }
+
+  @Test
+  void assignsCodeOrderIdentifiersByDefault() {
+    // Without the option, identifiers ascend with the concept code, exactly as before the option
+    // existed, so an existing store and an existing import are unaffected.
+    assertEquals(Rf2Mini.CONCEPT_COUNT_20230601, codeOrderIds.size());
+    final List<String> codesInAscendingOrder =
+        new ArrayList<>(new TreeMap<>(codeOrderIds).keySet());
+    for (int position = 0; position < codesInAscendingOrder.size(); position++) {
+      assertEquals(
+          position,
+          codeOrderIds.get(codesInAscendingOrder.get(position)),
+          "Code "
+              + codesInAscendingOrder.get(position)
+              + " did not take its code-order identifier");
+    }
+  }
+
+  @Test
+  void assignsEveryConceptExactlyOneIdentifierUnderThePreOrder() {
+    assertEquals(Rf2Mini.CONCEPT_COUNT_20230601, preOrderIds.size());
+    final boolean[] seen = new boolean[Rf2Mini.CONCEPT_COUNT_20230601];
+    for (final int dense : preOrderIds.values()) {
+      assertTrue(
+          dense >= 0 && dense < Rf2Mini.CONCEPT_COUNT_20230601,
+          "Dense identifier " + dense + " is outside the dictionary");
+      assertFalse(seen[dense], "Dense identifier " + dense + " was assigned twice");
+      seen[dense] = true;
+    }
+    // The fixture's code order is not already a pre-order, so the two orderings must differ.
+    assertNotEquals(codeOrderIds, preOrderIds);
+  }
+
+  @Test
+  void placesEachSubtreeInAContiguousIntervalUnderThePreOrder() {
+    // This is the property the whole change exists for: a concept precedes its own descendants, and
+    // its subtree occupies one unbroken interval, so a descendant set compresses into a single run
+    // instead of many scattered chunks. The fixture's is-a graph is a tree, so every subtree is
+    // exactly contiguous.
+    final HierarchyIndex hierarchy = preOrderIndexes.hierarchy();
+    for (final Map.Entry<String, Integer> entry : preOrderIds.entrySet()) {
+      final int ancestor = entry.getValue();
+      final RoaringBitmap descendants = hierarchy.descendantsOf(ancestor);
+      if (descendants.isEmpty()) {
+        continue;
+      }
+      assertEquals(
+          ancestor + 1,
+          descendants.first(),
+          "The subtree of " + entry.getKey() + " does not start immediately after it");
+      assertEquals(
+          ancestor + descendants.getCardinality(),
+          descendants.last(),
+          "The subtree of " + entry.getKey() + " is not a contiguous interval");
+    }
+  }
+
+  @Test
+  void assignsIdenticalIdentifiersWhenTheSameSourceIsImportedTwice() {
+    assertEquals(preOrderIds, repeatedPreOrderIds);
+  }
+
+  @Test
+  void answersEveryHierarchyQueryIdenticallyUnderBothOrderings() {
+    // Dense identifiers are internal, so the two stores are compared through concept codes. Every
+    // hierarchy relation the terminology functions rest on must agree.
+    final HierarchyIndex codeOrder = codeOrderIndexes.hierarchy();
+    final HierarchyIndex preOrder = preOrderIndexes.hierarchy();
+    for (final String code : codeOrderIds.keySet()) {
+      final int underCodeOrder = codeOrderIds.get(code);
+      final int underPreOrder = preOrderIds.get(code);
+      assertEquals(
+          codeOrderCodes(codeOrder.descendantsOf(underCodeOrder)),
+          preOrderCodes(preOrder.descendantsOf(underPreOrder)),
+          "Descendants of " + code + " differ between the orderings");
+      assertEquals(
+          codeOrderCodes(codeOrder.ancestorsOf(underCodeOrder)),
+          preOrderCodes(preOrder.ancestorsOf(underPreOrder)),
+          "Ancestors of " + code + " differ between the orderings");
+      assertEquals(
+          codeOrderCodes(codeOrder.childrenOf(underCodeOrder)),
+          preOrderCodes(preOrder.childrenOf(underPreOrder)),
+          "Children of " + code + " differ between the orderings");
+      assertEquals(
+          codeOrderCodes(codeOrder.parentsOf(underCodeOrder)),
+          preOrderCodes(preOrder.parentsOf(underPreOrder)),
+          "Parents of " + code + " differ between the orderings");
+    }
+    for (final String ancestor : codeOrderIds.keySet()) {
+      for (final String descendant : codeOrderIds.keySet()) {
+        assertEquals(
+            codeOrder.subsumes(codeOrderIds.get(ancestor), codeOrderIds.get(descendant)),
+            preOrder.subsumes(preOrderIds.get(ancestor), preOrderIds.get(descendant)),
+            "Subsumption of (" + ancestor + ", " + descendant + ") differs between the orderings");
+      }
+    }
+  }
+
+  @Test
+  void carriesTheSameConceptMetadataUnderBothOrderings() {
+    // Every other index addresses concepts by the same dense identifiers, so a permutation applied
+    // to
+    // only some of them would silently corrupt the store.
+    final ConceptDictionary codeOrder = codeOrderIndexes.dictionary();
+    final ConceptDictionary preOrder = preOrderIndexes.dictionary();
+    assertEquals(codeOrder.size(), preOrder.size());
+    for (final String code : codeOrderIds.keySet()) {
+      final int underCodeOrder = codeOrderIds.get(code);
+      final int underPreOrder = preOrderIds.get(code);
+      assertEquals(code, preOrder.code(underPreOrder));
+      assertEquals(codeOrder.display(underCodeOrder), preOrder.display(underPreOrder));
+      assertEquals(codeOrder.isActive(underCodeOrder), preOrder.isActive(underPreOrder));
+      assertEquals(codeOrder.isDefined(underCodeOrder), preOrder.isDefined(underPreOrder));
+      assertEquals(codeOrder.moduleId(underCodeOrder), preOrder.moduleId(underPreOrder));
+      assertEquals(codeOrder.effectiveTime(underCodeOrder), preOrder.effectiveTime(underPreOrder));
+    }
+  }
+
+  @Nonnull
+  private static Map<String, Integer> readDenseIds(@Nonnull final String storagePath) {
+    final Map<String, Integer> denseByCode = new HashMap<>();
+    TerminologyStoreReader.open(storagePath, Map.of())
+        .readTable(
+            CONCEPT,
+            row -> denseByCode.put(row.getString(COLUMN_CODE), row.getInt(COLUMN_DENSE_ID)));
+    return denseByCode;
+  }
+
+  @Nonnull
+  private static CodeSystemIndexes loadIndexes(@Nonnull final String storagePath) {
+    return CodeSystemIndexes.load(
+        TerminologyStoreReader.open(storagePath, Map.of()),
+        TerminologyStoreSchema.systemVersionId(Rf2Mini.SNOMED_URI, Rf2Mini.VERSION_20230601));
+  }
+
+  @Nonnull
+  private static Set<String> codeOrderCodes(@Nonnull final RoaringBitmap bitmap) {
+    return codesOf(bitmap, codeOrderIndexes.dictionary());
+  }
+
+  @Nonnull
+  private static Set<String> preOrderCodes(@Nonnull final RoaringBitmap bitmap) {
+    return codesOf(bitmap, preOrderIndexes.dictionary());
+  }
+
+  /** Translates a bitmap of dense identifiers into the concept codes it addresses. */
+  @Nonnull
+  private static Set<String> codesOf(
+      @Nonnull final RoaringBitmap bitmap, @Nonnull final ConceptDictionary dictionary) {
+    final Set<String> codes = new TreeSet<>();
+    bitmap.forEach((IntConsumer) dense -> codes.add(dictionary.code(dense)));
+    return codes;
+  }
+}

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterDenseIdOrderTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterDenseIdOrderTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.roaringbitmap.ContainerPointer;
 import org.roaringbitmap.IntConsumer;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -168,6 +169,31 @@ class SnomedRf2ImporterDenseIdOrderTest {
   @Test
   void assignsIdenticalIdentifiersWhenTheSameSourceIsImportedTwice() {
     assertEquals(preOrderIds, repeatedPreOrderIds);
+  }
+
+  @Test
+  void representsAContiguousSubtreeAsASingleRun() {
+    // The two changes only pay off together: a contiguous subtree is what run-length encoding can
+    // compress, and the index has to ask for that encoding to get it. The largest subtree in the
+    // fixture is contiguous under the pre-order, so it must be held as a run rather than as a list
+    // of its members.
+    final HierarchyIndex hierarchy = preOrderIndexes.hierarchy();
+    RoaringBitmap descendants = new RoaringBitmap();
+    for (final int dense : preOrderIds.values()) {
+      final RoaringBitmap candidate = hierarchy.descendantsOf(dense);
+      if (candidate.getCardinality() > descendants.getCardinality()) {
+        descendants = candidate;
+      }
+    }
+    assertTrue(descendants.getCardinality() > 1, "The fixture has no subtree to compress");
+
+    final ContainerPointer pointer = descendants.getContainerPointer();
+    boolean sawRun = false;
+    while (pointer.getContainer() != null) {
+      sawRun |= pointer.isRunContainer();
+      pointer.advance();
+    }
+    assertTrue(sawRun, "The root's contiguous subtree was not run-length encoded");
   }
 
   @Test

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterDenseIdOrderTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterDenseIdOrderTest.java
@@ -25,11 +25,20 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import au.csiro.pathling.config.LocalTerminologyConfiguration;
+import au.csiro.pathling.config.TerminologyConfiguration;
+import au.csiro.pathling.config.TerminologyMode;
+import au.csiro.pathling.terminology.TerminologyService.Property;
+import au.csiro.pathling.terminology.local.LocalTerminologyService;
 import au.csiro.pathling.terminology.local.index.CodeSystemIndexes;
 import au.csiro.pathling.terminology.local.index.ConceptDictionary;
 import au.csiro.pathling.terminology.local.index.HierarchyIndex;
 import au.csiro.pathling.test.Rf2Mini;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -39,6 +48,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import org.apache.spark.sql.SparkSession;
+import org.hl7.fhir.r4.model.Coding;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -60,15 +70,35 @@ import org.roaringbitmap.RoaringBitmap;
  */
 class SnomedRf2ImporterDenseIdOrderTest {
 
+  // Codes for the purpose-built non-tree release. They are equal length so that string order, which
+  // is what the importer sorts by, matches numeric order. The branch sorts before the deep parent,
+  // so the traversal descends the branch and reaches the shallow parent first, even though the
+  // shallow parent's code sorts after the deep parent's.
+  private static final String DIAMOND_ROOT = "100000";
+  private static final String DIAMOND_BRANCH = "200000";
+  private static final String DIAMOND_DEEP_PARENT = "500000";
+  private static final String DIAMOND_SHALLOW_PARENT = "600000";
+  private static final String DIAMOND_CHILD = "900000";
+  private static final String DIAMOND_TIME = "20240101";
+  private static final String DIAMOND_VERSION =
+      "http://snomed.info/sct/900000000000207008/version/20240101";
+
   private static SparkSession spark;
   private static Map<String, Integer> codeOrderIds;
   private static Map<String, Integer> preOrderIds;
   private static Map<String, Integer> repeatedPreOrderIds;
   private static CodeSystemIndexes codeOrderIndexes;
   private static CodeSystemIndexes preOrderIndexes;
+  private static LocalTerminologyService codeOrderService;
+  private static LocalTerminologyService preOrderService;
+  private static Path diamondRelease;
+  private static Path diamondStore;
 
   @BeforeAll
-  static void setUp(@TempDir final Path warehouse, @TempDir final Path storeDir) {
+  static void setUp(
+      @TempDir final Path warehouse, @TempDir final Path storeDir, @TempDir final Path diamondDir) {
+    diamondRelease = diamondDir.resolve("release");
+    diamondStore = diamondDir.resolve("stores");
     spark =
         SparkSession.builder()
             .appName("SnomedRf2ImporterDenseIdOrderTest")
@@ -89,8 +119,7 @@ class SnomedRf2ImporterDenseIdOrderTest {
     final String preOrderStore = storeDir.resolve("pre-order").toString();
     final String repeatedStore = storeDir.resolve("pre-order-again").toString();
 
-    // The two-argument overload takes no ordering at all, which is how an existing caller reaches
-    // it.
+    // The two-argument overload takes no ordering, which is how an existing caller reaches it.
     new SnomedRf2Importer(spark, codeOrderStore).importFrom(release, null);
     new SnomedRf2Importer(spark, preOrderStore).importFrom(release, null, DenseIdOrder.PRE_ORDER);
     new SnomedRf2Importer(spark, repeatedStore).importFrom(release, null, DenseIdOrder.PRE_ORDER);
@@ -100,10 +129,14 @@ class SnomedRf2ImporterDenseIdOrderTest {
     repeatedPreOrderIds = readDenseIds(repeatedStore);
     codeOrderIndexes = loadIndexes(codeOrderStore);
     preOrderIndexes = loadIndexes(preOrderStore);
+    codeOrderService = serviceOver(codeOrderStore);
+    preOrderService = serviceOver(preOrderStore);
   }
 
   @AfterAll
   static void tearDown() {
+    closeQuietly(codeOrderService);
+    closeQuietly(preOrderService);
     if (spark != null) {
       spark.stop();
       spark = null;
@@ -249,6 +282,202 @@ class SnomedRf2ImporterDenseIdOrderTest {
       assertEquals(codeOrder.isDefined(underCodeOrder), preOrder.isDefined(underPreOrder));
       assertEquals(codeOrder.moduleId(underCodeOrder), preOrder.moduleId(underPreOrder));
       assertEquals(codeOrder.effectiveTime(underCodeOrder), preOrder.effectiveTime(underPreOrder));
+    }
+  }
+
+  @Test
+  void returnsIdenticalResultsFromAllSevenTerminologyFunctionsUnderBothOrderings() {
+    // The hierarchy-level comparison above tests set membership, which cannot see a difference in
+    // the
+    // order results are returned in. This compares what the functions actually return, as ordered
+    // lists, because a lookup answer is a sequence and a caller can observe its order. Dense
+    // identifiers are internal, so nothing about how the store was imported may show through here.
+    for (final String code : new TreeSet<>(codeOrderIds.keySet())) {
+      final Coding coding = new Coding().setSystem(Rf2Mini.SNOMED_URI).setCode(code);
+
+      // member_of, over an implicit value set of the concept's own descendants.
+      final String valueSet = Rf2Mini.SNOMED_URI + "?fhir_vs=isa/" + Rf2Mini.DIABETES;
+      assertEquals(
+          codeOrderService.validateCode(valueSet, coding),
+          preOrderService.validateCode(valueSet, coding),
+          "member_of differs for " + code);
+
+      // translate, over the fixture's SAME AS association reference set.
+      final String conceptMap = Rf2Mini.SNOMED_URI + "?fhir_cm=" + Rf2Mini.SAME_AS_REFSET;
+      assertEquals(
+          codeOrderService.translate(coding, conceptMap, false, null),
+          preOrderService.translate(coding, conceptMap, false, null),
+          "translate differs for " + code);
+
+      // subsumes and subsumed_by, which are the two directions of the same call.
+      final Coding other = new Coding().setSystem(Rf2Mini.SNOMED_URI).setCode(Rf2Mini.DIABETES);
+      assertEquals(
+          codeOrderService.subsumes(other, coding),
+          preOrderService.subsumes(other, coding),
+          "subsumes differs for " + code);
+      assertEquals(
+          codeOrderService.subsumes(coding, other),
+          preOrderService.subsumes(coding, other),
+          "subsumed_by differs for " + code);
+
+      // display, property_of and designation are all served by lookup. property_of is asked for the
+      // parent and child properties specifically, because those are the multi-valued ones derived
+      // from the hierarchy and so the only ones whose order could follow the dense identifiers.
+      for (final String property :
+          List.of("display", "parent", "child", "designation", "moduleId", "inactive")) {
+        assertEquals(
+            codeOrderService.lookup(coding, property),
+            preOrderService.lookup(coding, property),
+            "lookup of " + property + " differs for " + code);
+      }
+      assertEquals(
+          codeOrderService.lookup(coding, null),
+          preOrderService.lookup(coding, null),
+          "an unfiltered lookup differs for " + code);
+    }
+  }
+
+  @Test
+  void emitsMultiParentPropertiesInTheSameOrderUnderBothOrderings() {
+    // The rf2-mini hierarchy is a tree, so no concept there has two parents and the two orderings
+    // cannot disagree about the order a parent list comes back in. This uses a purpose-built
+    // release
+    // where a concept's two parents sit at different depths, so their pre-order positions bear no
+    // relation to their codes - which is the case a full edition is full of, and the case that once
+    // let the internal ordering show through in a lookup result.
+    final Path release = writeDiamondRelease();
+    final String codeOrder = diamondStore.resolve("code-order").toString();
+    final String preOrder = diamondStore.resolve("pre-order").toString();
+    new SnomedRf2Importer(spark, codeOrder).importFrom(release.toString(), DIAMOND_VERSION);
+    new SnomedRf2Importer(spark, preOrder)
+        .importFrom(release.toString(), DIAMOND_VERSION, DenseIdOrder.PRE_ORDER);
+
+    // The two parents of the multi-parent concept are ordered differently by dense identifier under
+    // the two orderings, which is what makes this a real test rather than a tautology.
+    final Map<String, Integer> underCodeOrder = readDenseIds(codeOrder);
+    final Map<String, Integer> underPreOrder = readDenseIds(preOrder);
+    assertNotEquals(
+        underCodeOrder.get(DIAMOND_SHALLOW_PARENT) < underCodeOrder.get(DIAMOND_DEEP_PARENT),
+        underPreOrder.get(DIAMOND_SHALLOW_PARENT) < underPreOrder.get(DIAMOND_DEEP_PARENT),
+        "The release does not order the two parents differently under the two orderings");
+
+    try (final LocalTerminologyService codeOrderService = serviceOver(codeOrder);
+        final LocalTerminologyService preOrderService = serviceOver(preOrder)) {
+      final Coding coding = new Coding().setSystem(Rf2Mini.SNOMED_URI).setCode(DIAMOND_CHILD);
+      assertEquals(
+          codeOrderService.lookup(coding, "parent"),
+          preOrderService.lookup(coding, "parent"),
+          "The parent property list differs between the orderings");
+      assertEquals(
+          List.of(DIAMOND_DEEP_PARENT, DIAMOND_SHALLOW_PARENT),
+          codeOrderService.lookup(coding, "parent").stream()
+              .map(property -> ((Property) property).getValue().primitiveValue())
+              .toList(),
+          "The parent property list is not in ascending code order");
+    }
+  }
+
+  /**
+   * Writes a minimal RF2 snapshot release whose hierarchy is not a tree. The root has two children,
+   * one of which has a child of its own, and a fifth concept is a child of both the shallow branch
+   * and the deep one. Codes are chosen so that the deep parent sorts before the shallow one, while
+   * a depth-first traversal reaches the shallow one first.
+   *
+   * @return the release directory
+   */
+  @Nonnull
+  private static Path writeDiamondRelease() {
+    final Path terminology = diamondRelease.resolve("Snapshot").resolve("Terminology");
+    final String module = Rf2Mini.CORE_MODULE;
+    final StringBuilder concepts = new StringBuilder("id\teffectiveTime\tactive\tmoduleId\t");
+    concepts.append("definitionStatusId\r\n");
+    final StringBuilder descriptions =
+        new StringBuilder(
+            "id\teffectiveTime\tactive\tmoduleId\tconceptId\tlanguageCode\ttypeId\tterm\t"
+                + "caseSignificanceId\r\n");
+    final StringBuilder relationships =
+        new StringBuilder(
+            "id\teffectiveTime\tactive\tmoduleId\tsourceId\tdestinationId\trelationshipGroup\t"
+                + "typeId\tcharacteristicTypeId\tmodifierId\r\n");
+    int identifier = 0;
+    for (final String code :
+        List.of(
+            DIAMOND_ROOT,
+            DIAMOND_DEEP_PARENT,
+            DIAMOND_SHALLOW_PARENT,
+            DIAMOND_BRANCH,
+            DIAMOND_CHILD)) {
+      concepts.append(
+          String.join("\t", code, DIAMOND_TIME, "1", module, "900000000000074008") + "\r\n");
+      descriptions.append(
+          String.join(
+                  "\t",
+                  "d" + ++identifier,
+                  DIAMOND_TIME,
+                  "1",
+                  module,
+                  code,
+                  "en",
+                  "900000000000003001",
+                  "Concept " + code + " (finding)",
+                  "900000000000448009")
+              + "\r\n");
+    }
+    // Edges, as child to parent: the branch and the deep parent hang off the root, the shallow
+    // parent hangs off the branch, and the child has both the shallow and the deep parent.
+    for (final String[] edge :
+        new String[][] {
+          {DIAMOND_BRANCH, DIAMOND_ROOT},
+          {DIAMOND_DEEP_PARENT, DIAMOND_ROOT},
+          {DIAMOND_SHALLOW_PARENT, DIAMOND_BRANCH},
+          {DIAMOND_CHILD, DIAMOND_SHALLOW_PARENT},
+          {DIAMOND_CHILD, DIAMOND_DEEP_PARENT}
+        }) {
+      relationships.append(
+          String.join(
+                  "\t",
+                  "r" + ++identifier,
+                  DIAMOND_TIME,
+                  "1",
+                  module,
+                  edge[0],
+                  edge[1],
+                  "0",
+                  "116680003",
+                  "900000000000011006",
+                  "900000000000451002")
+              + "\r\n");
+    }
+    try {
+      Files.createDirectories(terminology);
+      Files.writeString(
+          terminology.resolve("sct2_Concept_Snapshot_INT_" + DIAMOND_TIME + ".txt"),
+          concepts.toString());
+      Files.writeString(
+          terminology.resolve("sct2_Description_Snapshot-en_INT_" + DIAMOND_TIME + ".txt"),
+          descriptions.toString());
+      Files.writeString(
+          terminology.resolve("sct2_Relationship_Snapshot_INT_" + DIAMOND_TIME + ".txt"),
+          relationships.toString());
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return diamondRelease;
+  }
+
+  @Nonnull
+  private static LocalTerminologyService serviceOver(@Nonnull final String storagePath) {
+    return new LocalTerminologyService(
+        TerminologyConfiguration.builder()
+            .mode(TerminologyMode.LOCAL)
+            .local(LocalTerminologyConfiguration.builder().storagePath(storagePath).build())
+            .build(),
+        Map.of());
+  }
+
+  private static void closeQuietly(@Nullable final LocalTerminologyService service) {
+    if (service != null) {
+      service.close();
     }
   }
 


### PR DESCRIPTION
Measures what the local terminology store's hierarchy index costs in memory, attributes that cost between two independent factors, and then implements the one that earns it. Follows up the feedback on #2665.

The measurement comes first and stands on its own. A standalone harness in the `benchmark` module loads a store once, derives a depth-first pre-order from the index's own direct edges, and builds the reordered and optimised variants in memory alongside the original, so all four combinations of identifier ordering and representation optimisation come from a single load with no production code involved. Retained heap is measured by walking the object graph rather than through RoaringBitmap's own estimate, which its documentation rules out for exactly the sparse, wide-range data being baselined.

Over a full SNOMED CT UK edition of 1,115,237 concepts the index goes from 738 MB to 536 MB, a 27% saving, and the minimum viable driver heap for all seven terminology functions goes from 4.0 GB to 3.5 GB. The reported 4 GB baseline reproduced exactly. The decision rule was fixed in the plan before any figure was taken, and both of its limbs are met. Full figures, including the two editions measured and three predictions that the measurement contradicted, are on #2665.

The reordering is off by default and selected with `--dense-id-order pre-order` (or `dense_id_order=` in the language libraries). It has a real cost: under code order a concept keeps its identifier across re-imports, whereas under the pre-order a change anywhere in the shape of the hierarchy shifts everything after it. Identifiers are internal and never surface in a query result, so this only matters if you compare the internal identifiers of two separately imported stores, but it is why the option exists rather than the behaviour simply changing.

Two smaller changes came out of the work. The index now asks its bitmaps to adopt run-length encoding, which is worth a further 2.2% once the reordering is in place and effectively nothing without it - kept as its own commit so it can be reverted independently. And multi-valued lookup properties, a concept's parents, children and defining-relationship targets, are now ordered by concept code rather than by internal identifier; they were not, which meant `property_of` returned a different order depending on how the store had been imported. Ordering by code reproduces the existing output exactly for a default-ordered store, and makes the option genuinely invisible to a caller: all seven functions are byte-identical across the two orderings over the full UK edition, including a property lookup over concepts with 29 same-type targets.

Not measured: the effect of run-length encoding on query throughput. The existing terminology benchmark would answer that, and it is worth running before release; the change is isolated in its own commit if it turns out not to pay.


## Merge order

This branch conflicts with two of its siblings and should be rebased after both have landed. Neither of them depends on anything, they do not conflict with each other, and both merge cleanly to `release/9.9.0` as it stands, so they can go in either order.

- #2672 conflicts here in `SnomedRf2Importer.java`, where it wraps `importFromRelease` in row-count observation and this branch threads a `denseIdOrder` parameter through the same lines, and in `site/docs/libraries/terminology.md`.
- #2673 conflicts here in `lib/python/pathling/cli/import_terminology.py`, where it renames the CLI context across every command and this branch adds `--dense-id-order` to `import-snomed`.

All three touch `site/docs/libraries/cli.md`, but in different sections, so that one merges cleanly.

Rebased onto `release/9.9.0` at 9ce4fd1119; `mvn clean install -pl benchmark -am` is green against that base.
