### PR TITLE
Enforce the Admin UI quality gates and remove the end-to-end sleeps

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -1,3 +1,8 @@
+# Runs the Admin UI quality checks documented in ui/CONTRIBUTING.md. Called by
+# both test.yml and pre-release.yml.
+#
+# Author: John Grimes
+
 name: Test UI
 
 on:

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -27,11 +27,14 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Check duplication
+        run: bun run lint:duplication
+
       - name: Build
         run: bun run build
 
-      - name: Run unit tests
-        run: bun run test:run
+      - name: Run unit tests with coverage
+        run: bun run test:coverage
 
       - name: Install Playwright browsers
         # The pinned version must be kept in step with @playwright/test in

--- a/ui/CONTRIBUTING.md
+++ b/ui/CONTRIBUTING.md
@@ -93,6 +93,14 @@ bun run test:e2e:headed
   React primitives.
 - Use role-based selectors (`getByRole`, `getByText`) in E2E tests.
 - Mock network requests using `page.route()` in Playwright tests.
+- **Never use a fixed sleep in an E2E test.** `page.waitForTimeout()` is
+  rejected by linting, at error severity, for every test under `e2e/`. Wait on a
+  condition instead. Where the point of the test is that recurring work does
+  _not_ happen, and so there is no condition to wait for, install Playwright's
+  clock with `page.clock.install()` before navigating and advance it with
+  `page.clock.runFor()`. A test that proves a negative this way needs a positive
+  control alongside it, or it can pass without proving anything - see the
+  control in `e2e/jobs.spec.ts` for the pattern.
 
 ## Coding conventions
 
@@ -238,3 +246,8 @@ Run the following after making code changes to ensure quality:
 - `bun run lint:duplication`
 - `bun run test:coverage`
 - `bun run test:e2e`
