### PR TITLE
Stop job deletion racing the work it cancels

### DIFF
--- a/server/src/main/java/au/csiro/pathling/async/AsyncAspect.java
+++ b/server/src/main/java/au/csiro/pathling/async/AsyncAspect.java
@@ -192,7 +192,8 @@ public class AsyncAspect {
                   executor.submit(
                       () -> {
                         // Resolve the job once, up front. See removeFilesIfOwned for why the
-                        // clean-up on the way out cannot look it up again.
+                        // clean-up on the way out cannot look it up again, and for what an empty
+                        // result here means.
                         final Job<?> currentJob = jobRegistry.get(jobId);
                         boolean failed = false;
                         try {
@@ -309,11 +310,17 @@ public class AsyncAspect {
    * output, whether or not a client asked for it to be deleted.
    *
    * <p>The job is passed in rather than looked up, because by this point a {@code DELETE} may
-   * already have removed it from the registry. Resolving it when the task starts is safe even
-   * though the task is submitted from inside {@link JobRegistry#getOrCreate}: that method and
-   * {@link JobRegistry#get} are both synchronized, so the lookup blocks until the registration
-   * completes, and no {@code DELETE} can precede it because the client does not learn the job
-   * identifier until the kick-off response is returned.
+   * already have removed it from the registry, and a lookup would then find nothing and skip a
+   * removal that is owed.
+   *
+   * <p>A job that was already absent when the task started owns its removal too. The task resolves
+   * the job as its first statement, and {@link JobRegistry#getOrCreate} holds the same monitor as
+   * {@link JobRegistry#get} until the registration completes, so the lookup cannot observe the gap
+   * before registration. The only way it can come back empty is a {@code DELETE} that removed the
+   * job in the narrow window between the task entering its body and that first statement running.
+   * Such a request cannot have taken the claim, because the work had not terminated when it asked,
+   * and it is the only thing in the server that removes a job from the registry. Removing an absent
+   * directory is a no-op, so nothing is lost if that reasoning is ever widened.
    *
    * <p>Nothing is thrown from here, because this runs in a {@code finally} block where an
    * incidental exception would replace the job's own.
@@ -326,7 +333,7 @@ public class AsyncAspect {
       @Nonnull final String jobId, @Nullable final Job<?> job, final boolean failed) {
     // markTerminatedAndClaim is what records that the job's thread has finished, so it has to be
     // evaluated before any short-circuiting on the failure flag.
-    final boolean claimedDeletion = job != null && job.markTerminatedAndClaim();
+    final boolean claimedDeletion = job == null || job.markTerminatedAndClaim();
     if (!claimedDeletion && !failed) {
       return;
     }

--- a/server/src/main/java/au/csiro/pathling/async/AsyncAspect.java
+++ b/server/src/main/java/au/csiro/pathling/async/AsyncAspect.java
@@ -191,9 +191,9 @@ public class AsyncAspect {
               final Future<IBaseResource> result =
                   executor.submit(
                       () -> {
-                        // Resolve the job once, up front. See resolveJobAtStart for why the
-                        // clean-up below cannot look it up again.
-                        final Job<?> currentJob = resolveJobAtStart(jobId);
+                        // Resolve the job once, up front. See removeFilesIfOwned for why the
+                        // clean-up on the way out cannot look it up again.
+                        final Job<?> currentJob = jobRegistry.get(jobId);
                         boolean failed = false;
                         try {
                           diagnosticContext.configureScope(true);
@@ -302,29 +302,18 @@ public class AsyncAspect {
   }
 
   /**
-   * Resolves the job that the submitted task is about to run, at the point the task starts.
-   *
-   * <p>By the time the task unwinds, a {@code DELETE} may already have removed the job from the
-   * registry, so the clean-up on the way out cannot look it up again and has to use what is
-   * resolved here. Resolving it here is safe even though the task is submitted from inside {@link
-   * JobRegistry#getOrCreate}: that method and {@link JobRegistry#get} are both synchronized, so
-   * this lookup blocks until the registration completes, and no {@code DELETE} can precede it
-   * because the client does not learn the job identifier until the kick-off response is returned.
-   *
-   * @param jobId the identifier of the job being run
-   * @return the job, or null if it is not in the registry
-   */
-  @Nullable
-  private Job<?> resolveJobAtStart(@Nonnull final String jobId) {
-    return jobRegistry.get(jobId);
-  }
-
-  /**
    * Removes the job's output directory if the job's own thread owns the removal, as it unwinds.
    *
    * <p>That thread is the last party to touch the output, so it owns the removal whenever a client
    * has already asked for the job to be deleted. A job that failed also removes its own partial
    * output, whether or not a client asked for it to be deleted.
+   *
+   * <p>The job is passed in rather than looked up, because by this point a {@code DELETE} may
+   * already have removed it from the registry. Resolving it when the task starts is safe even
+   * though the task is submitted from inside {@link JobRegistry#getOrCreate}: that method and
+   * {@link JobRegistry#get} are both synchronized, so the lookup blocks until the registration
+   * completes, and no {@code DELETE} can precede it because the client does not learn the job
+   * identifier until the kick-off response is returned.
    *
    * <p>Nothing is thrown from here, because this runs in a {@code finally} block where an
    * incidental exception would replace the job's own.

--- a/server/src/main/java/au/csiro/pathling/async/AsyncAspect.java
+++ b/server/src/main/java/au/csiro/pathling/async/AsyncAspect.java
@@ -29,7 +29,9 @@ import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Arrays;
 import java.util.List;
@@ -189,6 +191,10 @@ public class AsyncAspect {
               final Future<IBaseResource> result =
                   executor.submit(
                       () -> {
+                        // Resolve the job once, up front. See resolveJobAtStart for why the
+                        // clean-up below cannot look it up again.
+                        final Job<?> currentJob = resolveJobAtStart(jobId);
+                        boolean failed = false;
                         try {
                           diagnosticContext.configureScope(true);
                           SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -198,13 +204,13 @@ public class AsyncAspect {
                           // access it without
                           // needing to look it up from the servlet request (which may have been
                           // recycled).
-                          final Job<?> currentJob = jobRegistry.get(jobId);
                           if (currentJob != null) {
                             AsyncJobContext.setCurrentJob(currentJob);
                           }
 
                           return (IBaseResource) joinPoint.proceed();
                         } catch (final Throwable e) {
+                          failed = true;
                           // Unwrap the actual exception from the aspect proxy wrapper, if needed.
                           final Throwable actualEx = unwrapFromProxy(e);
 
@@ -223,14 +229,12 @@ public class AsyncAspect {
                                 ErrorReportingInterceptor.getReportableError(convertedError)
                                     .getMessage());
                           }
-                          // Any (partial) files may be deleted if an unexpected error was thrown
-                          // during the processing
-                          jobProvider.deleteJobFiles(jobId);
                           throw new IllegalStateException(
                               "Problem processing request asynchronously", actualEx);
                         } finally {
                           AsyncJobContext.clear();
                           cleanUpAfterJob(spark, jobId);
+                          removeFilesIfOwned(jobId, currentJob, failed);
                         }
                       });
               final Optional<String> ownerId = getCurrentUserId(authentication);
@@ -295,6 +299,53 @@ public class AsyncAspect {
                     new IllegalArgumentException(
                         "Method annotated with @AsyncSupported must include a ServletRequestDetails"
                             + " parameter"));
+  }
+
+  /**
+   * Resolves the job that the submitted task is about to run, at the point the task starts.
+   *
+   * <p>By the time the task unwinds, a {@code DELETE} may already have removed the job from the
+   * registry, so the clean-up on the way out cannot look it up again and has to use what is
+   * resolved here. Resolving it here is safe even though the task is submitted from inside {@link
+   * JobRegistry#getOrCreate}: that method and {@link JobRegistry#get} are both synchronized, so
+   * this lookup blocks until the registration completes, and no {@code DELETE} can precede it
+   * because the client does not learn the job identifier until the kick-off response is returned.
+   *
+   * @param jobId the identifier of the job being run
+   * @return the job, or null if it is not in the registry
+   */
+  @Nullable
+  private Job<?> resolveJobAtStart(@Nonnull final String jobId) {
+    return jobRegistry.get(jobId);
+  }
+
+  /**
+   * Removes the job's output directory if the job's own thread owns the removal, as it unwinds.
+   *
+   * <p>That thread is the last party to touch the output, so it owns the removal whenever a client
+   * has already asked for the job to be deleted. A job that failed also removes its own partial
+   * output, whether or not a client asked for it to be deleted.
+   *
+   * <p>Nothing is thrown from here, because this runs in a {@code finally} block where an
+   * incidental exception would replace the job's own.
+   *
+   * @param jobId the identifier of the job that has just finished
+   * @param job the job, or null if it was not in the registry when the task started
+   * @param failed whether the job's work threw
+   */
+  private void removeFilesIfOwned(
+      @Nonnull final String jobId, @Nullable final Job<?> job, final boolean failed) {
+    // markTerminatedAndClaim is what records that the job's thread has finished, so it has to be
+    // evaluated before any short-circuiting on the failure flag.
+    final boolean claimedDeletion = job != null && job.markTerminatedAndClaim();
+    if (!claimedDeletion && !failed) {
+      return;
+    }
+    try {
+      jobProvider.deleteJobFiles(jobId);
+    } catch (final IOException | RuntimeException e) {
+      JobProvider.reportFileRemovalFailure(jobId, e);
+    }
   }
 
   private void cleanUpAfterJob(@Nonnull final SparkSession spark, @Nonnull final String requestId) {

--- a/server/src/main/java/au/csiro/pathling/async/Job.java
+++ b/server/src/main/java/au/csiro/pathling/async/Job.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -75,8 +76,27 @@ public class Job<T> {
   /** A consumer that modifies the HTTP response for this job, such as adding headers. */
   @Setter private Consumer<HttpServletResponse> responseModification;
 
-  /** Indicates whether this job has been marked for deletion. */
-  @Setter private boolean markedAsDeleted;
+  /**
+   * Indicates whether a client has asked for this job to be deleted. Guarded by this instance's
+   * monitor and only ever set through {@link #markDeletedAndClaim()}.
+   */
+  @Getter(AccessLevel.NONE)
+  private boolean markedAsDeleted;
+
+  /**
+   * Indicates whether the thread executing this job's work has finished unwinding. This is not the
+   * same as the job's future being done: cancelling a future whose task has already started reports
+   * the future as done immediately, while the work carries on. Guarded by this instance's monitor.
+   */
+  @Getter(AccessLevel.NONE)
+  private boolean terminated;
+
+  /**
+   * Indicates whether some party has taken responsibility for removing this job's output directory.
+   * Once set it never clears. Guarded by this instance's monitor.
+   */
+  @Getter(AccessLevel.NONE)
+  private boolean deletionClaimed;
 
   /**
    * The asynchronous wire contract this job follows. Under {@link
@@ -156,5 +176,84 @@ public class Job<T> {
    */
   public boolean isCancelled() {
     return result.isCancelled();
+  }
+
+  /**
+   * Checks whether a client has asked for this job to be deleted.
+   *
+   * @return true if the job has been marked for deletion, false otherwise
+   */
+  public synchronized boolean isMarkedAsDeleted() {
+    return markedAsDeleted;
+  }
+
+  /**
+   * Checks whether the thread executing this job's work has finished unwinding.
+   *
+   * @return true if the work has terminated, false otherwise
+   */
+  public synchronized boolean isTerminated() {
+    return terminated;
+  }
+
+  /**
+   * Records that a client has asked for this job to be deleted, and determines whether the caller
+   * owns the removal of the job's output directory.
+   *
+   * <p>Called by the request handling the deletion. A {@code true} return obliges the caller to
+   * remove the directory; a {@code false} return means the job's own thread has not finished yet
+   * and will perform the removal as it exits.
+   *
+   * @return true if the caller has taken responsibility for removing the job's output directory
+   */
+  public synchronized boolean markDeletedAndClaim() {
+    markedAsDeleted = true;
+    return terminated && claim();
+  }
+
+  /**
+   * Records that the thread executing this job's work has finished unwinding, and determines
+   * whether that thread owns the removal of the job's output directory.
+   *
+   * <p>Called by the job's own thread as it exits. A {@code true} return obliges the caller to
+   * remove the directory; a {@code false} return means either that no client has asked for the job
+   * to be deleted, or that the request handling the deletion has already removed it.
+   *
+   * @return true if the caller has taken responsibility for removing the job's output directory
+   */
+  public synchronized boolean markTerminatedAndClaim() {
+    markTerminated();
+    return markedAsDeleted && claim();
+  }
+
+  /**
+   * Records that the thread executing this job's work has finished unwinding, without contending
+   * for the removal of the job's output directory.
+   *
+   * <p>Called at registration time for jobs whose work is not run by the asynchronous request
+   * machinery. No thread will ever signal termination for such a job, so marking it terminated up
+   * front is what allows a deletion request to perform its own cleanup rather than deferring it to
+   * a thread that never arrives.
+   */
+  public synchronized void markTerminated() {
+    terminated = true;
+  }
+
+  /**
+   * Takes the single-use claim on removing this job's output directory, if it is still free.
+   *
+   * <p>Both entry points call this from inside the instance monitor, so their bodies are totally
+   * ordered. Whichever runs second observes the flag written by the first, which is what guarantees
+   * that at least one party claims once both have been called; this flag is what guarantees that at
+   * most one does.
+   *
+   * @return true if the claim was free and has now been taken by the caller
+   */
+  private synchronized boolean claim() {
+    if (deletionClaimed) {
+      return false;
+    }
+    deletionClaimed = true;
+    return true;
   }
 }

--- a/server/src/main/java/au/csiro/pathling/async/Job.java
+++ b/server/src/main/java/au/csiro/pathling/async/Job.java
@@ -232,7 +232,7 @@ public class Job<T> {
    *
    * <p>Called at registration time for jobs whose work is not run by the asynchronous request
    * machinery. No thread will ever signal termination for such a job, so marking it terminated up
-   * front is what allows a deletion request to perform its own cleanup rather than deferring it to
+   * front is what allows a deletion request to perform its own clean-up rather than deferring it to
    * a thread that never arrives.
    */
   public synchronized void markTerminated() {

--- a/server/src/main/java/au/csiro/pathling/async/JobProvider.java
+++ b/server/src/main/java/au/csiro/pathling/async/JobProvider.java
@@ -24,6 +24,7 @@ import static java.util.Objects.requireNonNull;
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.errors.AccessDeniedError;
 import au.csiro.pathling.errors.ErrorHandlingInterceptor;
+import au.csiro.pathling.errors.ErrorReportingInterceptor;
 import au.csiro.pathling.errors.ResourceNotFoundError;
 import au.csiro.pathling.io.JobDirectoryFileSystem;
 import au.csiro.pathling.security.PathlingAuthority;
@@ -40,8 +41,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.OperationOutcome;
@@ -174,7 +173,8 @@ public class JobProvider {
   private void handleJobDeleteRequest(final Job<?> job) {
     /*
     Two possible situations:
-      - The initial kick-off request is still ongoing -> cancel it and delete the partial files
+      - The initial kick-off request is still ongoing -> cancel it and let the job's own thread
+        remove the partial files as it exits
       - The initial kick-off request is complete (and the client may have already downloaded the
         files)
         -> interpret delete request from client as "do no longer need them". Depending on the
@@ -188,45 +188,72 @@ public class JobProvider {
     if (job.isMarkedAsDeleted()) {
       throw new ResourceNotFoundException("Already deleted this job.");
     }
-    job.setMarkedAsDeleted(true);
+    // Whichever party is last owns the removal of the job's output directory: this request if the
+    // work has already stopped, otherwise the job's own thread as it exits. Removing it here while
+    // tasks are still writing into it would leave output behind that nothing ever cleans up.
+    final boolean removeFilesNow = job.markDeletedAndClaim();
     if (!job.getResult().isDone()) {
       job.getResult().cancel(false);
-      // Currently, only the files up until "now" will be deleted. Anything that is created between
-      // the cancel request and the job actually being cancelled by spark will remain on the disk
     }
-    try {
-      deleteJobFiles(job.getId());
-    } catch (final IOException e) {
-      throw new InternalErrorException("Failed to delete files associated with the job.", e);
-    } finally {
-      final boolean removed = jobRegistry.remove(job);
-      if (removed) {
-        log.debug("Removed job {} from registry.", job.getId());
-      } else {
-        log.warn(
-            "Failed to remove job {} from registry. This might in wrong caching results.",
-            job.getId());
-      }
+    if (removeFilesNow) {
+      tryDeleteJobFiles(job.getId());
+    }
+    final boolean removed = jobRegistry.remove(job);
+    if (removed) {
+      log.debug("Removed job {} from registry.", job.getId());
+    } else {
+      log.warn(
+          "Failed to remove job {} from registry. This might in wrong caching results.",
+          job.getId());
     }
     throw new ProcessingNotCompletedException(
         "The job and its resources will be deleted.", buildDeletionOutcome());
   }
 
   /**
-   * Deletes the files associated with a job from the file system.
+   * Deletes the files associated with a job from the file system. Deleting a directory that does
+   * not exist is a normal outcome and is not reported as a failure.
    *
    * @param jobId the ID of the job whose files should be deleted
-   * @throws IOException if file deletion fails
+   * @throws IOException if the directory exists but could not be deleted
    */
   public void deleteJobFiles(final String jobId) throws IOException {
-    final FileSystem fs = jobDirectoryFileSystem.getFileSystem();
-    final Path jobDirToDel = jobDirectoryFileSystem.jobDirectory(jobId);
-    log.debug("Deleting dir {}", jobDirToDel);
-    final boolean deleted = fs.delete(jobDirToDel, true);
-    if (!deleted) {
-      log.warn("Failed to delete dir {}", jobDirToDel);
+    log.debug("Deleting job directory for job {}", jobId);
+    jobDirectoryFileSystem.deleteJobDirectory(jobId);
+    log.debug("Deleted job directory for job {}", jobId);
+  }
+
+  /**
+   * Removes the files associated with a job, reporting a failure rather than propagating it. By the
+   * time this runs the job has been cancelled, so there is nothing the client can usefully retry.
+   *
+   * @param jobId the ID of the job whose files should be removed
+   */
+  private void tryDeleteJobFiles(@Nonnull final String jobId) {
+    try {
+      deleteJobFiles(jobId);
+    } catch (final IOException e) {
+      reportFileRemovalFailure(jobId, e);
     }
-    log.debug("Deleted dir {}", jobDirToDel);
+  }
+
+  /**
+   * Records a failure to remove a job's output directory, in the server log and in error reporting.
+   * The operator is the only party who can act on it: the files are orphaned in the warehouse and
+   * need manual attention.
+   *
+   * <p>Shared with {@link AsyncAspect}, which performs the same removal from the job's own thread
+   * and has no response left to report the failure on.
+   *
+   * @param jobId the ID of the job whose files could not be removed
+   * @param cause the failure encountered while removing them
+   */
+  public static void reportFileRemovalFailure(
+      @Nonnull final String jobId, @Nonnull final Throwable cause) {
+    log.error("Failed to remove the output directory of job {}.", jobId, cause);
+    ErrorReportingInterceptor.reportExceptionToSentry(
+        new InternalErrorException(
+            "Failed to remove the output directory of job %s.".formatted(jobId), cause));
   }
 
   private IBaseResource handleJobGetRequest(

--- a/server/src/main/java/au/csiro/pathling/async/JobProvider.java
+++ b/server/src/main/java/au/csiro/pathling/async/JobProvider.java
@@ -205,9 +205,7 @@ public class JobProvider {
       // own. Those checks remain as a backstop.
       spark.sparkContext().cancelJobGroup(job.getId());
     }
-    if (removeFilesNow) {
-      tryDeleteJobFiles(job.getId());
-    }
+    final boolean removalFailed = removeFilesNow && !tryDeleteJobFiles(job.getId());
     final boolean removed = jobRegistry.remove(job);
     if (removed) {
       log.debug("Removed job {} from registry.", job.getId());
@@ -217,7 +215,7 @@ public class JobProvider {
           job.getId());
     }
     throw new ProcessingNotCompletedException(
-        "The job and its resources will be deleted.", buildDeletionOutcome());
+        "The job and its resources will be deleted.", buildDeletionOutcome(removalFailed));
   }
 
   /**
@@ -238,12 +236,15 @@ public class JobProvider {
    * time this runs the job has been cancelled, so there is nothing the client can usefully retry.
    *
    * @param jobId the ID of the job whose files should be removed
+   * @return true if the removal succeeded, false if it failed
    */
-  private void tryDeleteJobFiles(@Nonnull final String jobId) {
+  private boolean tryDeleteJobFiles(@Nonnull final String jobId) {
     try {
       deleteJobFiles(jobId);
+      return true;
     } catch (final IOException e) {
       reportFileRemovalFailure(jobId, e);
+      return false;
     }
   }
 
@@ -418,13 +419,29 @@ public class JobProvider {
     }
   }
 
-  private static IBaseOperationOutcome buildDeletionOutcome() {
+  /**
+   * Builds the outcome returned when a job is deleted. The informational issue comes first and is
+   * unchanged, so a client reading only the first issue sees what it always has.
+   *
+   * @param removalFailed whether the job's output directory could not be removed
+   * @return the outcome to attach to the acceptance
+   */
+  @Nonnull
+  private static IBaseOperationOutcome buildDeletionOutcome(final boolean removalFailed) {
     final OperationOutcome operationOutcome = new OperationOutcome();
     operationOutcome
         .addIssue()
         .setCode(IssueType.INFORMATIONAL)
         .setSeverity(IssueSeverity.INFORMATION)
         .setDiagnostics("The job and its resources will be deleted.");
+    if (removalFailed) {
+      operationOutcome
+          .addIssue()
+          .setCode(IssueType.INCOMPLETE)
+          .setSeverity(IssueSeverity.WARNING)
+          .setDiagnostics(
+              "The job's stored files could not be removed and may require manual clean-up.");
+    }
     return operationOutcome;
   }
 

--- a/server/src/main/java/au/csiro/pathling/async/JobProvider.java
+++ b/server/src/main/java/au/csiro/pathling/async/JobProvider.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.SparkSession;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.OperationOutcome;
@@ -73,6 +74,7 @@ public class JobProvider {
 
   @Nonnull private final JobRegistry jobRegistry;
   @Nonnull private final JobDirectoryFileSystem jobDirectoryFileSystem;
+  @Nonnull private final SparkSession spark;
 
   /**
    * Creates a new JobProvider.
@@ -81,14 +83,17 @@ public class JobProvider {
    * @param jobRegistry the {@link JobRegistry} used to keep track of running jobs
    * @param jobDirectoryFileSystem the {@link JobDirectoryFileSystem} used to resolve and delete
    *     per-job directories on the warehouse file system
+   * @param spark the {@link SparkSession} used to cancel the Spark work belonging to a deleted job
    */
   public JobProvider(
       @Nonnull final ServerConfiguration configuration,
       @Nonnull final JobRegistry jobRegistry,
-      @Nonnull final JobDirectoryFileSystem jobDirectoryFileSystem) {
+      @Nonnull final JobDirectoryFileSystem jobDirectoryFileSystem,
+      @Nonnull final SparkSession spark) {
     this.configuration = configuration;
     this.jobRegistry = jobRegistry;
     this.jobDirectoryFileSystem = jobDirectoryFileSystem;
+    this.spark = spark;
   }
 
   /**
@@ -194,6 +199,11 @@ public class JobProvider {
     final boolean removeFilesNow = job.markDeletedAndClaim();
     if (!job.getResult().isDone()) {
       job.getResult().cancel(false);
+      // Signal Spark directly. Cancelling the future does not interrupt the thread running the job,
+      // and the stage-event checks in SparkJobListener only reach Spark at the next stage boundary,
+      // which for a job inside a single long write stage is not until that stage finishes on its
+      // own. Those checks remain as a backstop.
+      spark.sparkContext().cancelJobGroup(job.getId());
     }
     if (removeFilesNow) {
       tryDeleteJobFiles(job.getId());

--- a/server/src/main/java/au/csiro/pathling/async/JobRegistry.java
+++ b/server/src/main/java/au/csiro/pathling/async/JobRegistry.java
@@ -18,7 +18,6 @@
 package au.csiro.pathling.async;
 
 import au.csiro.pathling.async.Job.JobTag;
-import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.HashMap;
@@ -131,11 +130,11 @@ public class JobRegistry {
       log.warn("Failed to remove job {} from registry.", job.getId());
       return false;
     }
+    // Jobs registered through register rather than getOrCreate have no tag, so finding no tag entry
+    // is a normal outcome rather than an inconsistency.
     final boolean removedFromTags = jobsByTags.values().removeIf(otherJob -> otherJob.equals(job));
     if (!removedFromTags) {
-      throw new InternalErrorException(
-          "Removed job %s from id map but failed to remove it from tag map."
-              .formatted(job.getId()));
+      log.debug("Job {} had no tag entry to remove.", job.getId());
     }
     removedFromRegistryButStillWithSparkJob.add(job.getId());
     return true;

--- a/server/src/main/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitExecutor.java
@@ -181,6 +181,11 @@ public class BulkSubmitExecutor {
       // Create and register the Job.
       final Optional<String> ownerId = Optional.ofNullable(submission.ownerId());
       final Job<Object> job = new Job<>(jobId, "bulk-submit-manifest", resultFuture, ownerId);
+      // This job's work is not run by the asynchronous request machinery, so no thread will ever
+      // signal its termination. Marking it terminated up front is what lets a deletion request
+      // clean
+      // up itself, rather than deferring to a signal that never arrives.
+      job.markTerminated();
       jobRegistry.register(job);
 
       // Store the job ID in the manifest job.

--- a/server/src/main/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitExecutor.java
@@ -182,9 +182,8 @@ public class BulkSubmitExecutor {
       final Optional<String> ownerId = Optional.ofNullable(submission.ownerId());
       final Job<Object> job = new Job<>(jobId, "bulk-submit-manifest", resultFuture, ownerId);
       // This job's work is not run by the asynchronous request machinery, so no thread will ever
-      // signal its termination. Marking it terminated up front is what lets a deletion request
-      // clean
-      // up itself, rather than deferring to a signal that never arrives.
+      // signal its termination. Marking it terminated up front is what lets a deletion request do
+      // its own clean-up, rather than defer it to a signal that never arrives.
       job.markTerminated();
       jobRegistry.register(job);
 

--- a/server/src/test/java/au/csiro/pathling/async/AsyncAspectTest.java
+++ b/server/src/test/java/au/csiro/pathling/async/AsyncAspectTest.java
@@ -18,12 +18,17 @@
 package au.csiro.pathling.async;
 
 import static au.csiro.pathling.async.RequestTagFactoryTest.createServerConfiguration;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -32,7 +37,12 @@ import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.operations.bulkexport.ExportResultRegistry;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import jakarta.annotation.Nonnull;
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -48,6 +58,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -57,6 +68,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.JwtClaimAccessor;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+/**
+ * Tests for {@link AsyncAspect}, covering job creation and reuse, the kick-off response, and the
+ * clean-up the job's own thread performs as it unwinds.
+ *
+ * @author John Grimes
+ */
 @SpringBootUnitTest
 @MockitoBean(types = ExportResultRegistry.class)
 @Slf4j
@@ -291,6 +308,131 @@ class AsyncAspectTest {
     assertTrue(
         AsyncJobContext.getCurrentJob().isEmpty(),
         "AsyncJobContext should be cleared after async execution");
+  }
+
+  // -- Removal of the job's output directory as the job's thread unwinds --
+
+  @Test
+  void deletedJobHasItsFilesRemovedAsTheTaskUnwinds() throws Throwable {
+    // A client deleted the job while its work was still running, so the request left the removal to
+    // this thread. As the task unwinds it takes the claim and removes the output.
+    final Callable<IBaseResource> task = captureSubmittedTask();
+    final String jobId = assertExecutedAsync();
+    final Job<?> job = jobRegistry.get(jobId);
+    assertNotNull(job);
+    // The delete request marked the job but did not claim, because the work had not terminated.
+    assertFalse(job.markDeletedAndClaim());
+
+    task.call();
+
+    verify(jobProvider).deleteJobFiles(jobId);
+  }
+
+  @Test
+  void completedJobThatWasNeverDeletedKeepsItsFiles() throws Throwable {
+    // Nothing was deleted, so the output must survive for the client to download.
+    final Callable<IBaseResource> task = captureSubmittedTask();
+    final String jobId = assertExecutedAsync();
+
+    task.call();
+
+    verify(jobProvider, never()).deleteJobFiles(jobId);
+  }
+
+  @Test
+  void failedJobHasItsFilesRemovedEvenWhenNeverDeleted() throws Throwable {
+    // A job that fails removes its own partial output as it unwinds, whether or not a client asked
+    // for it to be deleted. This is existing behaviour, retained now that the removal has moved to
+    // the single site in the finally block.
+    final Callable<IBaseResource> task = captureSubmittedTask();
+    final String jobId = assertExecutedAsync();
+    when(proceedingJoinPoint.proceed()).thenThrow(new IllegalArgumentException("failed"));
+
+    assertThrows(IllegalStateException.class, task::call);
+
+    verify(jobProvider).deleteJobFiles(jobId);
+  }
+
+  @Test
+  void removalUsesTheCapturedJobRatherThanTheRegistry() throws Throwable {
+    // The delete request lands while the work is running, so by the time the task unwinds the job
+    // is
+    // no longer in the registry. A lookup at that point would find nothing and skip the removal, so
+    // the task must use the reference it captured when it started.
+    final Callable<IBaseResource> task = captureSubmittedTask();
+    final String jobId = assertExecutedAsync();
+    final Job<?> job = jobRegistry.get(jobId);
+    assertNotNull(job);
+    when(proceedingJoinPoint.proceed())
+        .thenAnswer(
+            invocation -> {
+              // Stand in for the delete request arriving mid-work: the job is marked, the claim is
+              // left to this thread, and the job leaves the registry.
+              assertFalse(job.markDeletedAndClaim());
+              assertTrue(jobRegistry.remove(job));
+              return RESULT_RESOURCE;
+            });
+
+    task.call();
+
+    assertNull(jobRegistry.get(jobId));
+    verify(jobProvider).deleteJobFiles(jobId);
+  }
+
+  @Test
+  void removalFailureOnTheJobThreadIsNotPropagated() throws Throwable {
+    // Throwing out of the finally block would replace the job's own exception with an incidental
+    // one, so a failed removal is reported and swallowed instead.
+    final Callable<IBaseResource> task = captureSubmittedTask();
+    final String jobId = assertExecutedAsync();
+    final Job<?> job = jobRegistry.get(jobId);
+    assertNotNull(job);
+    assertFalse(job.markDeletedAndClaim());
+    doThrow(new IOException("warehouse is unavailable")).when(jobProvider).deleteJobFiles(jobId);
+
+    final ListAppender<ILoggingEvent> appender = attachAppender(JobProvider.class);
+    try {
+      assertDoesNotThrow(task::call);
+    } finally {
+      detachAppender(JobProvider.class, appender);
+    }
+
+    assertTrue(
+        appender.list.stream().anyMatch(event -> event.getLevel() == Level.ERROR),
+        "the failed removal should be logged at error level");
+  }
+
+  /**
+   * Arranges for the executor to capture the submitted task rather than run it, and returns a
+   * handle that invokes it on the calling thread. Stage map interactions are stubbed for the
+   * clean-up that the task performs as it unwinds.
+   *
+   * @return the task that the aspect submits for the next asynchronous request
+   */
+  @Nonnull
+  @SuppressWarnings("unchecked")
+  private Callable<IBaseResource> captureSubmittedTask() {
+    final Future<IBaseResource> mockFuture = mock(Future.class);
+    final ArgumentCaptor<Callable<IBaseResource>> captor = ArgumentCaptor.forClass(Callable.class);
+    when(threadPoolTaskExecutor.submit(captor.capture())).thenReturn(mockFuture);
+    when(stageMap.entrySet()).thenReturn(java.util.Collections.emptySet());
+    when(stageMap.keySet())
+        .thenReturn(new java.util.concurrent.ConcurrentHashMap<Integer, String>().keySet());
+    return () -> captor.getValue().call();
+  }
+
+  @Nonnull
+  private static ListAppender<ILoggingEvent> attachAppender(@Nonnull final Class<?> loggerClass) {
+    final Logger logger = (Logger) LoggerFactory.getLogger(loggerClass);
+    final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    return appender;
+  }
+
+  private static void detachAppender(
+      @Nonnull final Class<?> loggerClass, @Nonnull final ListAppender<ILoggingEvent> appender) {
+    ((Logger) LoggerFactory.getLogger(loggerClass)).detachAppender(appender);
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/async/AsyncAspectTest.java
+++ b/server/src/test/java/au/csiro/pathling/async/AsyncAspectTest.java
@@ -355,10 +355,9 @@ class AsyncAspectTest {
 
   @Test
   void removalUsesTheCapturedJobRatherThanTheRegistry() throws Throwable {
-    // The delete request lands while the work is running, so by the time the task unwinds the job
-    // is
-    // no longer in the registry. A lookup at that point would find nothing and skip the removal, so
-    // the task must use the reference it captured when it started.
+    // The delete request lands while the work is running, so the job has left the registry by the
+    // time the task unwinds. A lookup at that point would find nothing and skip the removal, so the
+    // task must use the reference it captured when it started.
     final Callable<IBaseResource> task = captureSubmittedTask();
     final String jobId = assertExecutedAsync();
     final Job<?> job = jobRegistry.get(jobId);
@@ -376,6 +375,25 @@ class AsyncAspectTest {
     task.call();
 
     assertNull(jobRegistry.get(jobId));
+    verify(jobProvider).deleteJobFiles(jobId);
+  }
+
+  @Test
+  void removalHappensWhenTheJobWasAlreadyGoneWhenTheTaskStarted() throws Throwable {
+    // A delete request can land in the narrow window between the task entering its body and its
+    // first statement resolving the job, leaving the task with nothing. That request cannot have
+    // taken the claim, because the work had not terminated when it asked, so this thread still owns
+    // the removal. Skipping it here would orphan the output directory permanently.
+    final Callable<IBaseResource> task = captureSubmittedTask();
+    final String jobId = assertExecutedAsync();
+    final Job<?> job = jobRegistry.get(jobId);
+    assertNotNull(job);
+    assertFalse(job.markDeletedAndClaim());
+    assertTrue(jobRegistry.remove(job));
+    assertNull(jobRegistry.get(jobId));
+
+    task.call();
+
     verify(jobProvider).deleteJobFiles(jobId);
   }
 

--- a/server/src/test/java/au/csiro/pathling/async/JobProviderSecurityTest.java
+++ b/server/src/test/java/au/csiro/pathling/async/JobProviderSecurityTest.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,7 +83,8 @@ class JobProviderSecurityTest {
     final JobDirectoryFileSystem jobDirectoryFileSystem =
         new JobDirectoryFileSystem(tempDir.toUri(), new Configuration());
 
-    jobProvider = new JobProvider(serverConfiguration, jobRegistry, jobDirectoryFileSystem);
+    jobProvider =
+        new JobProvider(serverConfiguration, jobRegistry, jobDirectoryFileSystem, mockSpark());
 
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();
@@ -174,7 +177,7 @@ class JobProviderSecurityTest {
     final JobDirectoryFileSystem fileSystem =
         new JobDirectoryFileSystem(tempDir.toUri(), new Configuration());
     final JobProvider authDisabledProvider =
-        new JobProvider(authDisabledConfiguration, jobRegistry, fileSystem);
+        new JobProvider(authDisabledConfiguration, jobRegistry, fileSystem, mockSpark());
 
     final String jobId = registerTaggedJob(OWNER_USER);
     SecurityContextHolder.clearContext();
@@ -197,6 +200,19 @@ class JobProviderSecurityTest {
             new Job.JobTag() {},
             id -> new Job<>(id, "export", new CompletableFuture<>(), Optional.of(owner)));
     return job.getId();
+  }
+
+  /**
+   * Creates a Spark session whose context accepts job-group cancellation, which the delete path
+   * calls to stop the work belonging to the job.
+   *
+   * @return a mock Spark session
+   */
+  @Nonnull
+  private static SparkSession mockSpark() {
+    final SparkSession spark = mock(SparkSession.class);
+    when(spark.sparkContext()).thenReturn(mock(SparkContext.class));
+    return spark;
   }
 
   private void setAuthenticatedUser(

--- a/server/src/test/java/au/csiro/pathling/async/JobProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/async/JobProviderTest.java
@@ -20,6 +20,7 @@ package au.csiro.pathling.async;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -454,6 +455,80 @@ class JobProviderTest {
    *
    * @return the registered job
    */
+  // -- Deleting a job: reporting a failed removal --
+
+  @Test
+  void failedRemovalStillAcceptsTheDeletionAndWarnsAboutTheFiles() throws Exception {
+    // By this point the job has been cancelled and removed from the registry, so the client's
+    // request succeeded; reporting a server error would misdescribe it and cannot be usefully
+    // retried, since a retry returns 404 and the client cannot repair the warehouse. The response
+    // says so instead.
+    final JobProvider provider = providerWithFailingRemoval();
+    final Job<IBaseResource> job = registerRunningJob();
+    assertThat(job.markTerminatedAndClaim()).isFalse();
+
+    assertThatThrownBy(() -> provider.deleteJob(job.getId()))
+        .isInstanceOf(ProcessingNotCompletedException.class)
+        .isNotInstanceOf(InternalErrorException.class)
+        .satisfies(
+            thrown -> {
+              assertThat(informationalDiagnostics(thrown))
+                  .containsExactly("The job and its resources will be deleted.");
+              assertThat(diagnosticsOfSeverity(thrown, IssueSeverity.WARNING))
+                  .singleElement()
+                  .satisfies(
+                      diagnostics ->
+                          assertThat(diagnostics)
+                              .contains("stored files")
+                              .contains("manual clean-up"));
+              // The informational issue stays first, so existing clients reading only the first
+              // issue see what they always have.
+              assertThat(issues(thrown).get(0).getSeverity()).isEqualTo(IssueSeverity.INFORMATION);
+            });
+  }
+
+  @Test
+  void failedRemovalIsLoggedAtErrorLevel() throws Exception {
+    // The operator is the only party who can act on it: the files are orphaned in the warehouse.
+    final JobProvider provider = providerWithFailingRemoval();
+    final Job<IBaseResource> job = registerRunningJob();
+    assertThat(job.markTerminatedAndClaim()).isFalse();
+
+    final ListAppender<ILoggingEvent> appender = attachJobProviderAppender();
+    try {
+      assertThatThrownBy(() -> provider.deleteJob(job.getId()))
+          .isInstanceOf(ProcessingNotCompletedException.class);
+    } finally {
+      detachJobProviderAppender(appender);
+    }
+
+    assertThat(appender.list)
+        .anySatisfy(
+            event -> {
+              assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+              assertThat(event.getFormattedMessage()).contains("Failed to remove the output");
+            });
+  }
+
+  /**
+   * Creates a provider whose warehouse rejects the removal of a job's output directory.
+   *
+   * @return a provider that cannot remove job files
+   * @throws IOException never; declared because the stubbed method does
+   */
+  @Nonnull
+  private JobProvider providerWithFailingRemoval() throws IOException {
+    final JobDirectoryFileSystem failing = mock(JobDirectoryFileSystem.class);
+    doThrow(new IOException("the warehouse is unavailable"))
+        .when(failing)
+        .deleteJobDirectory(anyString());
+    final ServerConfiguration config = mock(ServerConfiguration.class);
+    final AuthorizationConfiguration authConfig = mock(AuthorizationConfiguration.class);
+    when(config.getAuth()).thenReturn(authConfig);
+    when(authConfig.isEnabled()).thenReturn(false);
+    return new JobProvider(config, jobRegistry, failing, mockSpark());
+  }
+
   /**
    * Creates a Spark session whose context records job-group cancellation, and remembers the context
    * so that tests can assert against it.
@@ -499,8 +574,22 @@ class JobProviderTest {
    */
   @Nonnull
   private static List<String> informationalDiagnostics(@Nonnull final Throwable thrown) {
+    return diagnosticsOfSeverity(thrown, IssueSeverity.INFORMATION);
+  }
+
+  /**
+   * Extracts the diagnostics of the issues of a given severity carried by a thrown server
+   * exception.
+   *
+   * @param thrown the exception to inspect
+   * @param severity the severity to select
+   * @return the diagnostics of each matching issue, in order
+   */
+  @Nonnull
+  private static List<String> diagnosticsOfSeverity(
+      @Nonnull final Throwable thrown, @Nonnull final IssueSeverity severity) {
     return issues(thrown).stream()
-        .filter(issue -> issue.getSeverity() == IssueSeverity.INFORMATION)
+        .filter(issue -> issue.getSeverity() == severity)
         .map(OperationOutcomeIssueComponent::getDiagnostics)
         .toList();
   }

--- a/server/src/test/java/au/csiro/pathling/async/JobProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/async/JobProviderTest.java
@@ -449,12 +449,6 @@ class JobProviderTest {
     assertThat(Files.exists(jobsDir)).isFalse();
   }
 
-  /**
-   * Registers a running job through the tag-based factory, so it is present in both the id and tag
-   * maps and can be removed by the delete path exactly as a real asynchronous job would be.
-   *
-   * @return the registered job
-   */
   // -- Deleting a job: reporting a failed removal --
 
   @Test
@@ -543,6 +537,12 @@ class JobProviderTest {
     return spark;
   }
 
+  /**
+   * Registers a running job through the tag-based factory, so it is present in both the id and tag
+   * maps and can be removed by the delete path exactly as a real asynchronous job would be.
+   *
+   * @return the registered job
+   */
   @Nonnull
   private Job<IBaseResource> registerRunningJob() {
     return jobRegistry.getOrCreate(

--- a/server/src/test/java/au/csiro/pathling/async/JobProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/async/JobProviderTest.java
@@ -26,6 +26,7 @@ import au.csiro.pathling.config.AsyncConfiguration;
 import au.csiro.pathling.config.AuthorizationConfiguration;
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.io.JobDirectoryFileSystem;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
@@ -33,15 +34,21 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import jakarta.annotation.Nonnull;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.apache.hadoop.conf.Configuration;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
 import org.hl7.fhir.r4.model.Parameters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -331,23 +338,151 @@ class JobProviderTest {
 
   @Test
   void deleteJobFilesSucceedsWhenDirectoryDoesNotExist() throws Exception {
-    // Deleting a non-existent job directory should not throw; the underlying delete returns false
-    // and is logged as a warning. Capture the JobProvider log to assert the warning is emitted.
+    // An absent job directory is a normal outcome, not a failure: a job that fails removes its own
+    // output as it unwinds, so a deletion that follows finds nothing. It must not be logged as a
+    // problem, or the genuine failures would be lost among spurious ones.
+    final ListAppender<ILoggingEvent> appender = attachJobProviderAppender();
+    try {
+      jobProvider.deleteJobFiles(JOB_ID);
+    } finally {
+      detachJobProviderAppender(appender);
+    }
+
+    assertThat(appender.list).noneMatch(JobProviderTest::isProblem);
+  }
+
+  @Test
+  void deleteJobFilesTwiceDoesNotLogAFailure() throws Exception {
+    // The second removal of the same job directory finds nothing left to remove, which is the
+    // ordinary outcome once one party has already done the work.
+    final Path jobsDir = tempDir.resolve("jobs").resolve(JOB_ID);
+    Files.createDirectories(jobsDir);
+    Files.writeString(jobsDir.resolve("output.ndjson"), "{}");
+    jobProvider.deleteJobFiles(JOB_ID);
+
+    final ListAppender<ILoggingEvent> appender = attachJobProviderAppender();
+    try {
+      jobProvider.deleteJobFiles(JOB_ID);
+    } finally {
+      detachJobProviderAppender(appender);
+    }
+
+    assertThat(Files.exists(jobsDir)).isFalse();
+    assertThat(appender.list).noneMatch(JobProviderTest::isProblem);
+  }
+
+  // -- Deleting a job: who removes the output directory --
+
+  @Test
+  void deletingRunningJobLeavesTheDirectoryForTheJobThread() throws Exception {
+    // The work is still running, so removing its output directory now would pull the ground out
+    // from under tasks that are still writing into it. The removal is left to the job's own thread,
+    // and the client still receives the acceptance and sees the job leave the registry.
+    final Job<IBaseResource> job = registerRunningJob();
+    final Path jobsDir = createJobDirectory(job.getId());
+
+    assertThatThrownBy(() -> jobProvider.deleteJob(job.getId()))
+        .isInstanceOf(ProcessingNotCompletedException.class)
+        .satisfies(
+            thrown ->
+                assertThat(informationalDiagnostics(thrown))
+                    .containsExactly("The job and its resources will be deleted."));
+
+    assertThat(Files.exists(jobsDir)).as("no removal is attempted while the work runs").isTrue();
+    assertThat(jobRegistry.get(job.getId())).isNull();
+  }
+
+  @Test
+  void deletingTerminatedJobRemovesTheDirectoryInline() throws Exception {
+    // The work has already stopped, so nothing is writing and this request owns the removal.
+    final Job<IBaseResource> job = registerRunningJob();
+    // The job's own thread has finished unwinding without any deletion having been requested, so it
+    // leaves the claim untaken.
+    assertThat(job.markTerminatedAndClaim()).isFalse();
+    final Path jobsDir = createJobDirectory(job.getId());
+
+    assertThatThrownBy(() -> jobProvider.deleteJob(job.getId()))
+        .isInstanceOf(ProcessingNotCompletedException.class);
+
+    assertThat(Files.exists(jobsDir)).isFalse();
+  }
+
+  /**
+   * Registers a running job through the tag-based factory, so it is present in both the id and tag
+   * maps and can be removed by the delete path exactly as a real asynchronous job would be.
+   *
+   * @return the registered job
+   */
+  @Nonnull
+  private Job<IBaseResource> registerRunningJob() {
+    return jobRegistry.getOrCreate(
+        new Job.JobTag() {},
+        id -> new Job<>(id, "export", new CompletableFuture<>(), Optional.empty()));
+  }
+
+  /**
+   * Creates the per-job output directory with a file in it, standing in for output an operation has
+   * written.
+   *
+   * @param jobId the identifier of the job that owns the directory
+   * @return the path of the created directory
+   * @throws IOException if the directory cannot be created
+   */
+  @Nonnull
+  private Path createJobDirectory(@Nonnull final String jobId) throws IOException {
+    final Path jobsDir = tempDir.resolve("jobs").resolve(jobId);
+    Files.createDirectories(jobsDir);
+    Files.writeString(jobsDir.resolve("output.ndjson"), "{}");
+    return jobsDir;
+  }
+
+  /**
+   * Extracts the diagnostics of the informational issues carried by a thrown server exception.
+   *
+   * @param thrown the exception to inspect
+   * @return the diagnostics of each informational issue, in order
+   */
+  @Nonnull
+  private static List<String> informationalDiagnostics(@Nonnull final Throwable thrown) {
+    return issues(thrown).stream()
+        .filter(issue -> issue.getSeverity() == IssueSeverity.INFORMATION)
+        .map(OperationOutcomeIssueComponent::getDiagnostics)
+        .toList();
+  }
+
+  /**
+   * Extracts the issues carried by the {@code OperationOutcome} of a thrown server exception.
+   *
+   * @param thrown the exception to inspect
+   * @return the issues of the attached outcome
+   */
+  @Nonnull
+  private static List<OperationOutcomeIssueComponent> issues(@Nonnull final Throwable thrown) {
+    final BaseServerResponseException exception = (BaseServerResponseException) thrown;
+    return ((OperationOutcome) exception.getOperationOutcome()).getIssue();
+  }
+
+  @Nonnull
+  private static ListAppender<ILoggingEvent> attachJobProviderAppender() {
     final Logger logger = (Logger) LoggerFactory.getLogger(JobProvider.class);
     final ListAppender<ILoggingEvent> appender = new ListAppender<>();
     appender.start();
     logger.addAppender(appender);
-    try {
-      jobProvider.deleteJobFiles(JOB_ID);
-    } finally {
-      logger.detachAppender(appender);
-    }
+    return appender;
+  }
 
-    assertThat(appender.list)
-        .anySatisfy(
-            event -> {
-              assertThat(event.getLevel()).isEqualTo(Level.WARN);
-              assertThat(event.getFormattedMessage()).contains("Failed to delete dir");
-            });
+  private static void detachJobProviderAppender(
+      @Nonnull final ListAppender<ILoggingEvent> appender) {
+    ((Logger) LoggerFactory.getLogger(JobProvider.class)).detachAppender(appender);
+  }
+
+  /**
+   * Tests whether a log event reports a problem, as opposed to routine progress.
+   *
+   * @param event the log event to test
+   * @return true if the event was logged at warning level or above
+   */
+  private static boolean isProblem(@Nonnull final ILoggingEvent event) {
+    return event.getLevel().isGreaterOrEqual(Level.WARN);
   }
 }

--- a/server/src/test/java/au/csiro/pathling/async/JobProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/async/JobProviderTest.java
@@ -19,7 +19,10 @@ package au.csiro.pathling.async;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import au.csiro.pathling.config.AsyncConfiguration;
@@ -45,6 +48,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
@@ -70,6 +75,7 @@ class JobProviderTest {
 
   private JobRegistry jobRegistry;
   private JobProvider jobProvider;
+  private SparkContext sparkContext;
   private MockHttpServletRequest request;
   private MockHttpServletResponse response;
 
@@ -90,7 +96,7 @@ class JobProviderTest {
 
     final JobDirectoryFileSystem jobDirectoryFileSystem =
         new JobDirectoryFileSystem(tempDir.toUri(), new Configuration());
-    jobProvider = new JobProvider(config, jobRegistry, jobDirectoryFileSystem);
+    jobProvider = new JobProvider(config, jobRegistry, jobDirectoryFileSystem, mockSpark());
     request = new MockHttpServletRequest();
     request.setMethod("GET");
     // Set the servlet path to match the FHIR server mount point.
@@ -324,7 +330,8 @@ class JobProviderTest {
     final JobDirectoryFileSystem jobDirectoryFileSystem =
         new JobDirectoryFileSystem(tempDir.toUri(), hadoopConfig);
     final ServerConfiguration config = mock(ServerConfiguration.class);
-    final JobProvider provider = new JobProvider(config, jobRegistry, jobDirectoryFileSystem);
+    final JobProvider provider =
+        new JobProvider(config, jobRegistry, jobDirectoryFileSystem, mockSpark());
 
     final Path jobsDir = tempDir.resolve("jobs").resolve(JOB_ID);
     Files.createDirectories(jobsDir);
@@ -371,6 +378,40 @@ class JobProviderTest {
     assertThat(appender.list).noneMatch(JobProviderTest::isProblem);
   }
 
+  // -- Deleting a job: cancelling the Spark work --
+
+  @Test
+  void deletingRunningJobCancelsItsSparkJobGroup() {
+    // Nothing on the delete path used to touch Spark, so the work carried on until the server next
+    // happened to observe a stage boundary for it. Signalling Spark here is what makes abandoning a
+    // job actually stop it, and therefore what makes the deferred clean-up prompt.
+    final Job<IBaseResource> job = registerRunningJob();
+
+    assertThatThrownBy(() -> jobProvider.deleteJob(job.getId()))
+        .isInstanceOf(ProcessingNotCompletedException.class);
+
+    verify(sparkContext).cancelJobGroup(job.getId());
+  }
+
+  @Test
+  void deletingFinishedJobAttemptsNoSparkCancellation() {
+    // There is no work left to cancel, so the delete path leaves Spark alone.
+    final Job<IBaseResource> job =
+        jobRegistry.getOrCreate(
+            new Job.JobTag() {},
+            id ->
+                new Job<>(
+                    id,
+                    "export",
+                    CompletableFuture.completedFuture(new Parameters()),
+                    Optional.empty()));
+
+    assertThatThrownBy(() -> jobProvider.deleteJob(job.getId()))
+        .isInstanceOf(ProcessingNotCompletedException.class);
+
+    verify(sparkContext, never()).cancelJobGroup(anyString());
+  }
+
   // -- Deleting a job: who removes the output directory --
 
   @Test
@@ -413,6 +454,20 @@ class JobProviderTest {
    *
    * @return the registered job
    */
+  /**
+   * Creates a Spark session whose context records job-group cancellation, and remembers the context
+   * so that tests can assert against it.
+   *
+   * @return a mock Spark session
+   */
+  @Nonnull
+  private SparkSession mockSpark() {
+    sparkContext = mock(SparkContext.class);
+    final SparkSession spark = mock(SparkSession.class);
+    when(spark.sparkContext()).thenReturn(sparkContext);
+    return spark;
+  }
+
   @Nonnull
   private Job<IBaseResource> registerRunningJob() {
     return jobRegistry.getOrCreate(

--- a/server/src/test/java/au/csiro/pathling/async/JobRegistryTest.java
+++ b/server/src/test/java/au/csiro/pathling/async/JobRegistryTest.java
@@ -110,6 +110,21 @@ class JobRegistryTest {
   }
 
   @Test
+  void removesJobRegisteredWithoutATag() {
+    // Jobs registered outside the asynchronous request machinery, such as bulk submit manifest
+    // jobs, have no entry in the tag map. Their absence from it is the normal state and must not be
+    // mistaken for an inconsistency, or deleting such a job fails with a server error.
+    final Job<IBaseResource> job =
+        new Job<>("job-1", "bulk-submit-manifest", MOCK_FUTURE, Optional.empty());
+    registry.register(job);
+
+    assertThat(registry.remove(job)).isTrue();
+
+    assertThat(registry.get("job-1")).isNull();
+    assertThat(registry.allJobs()).isEmpty();
+  }
+
+  @Test
   void snapshotIsASafeCopy() {
     final Job<?> firstJob =
         registry.getOrCreate(

--- a/server/src/test/java/au/csiro/pathling/async/JobTest.java
+++ b/server/src/test/java/au/csiro/pathling/async/JobTest.java
@@ -19,21 +19,32 @@ package au.csiro.pathling.async;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import jakarta.annotation.Nonnull;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Parameters;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link Job}, covering the creation-time start timestamp used by the SQL on FHIR
- * export manifest's timing fields.
+ * export manifest's timing fields, and the state machine that decides which party removes a deleted
+ * job's output directory.
  *
  * @author John Grimes
  */
+@Tag("UnitTest")
 class JobTest {
+
+  private static final int CONCURRENCY_ITERATIONS = 2000;
 
   @Test
   void recordsNonNullStartTimeAtCreation() {
@@ -45,5 +56,126 @@ class JobTest {
     // The job records a creation timestamp that falls within the window in which it was created.
     assertThat(job.getStartTime()).isNotNull();
     assertThat(job.getStartTime()).isBetween(before, after);
+  }
+
+  // Deletion claim state machine.
+
+  @Test
+  void newJobIsNeitherTerminatedNorMarkedDeleted() {
+    // A job starts out with its work still to run and no deletion requested.
+    final Job<Object> job = newJob();
+
+    assertThat(job.isTerminated()).isFalse();
+    assertThat(job.isMarkedAsDeleted()).isFalse();
+  }
+
+  @Test
+  void deletionBeforeTerminationLeavesTheClaimToTheJobThread() {
+    // The delete request arrives while the work is still running, so it must not take the claim.
+    // The job's own thread takes it when it exits.
+    final Job<Object> job = newJob();
+
+    assertThat(job.markDeletedAndClaim()).isFalse();
+    assertThat(job.isMarkedAsDeleted()).isTrue();
+    assertThat(job.isTerminated()).isFalse();
+
+    assertThat(job.markTerminatedAndClaim()).isTrue();
+    assertThat(job.isTerminated()).isTrue();
+  }
+
+  @Test
+  void terminationBeforeDeletionLeavesTheClaimToTheDeleteRequest() {
+    // The work finishes before any delete arrives, so the job's thread must not take the claim. A
+    // delete that follows takes it and removes the directory inline.
+    final Job<Object> job = newJob();
+
+    assertThat(job.markTerminatedAndClaim()).isFalse();
+    assertThat(job.isTerminated()).isTrue();
+    assertThat(job.isMarkedAsDeleted()).isFalse();
+
+    assertThat(job.markDeletedAndClaim()).isTrue();
+    assertThat(job.isMarkedAsDeleted()).isTrue();
+  }
+
+  @Test
+  void secondClaimFromTheDeleteRequestReturnsFalse() {
+    // The claim is single use: once the job's thread has taken it, a later delete does not.
+    final Job<Object> job = newJob();
+    assertThat(job.markDeletedAndClaim()).isFalse();
+    assertThat(job.markTerminatedAndClaim()).isTrue();
+
+    assertThat(job.markDeletedAndClaim()).isFalse();
+  }
+
+  @Test
+  void secondClaimFromTheJobThreadReturnsFalse() {
+    // The claim is single use: once the delete request has taken it, the job's thread does not.
+    final Job<Object> job = newJob();
+    assertThat(job.markTerminatedAndClaim()).isFalse();
+    assertThat(job.markDeletedAndClaim()).isTrue();
+
+    assertThat(job.markTerminatedAndClaim()).isFalse();
+  }
+
+  @Test
+  void terminationWithoutDeletionNeverClaims() {
+    // A job that runs to completion and is never deleted leaves the claim untaken, so its result
+    // stays available for download.
+    final Job<Object> job = newJob();
+
+    assertThat(job.markTerminatedAndClaim()).isFalse();
+    assertThat(job.markTerminatedAndClaim()).isFalse();
+  }
+
+  @Test
+  void markTerminatedRecordsTerminationWithoutTakingTheClaim() {
+    // Jobs registered outside the asynchronous request machinery are marked terminated up front, so
+    // that a delete request handles their cleanup itself. Doing so must not consume the claim.
+    final Job<Object> job = newJob();
+
+    job.markTerminated();
+
+    assertThat(job.isTerminated()).isTrue();
+    assertThat(job.markDeletedAndClaim()).isTrue();
+  }
+
+  @Test
+  void exactlyOnePartyClaimsWhenBothArriveConcurrently() throws Exception {
+    // The delete request and the job's own thread may reach the decision point at the same time.
+    // Whichever enters the monitor second observes the other's flag, so exactly one claims: never
+    // both (which would remove the directory twice) and never neither (which would leak it).
+    final ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      for (int iteration = 0; iteration < CONCURRENCY_ITERATIONS; iteration++) {
+        final Job<Object> job = newJob();
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        final Future<Boolean> deleteClaim =
+            executor.submit(
+                () -> {
+                  barrier.await();
+                  return job.markDeletedAndClaim();
+                });
+        final Future<Boolean> threadClaim =
+            executor.submit(
+                () -> {
+                  barrier.await();
+                  return job.markTerminatedAndClaim();
+                });
+
+        final List<Boolean> claims = List.of(deleteClaim.get(), threadClaim.get());
+        assertThat(claims)
+            .as("iteration %d: exactly one party must claim the deletion", iteration)
+            .containsOnlyOnce(true);
+      }
+    } finally {
+      executor.shutdownNow();
+      assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+    }
+  }
+
+  @Nonnull
+  private static Job<Object> newJob() {
+    return new Job<>("job-1", "export", new CompletableFuture<>(), Optional.empty());
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitExecutorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulksubmit/BulkSubmitExecutorTest.java
@@ -188,6 +188,10 @@ class BulkSubmitExecutorTest {
     final Job<?> registeredJob = jobCaptor.getValue();
     assertThat(registeredJob).isNotNull();
     assertThat(registeredJob.getOwnerId()).isEqualTo(Optional.empty());
+    // The job is registered as already terminated. Its work is not run by the asynchronous request
+    // machinery, so no thread will ever signal termination for it, and a deletion request has to
+    // handle the clean-up itself rather than defer it to a signal that never arrives.
+    assertThat(registeredJob.isTerminated()).isTrue();
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/util/FhirServerTestConfiguration.java
+++ b/server/src/test/java/au/csiro/pathling/util/FhirServerTestConfiguration.java
@@ -173,8 +173,9 @@ public class FhirServerTestConfiguration {
   public JobProvider jobProvider(
       ServerConfiguration serverConfiguration,
       JobRegistry jobRegistry,
-      JobDirectoryFileSystem jobDirectoryFileSystem) {
-    return new JobProvider(serverConfiguration, jobRegistry, jobDirectoryFileSystem);
+      JobDirectoryFileSystem jobDirectoryFileSystem,
+      SparkSession sparkSession) {
+    return new JobProvider(serverConfiguration, jobRegistry, jobDirectoryFileSystem, sparkSession);
   }
 
   @Bean

--- a/site/docs/server/operations/jobs.md
+++ b/site/docs/server/operations/jobs.md
@@ -66,6 +66,28 @@ The `url` of each job can be used to poll its status (`GET`) or to cancel it
 (`DELETE`), exactly as with the `Content-Location` returned when the job was
 started.
 
+## Cancellation
+
+A `DELETE` is acknowledged immediately with `202 Accepted`. The server does not
+wait for the work to stop before responding, and the job disappears from the
+list straight away; a repeated `DELETE` returns `404 Not Found`.
+
+The work belonging to the job is cancelled as part of handling the request, so
+abandoning a job stops the query rather than leaving it running until the stage
+it happens to be in has finished.
+
+Any output the job had written is removed once the work has actually stopped,
+rather than at the moment of the request. For a job that had already finished,
+that means the output is gone by the time the response is returned. For a job
+that was still running, the removal happens when the work unwinds, which is
+what keeps partial output from being left behind by tasks that were still
+writing when the request arrived.
+
+If the output cannot be removed, the response is still `202 Accepted` and
+carries an additional warning issue saying that the job's stored files could not
+be removed and may require manual clean-up. The failure is also recorded in the
+server log, so an operator can find the affected directory.
+
 ## Ownership
 
 When [authorisation](../authorization) is enabled, the caller must hold the


### PR DESCRIPTION
Closes #2687.

Deleting an asynchronous job removed its output directory straight away, while the thread doing the work kept running and kept writing into it. Output therefore continued to appear after the deletion and was never cleaned up; where the write finished before the cancellation was noticed, a complete set of output files was left behind permanently.

The surface for this widened with #2681. Before that fix the SQL query execution path replaced the Spark job group the asynchronous machinery had established, so a `DELETE` of a running `$sqlquery-export` never reached the Spark work and there was nothing in flight to race with. Removing that override was the point of the fix, and the consequence is that cancellation now genuinely interrupts in-flight tasks on this path.

Ownership of the removal now goes to whichever party is last: the request if the work has already terminated, the job's own thread as it exits if it is still running. A single-use claim on the job, guarded by the object's own monitor, makes that decision exactly once. Nothing waits, nothing polls, and no thread is parked.

Alongside it, the delete path now cancels the Spark job group directly. Nothing on that path touched Spark before, so a cancellation only arrived when the server next observed a stage boundary for the job, which for a job inside a single long write stage is not until that stage has finished on its own. Since the clean-up now follows the work stopping, slow cancellation had become slow clean-up as well. The existing stage-event checks stay as a backstop.

A removal that fails is no longer reported as a server error. By that point the job has been cancelled and removed from the registry, so the client's request succeeded and cannot usefully be retried. The response stays `202 Accepted` and carries an additional warning issue saying the stored files could not be removed and may need manual attention, and the failure reaches the operator through the server log and error reporting.

Two things worth a reviewer's attention:

The wire contract is otherwise unchanged, so no client or admin UI change is needed. `JobListIT.cancelledJobLeavesTheList` covers the round trip and passes unmodified.

There is no new integration test. Reaching the underlying race end to end means timing a `DELETE` against an in-flight Spark commit, which is a test that passes by winning a race and a strong candidate for intermittent CI failure. The mechanism is asserted deterministically instead, including exactly-once behaviour under repeated concurrent execution.

Two smaller fixes ride along, each in its own commit. Removing a job registered without a tag raised a server error, because the absence of a tag entry was treated as an inconsistency; every bulk submit manifest job is registered that way, so deleting one failed with a `500`. And an absent output directory is no longer logged as a failed delete, since a job that fails removes its own output as it unwinds and a later deletion legitimately finds nothing.