### PR TITLE
Drive the session expiry poll rather than waiting for it

### DIFF
--- a/ui/e2e/auth.spec.ts
+++ b/ui/e2e/auth.spec.ts
@@ -211,6 +211,10 @@ test.describe("Authentication", () => {
     test("shows the failure in the session expiry dialog and keeps it open", async ({
       page,
     }) => {
+      // The clock is installed before authenticating, since that navigates, and
+      // the page's timers must be under the test's control from the outset.
+      await page.clock.install();
+
       await setupAuthRequiredMocks(page);
 
       // The first job list request succeeds; every later one reports that the
@@ -232,9 +236,14 @@ test.describe("Authentication", () => {
       await authenticate(page, "/jobs");
       await expect(page.getByText("No jobs to show")).toBeVisible();
 
-      // The poll fails, raising the expiry dialog.
+      // Advancing well past the refresh interval drives the next poll, which
+      // fails and so raises the expiry dialog. Driving the clock rather than
+      // waiting out the interval keeps the test off the ten second floor that
+      // the real interval would otherwise impose.
+      await page.clock.runFor(30000);
+
       const dialog = page.getByRole("alertdialog");
-      await expect(dialog).toBeVisible({ timeout: 15000 });
+      await expect(dialog).toBeVisible();
 
       await breakAuthorisationDiscovery(page);
       await dialog.getByRole("button", { name: /log in/i }).click();


### PR DESCRIPTION
Fixes #2693.

The test that checks the session expiry dialog reports its failures had to wait out the ten second idle job refresh interval in real time, since raising the dialog depends on a second job list request failing. That made it the slowest test in the Admin UI end-to-end suite by a wide margin. Installing Playwright's clock and advancing it past the interval drives that request instead. No assertions change, and no application code is involved.

Measured on this branch, the test goes from 14.7s to 3.9s in a full suite run, and from 11.8s to 1.1s run on its own.

The assertion is self-validating rather than proving a negative: the dialog only becomes visible if the poll actually happens. Removing the clock advance makes the test fail with `element(s) not found`, so it is not passing vacuously.

Two related sleeps remain in the suite, in `auth.spec.ts` and `jobs.spec.ts`. Those are the ones #2690 removes, so they are left alone here.