+
+Continuous integration runs all five, along with the `bun run format:check`
+described above, so a coverage or duplication threshold breached locally will
+also fail the build. Running them before opening a pull request is the faster
+way to find out.

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -31,6 +31,7 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsdoc": "^62.0.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-playwright": "^2.11.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "eslint-plugin-unicorn": "^62.0.0",
@@ -1124,6 +1125,8 @@
     "eslint-plugin-jsdoc": ["eslint-plugin-jsdoc@62.0.0", "", { "dependencies": { "@es-joy/jsdoccomment": "~0.79.0", "@es-joy/resolve.exports": "1.2.0", "are-docs-informative": "^0.0.2", "comment-parser": "1.4.1", "debug": "^4.4.3", "escape-string-regexp": "^4.0.0", "espree": "^11.0.0", "esquery": "^1.7.0", "html-entities": "^2.6.0", "object-deep-merge": "^2.0.0", "parse-imports-exports": "^0.2.4", "semver": "^7.7.3", "spdx-expression-parse": "^4.0.0", "to-valid-identifier": "^1.0.0" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0" } }, "sha512-sNdIGLAvjFK3pB0SYFW74iXODZ4ifF8Ax13Wgq8jKepKnrCFzGo7+jRZfLf70h81SD7lPYnTE7MR2nhYSvaLTA=="],
 
     "eslint-plugin-jsx-a11y": ["eslint-plugin-jsx-a11y@6.10.2", "", { "dependencies": { "aria-query": "^5.3.2", "array-includes": "^3.1.8", "array.prototype.flatmap": "^1.3.2", "ast-types-flow": "^0.0.8", "axe-core": "^4.10.0", "axobject-query": "^4.1.0", "damerau-levenshtein": "^1.0.8", "emoji-regex": "^9.2.2", "hasown": "^2.0.2", "jsx-ast-utils": "^3.3.5", "language-tags": "^1.0.9", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "safe-regex-test": "^1.0.3", "string.prototype.includes": "^2.0.1" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9" } }, "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q=="],
+
+    "eslint-plugin-playwright": ["eslint-plugin-playwright@2.11.0", "", { "dependencies": { "globals": "^17.3.0" }, "peerDependencies": { "eslint": ">=8.40.0" } }, "sha512-zOIEYyv1TSn2izXkyg/yj0LXc4YBQI6pl3xIFWwMCcXt/dgQCz8dBqXiXFMoM3xc/GqZThAtaGYo8aPu/vBd+Q=="],
 
     "eslint-plugin-react-dom": ["eslint-plugin-react-dom@2.4.0", "", { "dependencies": { "@eslint-react/ast": "2.4.0", "@eslint-react/core": "2.4.0", "@eslint-react/eff": "2.4.0", "@eslint-react/shared": "2.4.0", "@eslint-react/var": "2.4.0", "@typescript-eslint/scope-manager": "^8.50.1", "@typescript-eslint/types": "^8.50.1", "@typescript-eslint/utils": "^8.50.1", "compare-versions": "^6.1.1", "string-ts": "^2.3.1", "ts-pattern": "^5.9.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-nzBLj2bD2JJuIJlonENAE9Dp8Sy9Gw7Y45Y4mwjJ8PLV6hABP6W/sgeF0NXpzBiyClXRnjoCPRwylY0XjUaR+w=="],
 
@@ -2370,6 +2373,8 @@
     "eslint-plugin-jsdoc/esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
     "eslint-plugin-jsdoc/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "eslint-plugin-playwright/globals": ["globals@17.8.0", "", {}, "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ=="],
 
     "eslint-plugin-unicorn/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 

--- a/ui/e2e/auth.spec.ts
+++ b/ui/e2e/auth.spec.ts
@@ -257,6 +257,10 @@ test.describe("Authentication", () => {
     test("raises the expiry dialog again after re-authenticating", async ({
       page,
     }) => {
+      // The clock is installed before authenticating, since that navigates, and
+      // the page's timers must be under the test's control from the outset.
+      await page.clock.install();
+
       await setupAuthRequiredMocks(page);
       await page.route("**/$jobs*", async (route) => {
         await route.fulfill({ status: 401, body: "" });
@@ -280,7 +284,9 @@ test.describe("Authentication", () => {
         jobsAfterExpiry += 1;
         await route.fulfill({ status: 401, body: "" });
       });
-      await page.waitForTimeout(11000);
+      // Advancing well past the refresh interval leaves the count at zero, so
+      // the page has genuinely stopped polling rather than merely not polled yet.
+      await page.clock.runFor(30000);
       expect(jobsAfterExpiry).toBe(0);
 
       // Re-authenticate, and let a further request fail.

--- a/ui/e2e/jobs.spec.ts
+++ b/ui/e2e/jobs.spec.ts
@@ -213,6 +213,10 @@ test.describe("Jobs page", () => {
   test("shows only the login prompt when logged out, and issues no requests", async ({
     page,
   }) => {
+    // The clock is installed before any navigation, so that the page's timers
+    // are under the test's control from the outset.
+    await page.clock.install();
+
     await mockMetadata(page, mockCapabilityStatementWithAuth);
 
     let jobsRequests = 0;
@@ -228,12 +232,48 @@ test.describe("Jobs page", () => {
     ).toBeVisible();
     await expect(page.getByRole("alertdialog")).toBeHidden();
 
-    // Wait past the slow refresh interval to confirm nothing polls behind the
-    // prompt.
-    await page.waitForTimeout(11000);
+    // Advance the clock well past the slow refresh interval to confirm nothing
+    // polls behind the prompt.
+    await page.clock.runFor(30000);
 
     expect(jobsRequests).toBe(0);
     await expect(page.getByRole("alertdialog")).toBeHidden();
+  });
+
+  // Guards the two assertions that no job list request is issued - the one
+  // above, and its counterpart in auth.spec.ts - against passing vacuously.
+  // Both rely on advancing a fake clock past the refresh interval, so if
+  // installing that clock were to suppress polling rather than drive it, they
+  // would hold for the wrong reason. The count must rise across two successive
+  // advances, which the flushing of a single pending timer would not satisfy.
+  test("keeps polling as the fake clock advances past the refresh interval", async ({
+    page,
+  }) => {
+    await page.clock.install();
+
+    let jobsRequests = 0;
+    await page.route("**/$jobs*", async (route) => {
+      jobsRequests += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/fhir+json",
+        body: jobsBody([exportJob("job-1", "completed")]),
+      });
+    });
+
+    await page.goto("/admin/jobs");
+    await expect(
+      page.getByRole("cell", { name: "export", exact: true }),
+    ).toBeVisible();
+
+    const afterLoad = jobsRequests;
+
+    await page.clock.runFor(30000);
+    await expect.poll(() => jobsRequests).toBeGreaterThan(afterLoad);
+    const afterFirstAdvance = jobsRequests;
+
+    await page.clock.runFor(30000);
+    await expect.poll(() => jobsRequests).toBeGreaterThan(afterFirstAdvance);
   });
 
   test("removes a finished job without confirmation", async ({ page }) => {

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -25,6 +25,7 @@ import reactHooks from "eslint-plugin-react-hooks";
 import jsxA11y from "eslint-plugin-jsx-a11y";
 import jsdoc from "eslint-plugin-jsdoc";
 import importPlugin from "eslint-plugin-import";
+import playwright from "eslint-plugin-playwright";
 import unicorn from "eslint-plugin-unicorn";
 import vitest from "eslint-plugin-vitest";
 import { defineConfig, globalIgnores } from "eslint/config";
@@ -117,6 +118,24 @@ export default defineConfig([
       ...vitest.configs.recommended.rules,
       // Relax JSDoc requirements for test files.
       "jsdoc/require-jsdoc": "off",
+    },
+  },
+
+  // End-to-end test configuration.
+  {
+    files: ["e2e/**/*.spec.ts"],
+    plugins: {
+      playwright,
+    },
+    rules: {
+      // A fixed sleep makes a test slow when it passes and flaky when it does
+      // not, because the duration is a guess about the machine rather than a
+      // statement about the application. Wait on a condition instead, or drive
+      // Playwright's clock when the point is that something recurring does not
+      // happen. Set to error rather than warning because `eslint .` exits
+      // successfully in the presence of warnings, so a warning would gate
+      // nothing.
+      "playwright/no-wait-for-timeout": "error",
     },
   },
 ]);

--- a/ui/package.json
+++ b/ui/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsdoc": "^62.0.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
+    "eslint-plugin-playwright": "^2.11.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "eslint-plugin-unicorn": "^62.0.0",


### PR DESCRIPTION
Closes #2685. Closes #2690.

`ui/CONTRIBUTING.md` documents five quality checks, but CI ran only three of them. Unit tests ran without coverage, so the 80% thresholds were never applied, and the duplication check did not run at all. Two of the five gates therefore existed only as a local convention, and a change could erode coverage or raise duplication past its threshold while still showing a green build. Both steps are now in the workflow. The thresholds themselves are unchanged - this enforces what was already configured. Each gate was observed failing on a deliberate breach before being switched on.

Separately, two end-to-end tests proved that no job list request is issued by sleeping for eleven seconds each to outlast the idle refresh interval, making them by a wide margin the two slowest tests in the suite. Both now drive Playwright's clock instead, advancing thirty seconds of fake time and so proving strictly more than the sleeps did, in under a second. No application code changes, and the refresh interval keeps no test-only seam.

Because both tests assert a negative, a positive control accompanies them. It would fail if the fake clock ever stopped driving the refetch, which would otherwise let the two assertions quietly decay into tautologies. A lint rule at error severity keeps fixed sleeps from returning; only that one rule is configured, because the plugin's recommended preset makes it a warning and `eslint .` exits successfully in the presence of warnings.

The jobs test went from 11.8s to under a second, and the auth test from 14.3s to roughly two. The suite is 166 tests and runs no slower than before.