### PR TITLE
Decode nested collection fields by name, and tolerate a narrower merge source

### DIFF
--- a/encoders/src/main/scala/au/csiro/pathling/encoders/DeserializerBuilder.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/DeserializerBuilder.scala
@@ -137,11 +137,18 @@ private[encoders] sealed class DeserializerBuilderProcessor(val path: Option[Exp
     }
 
     assert(path.isDefined, "We expect a non-empty path here")
-    val elementType: DataType = getSqlDatatypeFor(elementDefinition)
+    // The element type must come from the data rather than from the encoder's own schema.
+    // MapObjects binds its lambda variable to whatever type it is given, so supplying the
+    // encoder's type pins every field access inside the lambda to the encoder's field positions
+    // and then applies them to rows of a different shape - reading at the wrong offsets whenever
+    // the stored order differs, which is what a mergeSchema migration or a change of open types
+    // produces. UnresolvedMapObjects defers the type to the analyser, which takes it from the
+    // resolved input and rewrites the nested UnresolvedExtractValue nodes by name using the
+    // session resolver.
+    // The analyser applies the element mapper after the traversal has finished, so the nesting
+    // levels it needs have to be carried across with it.
     val array = Invoke(
-      MapObjects(elementMapper,
-        path.get,
-        elementType),
+      UnresolvedMapObjects(EncodingContext.deferring(elementMapper), path.get),
       "array",
       ObjectType(classOf[Array[Any]]))
     arrayExpression(array)

--- a/encoders/src/main/scala/au/csiro/pathling/encoders/DeserializerBuilder.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/DeserializerBuilder.scala
@@ -31,9 +31,10 @@ import ca.uhn.fhir.context._
 import org.apache.spark.sql.catalyst.analysis.{GetColumnByOrdinal, UnresolvedAttribute, UnresolvedExtractValue}
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions.objects._
-import org.apache.spark.sql.catalyst.expressions.{Expression, If, IsNotNull, IsNull, Literal}
+import org.apache.spark.sql.catalyst.expressions.{CreateNamedStruct, Expression, GetStructField, If, IsNotNull, IsNull, Literal}
 import org.apache.spark.sql.catalyst.util.ArrayData
-import org.apache.spark.sql.types.{DataType, ObjectType}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{DataType, ObjectType, StructType}
 import org.hl7.fhir.instance.model.api.IBaseResource
 
 import scala.jdk.CollectionConverters._
@@ -132,11 +133,16 @@ private[encoders] sealed class DeserializerBuilderProcessor(val path: Option[Exp
                                elementDefinition: BaseRuntimeElementDefinition[_],
                                elementName: String): Expression = {
 
+    assert(path.isDefined, "We expect a non-empty path here")
+    // The encoder's element type is no longer what the field accesses are bound to, but it is still
+    // needed to know which fields the encoder is going to ask for.
+    val encoderElementType: DataType = getSqlDatatypeFor(elementDefinition)
+
     def elementMapper(expression: Expression): Expression = {
-      withPath(Some(expression)).buildSimpleValue(childDefinition, elementDefinition, elementName)
+      withPath(Some(withEncoderFields(expression, encoderElementType)))
+        .buildSimpleValue(childDefinition, elementDefinition, elementName)
     }
 
-    assert(path.isDefined, "We expect a non-empty path here")
     // The element type must come from the data rather than from the encoder's own schema.
     // MapObjects binds its lambda variable to whatever type it is given, so supplying the
     // encoder's type pins every field access inside the lambda to the encoder's field positions
@@ -144,9 +150,8 @@ private[encoders] sealed class DeserializerBuilderProcessor(val path: Option[Exp
     // the stored order differs, which is what a mergeSchema migration or a change of open types
     // produces. UnresolvedMapObjects defers the type to the analyser, which takes it from the
     // resolved input and rewrites the nested UnresolvedExtractValue nodes by name using the
-    // session resolver.
-    // The analyser applies the element mapper after the traversal has finished, so the nesting
-    // levels it needs have to be carried across with it.
+    // session resolver. The analyser applies the element mapper after the traversal has finished,
+    // so the nesting levels it needs have to be carried across with it.
     val array = Invoke(
       UnresolvedMapObjects(EncodingContext.deferring(elementMapper), path.get),
       "array",
@@ -236,6 +241,64 @@ private[encoders] sealed class DeserializerBuilderProcessor(val path: Option[Exp
     path.map(path =>
       If(IsNull(path), Literal.create(null, ObjectType(definition.getImplementingClass)), result))
       .getOrElse(result)
+  }
+
+  /**
+   * Supplies, as typed nulls, the fields of a collection element that the encoder expects but the
+   * data does not carry.
+   *
+   * The data is authoritative about its own shape, so where the two disagree on which fields exist,
+   * the intersection is what can be represented. Resolving an absent field by name would otherwise
+   * fail the analysis, which would leave a table written with more open types configured than the
+   * reader has unreadable rather than partially readable.
+   *
+   * Only the element struct itself and the singular structs within it are rebuilt. A collection
+   * nested inside the element conforms its own elements, through the same path as this one, and its
+   * field accesses resolve against whatever this leaves in place for it.
+   *
+   * The element is returned unchanged when the data carries every field the encoder asks for, which
+   * is the aligned case, so nothing is added to the work done per row there.
+   */
+  private def withEncoderFields(element: Expression, encoderType: DataType): Expression = {
+    (element.dataType, encoderType) match {
+      case (dataStruct: StructType, encoderStruct: StructType)
+        if missingAnyField(dataStruct, encoderStruct) =>
+        val resolver = SQLConf.get.resolver
+        val conformedFields = encoderStruct.fields.toSeq.flatMap { encoderField =>
+          dataStruct.fields.indexWhere(field => resolver(field.name, encoderField.name)) match {
+            case -1 => Seq(Literal(encoderField.name),
+              Literal.create(null, encoderField.dataType))
+            case ordinal =>
+              val dataField = dataStruct(ordinal)
+              Seq(Literal(dataField.name),
+                withEncoderFields(GetStructField(element, ordinal, Some(dataField.name)),
+                  encoderField.dataType))
+          }
+        }
+        val conformed = CreateNamedStruct(conformedFields)
+        // A struct built field by field is never null, so the null case has to be restored: an
+        // absent element must stay absent rather than decoding as an empty composite.
+        If(IsNull(element), Literal.create(null, conformed.dataType), conformed)
+      case _ => element
+    }
+  }
+
+  /**
+   * Returns true if the data does not carry every field the encoder expects, at this level or
+   * within any singular struct below it.
+   */
+  private def missingAnyField(dataType: DataType, encoderType: DataType): Boolean = {
+    (dataType, encoderType) match {
+      case (dataStruct: StructType, encoderStruct: StructType) =>
+        val resolver = SQLConf.get.resolver
+        encoderStruct.fields.exists { encoderField =>
+          dataStruct.fields.find(field => resolver(field.name, encoderField.name)) match {
+            case None => true
+            case Some(dataField) => missingAnyField(dataField.dataType, encoderField.dataType)
+          }
+        }
+      case _ => false
+    }
   }
 
   def getSqlDatatypeFor(elementDefinition: BaseRuntimeElementDefinition[_]): DataType = {

--- a/encoders/src/main/scala/au/csiro/pathling/encoders/EncodingContext.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/EncodingContext.scala
@@ -48,6 +48,12 @@ private[encoders] class EncodingContext {
   private def nestingLevel(definition: BaseRuntimeElementDefinition[_]): Int = {
     definitionCounters.getOrElse(definition, 0)
   }
+
+  private def snapshot(): EncodingContext = {
+    val copy = new EncodingContext()
+    copy.definitionCounters ++= definitionCounters
+    copy
+  }
 }
 
 /**
@@ -108,6 +114,38 @@ object EncodingContext {
       CONTEXT_STORAGE.remove()
   }
 
+
+  /**
+   * Wraps a function so that it evaluates against the nesting levels current at the point of
+   * wrapping, however much later it is called.
+   *
+   * This is needed for the deserializer's collection lambdas, which the Spark analyser applies
+   * during `resolveAndBind` rather than during the traversal that builds them, by which time the
+   * traversal's context is long gone. The captured levels are copied on each call, so a wrapped
+   * function can be called more than once, and from a thread other than the one that wrapped it,
+   * without the calls interfering.
+   *
+   * @param f the function to wrap
+   * @tparam A the argument type of the function
+   * @tparam B the return type of the function
+   * @return a function that evaluates `f` against the captured nesting levels
+   */
+  def deferring[A, B](f: A => B): A => B = {
+    val captured = currentContext().snapshot()
+    argument => {
+      val enclosing = CONTEXT_STORAGE.get()
+      try {
+        CONTEXT_STORAGE.set(captured.snapshot())
+        f(argument)
+      } finally {
+        if (enclosing == null) {
+          CONTEXT_STORAGE.remove()
+        } else {
+          CONTEXT_STORAGE.set(enclosing)
+        }
+      }
+    }
+  }
 
   /**
    * Evaluates given code in the context with increased nesting level for given element definition.

--- a/encoders/src/main/scala/au/csiro/pathling/encoders/SerializerBuilder.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/SerializerBuilder.scala
@@ -72,6 +72,10 @@ private[encoders] class SerializerBuilderProcessor(expression: Expression,
   override def buildArrayValue(childDefinition: BaseRuntimeChildDefinition,
                                elementDefinition: BaseRuntimeElementDefinition[_],
                                elementName: String): Expression = {
+    // The serialiser keeps its explicit element type where the deserialiser has given one up. The
+    // asymmetry is deliberate: when writing, the encoder's schema is the authority and the element
+    // type is the type of the HAPI object being read from, so there is no second schema for it to
+    // disagree with. It is only on the way back in that the data has a shape of its own.
     MapObjects(withExpression(_).buildSimpleValue(childDefinition, elementDefinition, elementName),
       expression,
       objectTypeFor(childDefinition))

--- a/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/IdCustomCoder.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/IdCustomCoder.scala
@@ -58,6 +58,10 @@ case class IdCustomCoder(elementName: String) extends CustomCoder {
     val deserializerExp = if (!isCollection) {
       toVersionedId(addToPath(versionedName))
     } else {
+      // This MapObjects keeps its explicit element type, unlike the one in DeserializerBuilder.
+      // It maps over a collection of strings rather than of structs, so there are no fields whose
+      // order or presence could differ between the encoder's schema and the data's, and nothing to
+      // resolve by name.
       val array = Invoke(
         MapObjects(toVersionedId,
           addToPath(versionedName),

--- a/encoders/src/test/java/au/csiro/pathling/encoders/MisalignedSchemaDecodingTest.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/MisalignedSchemaDecodingTest.java
@@ -1,0 +1,482 @@
+/*
+ * This is a modified version of the Bunsen library, originally published at
+ * https://github.com/cerner/bunsen.
+ *
+ * Bunsen is copyright 2017 Cerner Innovation, Inc., and is licensed under
+ * the Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * These modifications are copyright 2018-2026 Commonwealth Scientific
+ * and Industrial Research Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.csiro.pathling.encoders;
+
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.conformTo;
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.elementStruct;
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.mapElementStruct;
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.migratedSchema;
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.narrowEncoders;
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.wideEncoders;
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.withFieldOrder;
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.withReversedFields;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer$;
+import org.apache.spark.sql.catalyst.analysis.UnresolvedExtractValue;
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.objects.MapObjects;
+import org.apache.spark.sql.catalyst.expressions.objects.UnresolvedMapObjects;
+import org.apache.spark.sql.catalyst.types.DataTypeUtils;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.HumanName;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import scala.collection.immutable.Seq;
+import scala.jdk.javaapi.CollectionConverters;
+
+/**
+ * Tests that decoding resolves the fields of a struct nested inside a collection by name against
+ * the schema of the data, rather than by position against the encoder's own schema.
+ *
+ * <p>The state under test is what a {@code mergeSchema} migration leaves behind: the fields the
+ * table already held stay where they were, and the fields only the new encoder emits are appended
+ * after them. The encoder that performed the migration then reads its own table at the wrong
+ * offsets.
+ *
+ * <p>The opposite direction - data carrying fields the encoder has no place for - crashed the JVM
+ * before the fix, so it is kept apart in {@link NarrowEncoderDecodingTest}.
+ *
+ * @author John Grimes
+ */
+class MisalignedSchemaDecodingTest {
+
+  private static final String STRING_EXTENSION_URL = "http://example.org/string-extension";
+  private static final String INTEGER_EXTENSION_URL = "http://example.org/integer-extension";
+  private static final String IDENTIFIER_SYSTEM = "http://example.org/identifiers";
+  private static final String IDENTIFIER_TYPE_SYSTEM = "http://example.org/identifier-types";
+
+  private static SparkSession spark;
+
+  /** Set up Spark. */
+  @BeforeAll
+  static void setUp() {
+    spark =
+        AnsiTestSupport.configureAnsiMode(
+            SparkSession.builder()
+                .master("local[*]")
+                .appName("testing")
+                .config("spark.driver.bindAddress", "localhost")
+                .config("spark.driver.host", "localhost")
+                .config("spark.ui.enabled", "false")
+                .getOrCreate());
+  }
+
+  /** Tear down Spark. */
+  @AfterAll
+  static void tearDown() {
+    spark.stop();
+  }
+
+  // Migrated field order.
+
+  /**
+   * A dataset whose extension struct carries the encoder's fields with two of them appended after
+   * the trailing internal field, rather than in the encoder's order, decodes to the values that
+   * were written (US1.1, US1.2, SC-001).
+   *
+   * <p>Before the fix this raised {@code AssertionError: sizeInBytes (17) should be a multiple of
+   * 8} from {@code UnsafeRow.pointTo}, surfaced as an {@code INTERNAL_ERROR} SparkException. The
+   * size in the message is a function of the row's contents, so it varies with the fixture; the
+   * assertion is the same one recorded against #2698.
+   */
+  @Test
+  void migratedFieldOrderDecodesToTheValuesWritten() {
+    // Arrange: encode a Patient carrying extensions with the narrow encoder, then present it under
+    // the schema a mergeSchema migration by the wide encoder produces.
+    final Dataset<Row> narrowlyEncoded = encode(narrowEncoders(), patientWithNestedCollections());
+    final Dataset<Row> migrated =
+        conformTo(
+            narrowlyEncoded, migratedSchema(narrowlyEncoded.schema(), schemaOf(wideEncoders())));
+
+    // Act: decode with the wide encoder, which is the encoder that performed the migration.
+    final Patient decoded = decode(migrated, wideEncoders());
+
+    // Assert: the extensions hold the values that were written.
+    assertExtensionsSurvived(decoded);
+  }
+
+  // Pure reordering, with no field added or removed.
+
+  /**
+   * A struct nested in an array within a map value - which is the shape of the extension container
+   * - decodes correctly when its fields are purely reordered, with none added and none removed
+   * (FR-004, FR-005, and the reordering and nesting edge cases).
+   */
+  @Test
+  void reorderedExtensionStructDecodesCorrectly() {
+    // Arrange: reverse the field order of the extension element struct alone, leaving every other
+    // struct in the schema as the encoder emits it.
+    final Dataset<Row> encoded = encode(wideEncoders(), patientWithNestedCollections());
+    final StructType reordered =
+        mapElementStruct(
+            encoded.schema(),
+            ExtensionSupport.EXTENSIONS_FIELD_NAME(),
+            struct -> withFieldOrder(struct, reversedNames(struct)));
+    // Guard: the reordering must actually have changed the order, or the test proves nothing.
+    assertFalse(
+        Arrays.equals(
+            elementStruct(encoded.schema(), ExtensionSupport.EXTENSIONS_FIELD_NAME()).fieldNames(),
+            elementStruct(reordered, ExtensionSupport.EXTENSIONS_FIELD_NAME()).fieldNames()));
+
+    // Act.
+    final Patient decoded = decode(conformTo(encoded, reordered), wideEncoders());
+
+    // Assert.
+    assertExtensionsSurvived(decoded);
+  }
+
+  /**
+   * A struct nested in an array - an ordinary repeating element - decodes correctly when its fields
+   * are purely reordered (FR-004, FR-005).
+   */
+  @Test
+  void reorderedRepeatingElementStructDecodesCorrectly() {
+    // Arrange: reverse the field order of the Identifier element struct alone.
+    final Dataset<Row> encoded = encode(wideEncoders(), patientWithNestedCollections());
+    final StructType reordered =
+        mapElementStruct(
+            encoded.schema(),
+            "identifier",
+            struct -> withFieldOrder(struct, reversedNames(struct)));
+
+    // Act.
+    final Patient decoded = decode(conformTo(encoded, reordered), wideEncoders());
+
+    // Assert: both identifiers, and the CodeableConcept nested inside the first one, survive.
+    assertIdentifiersSurvived(decoded);
+  }
+
+  /**
+   * Reversing the field order of every struct at every level of nesting - inside arrays, inside map
+   * values, and inside arrays within map values, all at once - does not affect any decoded value
+   * (FR-004, FR-005).
+   */
+  @Test
+  void reorderingEveryStructAtEveryDepthDecodesCorrectly() {
+    // Arrange.
+    final Dataset<Row> encoded = encode(wideEncoders(), patientWithNestedCollections());
+    final StructType reordered = withReversedFields(encoded.schema());
+
+    // Act.
+    final Patient decoded = decode(conformTo(encoded, reordered), wideEncoders());
+
+    // Assert.
+    assertExtensionsSurvived(decoded);
+    assertIdentifiersSurvived(decoded);
+    assertScalarsSurvived(decoded);
+  }
+
+  /**
+   * A collection of primitives, where field order cannot differ because there are no fields, must
+   * not regress when the struct that contains it is reordered (the primitive collection edge case).
+   */
+  @Test
+  void primitiveCollectionSurvivesReordering() {
+    // Arrange: HumanName.given is an array of strings, held inside the HumanName element struct,
+    // which the reversal reorders.
+    final Dataset<Row> encoded = encode(wideEncoders(), patientWithNestedCollections());
+    final StructType reordered = withReversedFields(encoded.schema());
+
+    // Act.
+    final Patient decoded = decode(conformTo(encoded, reordered), wideEncoders());
+
+    // Assert: every given name survives, in the order written.
+    final HumanName name = decoded.getName().getFirst();
+    assertEquals("Wilson", name.getFamily());
+    assertEquals(
+        List.of("Marie", "Jane"), name.getGiven().stream().map(StringType::getValue).toList());
+  }
+
+  /**
+   * A resource with no extensions and no repeating elements takes the same decode path it does
+   * today, whether its schema is aligned or reordered (the no-collections edge case).
+   */
+  @Test
+  void resourceWithNoCollectionsDecodesUnchanged() {
+    // Arrange: a Patient carrying only scalar elements.
+    final Patient scalarOnly = new Patient();
+    scalarOnly.setId("scalar-only");
+    scalarOnly.setGender(AdministrativeGender.FEMALE);
+    scalarOnly.setActive(true);
+    final Dataset<Row> encoded = encode(wideEncoders(), scalarOnly);
+
+    // Act: decode the aligned dataset, and the same dataset with every struct reordered.
+    final Patient aligned = decode(encoded, wideEncoders());
+    final Patient reordered =
+        decode(conformTo(encoded, withReversedFields(encoded.schema())), wideEncoders());
+
+    // Assert: both agree, and both carry what was written.
+    assertEquals(AdministrativeGender.FEMALE, aligned.getGender());
+    assertEquals(AdministrativeGender.FEMALE, reordered.getGender());
+    assertTrue(aligned.getActive());
+    assertTrue(reordered.getActive());
+    assertTrue(aligned.getExtension().isEmpty());
+    assertTrue(reordered.getExtension().isEmpty());
+  }
+
+  /**
+   * A dataset whose field order matches the encoder exactly decodes to the same result as it does
+   * today (US1.3, FR-007).
+   */
+  @Test
+  void alignedSchemaDecodesUnchanged() {
+    // Arrange: the same dataset decoded directly, and after a projection onto its own schema.
+    final Dataset<Row> encoded = encode(wideEncoders(), patientWithNestedCollections());
+
+    // Act.
+    final Patient direct = decode(encoded, wideEncoders());
+    final Patient viaProjection = decode(conformTo(encoded, encoded.schema()), wideEncoders());
+
+    // Assert: identical, field for field, as serialised by the FHIR parser.
+    assertEquals(asJson(direct), asJson(viaProjection));
+    assertExtensionsSurvived(direct);
+    assertIdentifiersSurvived(direct);
+  }
+
+  /**
+   * A stored field whose name differs from the encoder's only in case is resolved consistently with
+   * Spark's configured resolver, which is case-insensitive by default (the case-difference edge
+   * case).
+   */
+  @Test
+  void caseDifferenceInFieldNameIsResolvedByTheSparkResolver() {
+    // Arrange: store the extension's string value field under an upper-cased name.
+    final Dataset<Row> encoded = encode(wideEncoders(), patientWithNestedCollections());
+    final StructType upperCased =
+        mapElementStruct(
+            encoded.schema(),
+            ExtensionSupport.EXTENSIONS_FIELD_NAME(),
+            struct -> renameField(struct, "valueString", "VALUESTRING"));
+
+    // Act.
+    final Patient decoded = decode(conformTo(encoded, upperCased), wideEncoders());
+
+    // Assert: the value is found under the differently-cased name.
+    assertEquals(
+        "the written value",
+        ((StringType) decoded.getExtensionByUrl(STRING_EXTENSION_URL).getValue()).getValue());
+  }
+
+  // The resolved decode plan.
+
+  /**
+   * An aligned schema resolves to a decode plan of the same shape as a misaligned one, so decoding
+   * an aligned dataset adds no per-row work (SC-005, FR-007).
+   *
+   * <p>The resolution that replaced the encoder-derived element type happens once per query plan,
+   * during {@code resolveAndBind}. This is the check that it leaves nothing behind to be done per
+   * row: the aligned plan retains no unresolved node, and it has exactly the same node-by-node
+   * makeup as the plan for a migrated schema, which differs from it only in the ordinals the field
+   * accesses read. Nothing is conformed, cast or rebuilt on the way through.
+   */
+  @Test
+  void alignedSchemaResolvesToTheSameDecodePlanAsAMigratedOne() {
+    // Arrange.
+    final StructType alignedSchema = schemaOf(wideEncoders());
+    final StructType narrowSchema = schemaOf(narrowEncoders());
+    final StructType migratedSchema = migratedSchema(narrowSchema, alignedSchema);
+
+    // Act: resolve the same encoder against its own schema and against the migrated one.
+    final Expression alignedPlan = resolvedDeserializer(wideEncoders(), alignedSchema);
+    final Expression migratedPlan = resolvedDeserializer(wideEncoders(), migratedSchema);
+
+    // Assert: the aligned plan is fully resolved, with no element type left to derive per row.
+    final List<Expression> alignedNodes = nodes(alignedPlan);
+    assertTrue(
+        alignedNodes.stream().noneMatch(node -> node instanceof UnresolvedMapObjects),
+        "the aligned plan should carry no unresolved collection mapping");
+    assertTrue(
+        alignedNodes.stream().noneMatch(node -> node instanceof UnresolvedExtractValue),
+        "the aligned plan should carry no unresolved field access");
+
+    // Assert: the two plans are made of exactly the same nodes, so the misalignment is absorbed by
+    // the ordinals the plan reads rather than by extra work.
+    assertEquals(nodeHistogram(alignedPlan), nodeHistogram(migratedPlan));
+
+    // Assert: the collection mappings in the aligned plan take their element type from the data,
+    // which for an aligned schema is the encoder's own type - the type the plan used to be built
+    // with directly. The count guards against the assertion being vacuous.
+    final List<MapObjects> mappings =
+        alignedNodes.stream()
+            .filter(MapObjects.class::isInstance)
+            .map(MapObjects.class::cast)
+            .toList();
+    assertFalse(mappings.isEmpty(), "the plan should map over collections");
+    for (final MapObjects mapping : mappings) {
+      if (mapping.inputData().dataType() instanceof final ArrayType arrayType) {
+        assertEquals(arrayType.elementType(), mapping.loopVar().dataType());
+      }
+    }
+  }
+
+  // Fixtures and helpers.
+
+  /**
+   * Returns a Patient carrying extensions, repeating elements with structs nested inside them, a
+   * collection of primitives, and scalar elements.
+   */
+  private static Patient patientWithNestedCollections() {
+    final Patient patient = new Patient();
+    patient.setId("misaligned-patient");
+    patient.setGender(AdministrativeGender.FEMALE);
+    patient.setActive(true);
+
+    final Identifier withType = new Identifier();
+    withType.setSystem(IDENTIFIER_SYSTEM);
+    withType.setValue("first-identifier");
+    withType.setType(
+        new CodeableConcept()
+            .addCoding(new Coding(IDENTIFIER_TYPE_SYSTEM, "MR", "Medical record number")));
+    patient.addIdentifier(withType);
+    patient.addIdentifier(new Identifier().setSystem(IDENTIFIER_SYSTEM).setValue("second"));
+
+    patient.addName(new HumanName().setFamily("Wilson").addGiven("Marie").addGiven("Jane"));
+
+    patient.addExtension(new Extension(STRING_EXTENSION_URL, new StringType("the written value")));
+    patient.addExtension(new Extension(INTEGER_EXTENSION_URL, new IntegerType(42)));
+    return patient;
+  }
+
+  private static void assertExtensionsSurvived(final Patient decoded) {
+    assertEquals(
+        "the written value",
+        ((StringType) decoded.getExtensionByUrl(STRING_EXTENSION_URL).getValue()).getValue());
+    assertEquals(
+        42, ((IntegerType) decoded.getExtensionByUrl(INTEGER_EXTENSION_URL).getValue()).getValue());
+  }
+
+  private static void assertIdentifiersSurvived(final Patient decoded) {
+    assertEquals(2, decoded.getIdentifier().size());
+    final Identifier first = decoded.getIdentifier().getFirst();
+    assertEquals(IDENTIFIER_SYSTEM, first.getSystem());
+    assertEquals("first-identifier", first.getValue());
+    final Coding coding = first.getType().getCoding().getFirst();
+    assertEquals(IDENTIFIER_TYPE_SYSTEM, coding.getSystem());
+    assertEquals("MR", coding.getCode());
+    assertEquals("Medical record number", coding.getDisplay());
+    assertEquals("second", decoded.getIdentifier().get(1).getValue());
+  }
+
+  private static void assertScalarsSurvived(final Patient decoded) {
+    assertEquals(AdministrativeGender.FEMALE, decoded.getGender());
+    assertTrue(decoded.getActive());
+  }
+
+  private static Dataset<Row> encode(final FhirEncoders encoders, final Patient patient) {
+    return spark.createDataset(List.of(patient), encoders.of(Patient.class)).toDF();
+  }
+
+  private static Patient decode(final Dataset<Row> dataset, final FhirEncoders encoders) {
+    return dataset.as(encoders.of(Patient.class)).head();
+  }
+
+  private static StructType schemaOf(final FhirEncoders encoders) {
+    return encoders.of(Patient.class).schema();
+  }
+
+  private static String asJson(final Patient patient) {
+    return FhirEncoders.contextFor(FhirVersionEnum.R4)
+        .newJsonParser()
+        .encodeResourceToString(patient);
+  }
+
+  private static List<String> reversedNames(final StructType struct) {
+    final List<String> names = new ArrayList<>(Arrays.asList(struct.fieldNames()));
+    Collections.reverse(names);
+    return names;
+  }
+
+  private static StructType renameField(
+      final StructType struct, final String from, final String to) {
+    return new StructType(
+        Arrays.stream(struct.fields())
+            .map(
+                field ->
+                    field.name().equals(from)
+                        ? new StructField(to, field.dataType(), field.nullable(), field.metadata())
+                        : field)
+            .toArray(StructField[]::new));
+  }
+
+  /** Resolves the encoder's deserializer against the given data schema, as {@code as()} does. */
+  @SuppressWarnings("unchecked")
+  private static Expression resolvedDeserializer(
+      final FhirEncoders encoders, final StructType dataSchema) {
+    final ExpressionEncoder<Patient> encoder = encoders.of(Patient.class);
+    // Seq is covariant in Scala but invariant to Java's generics, so the element type of the
+    // attribute list has to be widened by hand.
+    final Seq<Attribute> attributes =
+        (Seq<Attribute>) (Seq<?>) DataTypeUtils.toAttributes(dataSchema);
+    return encoder.resolveAndBind(attributes, SimpleAnalyzer$.MODULE$).objDeserializer();
+  }
+
+  /** Returns every node of the expression tree, parents before children. */
+  private static List<Expression> nodes(final Expression root) {
+    final List<Expression> collected = new ArrayList<>();
+    final Deque<Expression> pending = new ArrayDeque<>();
+    pending.push(root);
+    while (!pending.isEmpty()) {
+      final Expression current = pending.pop();
+      collected.add(current);
+      CollectionConverters.asJava(current.children()).forEach(pending::push);
+    }
+    return collected;
+  }
+
+  /** Returns how many nodes of each expression class the tree holds. */
+  private static Map<String, Integer> nodeHistogram(final Expression root) {
+    final Map<String, Integer> histogram = new HashMap<>();
+    for (final Expression node : nodes(root)) {
+      histogram.merge(node.getClass().getName(), 1, Integer::sum);
+    }
+    return histogram;
+  }
+}

--- a/encoders/src/test/java/au/csiro/pathling/encoders/NarrowEncoderDecodingTest.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/NarrowEncoderDecodingTest.java
@@ -1,0 +1,135 @@
+/*
+ * This is a modified version of the Bunsen library, originally published at
+ * https://github.com/cerner/bunsen.
+ *
+ * Bunsen is copyright 2017 Cerner Innovation, Inc., and is licensed under
+ * the Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * These modifications are copyright 2018-2026 Commonwealth Scientific
+ * and Industrial Research Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.csiro.pathling.encoders;
+
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.narrowEncoders;
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.wideEncoders;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Date;
+import java.util.List;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Period;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that data carrying fields the running encoder does not know about decodes to the subset the
+ * encoder can represent.
+ *
+ * <p>This class stands alone rather than joining {@link MisalignedSchemaDecodingTest}. Before the
+ * fix, reading a wider dataset with a narrower encoder read a length out of a misaligned row and
+ * then copied that many bytes. Both tests here failed with {@code java.lang.InternalError: a fault
+ * occurred in an unsafe memory access operation}, and during the investigation of #2697 the same
+ * fault took the JVM down outright with {@code SIGBUS BUS_ADRALN} in {@code
+ * StubRoutines::forward_copy_longs}, reported by surefire as exit code 134. A fork that dies
+ * reports every other test in its class as crashed rather than reporting the failure, so the
+ * crashing case is kept on its own to keep a failure here diagnosable.
+ *
+ * @author John Grimes
+ */
+class NarrowEncoderDecodingTest {
+
+  private static final String STRING_EXTENSION_URL = "http://example.org/string-extension";
+  private static final String PERIOD_EXTENSION_URL = "http://example.org/period-extension";
+
+  private static SparkSession spark;
+
+  /** Set up Spark. */
+  @BeforeAll
+  static void setUp() {
+    spark =
+        AnsiTestSupport.configureAnsiMode(
+            SparkSession.builder()
+                .master("local[*]")
+                .appName("testing")
+                .config("spark.driver.bindAddress", "localhost")
+                .config("spark.driver.host", "localhost")
+                .config("spark.ui.enabled", "false")
+                .getOrCreate());
+  }
+
+  /** Tear down Spark. */
+  @AfterAll
+  static void tearDown() {
+    spark.stop();
+  }
+
+  /**
+   * A dataset encoded with an encoder including {@code Period} and {@code Quantity} decodes with an
+   * encoder excluding both: the other extension values are correct and the process survives (US2.1,
+   * SC-002).
+   */
+  @Test
+  void widerDataDecodesWithNarrowerEncoder() {
+    // Arrange: encode a Patient carrying a string extension and a Period extension with the wide
+    // encoder. The Period field sits before the string field in the extension struct, so the
+    // narrow encoder reads the string value at the Period value's offset.
+    final Dataset<Row> widelyEncoded = widePatient();
+
+    // Act: decode with the narrow encoder, which has no field for the Period value.
+    final Patient decoded = widelyEncoded.as(narrowEncoders().of(Patient.class)).head();
+
+    // Assert: the extension the narrow encoder can represent holds the value that was written.
+    assertEquals(
+        "the written value",
+        ((StringType) decoded.getExtensionByUrl(STRING_EXTENSION_URL).getValue()).getValue());
+  }
+
+  /**
+   * An extension whose only value is of an excluded type is absent from the decoded resource,
+   * rather than present with a wrong value (US2.2).
+   */
+  @Test
+  void extensionOfAnExcludedTypeIsAbsentRatherThanWrong() {
+    // Arrange: the same widely-encoded Patient, whose Period extension the narrow encoder cannot
+    // represent at all.
+    final Dataset<Row> widelyEncoded = widePatient();
+
+    // Act.
+    final Patient decoded = widelyEncoded.as(narrowEncoders().of(Patient.class)).head();
+
+    // Assert: the extension is either absent, or present with no value; what it must not be is
+    // present carrying a value read out of another field.
+    final Extension periodExtension = decoded.getExtensionByUrl(PERIOD_EXTENSION_URL);
+    if (periodExtension != null) {
+      assertNull(periodExtension.getValue());
+    }
+  }
+
+  /** Returns a Patient carrying a string extension and a Period extension, encoded widely. */
+  private static Dataset<Row> widePatient() {
+    final Patient patient = new Patient();
+    patient.setId("wide-patient");
+    patient.addExtension(new Extension(STRING_EXTENSION_URL, new StringType("the written value")));
+    patient.addExtension(new Extension(PERIOD_EXTENSION_URL, new Period().setStart(new Date(0L))));
+    return spark.createDataset(List.of(patient), wideEncoders().of(Patient.class)).toDF();
+  }
+}

--- a/encoders/src/test/java/au/csiro/pathling/encoders/NarrowEncoderDecodingTest.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/NarrowEncoderDecodingTest.java
@@ -22,16 +22,27 @@
  */
 package au.csiro.pathling.encoders;
 
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.conformTo;
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.mapElementStruct;
 import static au.csiro.pathling.encoders.utils.SchemaMisalignment.narrowEncoders;
 import static au.csiro.pathling.encoders.utils.SchemaMisalignment.wideEncoders;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import org.apache.spark.SparkRuntimeException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Period;
@@ -104,11 +115,16 @@ class NarrowEncoderDecodingTest {
   }
 
   /**
-   * An extension whose only value is of an excluded type is absent from the decoded resource,
-   * rather than present with a wrong value (US2.2).
+   * An extension whose only value is of an excluded type carries no value in the decoded resource,
+   * rather than a value read out of another field (US2.2, FR-002).
+   *
+   * <p>The stored value field has no counterpart in the narrow encoder's schema, so there is
+   * nothing for the encoder to put the value into. What it can represent of that extension is its
+   * url, and that is what it returns. Before the fix the same read produced a value taken from the
+   * neighbouring field, or brought the process down.
    */
   @Test
-  void extensionOfAnExcludedTypeIsAbsentRatherThanWrong() {
+  void extensionOfAnExcludedTypeCarriesNoValue() {
     // Arrange: the same widely-encoded Patient, whose Period extension the narrow encoder cannot
     // represent at all.
     final Dataset<Row> widelyEncoded = widePatient();
@@ -116,12 +132,82 @@ class NarrowEncoderDecodingTest {
     // Act.
     final Patient decoded = widelyEncoded.as(narrowEncoders().of(Patient.class)).head();
 
-    // Assert: the extension is either absent, or present with no value; what it must not be is
-    // present carrying a value read out of another field.
+    // Assert: the extension is present under its own url, and carries no value.
     final Extension periodExtension = decoded.getExtensionByUrl(PERIOD_EXTENSION_URL);
-    if (periodExtension != null) {
-      assertNull(periodExtension.getValue());
-    }
+    assertNotNull(periodExtension);
+    assertNull(periodExtension.getValue());
+    // Assert: and it did not take the neighbouring extension's value.
+    assertEquals(
+        "the written value",
+        ((StringType) decoded.getExtensionByUrl(STRING_EXTENSION_URL).getValue()).getValue());
+  }
+
+  /**
+   * A dataset encoded with the narrow encoder decodes with the wide encoder, presenting the fields
+   * the data does not carry as absent (US2.3, FR-003).
+   *
+   * <p>This is the direction an un-migrated table is read in after the open types are widened. The
+   * wide encoder asks for {@code valuePeriod} and {@code valueQuantity}, for which the narrow table
+   * has no column at all, so the encoder has to treat them as absent rather than failing to resolve
+   * them.
+   */
+  @Test
+  void narrowlyEncodedDataDecodesAbsentFieldsAsAbsent() {
+    // Arrange: encode with the narrow encoder, which emits no valuePeriod or valueQuantity field.
+    final Patient patient = new Patient();
+    patient.setId("narrow-patient");
+    patient.addExtension(new Extension(STRING_EXTENSION_URL, new StringType("the written value")));
+    final Dataset<Row> narrowlyEncoded =
+        spark.createDataset(List.of(patient), narrowEncoders().of(Patient.class)).toDF();
+
+    // Act: decode with the wide encoder.
+    final Patient decoded = narrowlyEncoded.as(wideEncoders().of(Patient.class)).head();
+
+    // Assert: the extension that was written is intact, and the fields the data does not carry are
+    // simply not there.
+    assertEquals(1, decoded.getExtension().size());
+    assertEquals(
+        "the written value",
+        ((StringType) decoded.getExtensionByUrl(STRING_EXTENSION_URL).getValue()).getValue());
+    assertNull(decoded.getExtensionByUrl(PERIOD_EXTENSION_URL));
+  }
+
+  /**
+   * A stored field that shares a name with the encoder's but not its type fails, rather than being
+   * misread (the name-and-type mismatch edge case).
+   *
+   * <p>Reconciling a type difference is out of scope: only a difference in name and order is in
+   * scope, and a type difference has to be loud.
+   */
+  @Test
+  void fieldSharingANameButNotATypeFails() {
+    // Arrange: present the extension's integer value field as a string.
+    final Dataset<Row> widelyEncoded = widePatient();
+    final Dataset<Row> retyped =
+        conformTo(
+            widelyEncoded,
+            mapElementStruct(
+                widelyEncoded.schema(),
+                ExtensionSupport.EXTENSIONS_FIELD_NAME(),
+                struct -> retypeField(struct, "valueInteger", DataTypes.StringType)));
+
+    // Act and assert: decoding fails rather than returning a misread value.
+    final SparkRuntimeException failure =
+        assertThrows(
+            SparkRuntimeException.class, () -> retyped.as(wideEncoders().of(Patient.class)).head());
+    assertTrue(failure.getMessage().contains("EXPRESSION_DECODING_FAILED"));
+  }
+
+  private static StructType retypeField(
+      final StructType struct, final String name, final DataType dataType) {
+    return new StructType(
+        Arrays.stream(struct.fields())
+            .map(
+                field ->
+                    field.name().equals(name)
+                        ? new StructField(name, dataType, field.nullable(), field.metadata())
+                        : field)
+            .toArray(StructField[]::new));
   }
 
   /** Returns a Patient carrying a string extension and a Period extension, encoded widely. */

--- a/encoders/src/test/java/au/csiro/pathling/encoders/utils/SchemaMisalignment.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/utils/SchemaMisalignment.java
@@ -1,0 +1,381 @@
+/*
+ * This is a modified version of the Bunsen library, originally published at
+ * https://github.com/cerner/bunsen.
+ *
+ * Bunsen is copyright 2017 Cerner Innovation, Inc., and is licensed under
+ * the Apache License, version 2.0 (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * These modifications are copyright 2018-2026 Commonwealth Scientific
+ * and Industrial Research Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.csiro.pathling.encoders.utils;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.apache.spark.sql.functions.lit;
+import static org.apache.spark.sql.functions.struct;
+import static org.apache.spark.sql.functions.transform;
+import static org.apache.spark.sql.functions.transform_values;
+import static org.apache.spark.sql.functions.when;
+
+import au.csiro.pathling.encoders.FhirEncoders;
+import jakarta.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Test support for constructing datasets whose schema is deliberately misaligned with the encoder
+ * that decodes them.
+ *
+ * <p>The {@code encoders} module has no Delta dependency, so the two states that put a warehouse
+ * out of alignment - a table migrated with {@code mergeSchema}, and a table written by a wider
+ * encoder than the one reading it - are reproduced here by projection rather than by writing
+ * storage. {@link #migratedSchema} models what a {@code mergeSchema} migration does to a schema,
+ * and {@link #conformTo} presents a dataset under any nominated schema, resolving fields by name at
+ * every depth.
+ *
+ * <p>The Delta-level form of the same scenario, against a real migrated table, lives in {@code
+ * library-api}, which does have delta-spark.
+ *
+ * @author John Grimes
+ */
+public final class SchemaMisalignment {
+
+  /** The open types the narrow encoder configures. */
+  public static final Set<String> NARROW_OPEN_TYPES = FhirEncoders.STANDARD_OPEN_TYPES;
+
+  /**
+   * The narrow open types plus {@code Period} and {@code Quantity}. Those two are useful here
+   * because their extension value fields sort into the middle of the extension struct rather than
+   * the end, so enabling them shifts the position of every field after them.
+   */
+  public static final Set<String> WIDE_OPEN_TYPES =
+      Stream.concat(NARROW_OPEN_TYPES.stream(), Stream.of("Period", "Quantity"))
+          .collect(toUnmodifiableSet());
+
+  private SchemaMisalignment() {}
+
+  /**
+   * Returns encoders configured with the narrow set of open types.
+   *
+   * @return the narrow encoders
+   */
+  @Nonnull
+  public static FhirEncoders narrowEncoders() {
+    return FhirEncoders.forR4()
+        .withExtensionsEnabled(true)
+        .withOpenTypes(NARROW_OPEN_TYPES)
+        .getOrCreate();
+  }
+
+  /**
+   * Returns encoders configured with the wide set of open types.
+   *
+   * @return the wide encoders
+   */
+  @Nonnull
+  public static FhirEncoders wideEncoders() {
+    return FhirEncoders.forR4()
+        .withExtensionsEnabled(true)
+        .withOpenTypes(WIDE_OPEN_TYPES)
+        .getOrCreate();
+  }
+
+  /**
+   * Presents the dataset under the given schema, resolving each target field against the dataset's
+   * own schema by name at every level of nesting.
+   *
+   * <p>Fields the target names but the dataset does not carry become typed nulls; fields the
+   * dataset carries but the target does not name are dropped; and the result is presented in the
+   * target's field order. This projection stands in for storage in this module: combined with
+   * {@link #migratedSchema} it produces the row layout a {@code mergeSchema} migration leaves
+   * behind.
+   *
+   * @param dataset the dataset to project
+   * @param target the schema to present it under
+   * @return the projected dataset
+   */
+  @Nonnull
+  public static Dataset<Row> conformTo(
+      @Nonnull final Dataset<Row> dataset, @Nonnull final StructType target) {
+    final StructType source = dataset.schema();
+    final Column[] columns =
+        Arrays.stream(target.fields())
+            .map(
+                field ->
+                    findField(source, field.name())
+                        .map(
+                            sourceField ->
+                                project(
+                                    dataset.col(sourceField.name()),
+                                    sourceField.dataType(),
+                                    field.dataType()))
+                        .orElseGet(() -> lit(null).cast(field.dataType()))
+                        .alias(field.name()))
+            .toArray(Column[]::new);
+    return dataset.select(columns);
+  }
+
+  /**
+   * Returns the schema that a {@code mergeSchema} append of {@code incoming} onto a table holding
+   * {@code stored} produces: each struct keeps the fields it already had, in the order it had them,
+   * with the fields only the incoming schema carries appended after them. This holds at every level
+   * of nesting, which is what makes a migrated table's nested structs disagree with the encoder
+   * that migrated it.
+   *
+   * @param stored the schema the table already holds
+   * @param incoming the schema being appended
+   * @return the merged schema
+   */
+  @Nonnull
+  public static StructType migratedSchema(
+      @Nonnull final StructType stored, @Nonnull final StructType incoming) {
+    return (StructType) migrated(stored, incoming);
+  }
+
+  /**
+   * Returns the schema with the field order of every struct reversed, at every level of nesting.
+   * This is the pure reordering case: no field is added and none removed, so nothing but the order
+   * can account for a difference in the decoded result.
+   *
+   * @param schema the schema to reverse
+   * @return the reversed schema
+   */
+  @Nonnull
+  public static StructType withReversedFields(@Nonnull final StructType schema) {
+    return (StructType) reversed(schema);
+  }
+
+  /**
+   * Returns the schema with the element struct of the named collection column replaced by the
+   * result of applying the given operator to it. The column may be an array of structs, or a map
+   * whose values are arrays of structs, which is the shape of the extension container.
+   *
+   * <p>This is how a test nominates an explicit field order, or an explicit field name, for one
+   * nested struct without disturbing the rest of the schema.
+   *
+   * @param schema the schema to rewrite
+   * @param columnName the name of the top-level column to rewrite within
+   * @param operator the rewrite to apply to the element struct
+   * @return the rewritten schema
+   * @throws IllegalArgumentException if the named column is not a collection of structs
+   */
+  @Nonnull
+  public static StructType mapElementStruct(
+      @Nonnull final StructType schema,
+      @Nonnull final String columnName,
+      @Nonnull final UnaryOperator<StructType> operator) {
+    final StructField field = schema.apply(columnName);
+    final StructField[] fields = schema.fields().clone();
+    fields[schema.fieldIndex(columnName)] =
+        withDataType(field, mapElementStruct(field.dataType(), operator));
+    return new StructType(fields);
+  }
+
+  /**
+   * Returns the struct type found at the bottom of the named collection column, unwrapping arrays
+   * and map values along the way.
+   *
+   * @param schema the schema to look in
+   * @param columnName the name of the top-level column
+   * @return the element struct type
+   * @throws IllegalArgumentException if the named column is not a collection of structs
+   */
+  @Nonnull
+  public static StructType elementStruct(
+      @Nonnull final StructType schema, @Nonnull final String columnName) {
+    final List<StructType> captured = new ArrayList<>();
+    mapElementStruct(
+        schema,
+        columnName,
+        element -> {
+          captured.add(element);
+          return element;
+        });
+    return captured.getFirst();
+  }
+
+  /**
+   * Returns the given struct type with its fields in the nominated order.
+   *
+   * @param struct the struct type to reorder
+   * @param fieldOrder the field names, which must be exactly the struct's own field names
+   * @return the reordered struct type
+   * @throws IllegalArgumentException if the nominated order is not a permutation of the struct's
+   *     field names
+   */
+  @Nonnull
+  public static StructType withFieldOrder(
+      @Nonnull final StructType struct, @Nonnull final List<String> fieldOrder) {
+    final Set<String> nominated = new HashSet<>(fieldOrder);
+    final Set<String> present = new HashSet<>(Arrays.asList(struct.fieldNames()));
+    if (!nominated.equals(present) || fieldOrder.size() != struct.fields().length) {
+      throw new IllegalArgumentException(
+          "The nominated field order must be a permutation of the struct's field names, but was "
+              + fieldOrder
+              + " for "
+              + Arrays.toString(struct.fieldNames()));
+    }
+    return new StructType(fieldOrder.stream().map(struct::apply).toArray(StructField[]::new));
+  }
+
+  /**
+   * Projects a column onto a target type, resolving struct fields by name at every level of
+   * nesting.
+   */
+  @Nonnull
+  private static Column project(
+      @Nonnull final Column column,
+      @Nonnull final DataType sourceType,
+      @Nonnull final DataType targetType) {
+    if (sourceType instanceof final StructType source
+        && targetType instanceof final StructType target) {
+      final Column[] fields =
+          Arrays.stream(target.fields())
+              .map(
+                  field ->
+                      findField(source, field.name())
+                          .map(
+                              sourceField ->
+                                  project(
+                                      column.getField(sourceField.name()),
+                                      sourceField.dataType(),
+                                      field.dataType()))
+                          .orElseGet(() -> lit(null).cast(field.dataType()))
+                          .alias(field.name()))
+              .toArray(Column[]::new);
+      // A struct built field by field is never null, so the null case has to be restored
+      // explicitly. Without this, a null nested struct would decode as an empty composite rather
+      // than as absent.
+      return when(column.isNull(), lit(null).cast(target)).otherwise(struct(fields));
+    }
+    if (sourceType instanceof final ArrayType source
+        && targetType instanceof final ArrayType target) {
+      return transform(
+          column, element -> project(element, source.elementType(), target.elementType()));
+    }
+    if (sourceType instanceof final MapType source && targetType instanceof final MapType target) {
+      return transform_values(
+          column, (key, value) -> project(value, source.valueType(), target.valueType()));
+    }
+    return column.cast(targetType);
+  }
+
+  @Nonnull
+  private static DataType migrated(
+      @Nonnull final DataType stored, @Nonnull final DataType incoming) {
+    if (stored instanceof final StructType storedStruct
+        && incoming instanceof final StructType incomingStruct) {
+      final List<StructField> fields = new ArrayList<>();
+      for (final StructField field : storedStruct.fields()) {
+        fields.add(
+            findField(incomingStruct, field.name())
+                .map(
+                    incomingField ->
+                        withDataType(field, migrated(field.dataType(), incomingField.dataType())))
+                .orElse(field));
+      }
+      for (final StructField field : incomingStruct.fields()) {
+        if (findField(storedStruct, field.name()).isEmpty()) {
+          // A field only the incoming schema carries is appended, which is what shifts the
+          // positions of the fields already present.
+          fields.add(field);
+        }
+      }
+      return new StructType(fields.toArray(new StructField[0]));
+    }
+    if (stored instanceof final ArrayType storedArray
+        && incoming instanceof final ArrayType incomingArray) {
+      return new ArrayType(
+          migrated(storedArray.elementType(), incomingArray.elementType()),
+          storedArray.containsNull());
+    }
+    if (stored instanceof final MapType storedMap
+        && incoming instanceof final MapType incomingMap) {
+      return new MapType(
+          storedMap.keyType(),
+          migrated(storedMap.valueType(), incomingMap.valueType()),
+          storedMap.valueContainsNull());
+    }
+    return stored;
+  }
+
+  @Nonnull
+  private static DataType reversed(@Nonnull final DataType dataType) {
+    if (dataType instanceof final StructType struct) {
+      final List<StructField> fields = new ArrayList<>(Arrays.asList(struct.fields()));
+      Collections.reverse(fields);
+      return new StructType(
+          fields.stream()
+              .map(field -> withDataType(field, reversed(field.dataType())))
+              .toArray(StructField[]::new));
+    }
+    if (dataType instanceof final ArrayType array) {
+      return new ArrayType(reversed(array.elementType()), array.containsNull());
+    }
+    if (dataType instanceof final MapType map) {
+      return new MapType(map.keyType(), reversed(map.valueType()), map.valueContainsNull());
+    }
+    return dataType;
+  }
+
+  @Nonnull
+  private static DataType mapElementStruct(
+      @Nonnull final DataType dataType, @Nonnull final UnaryOperator<StructType> operator) {
+    if (dataType instanceof final ArrayType array) {
+      return new ArrayType(mapElementStruct(array.elementType(), operator), array.containsNull());
+    }
+    if (dataType instanceof final MapType map) {
+      return new MapType(
+          map.keyType(), mapElementStruct(map.valueType(), operator), map.valueContainsNull());
+    }
+    if (dataType instanceof final StructType struct) {
+      return operator.apply(struct);
+    }
+    throw new IllegalArgumentException("Not a collection of structs: " + dataType.simpleString());
+  }
+
+  /**
+   * Returns the field with its data type replaced, preserving its name, nullability and metadata.
+   */
+  @Nonnull
+  private static StructField withDataType(
+      @Nonnull final StructField field, @Nonnull final DataType dataType) {
+    return new StructField(field.name(), dataType, field.nullable(), field.metadata());
+  }
+
+  /** Looks a field up case-insensitively, matching the resolver Spark applies by default. */
+  @Nonnull
+  private static Optional<StructField> findField(
+      @Nonnull final StructType struct, @Nonnull final String name) {
+    return Arrays.stream(struct.fields())
+        .filter(field -> field.name().equalsIgnoreCase(name))
+        .findFirst();
+  }
+}

--- a/lib/R/R/encoding.R
+++ b/lib/R/R/encoding.R
@@ -30,7 +30,6 @@ library(purrr)
 #'
 #' @family encoding functions
 #'
-#' @importFrom rlang `%||%`
 #' @importFrom sparklyr sdf_register spark_dataframe j_invoke
 #'
 #' @export
@@ -65,7 +64,6 @@ pathling_encode <- function(pc, df, resource_name, input_type = NULL, column = N
 #'
 #' @family encoding functions
 #'
-#' @importFrom rlang `%||%`
 #' @importFrom sparklyr sdf_register spark_dataframe j_invoke
 #'
 #' @export

--- a/lib/R/R/utils.R
+++ b/lib/R/R/utils.R
@@ -18,3 +18,12 @@
 j_to_set <- function(spark, values) {
   spark %>% j_invoke_static("com.google.common.collect.ImmutableSet", "copyOf", as.list(values))
 }
+
+# Returns the first argument unless it is NULL, in which case it returns the second.
+#
+# This is defined here rather than imported from rlang, which as of version 1.3.0 only re-exports the
+# operator that base R provides from version 4.4.0. The package supports R 3.5.0 and above, so on an
+# older R there is nothing for rlang to export.
+`%||%` <- function(x, y) {
+  if (is.null(x)) y else x
+}

--- a/library-api/src/main/java/au/csiro/pathling/library/io/sink/DeltaSink.java
+++ b/library-api/src/main/java/au/csiro/pathling/library/io/sink/DeltaSink.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
@@ -210,22 +211,7 @@ final class DeltaSink implements DataSink {
   @Nonnull
   private static Dataset<Row> conformToTarget(
       @Nonnull final Dataset<Row> dataset, @Nonnull final StructType target) {
-    final StructType source = dataset.schema();
-    final Column[] columns =
-        Arrays.stream(target.fields())
-            .map(
-                field -> {
-                  final StructField sourceField = fieldOrNull(source, field.name());
-                  return (sourceField == null
-                          ? lit(null).cast(field.dataType())
-                          : conformColumn(
-                              dataset.col(sourceField.name()),
-                              sourceField.dataType(),
-                              field.dataType()))
-                      .alias(field.name());
-                })
-            .toArray(Column[]::new);
-    return dataset.select(columns);
+    return dataset.select(conformFields(dataset::col, dataset.schema(), target));
   }
 
   /** Projects a column onto a target type, resolving struct fields by name at every depth. */
@@ -240,23 +226,10 @@ final class DeltaSink implements DataSink {
     }
     if (sourceType instanceof final StructType source
         && targetType instanceof final StructType target) {
-      final Column[] fields =
-          Arrays.stream(target.fields())
-              .map(
-                  field -> {
-                    final StructField sourceField = fieldOrNull(source, field.name());
-                    return (sourceField == null
-                            ? lit(null).cast(field.dataType())
-                            : conformColumn(
-                                column.getField(sourceField.name()),
-                                sourceField.dataType(),
-                                field.dataType()))
-                        .alias(field.name());
-                  })
-              .toArray(Column[]::new);
       // A struct built field by field is never null, so the null case has to be restored
       // explicitly, or an absent nested struct would be written as one full of nulls.
-      return when(column.isNull(), lit(null).cast(target)).otherwise(struct(fields));
+      return when(column.isNull(), lit(null).cast(target))
+          .otherwise(struct(conformFields(column::getField, source, target)));
     }
     if (sourceType instanceof final ArrayType source
         && targetType instanceof final ArrayType target) {
@@ -268,6 +241,36 @@ final class DeltaSink implements DataSink {
           column, (key, value) -> conformColumn(value, source.valueType(), target.valueType()));
     }
     return column;
+  }
+
+  /**
+   * Builds one column per target field, taking it from the source by name where the source has it,
+   * and supplying a typed null where it does not.
+   *
+   * @param fieldAccessor how to reach a named field of the source, which differs between the top
+   *     level of a dataset and a nested struct
+   * @param source the schema the columns are being taken from
+   * @param target the schema the columns are being presented under
+   * @return the projected columns, in the target's field order
+   */
+  @Nonnull
+  private static Column[] conformFields(
+      @Nonnull final Function<String, Column> fieldAccessor,
+      @Nonnull final StructType source,
+      @Nonnull final StructType target) {
+    return Arrays.stream(target.fields())
+        .map(
+            field -> {
+              final StructField sourceField = fieldOrNull(source, field.name());
+              return (sourceField == null
+                      ? lit(null).cast(field.dataType())
+                      : conformColumn(
+                          fieldAccessor.apply(sourceField.name()),
+                          sourceField.dataType(),
+                          field.dataType()))
+                  .alias(field.name());
+            })
+        .toArray(Column[]::new);
   }
 
   /** Returns the named field of the struct, or null if it has none. */

--- a/library-api/src/main/java/au/csiro/pathling/library/io/sink/DeltaSink.java
+++ b/library-api/src/main/java/au/csiro/pathling/library/io/sink/DeltaSink.java
@@ -18,17 +18,32 @@
 package au.csiro.pathling.library.io.sink;
 
 import static au.csiro.pathling.library.io.FileSystemPersistence.safelyJoinPaths;
+import static org.apache.spark.sql.functions.lit;
+import static org.apache.spark.sql.functions.struct;
+import static org.apache.spark.sql.functions.transform;
+import static org.apache.spark.sql.functions.transform_values;
+import static org.apache.spark.sql.functions.when;
 
 import au.csiro.pathling.io.source.DataSource;
 import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.SaveMode;
 import io.delta.tables.DeltaTable;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.UnaryOperator;
+import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 
 /**
  * A data sink that writes data to a Delta Lake table on a filesystem.
@@ -141,19 +156,178 @@ final class DeltaSink implements DataSink {
   /**
    * Merges the given dataset into the specified Delta table.
    *
+   * <p>Where the table carries fields the dataset does not, the merge is permitted to leave those
+   * fields null on the rows it writes, rather than failing. This is the state a warehouse is in
+   * when it was written with more open types configured than the encoder now writing to it, which
+   * is otherwise unwritable even though the data is perfectly readable.
+   *
    * @param table the Delta table to merge into
    * @param dataset the dataset containing updates to be merged
    */
   static void merge(@Nonnull final DeltaTable table, @Nonnull final Dataset<Row> dataset) {
+    final StructType targetSchema = table.toDF().schema();
+
+    // Where the target carries fields the dataset does not, and the dataset carries none the target
+    // does not, present the dataset under the target's own schema with those fields null. The merge
+    // itself is then an ordinary aligned one, so a row it matches is replaced in full rather than
+    // keeping the values the target happened to hold for the fields the source cannot express.
+    //
+    // Delta's own schema evolution was not used for this. It is the mechanism that makes the write
+    // possible at all, but it couples two behaviours behind one flag - null-filling on insert, and
+    // evolving the target to admit fields only the source carries - and it leaves a matched row's
+    // other columns untouched rather than replacing the row.
+    //
+    // Where the two schemas differ in both directions at once, the dataset is passed through
+    // unchanged and the merge fails as it otherwise would: widening the target is the caller's
+    // decision, not this method's.
+    final Dataset<Row> updates =
+        isPurelyNarrowing(targetSchema, dataset.schema())
+            ? conformToTarget(dataset, targetSchema)
+            : dataset;
+
     // Perform a merge operation where we match on the 'id' column.
     table
         .as("original")
-        .merge(dataset.as("updates"), "original.id = updates.id")
+        .merge(updates.as("updates"), "original.id = updates.id")
         .whenMatched()
         .updateAll()
         .whenNotMatched()
         .insertAll()
         .execute();
+  }
+
+  /**
+   * Presents the dataset under the target schema, supplying as nulls the fields the target carries
+   * and the dataset does not.
+   *
+   * <p>Only the parts of the dataset that differ from the target are rebuilt; a subtree whose type
+   * already matches is passed straight through.
+   *
+   * @param dataset the dataset to project, whose fields must be a subset of the target's
+   * @param target the schema to present it under
+   * @return the projected dataset
+   */
+  @Nonnull
+  private static Dataset<Row> conformToTarget(
+      @Nonnull final Dataset<Row> dataset, @Nonnull final StructType target) {
+    final StructType source = dataset.schema();
+    final Column[] columns =
+        Arrays.stream(target.fields())
+            .map(
+                field -> {
+                  final StructField sourceField = fieldOrNull(source, field.name());
+                  return (sourceField == null
+                          ? lit(null).cast(field.dataType())
+                          : conformColumn(
+                              dataset.col(sourceField.name()),
+                              sourceField.dataType(),
+                              field.dataType()))
+                      .alias(field.name());
+                })
+            .toArray(Column[]::new);
+    return dataset.select(columns);
+  }
+
+  /** Projects a column onto a target type, resolving struct fields by name at every depth. */
+  @Nonnull
+  private static Column conformColumn(
+      @Nonnull final Column column,
+      @Nonnull final DataType sourceType,
+      @Nonnull final DataType targetType) {
+    if (sourceType.sameType(targetType)) {
+      // Nothing below this point differs, so there is nothing to rebuild.
+      return column;
+    }
+    if (sourceType instanceof final StructType source
+        && targetType instanceof final StructType target) {
+      final Column[] fields =
+          Arrays.stream(target.fields())
+              .map(
+                  field -> {
+                    final StructField sourceField = fieldOrNull(source, field.name());
+                    return (sourceField == null
+                            ? lit(null).cast(field.dataType())
+                            : conformColumn(
+                                column.getField(sourceField.name()),
+                                sourceField.dataType(),
+                                field.dataType()))
+                        .alias(field.name());
+                  })
+              .toArray(Column[]::new);
+      // A struct built field by field is never null, so the null case has to be restored
+      // explicitly, or an absent nested struct would be written as one full of nulls.
+      return when(column.isNull(), lit(null).cast(target)).otherwise(struct(fields));
+    }
+    if (sourceType instanceof final ArrayType source
+        && targetType instanceof final ArrayType target) {
+      return transform(
+          column, element -> conformColumn(element, source.elementType(), target.elementType()));
+    }
+    if (sourceType instanceof final MapType source && targetType instanceof final MapType target) {
+      return transform_values(
+          column, (key, value) -> conformColumn(value, source.valueType(), target.valueType()));
+    }
+    return column;
+  }
+
+  /** Returns the named field of the struct, or null if it has none. */
+  @Nullable
+  private static StructField fieldOrNull(
+      @Nonnull final StructType struct, @Nonnull final String name) {
+    return Arrays.stream(struct.fields())
+        .filter(field -> field.name().equals(name))
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
+   * Determines whether the source schema is a strict subset of the target schema, at every level of
+   * nesting.
+   *
+   * @param target the schema of the table being merged into
+   * @param source the schema of the dataset being merged
+   * @return true if the target carries fields the source does not, and the source carries none the
+   *     target does not
+   */
+  private static boolean isPurelyNarrowing(
+      @Nonnull final StructType target, @Nonnull final StructType source) {
+    final Set<String> targetPaths = fieldPaths(target);
+    final Set<String> sourcePaths = fieldPaths(source);
+    return targetPaths.containsAll(sourcePaths) && !sourcePaths.containsAll(targetPaths);
+  }
+
+  /**
+   * Collects the path of every field in the schema, at every level of nesting.
+   *
+   * <p>Array elements and map values contribute a marker to the path rather than a name, so that a
+   * field of a struct within an array cannot be confused with a field of a struct of the same name
+   * held directly.
+   *
+   * @param schema the schema to walk
+   * @return the set of field paths
+   */
+  @Nonnull
+  private static Set<String> fieldPaths(@Nonnull final StructType schema) {
+    final Set<String> paths = new HashSet<>();
+    collectFieldPaths("", schema, paths);
+    return paths;
+  }
+
+  private static void collectFieldPaths(
+      @Nonnull final String prefix,
+      @Nonnull final DataType dataType,
+      @Nonnull final Set<String> paths) {
+    if (dataType instanceof final StructType struct) {
+      for (final StructField field : struct.fields()) {
+        final String path = prefix.isEmpty() ? field.name() : prefix + "." + field.name();
+        paths.add(path);
+        collectFieldPaths(path, field.dataType(), paths);
+      }
+    } else if (dataType instanceof final ArrayType array) {
+      collectFieldPaths(prefix + "[]", array.elementType(), paths);
+    } else if (dataType instanceof final MapType map) {
+      collectFieldPaths(prefix + "{}", map.valueType(), paths);
+    }
   }
 
   /**

--- a/library-api/src/main/java/au/csiro/pathling/library/io/sink/DeltaSink.java
+++ b/library-api/src/main/java/au/csiro/pathling/library/io/sink/DeltaSink.java
@@ -273,7 +273,14 @@ final class DeltaSink implements DataSink {
         .toArray(Column[]::new);
   }
 
-  /** Returns the named field of the struct, or null if it has none. */
+  /**
+   * Returns the named field of the struct, or null if it has none.
+   *
+   * <p>Matched on the exact name rather than through the session's resolver, unlike the decode
+   * side. A difference of case alone therefore reads as a difference of field, so the merge is left
+   * to whatever Delta would have done with it rather than being quietly conformed - which is the
+   * conservative reading, since the two names may well have been meant to be different.
+   */
   @Nullable
   private static StructField fieldOrNull(
       @Nonnull final StructType struct, @Nonnull final String name) {

--- a/library-api/src/test/java/au/csiro/pathling/library/io/DataSourcesTest.java
+++ b/library-api/src/test/java/au/csiro/pathling/library/io/DataSourcesTest.java
@@ -41,6 +41,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -52,6 +53,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -782,6 +784,41 @@ class DataSourcesTest {
 
     // Query the data.
     queryNdjsonData(newData);
+  }
+
+  /**
+   * The catalog sink shares {@code DeltaSink.merge}, so it inherits the tolerance for a source
+   * narrower than the target table: the merge succeeds and leaves the target's additional columns
+   * null on the rows it writes (US3.6 of {@code 048-name-based-nested-decode}).
+   */
+  @Test
+  void tablesMergeWithNarrowerSource() {
+    // Arrange: write a Delta-backed catalog table holding the full encoded schema.
+    final QueryableDataSource data =
+        pathlingContext.read().ndjson(TEST_DATA_PATH.resolve("ndjson").toString());
+    data.write().saveMode("overwrite").tables("test", "delta");
+    final StructType before = spark.table("test.Patient").schema();
+
+    // Arrange: a source that carries every Patient the table holds, but no gender column.
+    final Dataset<Row> narrowerSource = data.read("Patient").drop("gender");
+    assertTrue(
+        List.of(before.fieldNames()).contains("gender"),
+        "the target table should carry the column the source is missing");
+
+    // Act: merge it back in through the catalog sink.
+    pathlingContext
+        .read()
+        .datasets()
+        .dataset("Patient", narrowerSource)
+        .write()
+        .saveMode("merge")
+        .tables("test", "delta");
+
+    // Assert: the table kept its own schema, and the written rows carry no gender.
+    assertEquals(before, spark.table("test.Patient").schema());
+    assertTrue(
+        spark.table("test.Patient").filter("gender is not null").isEmpty(),
+        "the column the source lacked should be null on every written row");
   }
 
   @Test

--- a/library-api/src/test/java/au/csiro/pathling/library/io/ExtensionContexts.java
+++ b/library-api/src/test/java/au/csiro/pathling/library/io/ExtensionContexts.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.library.io;
+
+import au.csiro.pathling.config.EncodingConfiguration;
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.encoders.utils.SchemaMisalignment;
+import au.csiro.pathling.library.PathlingContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import jakarta.annotation.Nonnull;
+import java.util.List;
+import java.util.Set;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.hl7.fhir.r4.model.Patient;
+
+/**
+ * Test support for the library API tests that need two encoder configurations differing only in
+ * their open types, and a way to move resources in and out of them.
+ *
+ * <p>The two configurations are the ones {@link SchemaMisalignment} defines for the {@code
+ * encoders} module, so the projection-based tests there and the Delta-level tests here are
+ * describing the same pair of encoders.
+ *
+ * @author John Grimes
+ */
+final class ExtensionContexts {
+
+  /** The MIME type used when moving decoded resources back out as strings. */
+  private static final String FHIR_JSON = "application/fhir+json";
+
+  private ExtensionContexts() {}
+
+  /**
+   * Returns a context configured with the narrow set of open types.
+   *
+   * @param spark the Spark session to use
+   * @return the narrow context
+   */
+  @Nonnull
+  static PathlingContext narrow(@Nonnull final SparkSession spark) {
+    return contextFor(spark, SchemaMisalignment.NARROW_OPEN_TYPES);
+  }
+
+  /**
+   * Returns a context configured with the wide set of open types.
+   *
+   * @param spark the Spark session to use
+   * @return the wide context
+   */
+  @Nonnull
+  static PathlingContext wide(@Nonnull final SparkSession spark) {
+    return contextFor(spark, SchemaMisalignment.WIDE_OPEN_TYPES);
+  }
+
+  /**
+   * Encodes the given resources with the narrow encoder.
+   *
+   * @param spark the Spark session to use
+   * @param patients the resources to encode
+   * @return the encoded dataset
+   */
+  @Nonnull
+  static Dataset<Row> encodeNarrow(
+      @Nonnull final SparkSession spark, @Nonnull final List<Patient> patients) {
+    return spark
+        .createDataset(patients, SchemaMisalignment.narrowEncoders().of(Patient.class))
+        .toDF();
+  }
+
+  /**
+   * Encodes the given resources with the wide encoder.
+   *
+   * @param spark the Spark session to use
+   * @param patients the resources to encode
+   * @return the encoded dataset
+   */
+  @Nonnull
+  static Dataset<Row> encodeWide(
+      @Nonnull final SparkSession spark, @Nonnull final List<Patient> patients) {
+    return spark
+        .createDataset(patients, SchemaMisalignment.wideEncoders().of(Patient.class))
+        .toDF();
+  }
+
+  /**
+   * Decodes the first row of the given dataset through the library API, which is the path a caller
+   * takes when reading resources back out of storage.
+   *
+   * @param context the context whose encoder configuration decodes the data
+   * @param dataset the dataset to decode
+   * @return the decoded resource
+   */
+  @Nonnull
+  static Patient decodeOne(
+      @Nonnull final PathlingContext context, @Nonnull final Dataset<Row> dataset) {
+    final String json = context.decode(dataset, "Patient", FHIR_JSON).head();
+    return (Patient)
+        FhirEncoders.contextFor(FhirVersionEnum.R4).newJsonParser().parseResource(json);
+  }
+
+  @Nonnull
+  private static PathlingContext contextFor(
+      @Nonnull final SparkSession spark, @Nonnull final Set<String> openTypes) {
+    return PathlingContext.createForEncoding(
+        spark, EncodingConfiguration.builder().enableExtensions(true).openTypes(openTypes).build());
+  }
+}

--- a/library-api/src/test/java/au/csiro/pathling/library/io/MigratedTableDecodingTest.java
+++ b/library-api/src/test/java/au/csiro/pathling/library/io/MigratedTableDecodingTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.library.io;
+
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.elementStruct;
+import static au.csiro.pathling.encoders.utils.SchemaMisalignment.wideEncoders;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import au.csiro.pathling.encoders.ExtensionSupport;
+import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.TestHelpers;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The Delta-level form of the decode regression: a table created with a narrower encoder, migrated
+ * in place by a zero-row {@code mergeSchema} append using a wider one, then read back and decoded
+ * through the library API.
+ *
+ * <p>This is the reproduction recorded against #2698. The projection-based version of it lives in
+ * the {@code encoders} module, which has no Delta dependency; this one exercises a real migrated
+ * table, so it also confirms that {@code mergeSchema} appends new nested fields to the end of each
+ * struct rather than merging them into the encoder's order.
+ *
+ * @author John Grimes
+ */
+class MigratedTableDecodingTest {
+
+  private static final String STRING_EXTENSION_URL = "http://example.org/string-extension";
+  private static final String INTEGER_EXTENSION_URL = "http://example.org/integer-extension";
+
+  private static SparkSession spark;
+  private static Path temporaryDirectory;
+
+  /** Set up Spark and a temporary warehouse. */
+  @BeforeAll
+  static void setUp() throws IOException {
+    temporaryDirectory = Files.createTempDirectory("pathling-migrated-table-test-");
+    spark = TestHelpers.sparkBuilder().getOrCreate();
+  }
+
+  /** Tear down Spark and remove the temporary warehouse. */
+  @AfterAll
+  static void tearDown() throws IOException {
+    spark.stop();
+    FileUtils.deleteDirectory(temporaryDirectory.toFile());
+  }
+
+  /**
+   * A Delta table created with the narrow encoder and then migrated in place by a zero-row {@code
+   * mergeSchema} append using the wide encoder returns, when read back and decoded through the
+   * library API, the extension values it was written with (US1.4, SC-006).
+   */
+  @Test
+  void migratedDeltaTableDecodesToTheValuesWritten() {
+    final PathlingContext narrowContext = ExtensionContexts.narrow(spark);
+    final PathlingContext wideContext = ExtensionContexts.wide(spark);
+    final String warehouse = temporaryDirectory.resolve("migrated-warehouse").toString();
+    final String tablePath = Path.of(warehouse, "Patient.parquet").toString();
+
+    // Arrange: create the table with the narrow encoder, through the library API sink.
+    narrowContext
+        .read()
+        .datasets()
+        .dataset("Patient", ExtensionContexts.encodeNarrow(spark, List.of(patientWithExtensions())))
+        .write()
+        .saveMode("overwrite")
+        .delta(warehouse);
+
+    // Arrange: migrate the table in place, as a schemaAutoMerge warmup write does - a zero-row
+    // append by the wide encoder with mergeSchema enabled.
+    ExtensionContexts.encodeWide(spark, Collections.emptyList())
+        .write()
+        .format("delta")
+        .mode("append")
+        .option("mergeSchema", "true")
+        .save(tablePath);
+
+    // Guard: the migration must have left the stored extension struct in a different field order
+    // from the one the wide encoder emits, or the test proves nothing.
+    final StructType storedSchema = spark.read().format("delta").load(tablePath).schema();
+    assertFalse(
+        Arrays.equals(
+            extensionFieldNames(storedSchema),
+            extensionFieldNames(wideEncoders().of(Patient.class).schema())),
+        "the migrated table should not carry the wide encoder's field order");
+
+    // Act: read the table back and decode it through the library API, using the wide encoder that
+    // performed the migration.
+    final Patient decoded =
+        ExtensionContexts.decodeOne(
+            wideContext, wideContext.read().delta(warehouse).read("Patient"));
+
+    // Assert: the extension values are the ones that were written.
+    assertEquals(
+        "the written value",
+        ((StringType) decoded.getExtensionByUrl(STRING_EXTENSION_URL).getValue()).getValue());
+    assertEquals(
+        42, ((IntegerType) decoded.getExtensionByUrl(INTEGER_EXTENSION_URL).getValue()).getValue());
+    // Assert: and the narrow encoder that wrote the table can still read it too.
+    assertEquals(
+        "the written value",
+        ((StringType)
+                ExtensionContexts.decodeOne(
+                        narrowContext, narrowContext.read().delta(warehouse).read("Patient"))
+                    .getExtensionByUrl(STRING_EXTENSION_URL)
+                    .getValue())
+            .getValue());
+  }
+
+  private static Patient patientWithExtensions() {
+    final Patient patient = new Patient();
+    patient.setId("migrated-patient");
+    patient.addExtension(new Extension(STRING_EXTENSION_URL, new StringType("the written value")));
+    patient.addExtension(new Extension(INTEGER_EXTENSION_URL, new IntegerType(42)));
+    return patient;
+  }
+
+  /** Returns the field names of the struct held in the extension container's arrays. */
+  private static String[] extensionFieldNames(final StructType schema) {
+    return elementStruct(schema, ExtensionSupport.EXTENSIONS_FIELD_NAME()).fieldNames();
+  }
+}

--- a/library-api/src/test/java/au/csiro/pathling/library/io/NarrowMergeTest.java
+++ b/library-api/src/test/java/au/csiro/pathling/library/io/NarrowMergeTest.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -192,15 +193,19 @@ class NarrowMergeTest {
         "overwrite");
     final StructType before = storedSchema(warehouse);
 
-    // Act and assert: merging a widely-encoded source is refused.
-    assertThrows(
-        Exception.class,
-        () ->
-            write(
-                wideContext,
-                ExtensionContexts.encodeWide(spark, sourcePatients()),
-                warehouse,
-                "merge"));
+    // Act and assert: merging a widely-encoded source is refused, for the same reason it is today.
+    final AnalysisException failure =
+        assertThrows(
+            AnalysisException.class,
+            () ->
+                write(
+                    wideContext,
+                    ExtensionContexts.encodeWide(spark, sourcePatients()),
+                    warehouse,
+                    "merge"));
+    assertTrue(
+        failure.getMessage().contains("DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION"),
+        "expected the merge to fail on the struct mismatch, but got: " + failure.getMessage());
 
     // Assert: the target was left alone, and in particular was not widened.
     assertEquals(2, gendersById(warehouse).size());
@@ -252,8 +257,14 @@ class NarrowMergeTest {
             .drop("gender")
             .withColumn("unexpected", lit(1));
 
-    // Act and assert.
-    assertThrows(Exception.class, () -> write(wideContext, mixedSource, warehouse, "merge"));
+    // Act and assert: refused, for the same reason it is today - the column the source lacks cannot
+    // be resolved in the update clause.
+    final AnalysisException failure =
+        assertThrows(
+            AnalysisException.class, () -> write(wideContext, mixedSource, warehouse, "merge"));
+    assertTrue(
+        failure.getMessage().contains("DELTA_MERGE_UNRESOLVED_EXPRESSION"),
+        "expected the merge to fail on the unresolved column, but got: " + failure.getMessage());
 
     // Assert: the target was left alone, and in particular was not widened.
     assertEquals(2, gendersById(warehouse).size());

--- a/library-api/src/test/java/au/csiro/pathling/library/io/NarrowMergeTest.java
+++ b/library-api/src/test/java/au/csiro/pathling/library/io/NarrowMergeTest.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.library.io;
+
+import static org.apache.spark.sql.functions.lit;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.TestHelpers;
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
+import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that merging into a Delta table through the library API tolerates a source narrower than
+ * the target, leaving the target's additional columns null on the written rows, while continuing to
+ * reject a source that would widen the target.
+ *
+ * <p>Both directions matter. The tolerance is what makes a warehouse written by one encoder
+ * configuration writable by a narrower one; refusing to widen is what keeps the tolerance from
+ * quietly turning into schema evolution the caller did not ask for.
+ *
+ * @author John Grimes
+ */
+class NarrowMergeTest {
+
+  private static final String STRING_EXTENSION_URL = "http://example.org/string-extension";
+  private static final String TABLE_FILE_NAME = "Patient.parquet";
+
+  private static SparkSession spark;
+  private static Path temporaryDirectory;
+  private static PathlingContext wideContext;
+  private static PathlingContext narrowContext;
+
+  /** Set up Spark and a temporary warehouse. */
+  @BeforeAll
+  static void setUp() throws IOException {
+    temporaryDirectory = Files.createTempDirectory("pathling-narrow-merge-test-");
+    spark = TestHelpers.sparkBuilder().getOrCreate();
+    wideContext = ExtensionContexts.wide(spark);
+    narrowContext = ExtensionContexts.narrow(spark);
+  }
+
+  /** Tear down Spark and remove the temporary warehouse. */
+  @AfterAll
+  static void tearDown() throws IOException {
+    spark.stop();
+    FileUtils.deleteDirectory(temporaryDirectory.toFile());
+  }
+
+  /**
+   * Merging a source that lacks a column the target carries succeeds, leaves that column null on
+   * the written rows, and replaces the row whose id already existed (US3.1, US3.2, SC-007).
+   *
+   * <p>Before the fix this failed with {@code DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION}.
+   */
+  @Test
+  void narrowerSourceMergesAndLeavesTheMissingColumnNull() {
+    // Arrange: a target holding two patients, both with a gender.
+    final String warehouse = warehouse("narrower-source");
+    write(
+        wideContext, ExtensionContexts.encodeWide(spark, targetPatients()), warehouse, "overwrite");
+
+    // Arrange: a source that updates one of them and adds a third, carrying no gender column at
+    // all.
+    final Dataset<Row> narrowerSource =
+        ExtensionContexts.encodeWide(spark, sourcePatients()).drop("gender");
+
+    // Act.
+    write(wideContext, narrowerSource, warehouse, "merge");
+
+    // Assert: the untouched row keeps its gender, and the two written rows have none.
+    final Map<String, String> genders = gendersById(warehouse);
+    assertEquals(3, genders.size());
+    assertEquals(AdministrativeGender.MALE.toCode(), genders.get("target-only"));
+    assertNull(genders.get("in-both"));
+    assertNull(genders.get("source-only"));
+
+    // Assert: the matched row was replaced, not merged field by field.
+    assertEquals(
+        "the updated value",
+        extensionValueOf(warehouse, "in-both"),
+        "the row matching an existing id should have been replaced");
+  }
+
+  /**
+   * The target keeps its own schema after a narrower source is merged into it, so a reader
+   * configured with the original open types still reads the columns written before (US3.3).
+   */
+  @Test
+  void mergeLeavesTheTargetSchemaUnchanged() {
+    // Arrange.
+    final String warehouse = warehouse("schema-unchanged");
+    write(
+        wideContext, ExtensionContexts.encodeWide(spark, targetPatients()), warehouse, "overwrite");
+    final StructType before = storedSchema(warehouse);
+
+    // Act.
+    write(
+        wideContext,
+        ExtensionContexts.encodeWide(spark, sourcePatients()).drop("gender"),
+        warehouse,
+        "merge");
+
+    // Assert: the schema is exactly what it was, so the merge widened nothing and dropped nothing.
+    assertEquals(before, storedSchema(warehouse));
+  }
+
+  /**
+   * A narrowly-encoded source merges into a table written with more open types configured, and the
+   * rows written before it remain readable by the encoder that wrote them (US3.1, SC-007).
+   *
+   * <p>This is the state the reporter of #2697 described, at the level of nested struct fields
+   * rather than whole columns: the target's extension struct carries {@code valuePeriod} and {@code
+   * valueQuantity}, and the source's does not.
+   */
+  @Test
+  void narrowlyEncodedSourceMergesIntoAWiderTable() {
+    // Arrange: a target written with Period and Quantity configured.
+    final String warehouse = warehouse("narrow-encoder");
+    write(
+        wideContext, ExtensionContexts.encodeWide(spark, targetPatients()), warehouse, "overwrite");
+    final StructType before = storedSchema(warehouse);
+
+    // Act: merge a source encoded without them, through the narrow context.
+    write(
+        narrowContext, ExtensionContexts.encodeNarrow(spark, sourcePatients()), warehouse, "merge");
+
+    // Assert: the table kept its wider schema.
+    assertEquals(before, storedSchema(warehouse));
+
+    // Assert: the row written by the wide encoder and never touched still decodes to its original
+    // extension value, read back with the wide encoder through the library API.
+    assertEquals(
+        "the original value",
+        extensionValueOf(warehouse, "target-only"),
+        "a row written before the merge should still carry its value");
+    // Assert: and the newly written rows are there.
+    assertEquals(3, gendersById(warehouse).size());
+  }
+
+  /**
+   * A source whose nested structs carry fields the target's do not still fails, so the change adds
+   * tolerance rather than schema evolution (US3.4, FR-012).
+   *
+   * <p>This is the inverse of {@link #narrowlyEncodedSourceMergesIntoAWiderTable}: a widely-encoded
+   * source merged into a narrowly-encoded target.
+   */
+  @Test
+  void wideningSourceStillFails() {
+    // Arrange: a target written with the narrow encoder.
+    final String warehouse = warehouse("widening-source");
+    write(
+        narrowContext,
+        ExtensionContexts.encodeNarrow(spark, targetPatients()),
+        warehouse,
+        "overwrite");
+    final StructType before = storedSchema(warehouse);
+
+    // Act and assert: merging a widely-encoded source is refused.
+    assertThrows(
+        Exception.class,
+        () ->
+            write(
+                wideContext,
+                ExtensionContexts.encodeWide(spark, sourcePatients()),
+                warehouse,
+                "merge"));
+
+    // Assert: the target was left alone, and in particular was not widened.
+    assertEquals(2, gendersById(warehouse).size());
+    assertEquals(before, storedSchema(warehouse));
+  }
+
+  /**
+   * A source carrying a top-level column the target lacks merges as it does today, ignoring that
+   * column, and does not widen the target (US3.4, FR-012).
+   *
+   * <p>This shape of widening difference does not fail today, unlike the nested one: {@code
+   * updateAll} and {@code insertAll} address the target's columns, so a column only the source
+   * carries is simply not written. What matters for FR-012 is that enabling the tolerance for a
+   * narrower source has not turned this into schema evolution.
+   */
+  @Test
+  void wideningSourceDoesNotWidenTheTarget() {
+    // Arrange.
+    final String warehouse = warehouse("widening-column");
+    write(
+        wideContext, ExtensionContexts.encodeWide(spark, targetPatients()), warehouse, "overwrite");
+    final StructType before = storedSchema(warehouse);
+    final Dataset<Row> widerSource =
+        ExtensionContexts.encodeWide(spark, sourcePatients()).withColumn("unexpected", lit(1));
+
+    // Act.
+    write(wideContext, widerSource, warehouse, "merge");
+
+    // Assert: the rows were written, and the target's schema is untouched.
+    assertEquals(3, gendersById(warehouse).size());
+    assertEquals(before, storedSchema(warehouse));
+    assertTrue(
+        !List.of(storedSchema(warehouse).fieldNames()).contains("unexpected"),
+        "the target should not have been widened by the source");
+  }
+
+  /**
+   * A source that differs from the target in both directions at once still fails, because admitting
+   * it would widen the target (US3.5, FR-012).
+   */
+  @Test
+  void sourceDifferingInBothDirectionsStillFails() {
+    // Arrange: a source that both lacks a column the target has and carries one it does not.
+    final String warehouse = warehouse("both-directions");
+    write(
+        wideContext, ExtensionContexts.encodeWide(spark, targetPatients()), warehouse, "overwrite");
+    final Dataset<Row> mixedSource =
+        ExtensionContexts.encodeWide(spark, sourcePatients())
+            .drop("gender")
+            .withColumn("unexpected", lit(1));
+
+    // Act and assert.
+    assertThrows(Exception.class, () -> write(wideContext, mixedSource, warehouse, "merge"));
+
+    // Assert: the target was left alone, and in particular was not widened.
+    assertEquals(2, gendersById(warehouse).size());
+    assertTrue(
+        List.of(storedSchema(warehouse).fieldNames()).contains("gender"),
+        "the target should still carry its own columns");
+    assertTrue(
+        !List.of(storedSchema(warehouse).fieldNames()).contains("unexpected"),
+        "the target should not have been widened by the source");
+  }
+
+  /** A merge whose source and target schemas are aligned behaves as it does today (US3.7). */
+  @Test
+  void alignedMergeIsUnaffected() {
+    // Arrange.
+    final String warehouse = warehouse("aligned");
+    write(
+        wideContext, ExtensionContexts.encodeWide(spark, targetPatients()), warehouse, "overwrite");
+
+    // Act.
+    assertDoesNotThrow(
+        () ->
+            write(
+                wideContext,
+                ExtensionContexts.encodeWide(spark, sourcePatients()),
+                warehouse,
+                "merge"));
+
+    // Assert: three rows, with the source's own genders intact rather than null-filled.
+    final Map<String, String> genders = gendersById(warehouse);
+    assertEquals(3, genders.size());
+    assertEquals(AdministrativeGender.MALE.toCode(), genders.get("target-only"));
+    assertEquals(AdministrativeGender.FEMALE.toCode(), genders.get("in-both"));
+    assertEquals(AdministrativeGender.FEMALE.toCode(), genders.get("source-only"));
+  }
+
+  // Fixtures and helpers.
+
+  /** Two patients, one of which the source also carries. */
+  @Nonnull
+  private static List<Patient> targetPatients() {
+    return List.of(
+        patient("target-only", AdministrativeGender.MALE, "the original value"),
+        patient("in-both", AdministrativeGender.MALE, "the original value"));
+  }
+
+  /** One patient the target already holds, and one it does not. */
+  @Nonnull
+  private static List<Patient> sourcePatients() {
+    return List.of(
+        patient("in-both", AdministrativeGender.FEMALE, "the updated value"),
+        patient("source-only", AdministrativeGender.FEMALE, "the updated value"));
+  }
+
+  @Nonnull
+  private static Patient patient(
+      @Nonnull final String id,
+      @Nonnull final AdministrativeGender gender,
+      @Nonnull final String extensionValue) {
+    final Patient patient = new Patient();
+    patient.setId(id);
+    patient.setGender(gender);
+    patient.addExtension(new Extension(STRING_EXTENSION_URL, new StringType(extensionValue)));
+    return patient;
+  }
+
+  @Nonnull
+  private static String warehouse(@Nonnull final String name) {
+    return temporaryDirectory.resolve(name).toString();
+  }
+
+  private static void write(
+      @Nonnull final PathlingContext context,
+      @Nonnull final Dataset<Row> dataset,
+      @Nonnull final String warehouse,
+      @Nonnull final String saveMode) {
+    context
+        .read()
+        .datasets()
+        .dataset("Patient", dataset)
+        .write()
+        .saveMode(saveMode)
+        .delta(warehouse);
+  }
+
+  @Nonnull
+  private static StructType storedSchema(@Nonnull final String warehouse) {
+    return storedTable(warehouse).schema();
+  }
+
+  @Nonnull
+  private static Dataset<Row> storedTable(@Nonnull final String warehouse) {
+    return spark.read().format("delta").load(Path.of(warehouse, TABLE_FILE_NAME).toString());
+  }
+
+  /** Returns the gender code held against each stored id, which is null where none was written. */
+  @Nonnull
+  private static Map<String, String> gendersById(@Nonnull final String warehouse) {
+    final Map<String, String> genders = new HashMap<>();
+    storedTable(warehouse)
+        .select("id", "gender")
+        .collectAsList()
+        .forEach(row -> genders.put(row.getString(0), row.getString(1)));
+    return genders;
+  }
+
+  /**
+   * Returns the string extension value of the stored resource with the given id, decoded through
+   * the library API with the wide encoder.
+   */
+  @Nonnull
+  private static String extensionValueOf(
+      @Nonnull final String warehouse, @Nonnull final String id) {
+    final Dataset<Row> row =
+        wideContext.read().delta(warehouse).read("Patient").filter("id = '" + id + "'");
+    final Patient decoded = ExtensionContexts.decodeOne(wideContext, row);
+    return ((StringType) decoded.getExtensionByUrl(STRING_EXTENSION_URL).getValue()).getValue();
+  }
+}

--- a/site/docs/libraries/io/index.md
+++ b/site/docs/libraries/io/index.md
@@ -331,7 +331,7 @@ val data = pc.read().bundles("/usr/share/staging/bundles",
 
 ```java
 BundlesSource data = pc.read().bundles("/usr/share/staging/bundles",
-        Set.of("Patient", "Condition", "Immunization"), FhirMimeTypes.FHIR_JSON) 
+        Set.of("Patient", "Condition", "Immunization"), FhirMimeTypes.FHIR_JSON)
 ```
 
 </TabItem>
@@ -625,6 +625,15 @@ parameter when initialising the Pathling context.
 The files are named according to their resource
 type (`[resource type].parquet`), e.g. `Patient.parquet`, `Condition.parquet`.
 
+Writing in merge mode into a table that carries columns your current encoder
+configuration does not produce - for example a table written with more open types
+enabled for extension values than you have configured now - succeeds. Those
+columns are left null on the rows that are written, and the table keeps its wider
+schema, so a reader configured with the original open types can still read the
+rows written before. A source that carries columns the table does not is a
+different matter: that would mean widening the table, which is not done for you,
+so such a write still fails.
+
 <!--suppress CheckEmptyScriptTag -->
 <Tabs>
 <TabItem value="python" label="Python">
@@ -706,4 +715,3 @@ tables("test");
 
 </TabItem>
 </Tabs>
-


### PR DESCRIPTION
Resolves #2698 (schema migration leaves nested struct fields in an order the encoder cannot decode), and the core half of the first two asks in #2697 (narrowing `encoding.openTypes` against an existing warehouse makes all writes for that resource type fail). The remainder of #2697 - the identical tolerance on the server's own merge path, and diagnostics for a mismatch that stays unreconcilable - is the server-side counterpart and lands separately.

Decoding a struct nested inside a collection assumed its fields sat where the running encoder would have put them, and applied those positions to whatever the stored data actually held. A table migrated with `mergeSchema`, or one written by an encoder with more open types configured, was then read at the wrong offsets: silently wrong values, an unsafe-row assertion, or a fault in an unsafe memory access operation.

The element type is now deferred to the analyser, which takes it from the data and resolves the nested field accesses by name. Fields the encoder expects that the data does not carry decode as absent. Every consumer of the encoders inherits this, including library API and language library callers who bind an encoder themselves.

Separately, a merge whose source lacks fields the target table carries now succeeds. The source is presented under the target's own schema with those fields null, so the merge is an ordinary aligned one and a matched row is still replaced in full. Where the two schemas differ in both directions the merge is left to fail as before, because widening the target is the caller's decision. This sits in the shared merge, so the catalog sink, the Python and R bindings, and the server's `$import` in merge mode all inherit it.

Two notes for review. Delta's own schema evolution was tried first and rejected: it makes the write possible, but `updateAll` leaves a matched row's target-only columns at their existing stored values, producing a hybrid row rather than a replacement. And a source carrying an extra top-level column never failed the merge in the first place, since `updateAll` and `insertAll` address the target's columns and simply ignore it; only a nested widening difference fails. Both shapes are covered by tests.

Verified by reproducing both pre-fix failures and then fixing them, including against a real `mergeSchema`-migrated Delta table, and by exercising the Python bindings against the rebuilt jar.