### PR TITLE
Give visible feedback on login attempts and correct session expiry prompting

### DIFF
--- a/ui/CONTRIBUTING.md
+++ b/ui/CONTRIBUTING.md
@@ -136,6 +136,17 @@ export (`ViewExportCard`) and the SQL query export (`SqlQueryExportCardWrapper`)
 flows. When adding a new export-style operation, reuse `ExportJobCard` rather
 than duplicating the status, progress, cancel, and download presentation.
 
+Every error message shown as a callout uses the shared
+`components/error/ErrorCallout.tsx`. It always renders the warning icon and
+always carries `role="alert"`, so errors look and behave the same wherever they
+appear. It takes a `message`, an optional bold `title`, optional `size` and
+`mt`, and children for recovery actions such as a retry button. Do not build a
+red `Callout.Root` directly.
+
+A transient failure from an operation, such as an export or import job failing,
+is reported with `showToast` from the toast context rather than with a callout.
+Never pass an error callback into state that nothing renders.
+
 ### Naming
 
 | Element               | Convention     | Example                         |

--- a/ui/e2e/auth.spec.ts
+++ b/ui/e2e/auth.spec.ts
@@ -55,6 +55,67 @@ async function setupAuthRequiredMocks(page: Page) {
 }
 
 /**
+ * Makes authorisation discovery fail, so that initiating a login rejects.
+ * Both the SMART configuration and the conformance statement that fhirclient
+ * falls back to are made to fail, which is what a server rejecting an
+ * unauthenticated discovery request looks like.
+ *
+ * @param page - The Playwright page object.
+ */
+async function breakAuthorisationDiscovery(page: Page) {
+  await page.route("**/.well-known/smart-configuration", async (route) => {
+    await route.fulfill({ status: 401, body: "" });
+  });
+  await page.route("**/metadata", async (route) => {
+    await route.fulfill({ status: 500, body: "" });
+  });
+}
+
+/**
+ * Establishes an authenticated session by seeding fhirclient state and visiting
+ * the OAuth callback, which is the only route that authenticates the
+ * application.
+ *
+ * @param page - The Playwright page object.
+ * @param returnUrl - The path to land on once authentication completes.
+ */
+async function authenticate(page: Page, returnUrl: string) {
+  await page.route("**/token", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        access_token: "fake-access-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "openid profile user/*.read",
+      }),
+    });
+  });
+
+  await page.goto("/admin");
+  await page.evaluate((url) => {
+    const stateKey = "test-state-key";
+    sessionStorage.setItem("SMART_KEY", JSON.stringify(stateKey));
+    sessionStorage.setItem(
+      stateKey,
+      JSON.stringify({
+        clientId: "test-client-id",
+        scope: "openid profile user/*.read",
+        redirectUri: window.location.origin + "/admin/callback",
+        serverUrl: window.location.origin + "/fhir",
+        tokenUri: window.location.origin + "/token",
+        key: stateKey,
+      }),
+    );
+    sessionStorage.setItem("pathling_return_url", url);
+  }, returnUrl);
+
+  await page.goto("/admin/callback?state=test-state-key&code=fake-auth-code");
+  await page.waitForURL(`**/admin${returnUrl}`);
+}
+
+/**
  * Sets up mocks for a server that does not require authentication.
  *
  * @param page - The Playwright page object.
@@ -119,6 +180,113 @@ test.describe("Authentication", () => {
       expect(authorizeUrl!.searchParams.get("client_id")).toBe(
         "test-client-id",
       );
+    });
+
+    // Regression for #2676: the login button used to give no feedback at all
+    // when authorisation could not be initiated.
+    test("shows the failure in the login prompt when authorisation cannot start", async ({
+      page,
+    }) => {
+      await setupAuthRequiredMocks(page);
+      await page.goto("/admin/resources");
+
+      const loginButton = page.getByRole("button", { name: /Login to/ });
+      await expect(loginButton).toBeVisible();
+
+      await breakAuthorisationDiscovery(page);
+      await loginButton.click();
+
+      // The failure is announced and the page has not navigated away.
+      await expect(page.getByRole("alert")).toBeVisible();
+      await expect(page).toHaveURL(/\/admin\/resources/);
+
+      // The button is usable again, so the attempt can be retried.
+      await expect(loginButton).toBeEnabled();
+      await loginButton.click();
+      await expect(page.getByRole("alert")).toBeVisible();
+    });
+
+    // Regression for #2676: the dialog used to close on click and report
+    // nothing, leaving the user with no indication of what happened.
+    test("shows the failure in the session expiry dialog and keeps it open", async ({
+      page,
+    }) => {
+      await setupAuthRequiredMocks(page);
+
+      // The first job list request succeeds; every later one reports that the
+      // session is no longer valid.
+      let jobsCalls = 0;
+      await page.route("**/$jobs*", async (route) => {
+        jobsCalls += 1;
+        if (jobsCalls === 1) {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/fhir+json",
+            body: JSON.stringify({ resourceType: "Parameters", parameter: [] }),
+          });
+          return;
+        }
+        await route.fulfill({ status: 401, body: "" });
+      });
+
+      await authenticate(page, "/jobs");
+      await expect(page.getByText("No jobs to show")).toBeVisible();
+
+      // The poll fails, raising the expiry dialog.
+      const dialog = page.getByRole("alertdialog");
+      await expect(dialog).toBeVisible({ timeout: 15000 });
+
+      await breakAuthorisationDiscovery(page);
+      await dialog.getByRole("button", { name: /log in/i }).click();
+
+      // The dialog stays open and reports the failure inside itself.
+      await expect(dialog).toBeVisible();
+      await expect(dialog.getByRole("alert")).toBeVisible();
+
+      // Both actions become usable again.
+      await expect(
+        dialog.getByRole("button", { name: /log in/i }),
+      ).toBeEnabled();
+      await expect(
+        dialog.getByRole("button", { name: /dismiss/i }),
+      ).toBeEnabled();
+    });
+
+    // Regression for #2676: a deduplication flag that was never reset meant
+    // only the first expiry in the life of the page was ever reported.
+    test("raises the expiry dialog again after re-authenticating", async ({
+      page,
+    }) => {
+      await setupAuthRequiredMocks(page);
+      await page.route("**/$jobs*", async (route) => {
+        await route.fulfill({ status: 401, body: "" });
+      });
+
+      await authenticate(page, "/jobs");
+
+      const dialog = page.getByRole("alertdialog");
+      await expect(dialog).toBeVisible({ timeout: 15000 });
+
+      // Once dismissed, the login prompt stands in for the withdrawn access.
+      await dialog.getByRole("button", { name: /dismiss/i }).click();
+      await expect(dialog).toBeHidden();
+      await expect(
+        page.getByText("You need to login before you can use this page."),
+      ).toBeVisible();
+
+      // FR-013: no further job list request is made once access is withdrawn.
+      let jobsAfterExpiry = 0;
+      await page.route("**/$jobs*", async (route) => {
+        jobsAfterExpiry += 1;
+        await route.fulfill({ status: 401, body: "" });
+      });
+      await page.waitForTimeout(11000);
+      expect(jobsAfterExpiry).toBe(0);
+
+      // Re-authenticate, and let a further request fail.
+      await authenticate(page, "/jobs");
+
+      await expect(dialog).toBeVisible({ timeout: 15000 });
     });
 
     test("login prompt appears on all protected pages", async ({ page }) => {

--- a/ui/e2e/auth.spec.ts
+++ b/ui/e2e/auth.spec.ts
@@ -316,7 +316,9 @@ test.describe("Authentication", () => {
       await page.goto("/admin/callback");
 
       // Should show authentication failed error.
-      await expect(page.getByText("Authentication Failed")).toBeVisible();
+      await expect(page.getByRole("alert")).toContainText(
+        "Authentication failed",
+      );
     });
 
     test("shows error with missing OAuth parameters", async ({ page }) => {
@@ -326,7 +328,9 @@ test.describe("Authentication", () => {
       await page.goto("/admin/callback?state=invalid-state");
 
       // Should show authentication failed error.
-      await expect(page.getByText("Authentication Failed")).toBeVisible();
+      await expect(page.getByRole("alert")).toContainText(
+        "Authentication failed",
+      );
     });
 
     test("redirects to stored return URL after successful auth", async ({

--- a/ui/e2e/import.spec.ts
+++ b/ui/e2e/import.spec.ts
@@ -403,8 +403,11 @@ test.describe("Import page", () => {
           .fill("s3a://invalid/data.ndjson");
         await page.getByRole("button", { name: "Start import" }).click();
 
-        // Verify error message is displayed.
-        await expect(page.getByText("Invalid source URL")).toBeVisible();
+        // Verify error message is displayed. A notification carries the same
+        // text, so match the first occurrence, which is the card.
+        await expect(
+          page.getByText("Invalid source URL").first(),
+        ).toBeVisible();
       });
     });
 
@@ -924,8 +927,9 @@ test.describe("Import page", () => {
         .fill("s3a://test/data.ndjson");
       await page.getByRole("button", { name: "Start import" }).click();
 
-      // Wait for error message to appear.
-      await expect(page.getByText("Import failed")).toBeVisible({
+      // Wait for error message to appear. A notification carries the same
+      // text, so match the first occurrence, which is the card.
+      await expect(page.getByText("Import failed").first()).toBeVisible({
         timeout: 10000,
       });
 
@@ -953,8 +957,9 @@ test.describe("Import page", () => {
         .fill("s3a://test/data.ndjson");
       await page.getByRole("button", { name: "Start import" }).click();
 
-      // Wait for error message and close button.
-      await expect(page.getByText("Import failed")).toBeVisible({
+      // Wait for error message and close button. A notification carries the
+      // same text, so match the first occurrence, which is the card.
+      await expect(page.getByText("Import failed").first()).toBeVisible({
         timeout: 10000,
       });
       await expect(page.getByRole("button", { name: "Close" })).toBeVisible();

--- a/ui/e2e/import.spec.ts
+++ b/ui/e2e/import.spec.ts
@@ -458,8 +458,12 @@ test.describe("Import page", () => {
         // Click cancel button.
         await page.getByRole("button", { name: "Cancel" }).click();
 
-        // Verify cancel was requested to the correct URL.
-        expect(cancelRequestUrl).toContain(`$job?id=${TEST_JOB_ID}`);
+        // Verify cancel was requested to the correct URL. The request is
+        // issued asynchronously, so poll rather than reading the captured URL
+        // straight after the click.
+        await expect
+          .poll(() => cancelRequestUrl)
+          .toContain(`$job?id=${TEST_JOB_ID}`);
       });
 
       test("shows cancelled status indicator when import is cancelled", async ({

--- a/ui/e2e/jobs.spec.ts
+++ b/ui/e2e/jobs.spec.ts
@@ -23,6 +23,7 @@
 
 import { expect, test } from "@playwright/test";
 
+import { mockCapabilityStatementWithAuth } from "./fixtures/fhirData";
 import { mockMetadata } from "./helpers/mockHelpers";
 
 import type { Page } from "@playwright/test";
@@ -204,6 +205,35 @@ test.describe("Jobs page", () => {
     await expect(
       page.getByRole("cell", { name: "export", exact: true }),
     ).toBeVisible();
+  });
+
+  // Regression for #2678: the page used to poll from the moment it loaded, so
+  // a logged-out visitor saw a "Session expired" dialog stacked on the login
+  // prompt and a stream of failing requests behind it.
+  test("shows only the login prompt when logged out, and issues no requests", async ({
+    page,
+  }) => {
+    await mockMetadata(page, mockCapabilityStatementWithAuth);
+
+    let jobsRequests = 0;
+    await page.route("**/$jobs*", async (route) => {
+      jobsRequests += 1;
+      await route.fulfill({ status: 401, body: "" });
+    });
+
+    await page.goto("/admin/jobs");
+
+    await expect(
+      page.getByText("You need to login before you can use this page."),
+    ).toBeVisible();
+    await expect(page.getByRole("alertdialog")).toBeHidden();
+
+    // Wait past the slow refresh interval to confirm nothing polls behind the
+    // prompt.
+    await page.waitForTimeout(11000);
+
+    expect(jobsRequests).toBe(0);
+    await expect(page.getByRole("alertdialog")).toBeHidden();
   });
 
   test("removes a finished job without confirmation", async ({ page }) => {

--- a/ui/e2e/sqlOnFhir.spec.ts
+++ b/ui/e2e/sqlOnFhir.spec.ts
@@ -459,8 +459,9 @@ test.describe("SQL on FHIR page", () => {
       await page.getByRole("option", { name: "Patient Demographics" }).click();
       await page.getByRole("button", { name: "Execute" }).click();
 
-      // Verify error message is displayed.
-      await expect(page.getByText(/View run failed/)).toBeVisible();
+      // Verify error message is displayed. A notification carries the same text,
+      // so match the first occurrence, which is the card.
+      await expect(page.getByText(/View run failed/).first()).toBeVisible();
     });
 
     test("displays the 422 message for an invalid custom view definition", async ({
@@ -499,8 +500,12 @@ test.describe("SQL on FHIR page", () => {
 
       await page.getByRole("button", { name: "Execute" }).click();
 
-      // The OperationOutcome diagnostics are shown clearly.
-      await expect(page.getByText(/Invalid ViewDefinition/)).toBeVisible();
+      // The OperationOutcome diagnostics are shown clearly. A notification
+      // carries the same text, so match the first occurrence, which is the
+      // card.
+      await expect(
+        page.getByText(/Invalid ViewDefinition/).first(),
+      ).toBeVisible();
     });
   });
 
@@ -1123,8 +1128,9 @@ test.describe("SQL on FHIR page", () => {
       await page.getByRole("option", { name: "Patient Demographics" }).click();
       await page.getByRole("button", { name: "Execute" }).click();
 
-      // Wait for error to appear.
-      await expect(page.getByText(/View run failed/)).toBeVisible({
+      // Wait for error to appear. A notification carries the same text, so match
+      // the first occurrence, which is the card.
+      await expect(page.getByText(/View run failed/).first()).toBeVisible({
         timeout: 10000,
       });
 
@@ -1152,7 +1158,7 @@ test.describe("SQL on FHIR page", () => {
       await page.getByRole("button", { name: "Execute" }).click();
 
       // Wait for error and close button.
-      await expect(page.getByText(/View run failed/)).toBeVisible({
+      await expect(page.getByText(/View run failed/).first()).toBeVisible({
         timeout: 10000,
       });
       await expect(page.getByRole("button", { name: "Close" })).toBeVisible();
@@ -1160,8 +1166,10 @@ test.describe("SQL on FHIR page", () => {
       // Click close button.
       await page.getByRole("button", { name: "Close" }).click();
 
-      // Verify the query card is removed.
-      await expect(page.getByText(/View run failed/)).not.toBeVisible();
+      // Verify the query card is removed. The notification of the failure
+      // outlives the card, so assert on the card's own close action rather
+      // than on the message text.
+      await expect(page.getByRole("button", { name: "Close" })).toBeHidden();
     });
   });
 });

--- a/ui/e2e/sqlQuery.spec.ts
+++ b/ui/e2e/sqlQuery.spec.ts
@@ -391,8 +391,10 @@ test.describe("SQL on FHIR page - SQL query mode", () => {
       .fill("Patient/pat-1");
     await page.getByRole("button", { name: /^execute$/i }).click();
 
+    // The failure is shown in the result card. A notification carries the same
+    // text, so match the first occurrence, which is the card.
     await expect(
-      page.getByText(/sql contains a disallowed operation/i),
+      page.getByText(/sql contains a disallowed operation/i).first(),
     ).toBeVisible();
   });
 });

--- a/ui/src/components/auth/LoginRequired.tsx
+++ b/ui/src/components/auth/LoginRequired.tsx
@@ -26,9 +26,9 @@ import { Box, Button, Callout } from "@radix-ui/themes";
 
 import { SessionExpiredDialog } from "./SessionExpiredDialog";
 import { config } from "../../config";
-import { useAuth } from "../../contexts/AuthContext";
+import { useLogin } from "../../hooks/useLogin";
 import { useServerCapabilities } from "../../hooks/useServerCapabilities";
-import { initiateAuth } from "../../services/auth";
+import { ErrorCallout } from "../error/ErrorCallout";
 
 /**
  * Displays a login prompt when authentication is required.
@@ -37,18 +37,8 @@ import { initiateAuth } from "../../services/auth";
  */
 export function LoginRequired() {
   const { fhirBaseUrl } = config;
-  const { setLoading, setError } = useAuth();
   const { data: capabilities } = useServerCapabilities(fhirBaseUrl);
-
-  const handleLogin = async () => {
-    if (!fhirBaseUrl) return;
-    setLoading(true);
-    try {
-      await initiateAuth(fhirBaseUrl);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Authentication failed");
-    }
-  };
+  const { login, isPending, error } = useLogin();
 
   return (
     <Box>
@@ -60,11 +50,16 @@ export function LoginRequired() {
       </Callout.Root>
 
       <Box mt="4">
-        <Button size="3" onClick={handleLogin}>
+        <Button size="3" loading={isPending} onClick={() => void login()}>
           <LockClosedIcon />
           Login to {capabilities?.serverName ?? window.location.hostname}
         </Button>
       </Box>
+      {error && (
+        <Box mt="4">
+          <ErrorCallout message={error} />
+        </Box>
+      )}
       <SessionExpiredDialog />
     </Box>
   );

--- a/ui/src/components/auth/LoginRequired.tsx
+++ b/ui/src/components/auth/LoginRequired.tsx
@@ -22,7 +22,7 @@
  */
 
 import { InfoCircledIcon, LockClosedIcon } from "@radix-ui/react-icons";
-import { Box, Button, Callout } from "@radix-ui/themes";
+import { Box, Button, Callout, Spinner } from "@radix-ui/themes";
 
 import { SessionExpiredDialog } from "./SessionExpiredDialog";
 import { config } from "../../config";
@@ -50,8 +50,12 @@ export function LoginRequired() {
       </Callout.Root>
 
       <Box mt="4">
-        <Button size="3" loading={isPending} onClick={() => void login()}>
-          <LockClosedIcon />
+        {/* The spinner replaces the icon rather than the whole label, so the
+            button still says what it does while the attempt is under way. */}
+        <Button size="3" disabled={isPending} onClick={() => void login()}>
+          <Spinner loading={isPending}>
+            <LockClosedIcon />
+          </Spinner>
           Login to {capabilities?.serverName ?? window.location.hostname}
         </Button>
       </Box>

--- a/ui/src/components/auth/SessionExpiredDialog.tsx
+++ b/ui/src/components/auth/SessionExpiredDialog.tsx
@@ -23,31 +23,25 @@
  */
 
 import { LockClosedIcon } from "@radix-ui/react-icons";
-import { AlertDialog, Button, Flex } from "@radix-ui/themes";
+import { AlertDialog, Box, Button, Flex } from "@radix-ui/themes";
 
-import { config } from "../../config";
 import { useAuth } from "../../contexts/AuthContext";
-import { initiateAuth } from "../../services/auth";
+import { useLogin } from "../../hooks/useLogin";
+import { ErrorCallout } from "../error/ErrorCallout";
 
 /**
  * Dialog prompting the user to re-authenticate after session expiry.
  *
+ * The dialog stays open while an authorisation attempt is under way, and stays
+ * open when that attempt fails, so the user sees the outcome where they asked
+ * for it. The login control is therefore a plain button rather than an
+ * `AlertDialog.Action`, which would close the dialog on activation.
+ *
  * @returns The session expired dialog component.
  */
 export function SessionExpiredDialog() {
-  const { sessionExpired, setSessionExpired, setLoading, setError } = useAuth();
-  const { fhirBaseUrl } = config;
-
-  const handleLogin = async () => {
-    if (!fhirBaseUrl) return;
-    setSessionExpired(false);
-    setLoading(true);
-    try {
-      await initiateAuth(fhirBaseUrl);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Authentication failed");
-    }
-  };
+  const { sessionExpired, setSessionExpired } = useAuth();
+  const { login, isPending, error } = useLogin();
 
   const handleDismiss = () => {
     setSessionExpired(false);
@@ -60,18 +54,21 @@ export function SessionExpiredDialog() {
         <AlertDialog.Description size="2">
           Your session has expired. Please log in again to continue working.
         </AlertDialog.Description>
+        {error && (
+          <Box mt="3">
+            <ErrorCallout message={error} size="1" />
+          </Box>
+        )}
         <Flex gap="3" mt="4" justify="end">
           <AlertDialog.Cancel>
-            <Button variant="soft" color="gray" onClick={handleDismiss}>
+            <Button variant="soft" color="gray" disabled={isPending} onClick={handleDismiss}>
               Dismiss
             </Button>
           </AlertDialog.Cancel>
-          <AlertDialog.Action>
-            <Button onClick={handleLogin}>
-              <LockClosedIcon />
-              Log in
-            </Button>
-          </AlertDialog.Action>
+          <Button loading={isPending} onClick={() => void login()}>
+            <LockClosedIcon />
+            Log in
+          </Button>
         </Flex>
       </AlertDialog.Content>
     </AlertDialog.Root>

--- a/ui/src/components/auth/SessionExpiredDialog.tsx
+++ b/ui/src/components/auth/SessionExpiredDialog.tsx
@@ -32,49 +32,71 @@ import { ErrorCallout } from "../error/ErrorCallout";
 /**
  * Dialog prompting the user to re-authenticate after session expiry.
  *
- * The dialog stays open while an authorisation attempt is under way, and stays
- * open when that attempt fails, so the user sees the outcome where they asked
- * for it. The login control is therefore a plain button rather than an
- * `AlertDialog.Action`, which would close the dialog on activation.
+ * The body is a separate component because the dialog primitive unmounts its
+ * content when closed. Holding the login attempt's state there means each
+ * expiry starts with a clean slate, rather than presenting the previous
+ * attempt's failure as though it described the new one.
  *
  * @returns The session expired dialog component.
  */
 export function SessionExpiredDialog() {
   const { sessionExpired, setSessionExpired } = useAuth();
-  const { login, isPending, error } = useLogin();
-
-  const handleDismiss = () => {
-    setSessionExpired(false);
-  };
 
   return (
     <AlertDialog.Root open={sessionExpired} onOpenChange={setSessionExpired}>
       <AlertDialog.Content maxWidth="450px">
-        <AlertDialog.Title>Session expired</AlertDialog.Title>
-        <AlertDialog.Description size="2">
-          Your session has expired. Please log in again to continue working.
-        </AlertDialog.Description>
-        {error && (
-          <Box mt="3">
-            <ErrorCallout message={error} size="1" />
-          </Box>
-        )}
-        <Flex gap="3" mt="4" justify="end">
-          <AlertDialog.Cancel>
-            <Button variant="soft" color="gray" disabled={isPending} onClick={handleDismiss}>
-              Dismiss
-            </Button>
-          </AlertDialog.Cancel>
-          {/* The spinner replaces the icon rather than the whole label, so the
-              button still says what it does while the attempt is under way. */}
-          <Button disabled={isPending} onClick={() => void login()}>
-            <Spinner loading={isPending}>
-              <LockClosedIcon />
-            </Spinner>
-            Log in
-          </Button>
-        </Flex>
+        <SessionExpiredDialogBody onDismiss={() => setSessionExpired(false)} />
       </AlertDialog.Content>
     </AlertDialog.Root>
+  );
+}
+
+interface SessionExpiredDialogBodyProps {
+  /** Closes the dialog without initiating authorisation. */
+  onDismiss: () => void;
+}
+
+/**
+ * The dialog's content and actions.
+ *
+ * The dialog stays open while an authorisation attempt is under way, and stays
+ * open when that attempt fails, so the user sees the outcome where they asked
+ * for it. The login control is therefore a plain button rather than an
+ * `AlertDialog.Action`, which would close the dialog on activation.
+ *
+ * @param props - The component props.
+ * @param props.onDismiss - Closes the dialog without initiating authorisation.
+ * @returns The dialog body.
+ */
+function SessionExpiredDialogBody({ onDismiss }: Readonly<SessionExpiredDialogBodyProps>) {
+  const { login, isPending, error } = useLogin();
+
+  return (
+    <>
+      <AlertDialog.Title>Session expired</AlertDialog.Title>
+      <AlertDialog.Description size="2">
+        Your session has expired. Please log in again to continue working.
+      </AlertDialog.Description>
+      {error && (
+        <Box mt="3">
+          <ErrorCallout message={error} size="1" />
+        </Box>
+      )}
+      <Flex gap="3" mt="4" justify="end">
+        <AlertDialog.Cancel>
+          <Button variant="soft" color="gray" disabled={isPending} onClick={onDismiss}>
+            Dismiss
+          </Button>
+        </AlertDialog.Cancel>
+        {/* The spinner replaces the icon rather than the whole label, so the
+            button still says what it does while the attempt is under way. */}
+        <Button disabled={isPending} onClick={() => void login()}>
+          <Spinner loading={isPending}>
+            <LockClosedIcon />
+          </Spinner>
+          Log in
+        </Button>
+      </Flex>
+    </>
   );
 }

--- a/ui/src/components/auth/SessionExpiredDialog.tsx
+++ b/ui/src/components/auth/SessionExpiredDialog.tsx
@@ -23,7 +23,7 @@
  */
 
 import { LockClosedIcon } from "@radix-ui/react-icons";
-import { AlertDialog, Box, Button, Flex } from "@radix-ui/themes";
+import { AlertDialog, Box, Button, Flex, Spinner } from "@radix-ui/themes";
 
 import { useAuth } from "../../contexts/AuthContext";
 import { useLogin } from "../../hooks/useLogin";
@@ -65,8 +65,12 @@ export function SessionExpiredDialog() {
               Dismiss
             </Button>
           </AlertDialog.Cancel>
-          <Button loading={isPending} onClick={() => void login()}>
-            <LockClosedIcon />
+          {/* The spinner replaces the icon rather than the whole label, so the
+              button still says what it does while the attempt is under way. */}
+          <Button disabled={isPending} onClick={() => void login()}>
+            <Spinner loading={isPending}>
+              <LockClosedIcon />
+            </Spinner>
             Log in
           </Button>
         </Flex>

--- a/ui/src/components/auth/__tests__/LoginRequired.test.tsx
+++ b/ui/src/components/auth/__tests__/LoginRequired.test.tsx
@@ -159,6 +159,8 @@ describe("LoginRequired", () => {
         expect(loginButton).toBeDisabled();
       });
       expect(container.querySelector(".rt-Spinner")).toBeInTheDocument();
+      // The label stays visible alongside the spinner, per the wireframe.
+      expect(loginButton).toHaveTextContent(/login to/i);
 
       attempt.resolve();
     });

--- a/ui/src/components/auth/__tests__/LoginRequired.test.tsx
+++ b/ui/src/components/auth/__tests__/LoginRequired.test.tsx
@@ -19,8 +19,8 @@
  * Tests for the LoginRequired component.
  *
  * This test suite verifies that the LoginRequired component correctly displays
- * the login prompt, handles login button clicks, and shows appropriate server
- * name in the button text.
+ * the login prompt, shows a pending indication while an authorisation attempt
+ * is under way, and reports a failure to initiate authorisation.
  *
  * @author John Grimes
  */
@@ -30,18 +30,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { render, screen, waitFor } from "../../../test/testUtils";
 import { LoginRequired } from "../LoginRequired";
-
-// Mock state for auth context.
-const mockSetLoading = vi.fn();
-const mockSetError = vi.fn();
-
-// Mock the auth context.
-vi.mock("../../../contexts/AuthContext", () => ({
-  useAuth: () => ({
-    setLoading: mockSetLoading,
-    setError: mockSetError,
-  }),
-}));
 
 // Mock config.
 vi.mock("../../../config", () => ({
@@ -68,6 +56,26 @@ vi.mock("../../../services/auth", () => ({
 vi.mock("../SessionExpiredDialog", () => ({
   SessionExpiredDialog: () => <div data-testid="session-expired-dialog" />,
 }));
+
+/**
+ * Creates a promise that the test controls, so an authorisation attempt can be
+ * held pending while assertions are made.
+ *
+ * @returns The promise and the functions that settle it.
+ */
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 describe("LoginRequired", () => {
   beforeEach(() => {
@@ -116,23 +124,94 @@ describe("LoginRequired", () => {
 
       expect(screen.getByTestId("session-expired-dialog")).toBeInTheDocument();
     });
+
+    it("shows no error before any attempt is made", () => {
+      render(<LoginRequired />);
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
   });
 
   describe("Login action", () => {
-    it("calls setLoading and initiateAuth when login button is clicked", async () => {
+    it("initiates authorisation with the FHIR base URL", async () => {
       const user = userEvent.setup();
       mockInitiateAuth.mockResolvedValue(undefined);
 
       render(<LoginRequired />);
 
-      const loginButton = screen.getByRole("button", { name: /login/i });
-      await user.click(loginButton);
+      await user.click(screen.getByRole("button", { name: /login/i }));
 
-      expect(mockSetLoading).toHaveBeenCalledWith(true);
       expect(mockInitiateAuth).toHaveBeenCalledWith("https://fhir.example.org/fhir");
     });
 
-    it("calls setError when initiateAuth fails", async () => {
+    // FR-001, FR-002: the button must show it is busy and refuse a second press.
+    it("disables the button and shows a pending indication while the attempt is under way", async () => {
+      const user = userEvent.setup();
+      const attempt = deferred();
+      mockInitiateAuth.mockReturnValue(attempt.promise);
+
+      const { container } = render(<LoginRequired />);
+
+      const loginButton = screen.getByRole("button", { name: /login/i });
+      await user.click(loginButton);
+
+      await waitFor(() => {
+        expect(loginButton).toBeDisabled();
+      });
+      expect(container.querySelector(".rt-Spinner")).toBeInTheDocument();
+
+      attempt.resolve();
+    });
+
+    // FR-002: repeated clicks must not start a second attempt.
+    it("starts no second attempt while one is already pending", async () => {
+      const user = userEvent.setup();
+      const attempt = deferred();
+      mockInitiateAuth.mockReturnValue(attempt.promise);
+
+      render(<LoginRequired />);
+
+      const loginButton = screen.getByRole("button", { name: /login/i });
+      await user.click(loginButton);
+      await waitFor(() => {
+        expect(loginButton).toBeDisabled();
+      });
+      // A disabled button swallows the click, so drive the handler directly too.
+      loginButton.click();
+
+      expect(mockInitiateAuth).toHaveBeenCalledTimes(1);
+
+      attempt.resolve();
+    });
+
+    // FR-003: the reason reported by the failure must be shown.
+    it("displays the failure message when authorisation cannot be initiated", async () => {
+      const user = userEvent.setup();
+      mockInitiateAuth.mockRejectedValue(new Error("Auth failed"));
+
+      render(<LoginRequired />);
+
+      await user.click(screen.getByRole("button", { name: /login/i }));
+
+      const alert = await screen.findByRole("alert");
+      expect(alert).toHaveTextContent("Auth failed");
+    });
+
+    // FR-003: a rejection that is not an Error still produces a message.
+    it("displays a fallback message when the failure is not an Error", async () => {
+      const user = userEvent.setup();
+      mockInitiateAuth.mockRejectedValue("string error");
+
+      render(<LoginRequired />);
+
+      await user.click(screen.getByRole("button", { name: /login/i }));
+
+      const alert = await screen.findByRole("alert");
+      expect(alert).toHaveTextContent("Authentication failed");
+    });
+
+    // FR-004: the user must be able to retry after a failure.
+    it("re-enables the button after a failed attempt", async () => {
       const user = userEvent.setup();
       mockInitiateAuth.mockRejectedValue(new Error("Auth failed"));
 
@@ -141,23 +220,12 @@ describe("LoginRequired", () => {
       const loginButton = screen.getByRole("button", { name: /login/i });
       await user.click(loginButton);
 
-      await waitFor(() => {
-        expect(mockSetError).toHaveBeenCalledWith("Auth failed");
-      });
-    });
+      await screen.findByRole("alert");
+      expect(loginButton).toBeEnabled();
 
-    it("sets generic error message when auth fails with non-Error", async () => {
-      const user = userEvent.setup();
-      mockInitiateAuth.mockRejectedValue("string error");
-
-      render(<LoginRequired />);
-
-      const loginButton = screen.getByRole("button", { name: /login/i });
+      // A second attempt can be made.
       await user.click(loginButton);
-
-      await waitFor(() => {
-        expect(mockSetError).toHaveBeenCalledWith("Authentication failed");
-      });
+      expect(mockInitiateAuth).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/ui/src/components/auth/__tests__/SessionExpiredDialog.test.tsx
+++ b/ui/src/components/auth/__tests__/SessionExpiredDialog.test.tsx
@@ -18,9 +18,10 @@
 /**
  * Tests for the SessionExpiredDialog component.
  *
- * This test suite verifies that the SessionExpiredDialog correctly displays
- * when session is expired, handles user interactions for dismiss and login
- * actions, and properly manages auth state.
+ * This test suite verifies that the dialog displays when the session has
+ * expired, stays open while an authorisation attempt is under way, reports a
+ * failure to initiate authorisation inside itself, and can be dismissed without
+ * initiating anything.
  *
  * @author John Grimes
  */
@@ -34,16 +35,12 @@ import { SessionExpiredDialog } from "../SessionExpiredDialog";
 // Mock state for auth context.
 let mockSessionExpired = false;
 const mockSetSessionExpired = vi.fn();
-const mockSetLoading = vi.fn();
-const mockSetError = vi.fn();
 
 // Mock the auth context.
 vi.mock("../../../contexts/AuthContext", () => ({
   useAuth: () => ({
     sessionExpired: mockSessionExpired,
     setSessionExpired: mockSetSessionExpired,
-    setLoading: mockSetLoading,
-    setError: mockSetError,
   }),
 }));
 
@@ -59,6 +56,26 @@ const mockInitiateAuth = vi.fn();
 vi.mock("../../../services/auth", () => ({
   initiateAuth: (url: string) => mockInitiateAuth(url),
 }));
+
+/**
+ * Creates a promise that the test controls, so an authorisation attempt can be
+ * held pending while assertions are made.
+ *
+ * @returns The promise and the functions that settle it.
+ */
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 describe("SessionExpiredDialog", () => {
   beforeEach(() => {
@@ -105,49 +122,32 @@ describe("SessionExpiredDialog", () => {
 
       expect(screen.getByRole("button", { name: /log in/i })).toBeInTheDocument();
     });
+
+    it("shows no error before any attempt is made", () => {
+      mockSessionExpired = true;
+
+      render(<SessionExpiredDialog />);
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
   });
 
   describe("Dismiss action", () => {
-    it("calls setSessionExpired with false when Dismiss is clicked", async () => {
+    // FR-006: dismissing closes the dialog and initiates nothing.
+    it("closes the dialog without initiating authorisation", async () => {
       const user = userEvent.setup();
       mockSessionExpired = true;
 
       render(<SessionExpiredDialog />);
 
-      const dismissButton = screen.getByRole("button", { name: /dismiss/i });
-      await user.click(dismissButton);
+      await user.click(screen.getByRole("button", { name: /dismiss/i }));
 
       expect(mockSetSessionExpired).toHaveBeenCalledWith(false);
+      expect(mockInitiateAuth).not.toHaveBeenCalled();
     });
   });
 
   describe("Login action", () => {
-    it("clears session expired state when Log in is clicked", async () => {
-      const user = userEvent.setup();
-      mockSessionExpired = true;
-      mockInitiateAuth.mockResolvedValue(undefined);
-
-      render(<SessionExpiredDialog />);
-
-      const loginButton = screen.getByRole("button", { name: /log in/i });
-      await user.click(loginButton);
-
-      expect(mockSetSessionExpired).toHaveBeenCalledWith(false);
-    });
-
-    it("sets loading state when Log in is clicked", async () => {
-      const user = userEvent.setup();
-      mockSessionExpired = true;
-      mockInitiateAuth.mockResolvedValue(undefined);
-
-      render(<SessionExpiredDialog />);
-
-      const loginButton = screen.getByRole("button", { name: /log in/i });
-      await user.click(loginButton);
-
-      expect(mockSetLoading).toHaveBeenCalledWith(true);
-    });
-
     it("calls initiateAuth with FHIR base URL when Log in is clicked", async () => {
       const user = userEvent.setup();
       mockSessionExpired = true;
@@ -155,13 +155,82 @@ describe("SessionExpiredDialog", () => {
 
       render(<SessionExpiredDialog />);
 
-      const loginButton = screen.getByRole("button", { name: /log in/i });
-      await user.click(loginButton);
+      await user.click(screen.getByRole("button", { name: /log in/i }));
 
       expect(mockInitiateAuth).toHaveBeenCalledWith("https://fhir.example.org/fhir");
     });
 
-    it("calls setError when initiateAuth fails with Error", async () => {
+    // FR-005: the dialog must not close itself when the attempt starts.
+    it("leaves the dialog open when Log in is clicked", async () => {
+      const user = userEvent.setup();
+      mockSessionExpired = true;
+      const attempt = deferred();
+      mockInitiateAuth.mockReturnValue(attempt.promise);
+
+      render(<SessionExpiredDialog />);
+
+      await user.click(screen.getByRole("button", { name: /log in/i }));
+
+      expect(mockSetSessionExpired).not.toHaveBeenCalled();
+      expect(screen.getByText("Session expired")).toBeInTheDocument();
+
+      attempt.resolve();
+    });
+
+    // FR-001, FR-002: both controls are locked out while the attempt runs.
+    it("disables both buttons and shows a pending indication while the attempt is under way", async () => {
+      const user = userEvent.setup();
+      mockSessionExpired = true;
+      const attempt = deferred();
+      mockInitiateAuth.mockReturnValue(attempt.promise);
+
+      render(<SessionExpiredDialog />);
+
+      const loginButton = screen.getByRole("button", { name: /log in/i });
+      const dismissButton = screen.getByRole("button", { name: /dismiss/i });
+      await user.click(loginButton);
+
+      await waitFor(() => {
+        expect(loginButton).toBeDisabled();
+      });
+      expect(dismissButton).toBeDisabled();
+      expect(document.querySelector(".rt-Spinner")).toBeInTheDocument();
+
+      attempt.resolve();
+    });
+
+    // FR-003, FR-005: the failure is reported inside the dialog, which stays open.
+    it("shows the failure inside the dialog and keeps it open", async () => {
+      const user = userEvent.setup();
+      mockSessionExpired = true;
+      mockInitiateAuth.mockRejectedValue(new Error("Login failed"));
+
+      render(<SessionExpiredDialog />);
+
+      await user.click(screen.getByRole("button", { name: /log in/i }));
+
+      const alert = await screen.findByRole("alert");
+      expect(alert).toHaveTextContent("Login failed");
+      expect(screen.getByText("Session expired")).toBeInTheDocument();
+      expect(mockSetSessionExpired).not.toHaveBeenCalled();
+    });
+
+    // FR-003: a rejection that is not an Error still produces a message.
+    it("shows a fallback message when the failure is not an Error", async () => {
+      const user = userEvent.setup();
+      mockSessionExpired = true;
+      mockInitiateAuth.mockRejectedValue("string error");
+
+      render(<SessionExpiredDialog />);
+
+      await user.click(screen.getByRole("button", { name: /log in/i }));
+
+      const alert = await screen.findByRole("alert");
+      expect(alert).toHaveTextContent("Authentication failed");
+    });
+
+    // FR-004: both controls become usable again so the attempt can be retried.
+    it("re-enables both buttons after a failed attempt", async () => {
       const user = userEvent.setup();
       mockSessionExpired = true;
       mockInitiateAuth.mockRejectedValue(new Error("Login failed"));
@@ -169,37 +238,12 @@ describe("SessionExpiredDialog", () => {
       render(<SessionExpiredDialog />);
 
       const loginButton = screen.getByRole("button", { name: /log in/i });
+      const dismissButton = screen.getByRole("button", { name: /dismiss/i });
       await user.click(loginButton);
 
-      await waitFor(() => {
-        expect(mockSetError).toHaveBeenCalledWith("Login failed");
-      });
-    });
-
-    it("calls setError with generic message when initiateAuth fails with non-Error", async () => {
-      const user = userEvent.setup();
-      mockSessionExpired = true;
-      mockInitiateAuth.mockRejectedValue("string error");
-
-      render(<SessionExpiredDialog />);
-
-      const loginButton = screen.getByRole("button", { name: /log in/i });
-      await user.click(loginButton);
-
-      await waitFor(() => {
-        expect(mockSetError).toHaveBeenCalledWith("Authentication failed");
-      });
-    });
-  });
-
-  describe("Dialog state management", () => {
-    it("passes sessionExpired to onOpenChange", () => {
-      mockSessionExpired = true;
-
-      render(<SessionExpiredDialog />);
-
-      // The dialog should be open (content visible).
-      expect(screen.getByText("Session expired")).toBeInTheDocument();
+      await screen.findByRole("alert");
+      expect(loginButton).toBeEnabled();
+      expect(dismissButton).toBeEnabled();
     });
   });
 });

--- a/ui/src/components/auth/__tests__/SessionExpiredDialog.test.tsx
+++ b/ui/src/components/auth/__tests__/SessionExpiredDialog.test.tsx
@@ -245,5 +245,31 @@ describe("SessionExpiredDialog", () => {
       expect(loginButton).toBeEnabled();
       expect(dismissButton).toBeEnabled();
     });
+
+    // A failed attempt belongs to the expiry that prompted it. Raising the
+    // dialog again must not present the previous attempt's failure as though
+    // it described the new one.
+    it("shows no stale error when the dialog is raised a second time", async () => {
+      const user = userEvent.setup();
+      mockSessionExpired = true;
+      mockInitiateAuth.mockRejectedValue(new Error("Login failed"));
+
+      const { rerender } = render(<SessionExpiredDialog />);
+
+      await user.click(screen.getByRole("button", { name: /log in/i }));
+      expect(await screen.findByRole("alert")).toHaveTextContent("Login failed");
+
+      // The user dismisses the dialog.
+      mockSessionExpired = false;
+      rerender(<SessionExpiredDialog />);
+      expect(screen.queryByText("Session expired")).not.toBeInTheDocument();
+
+      // A later expiry raises it again, with no attempt yet made.
+      mockSessionExpired = true;
+      rerender(<SessionExpiredDialog />);
+
+      expect(screen.getByText("Session expired")).toBeInTheDocument();
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
   });
 });

--- a/ui/src/components/error/ErrorCallout.tsx
+++ b/ui/src/components/error/ErrorCallout.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The shared presentation for every error callout in the admin UI. Always red,
+ * always carrying the warning icon, and always announced as an alert, so that
+ * errors look and behave the same wherever they appear.
+ *
+ * @author John Grimes
+ */
+
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
+import { Callout, Flex, Text } from "@radix-ui/themes";
+
+import type { ReactNode } from "react";
+
+interface ErrorCalloutProps {
+  /** The error message shown to the user. */
+  message: string;
+  /** An optional heading rendered in bold above the message. */
+  title?: string;
+  /** The callout size; defaults to the Radix default when omitted. */
+  size?: "1" | "2" | "3";
+  /** An optional top margin, for callouts that follow a form control. */
+  mt?: "1" | "2" | "3" | "4";
+  /** Optional recovery actions rendered below the message. */
+  children?: ReactNode;
+}
+
+/**
+ * Displays an error message in the shared callout presentation.
+ *
+ * @param props - The component props.
+ * @param props.message - The error message shown to the user.
+ * @param props.title - An optional heading rendered in bold above the message.
+ * @param props.size - The callout size, when the default is not wanted.
+ * @param props.mt - An optional top margin.
+ * @param props.children - Optional recovery actions rendered below the message.
+ * @returns The error callout component.
+ * @example
+ * <ErrorCallout message="Could not load jobs.">
+ *   <Button onClick={onRetry}>Retry</Button>
+ * </ErrorCallout>
+ */
+export function ErrorCallout({ message, title, size, mt, children }: Readonly<ErrorCalloutProps>) {
+  return (
+    <Callout.Root color="red" role="alert" size={size} mt={mt}>
+      <Callout.Icon>
+        <ExclamationTriangleIcon />
+      </Callout.Icon>
+      <Flex direction="column" gap="2" align="start">
+        {title && (
+          <Callout.Text>
+            <Text weight="bold">{title}</Text>
+          </Callout.Text>
+        )}
+        <Callout.Text>{message}</Callout.Text>
+        {children}
+      </Flex>
+    </Callout.Root>
+  );
+}

--- a/ui/src/components/error/__tests__/ErrorCallout.test.tsx
+++ b/ui/src/components/error/__tests__/ErrorCallout.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the shared error callout presentation.
+ *
+ * @author John Grimes
+ */
+
+import { Button } from "@radix-ui/themes";
+import { describe, expect, it } from "vitest";
+
+import { render, screen } from "../../../test/testUtils";
+import { ErrorCallout } from "../ErrorCallout";
+
+describe("ErrorCallout", () => {
+  // The message is the only required prop and is always shown.
+  it("renders the message", () => {
+    render(<ErrorCallout message="Search failed: unknown search parameter." />);
+
+    expect(screen.getByText("Search failed: unknown search parameter.")).toBeInTheDocument();
+  });
+
+  // A heading is optional and, when given, sits in bold above the message.
+  it("renders the optional title above the message", () => {
+    render(<ErrorCallout title="Authentication failed" message="No authorisation code." />);
+
+    const title = screen.getByText("Authentication failed");
+    const message = screen.getByText("No authorisation code.");
+    expect(title).toBeInTheDocument();
+    expect(message).toBeInTheDocument();
+    // The title precedes the message in document order.
+    expect(title.compareDocumentPosition(message)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  // Recovery actions are passed as children and stack under the message.
+  it("renders children below the message", () => {
+    render(
+      <ErrorCallout message="Could not load jobs.">
+        <Button>Retry</Button>
+      </ErrorCallout>,
+    );
+
+    const message = screen.getByText("Could not load jobs.");
+    const action = screen.getByRole("button", { name: "Retry" });
+    expect(action).toBeInTheDocument();
+    expect(message.compareDocumentPosition(action)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  // The two form sites need a smaller callout with a top margin.
+  it("applies the size and top margin when given", () => {
+    render(<ErrorCallout message="Save failed." size="1" mt="3" />);
+
+    const callout = screen.getByRole("alert");
+    expect(callout.className).toContain("rt-r-size-1");
+    expect(callout.className).toContain("rt-r-mt-3");
+  });
+
+  // Every callout is announced to assistive technology (FR-020).
+  it("is always announced as an alert", () => {
+    render(<ErrorCallout message="Something went wrong." />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Something went wrong.");
+  });
+
+  // Every callout carries the same warning icon (FR-021).
+  it("always renders the warning icon", () => {
+    const { container } = render(<ErrorCallout message="Something went wrong." />);
+
+    // The Radix exclamation triangle renders as an inline SVG within the callout.
+    expect(container.querySelector(".rt-CalloutIcon svg")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/jobs/JobsContent.tsx
+++ b/ui/src/components/jobs/JobsContent.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The body of the jobs page: the job list, its automatic refresh, and per-row
+ * cancellation. It lives behind the access check rather than in the page shell,
+ * so nothing is fetched on behalf of a user who is not permitted to fetch it.
+ *
+ * @author John Grimes
+ */
+
+import { Box, Heading, Text } from "@radix-ui/themes";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { CancelJobDialog } from "./CancelJobDialog";
+import { requiresCancelConfirmation } from "./jobsPresentation";
+import { JobsTable } from "./JobsTable";
+import { jobCancel } from "../../api";
+import { config } from "../../config";
+import { useAuth } from "../../contexts/AuthContext";
+import { useToast } from "../../contexts/ToastContext";
+import { JOBS_QUERY_KEY, useJobsList } from "../../hooks";
+
+import type { JobSummary } from "../../api";
+
+/**
+ * Lists the caller's jobs with live refresh and cancellation.
+ *
+ * @returns The jobs page content.
+ */
+export function JobsContent() {
+  const { fhirBaseUrl } = config;
+  const { client } = useAuth();
+  const accessToken = client?.state.tokenResponse?.access_token;
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  const jobsQuery = useJobsList();
+
+  // The job awaiting cancellation confirmation, or null when no dialog is open.
+  const [pendingJob, setPendingJob] = useState<JobSummary | null>(null);
+
+  const cancelMutation = useMutation<void, Error, JobSummary>({
+    mutationFn: (job) => jobCancel(fhirBaseUrl, { pollingUrl: job.url, accessToken }),
+    onSuccess: (_data, job) => {
+      void queryClient.invalidateQueries({ queryKey: JOBS_QUERY_KEY });
+      showToast(
+        job.status === "in-progress" ? "Job cancelled" : "Job removed",
+        `The ${job.operation} job has been removed.`,
+      );
+    },
+    onError: (error) => {
+      // On failure the job stays in the list; the toast explains why.
+      showToast("Could not cancel job", error.message);
+    },
+    onSettled: () => {
+      setPendingJob(null);
+    },
+  });
+
+  const handleCancelJob = (job: JobSummary) => {
+    // In-progress jobs are confirmed first; finished jobs are removed immediately.
+    if (requiresCancelConfirmation(job)) {
+      setPendingJob(job);
+    } else {
+      cancelMutation.mutate(job);
+    }
+  };
+
+  const handleConfirmCancel = () => {
+    if (pendingJob) {
+      cancelMutation.mutate(pendingJob);
+    }
+  };
+
+  return (
+    <>
+      <Box mb="4">
+        <Heading size="6" mb="1">
+          Jobs
+        </Heading>
+        <Text size="2" color="gray">
+          Background jobs you own on this server. The list refreshes automatically while jobs are
+          running.
+        </Text>
+      </Box>
+
+      <JobsTable
+        jobs={jobsQuery.data ?? []}
+        isLoading={jobsQuery.isLoading}
+        error={jobsQuery.error}
+        onRetry={() => void jobsQuery.refetch()}
+        onCancelJob={handleCancelJob}
+      />
+
+      <CancelJobDialog
+        job={pendingJob}
+        isCancelling={cancelMutation.isPending}
+        onConfirm={handleConfirmCancel}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingJob(null);
+          }
+        }}
+      />
+    </>
+  );
+}

--- a/ui/src/components/jobs/JobsTable.tsx
+++ b/ui/src/components/jobs/JobsTable.tsx
@@ -22,20 +22,11 @@
  * @author John Grimes
  */
 
-import { Cross2Icon, InfoCircledIcon, TrashIcon } from "@radix-ui/react-icons";
-import {
-  Badge,
-  Box,
-  Button,
-  Callout,
-  Flex,
-  Progress,
-  Spinner,
-  Table,
-  Text,
-} from "@radix-ui/themes";
+import { Cross2Icon, TrashIcon } from "@radix-ui/react-icons";
+import { Badge, Box, Button, Flex, Progress, Spinner, Table, Text } from "@radix-ui/themes";
 
 import { formatJobStartTime, isJobInProgress, statusBadge } from "./jobsPresentation";
+import { ErrorCallout } from "../error/ErrorCallout";
 
 import type { JobSummary } from "../../api/jobs";
 
@@ -77,17 +68,11 @@ export function JobsTable({
 }: Readonly<JobsTableProps>) {
   if (error) {
     return (
-      <Callout.Root color="red" role="alert">
-        <Callout.Icon>
-          <InfoCircledIcon />
-        </Callout.Icon>
-        <Flex direction="column" gap="2" align="start">
-          <Callout.Text>Could not load jobs: {error.message}</Callout.Text>
-          <Button size="1" variant="soft" onClick={onRetry}>
-            Retry
-          </Button>
-        </Flex>
-      </Callout.Root>
+      <ErrorCallout message={`Could not load jobs: ${error.message}`}>
+        <Button size="1" variant="soft" onClick={onRetry}>
+          Retry
+        </Button>
+      </ErrorCallout>
     );
   }
 

--- a/ui/src/components/jobs/__tests__/JobsContent.test.tsx
+++ b/ui/src/components/jobs/__tests__/JobsContent.test.tsx
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the JobsContent component, which holds the job list query and the
+ * cancellation behaviour previously kept in the jobs page.
+ *
+ * @author John Grimes
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { render, screen, waitFor } from "../../../test/testUtils";
+import { JobsContent } from "../JobsContent";
+
+import type { JobSummary } from "../../../api";
+
+const runningJob: JobSummary = {
+  id: "job-running",
+  operation: "export",
+  status: "in-progress",
+  startTime: "2026-07-27T00:00:00Z",
+  url: "https://fhir.example.org/fhir/$job?id=job-running",
+};
+
+const finishedJob: JobSummary = {
+  id: "job-finished",
+  operation: "import",
+  status: "completed",
+  startTime: "2026-07-27T00:00:00Z",
+  url: "https://fhir.example.org/fhir/$job?id=job-finished",
+};
+
+// Mock the toast context, used to report the outcome of a cancellation.
+const mockShowToast = vi.fn();
+vi.mock("../../../contexts/ToastContext", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+vi.mock("../../../contexts/AuthContext", () => ({
+  useAuth: () => ({ client: null }),
+}));
+
+vi.mock("../../../config", () => ({
+  config: { fhirBaseUrl: "https://fhir.example.org/fhir" },
+}));
+
+// Mock the job list query, toggled per test.
+let mockJobsQuery: { data?: JobSummary[]; isLoading: boolean; error: Error | null } = {
+  data: [],
+  isLoading: false,
+  error: null,
+};
+const mockRefetch = vi.fn();
+vi.mock("../../../hooks", () => ({
+  JOBS_QUERY_KEY: ["jobs"],
+  useJobsList: () => ({ ...mockJobsQuery, refetch: mockRefetch }),
+}));
+
+// Mock the cancellation API so no request is made.
+const mockJobCancel = vi.fn();
+vi.mock("../../../api", () => ({
+  jobCancel: (...args: unknown[]) => mockJobCancel(...args),
+}));
+
+/**
+ * Renders the component with the query client its cancellation mutation needs.
+ *
+ * @returns The render result.
+ */
+function renderJobsContent() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <JobsContent />
+    </QueryClientProvider>,
+  );
+}
+
+describe("JobsContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockJobsQuery = { data: [], isLoading: false, error: null };
+    mockJobCancel.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // FR-014: listing continues to behave as it does today.
+  it("lists the jobs returned by the query", () => {
+    mockJobsQuery = { data: [runningJob, finishedJob], isLoading: false, error: null };
+
+    renderJobsContent();
+
+    expect(screen.getByText("export")).toBeInTheDocument();
+    expect(screen.getByText("import")).toBeInTheDocument();
+  });
+
+  it("shows the loading state while the first list is loading", () => {
+    mockJobsQuery = { data: undefined, isLoading: true, error: null };
+
+    renderJobsContent();
+
+    expect(screen.getByText("Loading jobs...")).toBeInTheDocument();
+  });
+
+  it("shows the error state when the list cannot be loaded", () => {
+    mockJobsQuery = { data: undefined, isLoading: false, error: new Error("request timed out") };
+
+    renderJobsContent();
+
+    expect(screen.getByRole("alert")).toHaveTextContent("request timed out");
+  });
+
+  // FR-014: an in-progress job is confirmed before it is stopped.
+  it("asks for confirmation before cancelling an in-progress job", async () => {
+    const user = userEvent.setup();
+    mockJobsQuery = { data: [runningJob], isLoading: false, error: null };
+
+    renderJobsContent();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(screen.getByText("Cancel job?")).toBeInTheDocument();
+    expect(mockJobCancel).not.toHaveBeenCalled();
+  });
+
+  // FR-014: a finished job is removed straight away.
+  it("removes a finished job without confirmation", async () => {
+    const user = userEvent.setup();
+    mockJobsQuery = { data: [finishedJob], isLoading: false, error: null };
+
+    renderJobsContent();
+
+    await user.click(screen.getByRole("button", { name: /remove/i }));
+
+    await waitFor(() => {
+      expect(mockJobCancel).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText("Cancel job?")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/jobs/__tests__/JobsContent.test.tsx
+++ b/ui/src/components/jobs/__tests__/JobsContent.test.tsx
@@ -158,5 +158,68 @@ describe("JobsContent", () => {
       expect(mockJobCancel).toHaveBeenCalledTimes(1);
     });
     expect(screen.queryByText("Cancel job?")).not.toBeInTheDocument();
+    expect(mockShowToast).toHaveBeenCalledWith("Job removed", "The import job has been removed.");
+  });
+
+  // Confirming the dialog issues the cancellation and reports it.
+  it("cancels an in-progress job once confirmed", async () => {
+    const user = userEvent.setup();
+    mockJobsQuery = { data: [runningJob], isLoading: false, error: null };
+
+    renderJobsContent();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await user.click(screen.getByRole("button", { name: /cancel job/i }));
+
+    await waitFor(() => {
+      expect(mockJobCancel).toHaveBeenCalledTimes(1);
+    });
+    expect(mockShowToast).toHaveBeenCalledWith("Job cancelled", "The export job has been removed.");
+  });
+
+  // Dismissing the confirmation leaves the job alone.
+  it("leaves the job alone when the confirmation is dismissed", async () => {
+    const user = userEvent.setup();
+    mockJobsQuery = { data: [runningJob], isLoading: false, error: null };
+
+    renderJobsContent();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await user.click(screen.getByRole("button", { name: /keep running/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Cancel job?")).not.toBeInTheDocument();
+    });
+    expect(mockJobCancel).not.toHaveBeenCalled();
+  });
+
+  // A failed cancellation is reported and the job stays in the list.
+  it("reports a failed cancellation", async () => {
+    const user = userEvent.setup();
+    mockJobsQuery = { data: [finishedJob], isLoading: false, error: null };
+    mockJobCancel.mockRejectedValue(new Error("Job could not be deleted"));
+
+    renderJobsContent();
+
+    await user.click(screen.getByRole("button", { name: /remove/i }));
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        "Could not cancel job",
+        "Job could not be deleted",
+      );
+    });
+  });
+
+  // The error state offers a retry that refetches the list.
+  it("refetches the list when the retry action is used", async () => {
+    const user = userEvent.setup();
+    mockJobsQuery = { data: undefined, isLoading: false, error: new Error("request timed out") };
+
+    renderJobsContent();
+
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/src/components/jobs/__tests__/JobsTable.test.tsx
+++ b/ui/src/components/jobs/__tests__/JobsTable.test.tsx
@@ -18,7 +18,7 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-import { render, screen } from "../../../test/testUtils";
+import { render, screen, within } from "../../../test/testUtils";
 import { JobsTable } from "../JobsTable";
 
 import type { JobSummary } from "../../../api/jobs";
@@ -88,7 +88,12 @@ describe("JobsTable", () => {
     const onRetry = vi.fn();
     renderTable({ error: new Error("network down"), onRetry });
 
-    const retry = screen.getByRole("button", { name: /retry/i });
+    // The shared error presentation announces the error and keeps the recovery
+    // action inside the callout.
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Could not load jobs: network down");
+
+    const retry = within(alert).getByRole("button", { name: /retry/i });
     await userEvent.click(retry);
 
     expect(onRetry).toHaveBeenCalledTimes(1);

--- a/ui/src/components/resources/ResourceResultList.tsx
+++ b/ui/src/components/resources/ResourceResultList.tsx
@@ -21,10 +21,11 @@
  * @author John Grimes
  */
 
-import { ExclamationTriangleIcon, MagnifyingGlassIcon } from "@radix-ui/react-icons";
-import { Badge, Box, Callout, Flex, Heading, Spinner, Text } from "@radix-ui/themes";
+import { MagnifyingGlassIcon } from "@radix-ui/react-icons";
+import { Badge, Box, Flex, Heading, Spinner, Text } from "@radix-ui/themes";
 
 import { ResourceCard } from "./ResourceCard";
+import { ErrorCallout } from "../error/ErrorCallout";
 
 import type { Resource } from "fhir/r4";
 
@@ -97,12 +98,7 @@ export function ResourceResultList({
         <Heading size="4" mb="4">
           Results
         </Heading>
-        <Callout.Root color="red">
-          <Callout.Icon>
-            <ExclamationTriangleIcon />
-          </Callout.Icon>
-          <Callout.Text>{error.message}</Callout.Text>
-        </Callout.Root>
+        <ErrorCallout message={error.message} />
       </Box>
     );
   }

--- a/ui/src/components/resources/__tests__/ResourceResultList.test.tsx
+++ b/ui/src/components/resources/__tests__/ResourceResultList.test.tsx
@@ -106,7 +106,8 @@ describe("ResourceResultList", () => {
       );
 
       expect(screen.getByText("Results")).toBeInTheDocument();
-      expect(screen.getByText("Failed to fetch resources")).toBeInTheDocument();
+      // The shared error presentation announces every error as an alert.
+      expect(screen.getByRole("alert")).toHaveTextContent("Failed to fetch resources");
     });
   });
 

--- a/ui/src/components/sqlOnFhir/SqlOnFhirResultTable.tsx
+++ b/ui/src/components/sqlOnFhir/SqlOnFhirResultTable.tsx
@@ -21,11 +21,12 @@
  * @author John Grimes
  */
 
-import { ExclamationTriangleIcon, TableIcon } from "@radix-ui/react-icons";
-import { Badge, Box, Callout, Code, Flex, Heading, Spinner, Table, Text } from "@radix-ui/themes";
+import { TableIcon } from "@radix-ui/react-icons";
+import { Badge, Box, Code, Flex, Heading, Spinner, Table, Text } from "@radix-ui/themes";
 
 import { ExportControls } from "./ExportControls";
 import { ViewExportCard } from "./ViewExportCard";
+import { ErrorCallout } from "../error/ErrorCallout";
 
 import type { ViewExportJob } from "../../types/job";
 import type { ViewExportFormat } from "../../types/viewExport";
@@ -124,12 +125,7 @@ export function SqlOnFhirResultTable({
         <Heading size="4" mb="4">
           Results
         </Heading>
-        <Callout.Root color="red">
-          <Callout.Icon>
-            <ExclamationTriangleIcon />
-          </Callout.Icon>
-          <Callout.Text>{error.message}</Callout.Text>
-        </Callout.Root>
+        <ErrorCallout message={error.message} />
       </Box>
     );
   }

--- a/ui/src/components/sqlOnFhir/SqlQueryCard.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryCard.tsx
@@ -25,12 +25,11 @@
  * @author John Grimes
  */
 
-import { Cross2Icon, ExclamationTriangleIcon } from "@radix-ui/react-icons";
+import { Cross2Icon } from "@radix-ui/react-icons";
 import {
   Badge,
   Box,
   Button,
-  Callout,
   Card,
   Code,
   Flex,
@@ -47,6 +46,7 @@ import { SqlQueryExportCardWrapper } from "./SqlQueryExportCardWrapper";
 import { useSqlQueryRun } from "../../hooks";
 import { OperationOutcomeError } from "../../types/errors";
 import { formatDateTime } from "../../utils";
+import { ErrorCallout } from "../error/ErrorCallout";
 
 import type { SqlQueryExportFormat, SqlQueryJob, SqlQueryResult } from "../../types/sqlQuery";
 
@@ -300,12 +300,7 @@ function SqlQueryErrorBody({ sql, error }: Readonly<SqlQueryErrorBodyProps>) {
         Submitted SQL:
       </Text>
       <SqlPreview sql={sql || "(empty)"} ariaLabel="Submitted SQL" />
-      <Callout.Root color="red" size="1">
-        <Callout.Icon>
-          <ExclamationTriangleIcon />
-        </Callout.Icon>
-        <Callout.Text>{message}</Callout.Text>
-      </Callout.Root>
+      <ErrorCallout message={message} size="1" />
     </Flex>
   );
 }

--- a/ui/src/components/sqlOnFhir/SqlQueryForm.tsx
+++ b/ui/src/components/sqlOnFhir/SqlQueryForm.tsx
@@ -26,10 +26,11 @@
  */
 
 import { PlayIcon, UploadIcon } from "@radix-ui/react-icons";
-import { Box, Button, Callout, Card, Flex, Heading, Tabs } from "@radix-ui/themes";
+import { Box, Button, Card, Flex, Heading, Tabs } from "@radix-ui/themes";
 import { useState } from "react";
 
 import { useSqlQueryLibraries, useSqlViews, useViewDefinitions } from "../../hooks";
+import { ErrorCallout } from "../error/ErrorCallout";
 import { FieldLabel } from "../FieldLabel";
 import {
   areRuntimeBindingsValid,
@@ -246,11 +247,7 @@ export function SqlQueryForm({
                 }))}
                 disabled={disabled || isExecuting}
               />
-              {saveError && (
-                <Callout.Root color="red" mt="3" size="1">
-                  <Callout.Text>{saveError.message}</Callout.Text>
-                </Callout.Root>
-              )}
+              {saveError && <ErrorCallout message={saveError.message} size="1" mt="3" />}
             </Tabs.Content>
           </Box>
         </Tabs.Root>

--- a/ui/src/components/sqlOnFhir/ViewDefinitionForm.tsx
+++ b/ui/src/components/sqlOnFhir/ViewDefinitionForm.tsx
@@ -27,7 +27,6 @@ import { CopyIcon, PlayIcon, UploadIcon } from "@radix-ui/react-icons";
 import {
   Box,
   Button,
-  Callout,
   Card,
   Flex,
   Heading,
@@ -43,6 +42,7 @@ import { useState } from "react";
 
 import { useClipboard } from "../../hooks";
 import { useViewDefinitions } from "../../hooks/useViewDefinitions";
+import { ErrorCallout } from "../error/ErrorCallout";
 import { FieldGuidance } from "../FieldGuidance";
 import { FieldLabel } from "../FieldLabel";
 
@@ -229,11 +229,7 @@ export function ViewDefinitionForm({
                 <FieldGuidance mt="2">
                   Enter a valid view definition resource in JSON format.
                 </FieldGuidance>
-                {saveError && (
-                  <Callout.Root color="red" mt="2" size="1">
-                    <Callout.Text>{saveError.message}</Callout.Text>
-                  </Callout.Root>
-                )}
+                {saveError && <ErrorCallout message={saveError.message} size="1" mt="2" />}
               </Box>
             </Tabs.Content>
           </Box>

--- a/ui/src/components/sqlOnFhir/__tests__/SqlOnFhirResultTable.test.tsx
+++ b/ui/src/components/sqlOnFhir/__tests__/SqlOnFhirResultTable.test.tsx
@@ -113,7 +113,8 @@ describe("SqlOnFhirResultTable", () => {
       );
 
       expect(screen.getByText("Results")).toBeInTheDocument();
-      expect(screen.getByText("View execution failed")).toBeInTheDocument();
+      // The shared error presentation announces every error as an alert.
+      expect(screen.getByRole("alert")).toHaveTextContent("View execution failed");
     });
   });
 

--- a/ui/src/components/sqlOnFhir/__tests__/SqlPreview.test.tsx
+++ b/ui/src/components/sqlOnFhir/__tests__/SqlPreview.test.tsx
@@ -33,8 +33,7 @@ import { SqlPreview } from "../SqlPreview";
 
 const mockCopy = vi.fn();
 
-// The hooks barrel transitively imports main.tsx (via AuthContext), which
-// runs createRoot at load. Mock it; the preview only needs useClipboard.
+// Mock the hooks barrel; the preview only needs useClipboard.
 vi.mock("../../../hooks", () => ({
   useClipboard: () => mockCopy,
 }));

--- a/ui/src/components/sqlOnFhir/__tests__/SqlQueryCard.test.tsx
+++ b/ui/src/components/sqlOnFhir/__tests__/SqlQueryCard.test.tsx
@@ -246,7 +246,8 @@ describe("SqlQueryCard", () => {
         onClose={onClose}
       />,
     );
-    expect(screen.getByText(/sql contains a disallowed operation/i)).toBeInTheDocument();
+    // The shared error presentation announces every error as an alert.
+    expect(screen.getByRole("alert")).toHaveTextContent(/sql contains a disallowed operation/i);
     // The submitted SQL is echoed in the read-only preview area.
     expect(screen.getByRole("textbox", { name: /submitted sql/i })).toHaveValue(
       "DROP TABLE conditions",
@@ -258,7 +259,7 @@ describe("SqlQueryCard", () => {
     mockStatus = "error";
     mockError = new Error("Network error");
     render(<SqlQueryCard job={createJob()} onError={onError} onClose={onClose} />);
-    expect(screen.getByText(/network error/i)).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(/network error/i);
   });
 
   // The close button only appears once the request has terminated.

--- a/ui/src/components/sqlOnFhir/__tests__/SqlQueryForm.test.tsx
+++ b/ui/src/components/sqlOnFhir/__tests__/SqlQueryForm.test.tsx
@@ -78,11 +78,12 @@ const PLAIN_QUERY = makeSummary({
 const SQL_VIEW = makeSummary({
   id: "sql-view",
   title: "Active patients view",
+  url: "http://example.org/Library/active-patients-view",
   parameters: [],
 });
 
-// The hooks barrel transitively imports main.tsx (via AuthContext). Mock it
-// with the stored lists the form and its picker consume.
+// Mock the hooks barrel with the stored lists the form and its picker
+// consume.
 vi.mock("../../../hooks", () => ({
   useSqlQueryLibraries: () => ({
     data: [PARAM_QUERY, PLAIN_QUERY],
@@ -204,5 +205,32 @@ describe("SqlQueryForm stored execution", () => {
         sql: "SELECT 1",
       }),
     );
+  });
+
+  // A failed save is reported through the shared error presentation, which
+  // announces it as an alert.
+  it("announces a failed save as an alert", async () => {
+    const user = userEvent.setup();
+    render(
+      <SqlQueryForm
+        onExecute={vi.fn()}
+        onSaveToServer={vi.fn().mockRejectedValue(new Error("Save rejected by the server"))}
+        isExecuting={false}
+        isSaving={false}
+      />,
+    );
+
+    // Saving requires a title, some SQL, and at least one resolved view.
+    await user.click(screen.getByRole("tab", { name: /provide sql/i }));
+    await user.type(screen.getByRole("textbox", { name: /library title/i }), "My query");
+    await user.type(screen.getByRole("textbox", { name: /^sql$/i }), "SELECT 1");
+    await user.click(screen.getByRole("button", { name: /add view/i }));
+    await user.type(screen.getByRole("textbox", { name: /label for view 1/i }), "patients");
+    await user.click(screen.getByRole("combobox", { name: /source for view 1/i }));
+    await user.click(screen.getByRole("option", { name: "Active patients view" }));
+
+    await user.click(screen.getByRole("button", { name: /save to server/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Save rejected by the server");
   });
 });

--- a/ui/src/components/sqlOnFhir/__tests__/SqlQueryStoredTab.test.tsx
+++ b/ui/src/components/sqlOnFhir/__tests__/SqlQueryStoredTab.test.tsx
@@ -33,8 +33,7 @@ import { SqlQueryStoredTab } from "../SqlQueryStoredTab";
 
 import type { SqlQueryLibrarySummary } from "../../../types/sqlQuery";
 
-// The hooks barrel transitively imports main.tsx (via AuthContext), which
-// runs createRoot at load. Mock it; the tab only needs useClipboard.
+// Mock the hooks barrel; the tab only needs useClipboard.
 vi.mock("../../../hooks", () => ({
   useClipboard: () => vi.fn(),
 }));

--- a/ui/src/components/sqlOnFhir/__tests__/ViewDefinitionForm.test.tsx
+++ b/ui/src/components/sqlOnFhir/__tests__/ViewDefinitionForm.test.tsx
@@ -471,8 +471,9 @@ describe("ViewDefinitionForm", () => {
       // Click save.
       await user.click(screen.getByRole("button", { name: /save to server/i }));
 
+      // The shared error presentation announces every error as an alert.
       await waitFor(() => {
-        expect(screen.getByText(/save failed/i)).toBeInTheDocument();
+        expect(screen.getByRole("alert")).toHaveTextContent(/save failed/i);
       });
     });
 

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -23,7 +23,7 @@
 
 import { createContext, type ReactNode, use, useCallback, useEffect, useState } from "react";
 
-import { registerClearSession } from "../main";
+import { registerSessionExpiryHandler } from "../services/sessionExpiry";
 
 import type Client from "fhirclient/lib/Client";
 
@@ -105,15 +105,25 @@ export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
     }));
   };
 
+  // An authorisation failure only means the session expired if one was held.
+  // Deciding inside the updater keeps the check against the current state
+  // without introducing any state of its own, and makes the prompt idempotent
+  // so concurrent failures raise a single dialog.
   const clearSessionAndPromptLogin = useCallback(() => {
-    setState((prev) => ({
-      ...prev,
-      isAuthenticated: false,
-      isLoading: false,
-      client: null,
-      error: null,
-      sessionExpired: true,
-    }));
+    setState((prev) =>
+      prev.isAuthenticated
+        ? {
+            ...prev,
+            isAuthenticated: false,
+            isLoading: false,
+            client: null,
+            error: null,
+            sessionExpired: true,
+          }
+        : prev,
+    );
+    // Clear the key unconditionally, so a stale one from a previous page load
+    // does not survive.
     sessionStorage.removeItem("SMART_KEY");
   }, []);
 
@@ -134,7 +144,7 @@ export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
 
   // Register the session clearing function for global 401 handling.
   useEffect(() => {
-    registerClearSession(clearSessionAndPromptLogin);
+    registerSessionExpiryHandler(clearSessionAndPromptLogin);
   }, [clearSessionAndPromptLogin]);
 
   return (

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -29,17 +29,13 @@ import type Client from "fhirclient/lib/Client";
 
 interface AuthState {
   isAuthenticated: boolean;
-  isLoading: boolean;
   client: Client | null;
-  error: string | null;
   authRequired: boolean | null; // null = unknown, true = required, false = not required
   sessionExpired: boolean;
 }
 
 interface AuthContextValue extends AuthState {
   setClient: (client: Client) => void;
-  setError: (error: string) => void;
-  setLoading: (loading: boolean) => void;
   setAuthRequired: (required: boolean) => void;
   setSessionExpired: (expired: boolean) => void;
   clearSessionAndPromptLogin: () => void;
@@ -58,9 +54,7 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
   const [state, setState] = useState<AuthState>({
     isAuthenticated: false,
-    isLoading: false,
     client: null,
-    error: null,
     authRequired: null,
     sessionExpired: false,
   });
@@ -69,9 +63,7 @@ export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
     setState((prev) => ({
       ...prev,
       isAuthenticated: true,
-      isLoading: false,
       client,
-      error: null,
     }));
   };
 
@@ -79,22 +71,6 @@ export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
     setState((prev) => ({
       ...prev,
       authRequired: required,
-    }));
-  };
-
-  const setError = (error: string) => {
-    setState((prev) => ({
-      ...prev,
-      isLoading: false,
-      error,
-    }));
-  };
-
-  const setLoading = (loading: boolean) => {
-    setState((prev) => ({
-      ...prev,
-      isLoading: loading,
-      error: loading ? null : prev.error,
     }));
   };
 
@@ -112,14 +88,7 @@ export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
   const clearSessionAndPromptLogin = useCallback(() => {
     setState((prev) =>
       prev.isAuthenticated
-        ? {
-            ...prev,
-            isAuthenticated: false,
-            isLoading: false,
-            client: null,
-            error: null,
-            sessionExpired: true,
-          }
+        ? { ...prev, isAuthenticated: false, client: null, sessionExpired: true }
         : prev,
     );
     // Clear the key unconditionally, so a stale one from a previous page load
@@ -131,9 +100,7 @@ export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
     setState((prev) => ({
       ...prev,
       isAuthenticated: false,
-      isLoading: false,
       client: null,
-      error: null,
       sessionExpired: false,
     }));
     // Clear any stored session data.
@@ -152,8 +119,6 @@ export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
       value={{
         ...state,
         setClient,
-        setError,
-        setLoading,
         setAuthRequired,
         setSessionExpired,
         clearSessionAndPromptLogin,

--- a/ui/src/contexts/__tests__/AuthContext.test.tsx
+++ b/ui/src/contexts/__tests__/AuthContext.test.tsx
@@ -24,7 +24,7 @@
 
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { notifyUnauthorized } from "../../services/sessionExpiry";
 import { render, screen } from "../../test/testUtils";
@@ -41,12 +41,21 @@ const stubClient = { state: {} } as Client;
  * @returns The harness component.
  */
 function Harness() {
-  const { isAuthenticated, sessionExpired, setClient, setSessionExpired } = useAuth();
+  const {
+    isAuthenticated,
+    sessionExpired,
+    authRequired,
+    setClient,
+    setSessionExpired,
+    setAuthRequired,
+    logout,
+  } = useAuth();
 
   return (
     <>
       <div data-testid="authenticated">{String(isAuthenticated)}</div>
       <div data-testid="expired">{String(sessionExpired)}</div>
+      <div data-testid="auth-required">{String(authRequired)}</div>
       <button
         onClick={() => {
           setClient(stubClient);
@@ -61,6 +70,14 @@ function Harness() {
       >
         Dismiss
       </button>
+      <button
+        onClick={() => {
+          setAuthRequired(true);
+        }}
+      >
+        Require auth
+      </button>
+      <button onClick={logout}>Log out</button>
     </>
   );
 }
@@ -160,5 +177,46 @@ describe("AuthContext", () => {
     await user.click(screen.getByRole("button", { name: "Dismiss" }));
 
     expect(screen.getByTestId("expired")).toHaveTextContent("false");
+  });
+
+  it("records whether the server requires authentication", async () => {
+    const user = userEvent.setup();
+    renderHarness();
+
+    expect(screen.getByTestId("auth-required")).toHaveTextContent("null");
+
+    await user.click(screen.getByRole("button", { name: "Require auth" }));
+
+    expect(screen.getByTestId("auth-required")).toHaveTextContent("true");
+  });
+
+  // Logging out drops the session, clears the stored key and reloads so no
+  // stale state survives.
+  it("clears the session and reloads the page on logout", async () => {
+    const user = userEvent.setup();
+    const reload = vi.fn();
+    vi.spyOn(window, "location", "get").mockReturnValue({
+      ...window.location,
+      reload,
+    } as unknown as Location);
+    sessionStorage.setItem("SMART_KEY", "some-key");
+    renderHarness();
+
+    await user.click(screen.getByRole("button", { name: "Authenticate" }));
+    await user.click(screen.getByRole("button", { name: "Log out" }));
+
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+    expect(screen.getByTestId("expired")).toHaveTextContent("false");
+    expect(sessionStorage.getItem("SMART_KEY")).toBeNull();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when the hook is used outside a provider", () => {
+    // Suppress the error React logs for the thrown render.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => render(<Harness />)).toThrow("useAuth must be used within an AuthProvider");
+
+    consoleError.mockRestore();
   });
 });

--- a/ui/src/contexts/__tests__/AuthContext.test.tsx
+++ b/ui/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the authentication context, focused on when a failed request
+ * raises the session expiry prompt.
+ *
+ * @author John Grimes
+ */
+
+import userEvent from "@testing-library/user-event";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { notifyUnauthorized } from "../../services/sessionExpiry";
+import { render, screen } from "../../test/testUtils";
+import { AuthProvider, useAuth } from "../AuthContext";
+
+import type Client from "fhirclient/lib/Client";
+
+/** A stand-in for an authenticated fhirclient. */
+const stubClient = { state: {} } as Client;
+
+/**
+ * Harness exposing the parts of the authentication context under test.
+ *
+ * @returns The harness component.
+ */
+function Harness() {
+  const { isAuthenticated, sessionExpired, setClient, setSessionExpired } = useAuth();
+
+  return (
+    <>
+      <div data-testid="authenticated">{String(isAuthenticated)}</div>
+      <div data-testid="expired">{String(sessionExpired)}</div>
+      <button
+        onClick={() => {
+          setClient(stubClient);
+        }}
+      >
+        Authenticate
+      </button>
+      <button
+        onClick={() => {
+          setSessionExpired(false);
+        }}
+      >
+        Dismiss
+      </button>
+    </>
+  );
+}
+
+/**
+ * Renders the harness inside a provider.
+ *
+ * @returns The render result.
+ */
+function renderHarness() {
+  return render(
+    <AuthProvider>
+      <Harness />
+    </AuthProvider>,
+  );
+}
+
+describe("AuthContext", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  // FR-008, FR-010: an expiry while a session is held raises the prompt and
+  // drops the session so the access check falls back to the login prompt.
+  it("raises the expiry prompt and clears the session when authenticated", async () => {
+    const user = userEvent.setup();
+    sessionStorage.setItem("SMART_KEY", "some-key");
+    renderHarness();
+
+    await user.click(screen.getByRole("button", { name: "Authenticate" }));
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
+
+    act(() => {
+      notifyUnauthorized();
+    });
+
+    expect(screen.getByTestId("expired")).toHaveTextContent("true");
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+    expect(sessionStorage.getItem("SMART_KEY")).toBeNull();
+  });
+
+  // FR-011: there is no session to expire, so no prompt is raised. The stale
+  // key is still cleared.
+  it("raises no prompt when no session is held", () => {
+    sessionStorage.setItem("SMART_KEY", "stale-key");
+    renderHarness();
+
+    act(() => {
+      notifyUnauthorized();
+    });
+
+    expect(screen.getByTestId("expired")).toHaveTextContent("false");
+    expect(sessionStorage.getItem("SMART_KEY")).toBeNull();
+  });
+
+  // FR-008: this is the defect in #2676. Every expiry is reported, not only
+  // the first one in the life of the page.
+  it("raises the prompt again after re-authenticating", async () => {
+    const user = userEvent.setup();
+    renderHarness();
+
+    await user.click(screen.getByRole("button", { name: "Authenticate" }));
+    act(() => {
+      notifyUnauthorized();
+    });
+    expect(screen.getByTestId("expired")).toHaveTextContent("true");
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(screen.getByTestId("expired")).toHaveTextContent("false");
+
+    await user.click(screen.getByRole("button", { name: "Authenticate" }));
+    act(() => {
+      notifyUnauthorized();
+    });
+
+    expect(screen.getByTestId("expired")).toHaveTextContent("true");
+  });
+
+  // FR-009: concurrent failures collapse into a single prompt, so one dismiss
+  // is enough to clear it.
+  it("produces a single expiry from concurrent failures", async () => {
+    const user = userEvent.setup();
+    renderHarness();
+
+    await user.click(screen.getByRole("button", { name: "Authenticate" }));
+    act(() => {
+      notifyUnauthorized();
+      notifyUnauthorized();
+      notifyUnauthorized();
+    });
+    expect(screen.getByTestId("expired")).toHaveTextContent("true");
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(screen.getByTestId("expired")).toHaveTextContent("false");
+  });
+});

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -72,6 +72,9 @@ export type {
   UseSqlQueryRunResult,
 } from "./useSqlQueryRun";
 
+// Authentication.
+export { useLogin } from "./useLogin";
+
 // Other operations.
 export { useClipboard } from "./useClipboard";
 export { useDownloadFile } from "./useDownloadFile";

--- a/ui/src/hooks/useLogin.ts
+++ b/ui/src/hooks/useLogin.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Hook holding the pending and error state of a single user-initiated
+ * authorisation attempt. The state belongs to the control that started the
+ * attempt, so each login control reports its own progress and its own failure.
+ *
+ * @author John Grimes
+ */
+
+import { useCallback, useRef, useState } from "react";
+
+import { config } from "../config";
+import { initiateAuth } from "../services/auth";
+
+interface UseLoginResult {
+  /** Starts an authorisation attempt, unless one is already pending. */
+  login: () => Promise<void>;
+  /** Whether an authorisation attempt is currently under way. */
+  isPending: boolean;
+  /** The reason the last attempt failed, or null if none has. */
+  error: string | null;
+}
+
+/**
+ * Provides a login action together with its pending and error state.
+ *
+ * A successful attempt navigates the browser away to the authorisation server,
+ * so the pending state is deliberately left set: there is no completion to
+ * render. A failed attempt clears the pending state and records the reason, so
+ * the control can report it and be retried.
+ *
+ * @returns The login action and its pending and error state.
+ * @example
+ * const { login, isPending, error } = useLogin();
+ * return (
+ *   <>
+ *     <Button loading={isPending} onClick={() => void login()}>Log in</Button>
+ *     {error && <ErrorCallout message={error} />}
+ *   </>
+ * );
+ */
+export function useLogin(): UseLoginResult {
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Guards against a second attempt started before the pending state renders.
+  const pendingRef = useRef(false);
+
+  const login = useCallback(async () => {
+    if (pendingRef.current) return;
+    pendingRef.current = true;
+    setIsPending(true);
+    setError(null);
+
+    try {
+      await initiateAuth(config.fhirBaseUrl);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Authentication failed");
+      pendingRef.current = false;
+      setIsPending(false);
+    }
+  }, []);
+
+  return { login, isPending, error };
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -33,36 +33,22 @@ import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { AuthProvider } from "./contexts/AuthContext";
 import { ToastProvider } from "./contexts/ToastContext";
+import { notifyUnauthorized } from "./services/sessionExpiry";
 import { UnauthorizedError } from "./types/errors";
 import { setupGlobalErrorHandlers } from "./utils/errorHandler";
 
 setupGlobalErrorHandlers();
 
-// Module-level callback and deduplication flag for global 401 handling.
-let clearSession: (() => void) | null = null;
-let sessionCleared = false;
-
 /**
- * Registers the session clearing function from AuthContext. Called on mount
- * and after re-authentication to reset the deduplication flag.
- *
- * @param fn - The function to call when a 401 error is detected.
- */
-export function registerClearSession(fn: () => void): void {
-  clearSession = fn;
-  sessionCleared = false;
-}
-
-/**
- * Global error handler for TanStack Query. Triggers session clearing on
- * UnauthorizedError, with deduplication to prevent multiple dialogs.
+ * Global error handler for TanStack Query. Reports an authorisation failure to
+ * the authentication state, which decides whether it means the session expired
+ * or the user was never logged in.
  *
  * @param error - The error from a failed query or mutation.
  */
 function handleGlobalError(error: Error): void {
-  if (error instanceof UnauthorizedError && clearSession && !sessionCleared) {
-    sessionCleared = true;
-    clearSession();
+  if (error instanceof UnauthorizedError) {
+    notifyUnauthorized();
   }
 }
 

--- a/ui/src/pages/BulkSubmit.tsx
+++ b/ui/src/pages/BulkSubmit.tsx
@@ -28,7 +28,7 @@ import { CapabilityGuard } from "../components/auth/CapabilityGuard";
 import { BulkSubmitMonitorForm } from "../components/bulkSubmit/BulkSubmitMonitorForm";
 import { OperationOutcomeDisplay } from "../components/error/OperationOutcomeDisplay";
 import { JobProgressIndicator } from "../components/JobProgressIndicator";
-import { useAuth } from "../contexts/AuthContext";
+import { useToast } from "../contexts/ToastContext";
 import { useBulkSubmit } from "../hooks";
 
 import type { SubmitterIdentifier } from "../types/bulkSubmit";
@@ -39,11 +39,11 @@ import type { SubmitterIdentifier } from "../types/bulkSubmit";
  * @returns The bulk submit page component.
  */
 export function BulkSubmit() {
-  const { setError } = useAuth();
+  const { showToast } = useToast();
 
   // Monitor bulk submit operations. 401 errors handled globally.
   const monitor = useBulkSubmit({
-    onError: (error) => setError(error.message),
+    onError: (error) => showToast("Bulk submit failed", error.message),
   });
 
   // Derive display state from the hook.

--- a/ui/src/pages/Callback.tsx
+++ b/ui/src/pages/Callback.tsx
@@ -21,11 +21,11 @@
  * @author John Grimes
  */
 
-import { CrossCircledIcon } from "@radix-ui/react-icons";
-import { Box, Callout, Flex, Spinner, Text } from "@radix-ui/themes";
+import { Box, Flex, Spinner, Text } from "@radix-ui/themes";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 
+import { ErrorCallout } from "../components/error/ErrorCallout";
 import { useAuth } from "../contexts/AuthContext";
 import { clearReturnUrl, completeAuth, getReturnUrl } from "../services/auth";
 
@@ -65,16 +65,7 @@ export function Callback() {
   if (localError) {
     return (
       <Box p="6">
-        <Callout.Root color="red">
-          <Callout.Icon>
-            <CrossCircledIcon />
-          </Callout.Icon>
-          <Callout.Text>
-            <Text weight="bold">Authentication Failed</Text>
-            <br />
-            {localError}
-          </Callout.Text>
-        </Callout.Root>
+        <ErrorCallout title="Authentication failed" message={localError} />
       </Box>
     );
   }

--- a/ui/src/pages/Callback.tsx
+++ b/ui/src/pages/Callback.tsx
@@ -36,7 +36,7 @@ import { clearReturnUrl, completeAuth, getReturnUrl } from "../services/auth";
  */
 export function Callback() {
   const navigate = useNavigate();
-  const { setClient, setError } = useAuth();
+  const { setClient } = useAuth();
   const [localError, setLocalError] = useState<string | null>(null);
 
   // Track whether callback has been processed to prevent double-execution.
@@ -55,14 +55,12 @@ export function Callback() {
         clearReturnUrl();
         navigate(returnUrl, { replace: true });
       } catch (err) {
-        const message = err instanceof Error ? err.message : "Authentication failed";
-        setLocalError(message);
-        setError(message);
+        setLocalError(err instanceof Error ? err.message : "Authentication failed");
       }
     }
 
     handleCallback();
-  }, [navigate, setClient, setError]);
+  }, [navigate, setClient]);
 
   if (localError) {
     return (

--- a/ui/src/pages/Export.tsx
+++ b/ui/src/pages/Export.tsx
@@ -23,7 +23,7 @@
  */
 
 import { Box, Flex } from "@radix-ui/themes";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import { CapabilityGuard } from "../components/auth/CapabilityGuard";
 import { ExportCard } from "../components/export/ExportCard";
@@ -47,6 +47,13 @@ interface ExportJob {
 export function Export() {
   const { showToast } = useToast();
   const [exports, setExports] = useState<ExportJob[]>([]);
+
+  // Keep a stable identity, so a card that reports a failure from an effect
+  // does not re-fire it each time a notification re-renders the page.
+  const handleExportError = useCallback(
+    (message: string) => showToast("Export failed", message),
+    [showToast],
+  );
 
   const handleExport = (request: ExportRequest) => {
     const newExport: ExportJob = {
@@ -84,7 +91,7 @@ export function Export() {
                   key={exportJob.id}
                   request={exportJob.request}
                   createdAt={exportJob.createdAt}
-                  onError={(message) => showToast("Export failed", message)}
+                  onError={handleExportError}
                   onClose={() => handleCloseExport(exportJob.id)}
                 />
               ))}

--- a/ui/src/pages/Export.tsx
+++ b/ui/src/pages/Export.tsx
@@ -28,7 +28,7 @@ import { useState } from "react";
 import { CapabilityGuard } from "../components/auth/CapabilityGuard";
 import { ExportCard } from "../components/export/ExportCard";
 import { ExportForm } from "../components/export/ExportForm";
-import { useAuth } from "../contexts/AuthContext";
+import { useToast } from "../contexts/ToastContext";
 import { buildSearchParamMap } from "../hooks";
 
 import type { ExportRequest } from "../types/export";
@@ -45,7 +45,7 @@ interface ExportJob {
  * @returns The export page component.
  */
 export function Export() {
-  const { setError } = useAuth();
+  const { showToast } = useToast();
   const [exports, setExports] = useState<ExportJob[]>([]);
 
   const handleExport = (request: ExportRequest) => {
@@ -84,7 +84,7 @@ export function Export() {
                   key={exportJob.id}
                   request={exportJob.request}
                   createdAt={exportJob.createdAt}
-                  onError={(message) => setError(message)}
+                  onError={(message) => showToast("Export failed", message)}
                   onClose={() => handleCloseExport(exportJob.id)}
                 />
               ))}

--- a/ui/src/pages/Import.tsx
+++ b/ui/src/pages/Import.tsx
@@ -28,6 +28,7 @@ import { CapabilityGuard } from "../components/auth/CapabilityGuard";
 import { ImportCard } from "../components/import/ImportCard";
 import { ImportForm } from "../components/import/ImportForm";
 import { ImportPnpForm } from "../components/import/ImportPnpForm";
+import { useToast } from "../contexts/ToastContext";
 import { buildSearchParamMap } from "../hooks";
 
 import type { ImportJob, ImportRequest } from "../types/import";
@@ -42,8 +43,7 @@ export function Import() {
   // Track all import jobs.
   const [imports, setImports] = useState<ImportJob[]>([]);
 
-  // Track error messages for display.
-  const [, setError] = useState<string | null>(null);
+  const { showToast } = useToast();
 
   /**
    * Handles submission of a standard import.
@@ -125,7 +125,7 @@ export function Import() {
                 <ImportCard
                   key={job.id}
                   job={job}
-                  onError={(message) => setError(message)}
+                  onError={(message) => showToast("Import failed", message)}
                   onClose={() => handleCloseImport(job.id)}
                 />
               ))}

--- a/ui/src/pages/Import.tsx
+++ b/ui/src/pages/Import.tsx
@@ -22,7 +22,7 @@
  */
 
 import { Box, Flex, Tabs } from "@radix-ui/themes";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import { CapabilityGuard } from "../components/auth/CapabilityGuard";
 import { ImportCard } from "../components/import/ImportCard";
@@ -44,6 +44,13 @@ export function Import() {
   const [imports, setImports] = useState<ImportJob[]>([]);
 
   const { showToast } = useToast();
+
+  // The card reports a failure from an effect keyed on this callback, so it
+  // must keep a stable identity or each notification would trigger another.
+  const handleImportError = useCallback(
+    (message: string) => showToast("Import failed", message),
+    [showToast],
+  );
 
   /**
    * Handles submission of a standard import.
@@ -125,7 +132,7 @@ export function Import() {
                 <ImportCard
                   key={job.id}
                   job={job}
-                  onError={(message) => showToast("Import failed", message)}
+                  onError={handleImportError}
                   onClose={() => handleCloseImport(job.id)}
                 />
               ))}

--- a/ui/src/pages/Jobs.tsx
+++ b/ui/src/pages/Jobs.tsx
@@ -22,21 +22,8 @@
  * @author John Grimes
  */
 
-import { Box, Heading, Text } from "@radix-ui/themes";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
-
-import { jobCancel } from "../api";
 import { CapabilityGuard } from "../components/auth/CapabilityGuard";
-import { CancelJobDialog } from "../components/jobs/CancelJobDialog";
-import { requiresCancelConfirmation } from "../components/jobs/jobsPresentation";
-import { JobsTable } from "../components/jobs/JobsTable";
-import { config } from "../config";
-import { useAuth } from "../contexts/AuthContext";
-import { useToast } from "../contexts/ToastContext";
-import { JOBS_QUERY_KEY, useJobsList } from "../hooks";
-
-import type { JobSummary } from "../api";
+import { JobsContent } from "../components/jobs/JobsContent";
 
 /**
  * Page component listing the caller's jobs with live refresh and cancellation.
@@ -44,84 +31,5 @@ import type { JobSummary } from "../api";
  * @returns The jobs page component.
  */
 export function Jobs() {
-  const { fhirBaseUrl } = config;
-  const { client } = useAuth();
-  const accessToken = client?.state.tokenResponse?.access_token;
-  const queryClient = useQueryClient();
-  const { showToast } = useToast();
-
-  const jobsQuery = useJobsList();
-
-  // The job awaiting cancellation confirmation, or null when no dialog is open.
-  const [pendingJob, setPendingJob] = useState<JobSummary | null>(null);
-
-  const cancelMutation = useMutation<void, Error, JobSummary>({
-    mutationFn: (job) => jobCancel(fhirBaseUrl, { pollingUrl: job.url, accessToken }),
-    onSuccess: (_data, job) => {
-      void queryClient.invalidateQueries({ queryKey: JOBS_QUERY_KEY });
-      showToast(
-        job.status === "in-progress" ? "Job cancelled" : "Job removed",
-        `The ${job.operation} job has been removed.`,
-      );
-    },
-    onError: (error) => {
-      // On failure the job stays in the list; the toast explains why.
-      showToast("Could not cancel job", error.message);
-    },
-    onSettled: () => {
-      setPendingJob(null);
-    },
-  });
-
-  const handleCancelJob = (job: JobSummary) => {
-    // In-progress jobs are confirmed first; finished jobs are removed immediately.
-    if (requiresCancelConfirmation(job)) {
-      setPendingJob(job);
-    } else {
-      cancelMutation.mutate(job);
-    }
-  };
-
-  const handleConfirmCancel = () => {
-    if (pendingJob) {
-      cancelMutation.mutate(pendingJob);
-    }
-  };
-
-  return (
-    <CapabilityGuard>
-      {() => (
-        <>
-          <Box mb="4">
-            <Heading size="6" mb="1">
-              Jobs
-            </Heading>
-            <Text size="2" color="gray">
-              Background jobs you own on this server. The list refreshes automatically while jobs
-              are running.
-            </Text>
-          </Box>
-
-          <JobsTable
-            jobs={jobsQuery.data ?? []}
-            isLoading={jobsQuery.isLoading}
-            error={jobsQuery.error}
-            onRetry={() => void jobsQuery.refetch()}
-            onCancelJob={handleCancelJob}
-          />
-
-          <CancelJobDialog
-            job={pendingJob}
-            isCancelling={cancelMutation.isPending}
-            onConfirm={handleConfirmCancel}
-            onOpenChange={(open) => {
-              if (!open) {
-                setPendingJob(null);
-              }
-            }}
-          />
-        </>
-      )}
-    </CapabilityGuard>
-  );
+  return <CapabilityGuard>{() => <JobsContent />}</CapabilityGuard>;
 }

--- a/ui/src/pages/SqlOnFhir.tsx
+++ b/ui/src/pages/SqlOnFhir.tsx
@@ -23,7 +23,7 @@
  */
 
 import { Box, Flex, Heading } from "@radix-ui/themes";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import { CapabilityGuard } from "../components/auth/CapabilityGuard";
 import { SqlOnFhirForm } from "../components/sqlOnFhir/SqlOnFhirForm";
@@ -57,6 +57,17 @@ export function SqlOnFhir() {
   const [pageJobs, setPageJobs] = useState<PageJob[]>([]);
 
   const { showToast } = useToast();
+
+  // The cards report a failure from an effect keyed on this callback, so it
+  // must keep a stable identity or each notification would trigger another.
+  const handleViewError = useCallback(
+    (message: string) => showToast("View execution failed", message),
+    [showToast],
+  );
+  const handleSqlQueryError = useCallback(
+    (message: string) => showToast("SQL query failed", message),
+    [showToast],
+  );
 
   // Mutations: ViewDefinition save and SQL query Library save.
   const { mutateAsync: saveViewDefinition, isPending: isSavingViewDefinition } =
@@ -137,14 +148,14 @@ export function SqlOnFhir() {
                   <ViewCard
                     key={entry.job.id}
                     job={entry.job as ViewJob}
-                    onError={(message) => showToast("View execution failed", message)}
+                    onError={handleViewError}
                     onClose={() => handleCloseJob(entry.job.id)}
                   />
                 ) : (
                   <SqlQueryCard
                     key={entry.job.id}
                     job={entry.job as SqlQueryJob}
-                    onError={(message) => showToast("SQL query failed", message)}
+                    onError={handleSqlQueryError}
                     onClose={() => handleCloseJob(entry.job.id)}
                   />
                 ),

--- a/ui/src/pages/SqlOnFhir.tsx
+++ b/ui/src/pages/SqlOnFhir.tsx
@@ -30,6 +30,7 @@ import { SqlOnFhirForm } from "../components/sqlOnFhir/SqlOnFhirForm";
 import { SqlQueryCard } from "../components/sqlOnFhir/SqlQueryCard";
 import { extractRequestSql } from "../components/sqlOnFhir/sqlQueryFormHelpers";
 import { ViewCard } from "../components/sqlOnFhir/ViewCard";
+import { useToast } from "../contexts/ToastContext";
 import { useSaveSqlQueryLibrary, useSaveViewDefinition } from "../hooks";
 
 import type { SqlOnFhirMode } from "../components/sqlOnFhir/SqlOnFhirForm";
@@ -55,7 +56,7 @@ export function SqlOnFhir() {
   // they can be sorted by createdAt regardless of source.
   const [pageJobs, setPageJobs] = useState<PageJob[]>([]);
 
-  const [, setError] = useState<string | null>(null);
+  const { showToast } = useToast();
 
   // Mutations: ViewDefinition save and SQL query Library save.
   const { mutateAsync: saveViewDefinition, isPending: isSavingViewDefinition } =
@@ -136,14 +137,14 @@ export function SqlOnFhir() {
                   <ViewCard
                     key={entry.job.id}
                     job={entry.job as ViewJob}
-                    onError={(message) => setError(message)}
+                    onError={(message) => showToast("View execution failed", message)}
                     onClose={() => handleCloseJob(entry.job.id)}
                   />
                 ) : (
                   <SqlQueryCard
                     key={entry.job.id}
                     job={entry.job as SqlQueryJob}
-                    onError={(message) => setError(message)}
+                    onError={(message) => showToast("SQL query failed", message)}
                     onClose={() => handleCloseJob(entry.job.id)}
                   />
                 ),

--- a/ui/src/pages/__tests__/BulkSubmit.test.tsx
+++ b/ui/src/pages/__tests__/BulkSubmit.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the BulkSubmit page, covering the reporting of monitoring failures.
+ *
+ * @author John Grimes
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { render } from "../../test/testUtils";
+import { BulkSubmit } from "../BulkSubmit";
+
+import type { ReactNode } from "react";
+
+// Mock the toast context, which is where failures must be reported.
+const mockShowToast = vi.fn();
+vi.mock("../../contexts/ToastContext", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+// Mock the guard so the page content renders without an access check.
+vi.mock("../../components/auth/CapabilityGuard", () => ({
+  CapabilityGuard: ({ children }: { children: () => ReactNode }) => children(),
+}));
+
+// Mock the form, which plays no part in these assertions.
+vi.mock("../../components/bulkSubmit/BulkSubmitMonitorForm", () => ({
+  BulkSubmitMonitorForm: () => <div data-testid="bulk-submit-form" />,
+}));
+
+// Capture the options the page passes to the monitoring hook, so the test can
+// drive its error callback directly.
+let capturedOnError: ((error: Error) => void) | undefined;
+vi.mock("../../hooks", () => ({
+  useBulkSubmit: (options: { onError?: (error: Error) => void }) => {
+    capturedOnError = options.onError;
+    return { status: "idle" };
+  },
+}));
+
+describe("BulkSubmit page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOnError = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // FR-016: a bulk submit failure must produce a visible message.
+  it("reports a bulk submit failure to the user", () => {
+    render(<BulkSubmit />);
+
+    capturedOnError?.(new Error("Submission status request failed"));
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      "Bulk submit failed",
+      "Submission status request failed",
+    );
+  });
+});

--- a/ui/src/pages/__tests__/Export.test.tsx
+++ b/ui/src/pages/__tests__/Export.test.tsx
@@ -42,6 +42,10 @@ vi.mock("../../components/auth/CapabilityGuard", () => ({
     children(undefined),
 }));
 
+vi.mock("../../hooks", () => ({
+  buildSearchParamMap: () => undefined,
+}));
+
 // Mock the form so a single click starts an export.
 vi.mock("../../components/export/ExportForm", () => ({
   ExportForm: ({ onSubmit }: { onSubmit: (request: ExportRequest) => void }) => (

--- a/ui/src/pages/__tests__/Export.test.tsx
+++ b/ui/src/pages/__tests__/Export.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the Export page, covering the reporting of export failures.
+ *
+ * @author John Grimes
+ */
+
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "../../test/testUtils";
+import { Export } from "../Export";
+
+import type { ExportRequest } from "../../types/export";
+import type { ReactNode } from "react";
+
+// Mock the toast context, which is where failures must be reported.
+const mockShowToast = vi.fn();
+vi.mock("../../contexts/ToastContext", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+// Mock the guard so the page content renders without an access check.
+vi.mock("../../components/auth/CapabilityGuard", () => ({
+  CapabilityGuard: ({ children }: { children: (capabilities: undefined) => ReactNode }) =>
+    children(undefined),
+}));
+
+// Mock the form so a single click starts an export.
+vi.mock("../../components/export/ExportForm", () => ({
+  ExportForm: ({ onSubmit }: { onSubmit: (request: ExportRequest) => void }) => (
+    <button onClick={() => onSubmit({ level: "system" })}>Start export</button>
+  ),
+}));
+
+// Mock the card so a single click drives its error callback.
+vi.mock("../../components/export/ExportCard", () => ({
+  ExportCard: ({ onError }: { onError: (message: string) => void }) => (
+    <button onClick={() => onError("Download failed: connection reset")}>Fail export</button>
+  ),
+}));
+
+describe("Export page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // FR-015: the export card's error callback is the only channel for a failed
+  // file download, so it must reach the user.
+  it("reports an export failure to the user", async () => {
+    const user = userEvent.setup();
+
+    render(<Export />);
+
+    await user.click(screen.getByRole("button", { name: "Start export" }));
+    await user.click(screen.getByRole("button", { name: "Fail export" }));
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      "Export failed",
+      "Download failed: connection reset",
+    );
+  });
+});

--- a/ui/src/pages/__tests__/Import.test.tsx
+++ b/ui/src/pages/__tests__/Import.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the Import page, covering the reporting of import failures.
+ *
+ * @author John Grimes
+ */
+
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "../../test/testUtils";
+import { Import } from "../Import";
+
+import type { ImportRequest } from "../../types/import";
+import type { ReactNode } from "react";
+
+// Mock the toast context, which is where failures must be reported.
+const mockShowToast = vi.fn();
+vi.mock("../../contexts/ToastContext", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+// Mock the guard so the page content renders without an access check.
+vi.mock("../../components/auth/CapabilityGuard", () => ({
+  CapabilityGuard: ({ children }: { children: (capabilities: undefined) => ReactNode }) =>
+    children(undefined),
+}));
+
+vi.mock("../../hooks", () => ({
+  buildSearchParamMap: () => undefined,
+}));
+
+// Mock the forms so a single click starts an import.
+vi.mock("../../components/import/ImportForm", () => ({
+  ImportForm: ({ onSubmit }: { onSubmit: (request: ImportRequest) => void }) => (
+    <button onClick={() => onSubmit({} as ImportRequest)}>Start import</button>
+  ),
+}));
+vi.mock("../../components/import/ImportPnpForm", () => ({
+  ImportPnpForm: () => <div data-testid="import-pnp-form" />,
+}));
+
+// Mock the card so a single click drives its error callback.
+vi.mock("../../components/import/ImportCard", () => ({
+  ImportCard: ({ onError }: { onError: (message: string) => void }) => (
+    <button onClick={() => onError("Import job failed: invalid NDJSON")}>Fail import</button>
+  ),
+}));
+
+describe("Import page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // FR-017: an import job failure must produce a visible message.
+  it("reports an import failure to the user", async () => {
+    const user = userEvent.setup();
+
+    render(<Import />);
+
+    await user.click(screen.getByRole("button", { name: "Start import" }));
+    await user.click(screen.getByRole("button", { name: "Fail import" }));
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      "Import failed",
+      "Import job failed: invalid NDJSON",
+    );
+  });
+});

--- a/ui/src/pages/__tests__/SqlOnFhir.test.tsx
+++ b/ui/src/pages/__tests__/SqlOnFhir.test.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the SQL on FHIR page, covering the reporting of job failures.
+ *
+ * @author John Grimes
+ */
+
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "../../test/testUtils";
+import { SqlOnFhir } from "../SqlOnFhir";
+
+import type { ViewRunRequest } from "../../hooks";
+import type { SqlQueryRequest } from "../../types/sqlQuery";
+import type { ReactNode } from "react";
+
+// Mock the toast context, which is where failures must be reported.
+const mockShowToast = vi.fn();
+vi.mock("../../contexts/ToastContext", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+// Mock the guard so the page content renders without an access check.
+vi.mock("../../components/auth/CapabilityGuard", () => ({
+  CapabilityGuard: ({ children }: { children: () => ReactNode }) => children(),
+}));
+
+vi.mock("../../hooks", () => ({
+  useSaveViewDefinition: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useSaveSqlQueryLibrary: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("../../components/sqlOnFhir/sqlQueryFormHelpers", () => ({
+  extractRequestSql: () => "SELECT 1",
+}));
+
+// Mock the form so single clicks start each kind of job.
+vi.mock("../../components/sqlOnFhir/SqlOnFhirForm", () => ({
+  SqlOnFhirForm: ({
+    onExecuteViewDefinition,
+    onExecuteSqlQuery,
+  }: {
+    onExecuteViewDefinition: (request: ViewRunRequest) => void;
+    onExecuteSqlQuery: (request: SqlQueryRequest) => void;
+  }) => (
+    <>
+      <button onClick={() => onExecuteViewDefinition({ mode: "inline" } as ViewRunRequest)}>
+        Run view
+      </button>
+      <button onClick={() => onExecuteSqlQuery({ mode: "inline" } as SqlQueryRequest)}>
+        Run query
+      </button>
+    </>
+  ),
+}));
+
+// Mock the cards so single clicks drive their error callbacks.
+vi.mock("../../components/sqlOnFhir/ViewCard", () => ({
+  ViewCard: ({ onError }: { onError: (message: string) => void }) => (
+    <button onClick={() => onError("View run failed: unknown column")}>Fail view</button>
+  ),
+}));
+vi.mock("../../components/sqlOnFhir/SqlQueryCard", () => ({
+  SqlQueryCard: ({ onError }: { onError: (message: string) => void }) => (
+    <button onClick={() => onError("SQL query failed: syntax error")}>Fail query</button>
+  ),
+}));
+
+describe("SqlOnFhir page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // FR-017: a SQL on FHIR job failure must produce a visible message.
+  it("reports a view definition failure to the user", async () => {
+    const user = userEvent.setup();
+
+    render(<SqlOnFhir />);
+
+    await user.click(screen.getByRole("button", { name: "Run view" }));
+    await user.click(screen.getByRole("button", { name: "Fail view" }));
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      "View execution failed",
+      "View run failed: unknown column",
+    );
+  });
+
+  it("reports a SQL query failure to the user", async () => {
+    const user = userEvent.setup();
+
+    render(<SqlOnFhir />);
+
+    await user.click(screen.getByRole("button", { name: "Run query" }));
+    await user.click(screen.getByRole("button", { name: "Fail query" }));
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      "SQL query failed",
+      "SQL query failed: syntax error",
+    );
+  });
+});

--- a/ui/src/services/__tests__/sessionExpiry.test.ts
+++ b/ui/src/services/__tests__/sessionExpiry.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the session expiry notification bridge.
+ *
+ * @author John Grimes
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  notifyUnauthorized,
+  registerSessionExpiryHandler,
+} from "../sessionExpiry";
+
+describe("sessionExpiry", () => {
+  afterEach(() => {
+    // Leave no handler behind for the next test.
+    registerSessionExpiryHandler(() => {});
+    vi.restoreAllMocks();
+  });
+
+  // The bridge is used from the query cache, which can fire before the
+  // application has mounted.
+  it("does nothing when no handler is registered", () => {
+    expect(() => {
+      notifyUnauthorized();
+    }).not.toThrow();
+  });
+
+  it("invokes the registered handler", () => {
+    const handler = vi.fn();
+    registerSessionExpiryHandler(handler);
+
+    notifyUnauthorized();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  // FR-008: there is no deduplication here, so a second expiry is reported.
+  it("invokes the handler again on a second notification", () => {
+    const handler = vi.fn();
+    registerSessionExpiryHandler(handler);
+
+    notifyUnauthorized();
+    notifyUnauthorized();
+
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("replaces the handler when a second one is registered", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    registerSessionExpiryHandler(first);
+    registerSessionExpiryHandler(second);
+
+    notifyUnauthorized();
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/services/sessionExpiry.ts
+++ b/ui/src/services/sessionExpiry.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The bridge between a request that failed with an authorisation error and the
+ * authentication state that decides what to do about it. Keeping it here rather
+ * than in the application entry point means the path can be exercised without
+ * booting the whole application.
+ *
+ * There is deliberately no deduplication: raising the prompt is idempotent, so
+ * concurrent notifications produce a single prompt on their own.
+ *
+ * @author John Grimes
+ */
+
+// The handler registered by the authentication state, if it has mounted.
+let handler: (() => void) | null = null;
+
+/**
+ * Registers the function to call when a request fails with an authorisation
+ * error. Registering again replaces the previous handler.
+ *
+ * @param fn - The function to call on an authorisation failure.
+ */
+export function registerSessionExpiryHandler(fn: () => void): void {
+  handler = fn;
+}
+
+/**
+ * Reports that a request failed with an authorisation error. Does nothing when
+ * no handler has been registered.
+ */
+export function notifyUnauthorized(): void {
+  handler?.();
+}


### PR DESCRIPTION
Fixes three defects in the admin UI authentication flow, each of which left the user with no way to tell what the application was doing.

Resolves #2676 and #2678.

Clicking a login button produced no perceptible response. If authorisation could not be initiated, the reason was written to application-wide state that no component read, so the button simply looked broken and the only recovery was a page refresh. Login progress now belongs to the control that started the attempt: both the login prompt and the session expiry dialog show a spinner from the moment they are pressed, disable themselves so a second attempt cannot start, and display the reason for a failure next to the control before becoming usable again. The dialog no longer closes itself when "Log in" is pressed, so its feedback stays where the user asked for it.

The session expiry dialog appeared at most once per page load, because a deduplication flag intended to prevent duplicate dialogs was never reset. The flag is gone. An expiry now raises the dialog whenever the application actually holds an authenticated session, decided from state that already exists. As a side effect this makes the misleading dialog impossible on any page rather than only on the jobs page. The notification bridge moves out of the application entry point into its own service, which breaks an import cycle and makes the path from a failed request to the prompt testable on its own.

Visiting the jobs page while logged out started polling straight away behind the login prompt, producing a stream of failing requests. The job list query and its cancellation now live behind the access check, so nothing is requested on behalf of a user who is not permitted to request it.

Two things beyond the two issues, each in its own commit. Four pages passed an error callback into state that nothing rendered, so a failed export, import, bulk submit or SQL on FHIR job produced no message at all; for an export whose file download fails, that callback was the only channel there was. All four now raise a notification. Separately, the seven hand-built red callouts across the UI used three different icons, none at two of them, and set an alert role at only one; they now share a single presentation that always carries the warning icon and is always announced to assistive technology. Four of those sites change appearance as a result.

All admin UI quality gates pass: build, lint, duplication, 1161 unit tests at 87.97% statements and 80.84% branches, and 165 end-to-end tests. The suite gains regression coverage for all four reproductions described in the two issues, and each of the four was confirmed to fail against the base commit before these changes.

Still outstanding: manual verification against a deployed server. The automated coverage cannot exercise the real OAuth redirect, since mocked flows never navigate to an authorisation server.