### PR TITLE
Diagnose and tolerate schema drift on the server

### DIFF
--- a/server/src/main/java/au/csiro/pathling/errors/ErrorHandlingInterceptor.java
+++ b/server/src/main/java/au/csiro/pathling/errors/ErrorHandlingInterceptor.java
@@ -20,6 +20,7 @@ package au.csiro.pathling.errors;
 import static java.util.Objects.requireNonNull;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 
+import au.csiro.pathling.io.SchemaDrift;
 import au.csiro.pathling.io.SchemaDriftError;
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Interceptor;
@@ -40,8 +41,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Collections;
 import org.apache.spark.SparkException;
 import org.apache.spark.SparkRuntimeException;
+import org.apache.spark.sql.delta.DeltaAnalysisException;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.StructType;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
 import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
@@ -54,6 +59,15 @@ import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
  */
 @Interceptor
 public class ErrorHandlingInterceptor {
+
+  /**
+   * The Delta condition raised when a MERGE cannot cast the source struct to the target struct
+   * because their fields do not correspond. This is the condition a stored table produces when its
+   * schema and this server's encoders disagree in a way Delta will not reconcile, in either
+   * direction.
+   */
+  private static final String DELTA_SCHEMA_MISMATCH_CONDITION =
+      "DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION";
 
   /**
    * HAPI hook to convert errors and exceptions to BaseServerResponseException.
@@ -74,7 +88,8 @@ public class ErrorHandlingInterceptor {
       @Nullable final HttpServletRequest request,
       @Nullable final HttpServletResponse response) {
 
-    return convertError(throwable);
+    return convertError(
+        throwable, requestDetails == null ? null : requestDetails.getResourceName());
   }
 
   /**
@@ -84,9 +99,26 @@ public class ErrorHandlingInterceptor {
    * @return a HAPI {@link BaseServerResponseException} that will deliver an appropriate response to
    *     a user of the FHIR API
    */
-  @SuppressWarnings("java:S3776") // Complexity is acceptable for centralised exception handling.
   @Nonnull
   public static BaseServerResponseException convertError(@Nonnull final Throwable error) {
+    return convertError(error, null);
+  }
+
+  /**
+   * Converts an error into a HAPI BaseServerResponseException, naming the resource type in those
+   * messages that describe a problem with a particular type's stored data.
+   *
+   * @param error an error that could be raised during processing
+   * @param resourceType the resource type the request concerns, or null where it is not known. A
+   *     Delta schema-mismatch exception does not carry it, so it is supplied by the caller that
+   *     does know it.
+   * @return a HAPI {@link BaseServerResponseException} that will deliver an appropriate response to
+   *     a user of the FHIR API
+   */
+  @SuppressWarnings("java:S3776") // Complexity is acceptable for centralised exception handling.
+  @Nonnull
+  public static BaseServerResponseException convertError(
+      @Nonnull final Throwable error, @Nullable final String resourceType) {
     try {
       throw error;
 
@@ -105,7 +137,7 @@ public class ErrorHandlingInterceptor {
       // (see: ca.uhn.fhir.rest.server.method.BaseMethodBinding.invokeServerMethod )
       @Nullable final Throwable cause = e.getCause();
       if (cause != null) {
-        return convertError(cause);
+        return convertError(cause, resourceType);
       } else {
         return internalServerError(e);
       }
@@ -153,12 +185,64 @@ public class ErrorHandlingInterceptor {
       // Other SparkRuntimeExceptions might wrap a cause we can convert.
       @Nullable final Throwable cause = e.getCause();
       if (cause != null) {
-        return convertError(cause);
+        return convertError(cause, resourceType);
       }
       return internalServerError(e);
+    } catch (final DeltaAnalysisException e) {
+      // A stored table that cannot be reconciled with this server's encoders is a deployment state,
+      // not a request defect, but the raw Delta message embeds both struct definitions in full and
+      // so cannot be returned. Translate the one condition that describes it and let every other
+      // Delta condition fall through to the generic message.
+      if (!DELTA_SCHEMA_MISMATCH_CONDITION.equals(e.getCondition())) {
+        return internalServerError(e);
+      }
+      return buildException(
+          HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+          requireNonNull(describeSchemaMismatch(e, resourceType).getMessage()),
+          IssueType.PROCESSING);
     } catch (final Throwable e) { // NO-SONAR we really want to catch everything here
       // Anything else is unexpected and triggers a 500.
       return internalServerError(e);
+    }
+  }
+
+  /**
+   * Describes a Delta schema-mismatch condition in terms of the resource type, the direction of the
+   * disagreement and the field paths involved.
+   *
+   * <p>The exception's two message parameters are the catalog strings of the source and target
+   * structs, in that order. Parsing them back into schemas lets the same comparison that reports
+   * drift elsewhere derive the field paths, so no exception text reaches the message. The paths are
+   * relative to the struct Delta was casting, which is the element that actually differs.
+   *
+   * <p>A parameter that cannot be parsed - a shape this Delta version does not produce today, but
+   * nothing guarantees that - leaves both directions empty, and the resulting message names the
+   * condition without field detail rather than failing.
+   */
+  @Nonnull
+  private static SchemaDriftError describeSchemaMismatch(
+      @Nonnull final DeltaAnalysisException error, @Nullable final String resourceType) {
+    final String[] parameters = error.getMessageParametersArray();
+    @Nullable final StructType source = parameters.length > 0 ? parseStruct(parameters[0]) : null;
+    @Nullable final StructType target = parameters.length > 1 ? parseStruct(parameters[1]) : null;
+    if (source == null || target == null) {
+      return new SchemaDriftError(resourceType, Collections.emptySet(), Collections.emptySet());
+    }
+    return new SchemaDriftError(
+        resourceType,
+        SchemaDrift.missingFieldPaths(source, target),
+        SchemaDrift.excessFieldPaths(source, target));
+  }
+
+  /** Parses a struct's catalog string back into a schema, returning null if it is not one. */
+  @Nullable
+  private static StructType parseStruct(@Nonnull final String catalogString) {
+    try {
+      return DataType.fromDDL(catalogString) instanceof final StructType struct ? struct : null;
+    } catch (final Exception e) {
+      // The parameter was not a parseable type; the caller falls back to a message without field
+      // detail.
+      return null;
     }
   }
 

--- a/server/src/main/java/au/csiro/pathling/io/SchemaDrift.java
+++ b/server/src/main/java/au/csiro/pathling/io/SchemaDrift.java
@@ -29,10 +29,21 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
 /**
- * Detects schema drift between the schema produced by the current FHIR encoders and the schema of
- * an existing Delta table. Only field paths present in the source but absent from the target count
- * as drift; nullability and column metadata differences are ignored, and extra target-only fields
- * are tolerated.
+ * Compares the schema produced by the current FHIR encoders against the schema of an existing Delta
+ * table, in both directions. Nullability and column metadata differences are ignored throughout.
+ *
+ * <p>{@link #missingFieldPaths} reports paths the encoder emits that the table lacks. That
+ * direction is migratable, by an additive schema evolution, and is the subject of the {@code
+ * pathling.storage.schemaAutoMerge} policy.
+ *
+ * <p>{@link #excessFieldPaths} reports paths the table carries that the encoder does not emit. That
+ * direction is not migratable: the columns cannot be reconstructed, and narrowing the table would
+ * discard data. It exists so that startup can report the condition, and so that the write path can
+ * recognise when it is safe to let Delta null-fill the columns it cannot supply. It is not a reason
+ * to refuse service. Reading such a table back is made safe by the core-side decode fix in {@code
+ * 048-name-based-nested-decode}, which resolves nested fields by name rather than by position; the
+ * core Delta sink computes its own equivalent of this comparison, because the two modules are
+ * released independently.
  *
  * @author John Grimes
  */
@@ -67,6 +78,21 @@ public final class SchemaDrift {
     final SortedSet<String> missing = new TreeSet<>(collectFieldPaths(source));
     missing.removeAll(collectFieldPaths(target));
     return missing;
+  }
+
+  /**
+   * Returns the field paths present in the target schema but absent from the source schema, in
+   * lexicographic order. This is the reverse of {@link #missingFieldPaths}, and describes a table
+   * that carries fields the encoder does not emit.
+   *
+   * @param source the candidate schema (typically the encoder output)
+   * @param target the existing table schema
+   * @return the excess field paths, dot-separated
+   */
+  @Nonnull
+  public static SortedSet<String> excessFieldPaths(
+      @Nonnull final StructType source, @Nonnull final StructType target) {
+    return missingFieldPaths(target, source);
   }
 
   @Nonnull

--- a/server/src/main/java/au/csiro/pathling/io/SchemaDriftError.java
+++ b/server/src/main/java/au/csiro/pathling/io/SchemaDriftError.java
@@ -18,12 +18,26 @@
 package au.csiro.pathling.io;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
- * Raised when a request requires the data of a resource type whose Delta table schema is behind
- * this server's encoders and has not been migrated. The message names the affected type, the
- * condition, and the available remedies, and is surfaced to API clients through an
- * OperationOutcome.
+ * Raised when a request cannot be served because a resource type's Delta table schema and this
+ * server's encoders disagree. The message names the affected type where it is known, the direction
+ * of the disagreement, the field paths involved, and the available remedies, and is surfaced to API
+ * clients through an OperationOutcome.
+ *
+ * <p>Two forms exist. The single-argument form describes a table that startup found to be behind
+ * the encoders and could not migrate. The three-argument form describes a disagreement detected
+ * when it bit, and distinguishes the two directions: field paths the encoders require but the table
+ * lacks, which are migratable, and field paths the table carries but the encoders do not emit,
+ * which are not.
+ *
+ * <p>Neither form includes raw exception text, warehouse paths, or struct definitions, which is
+ * what makes the underlying Delta exception unsuitable to return to a client.
  *
  * @author John Grimes
  */
@@ -31,7 +45,14 @@ public class SchemaDriftError extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
 
-  @Nonnull private final String resourceCode;
+  /**
+   * The most field paths any one direction contributes to a message. A struct can carry hundreds of
+   * fields, and a response body is not the place to enumerate them all; the remainder is summarised
+   * by a count.
+   */
+  private static final int MAX_REPORTED_PATHS = 10;
+
+  @Nullable private final String resourceCode;
 
   /**
    * Constructs a new SchemaDriftError for the given resource type.
@@ -49,12 +70,80 @@ public class SchemaDriftError extends RuntimeException {
   }
 
   /**
+   * Constructs a new SchemaDriftError describing a disagreement between a stored table and this
+   * server's encoders, in one or both directions.
+   *
+   * @param resourceCode the resource type the table holds, or null where it is not known
+   * @param missingFieldPaths the field paths the encoders require but the table lacks
+   * @param excessFieldPaths the field paths the table carries but the encoders do not emit
+   */
+  public SchemaDriftError(
+      @Nullable final String resourceCode,
+      @Nonnull final Collection<String> missingFieldPaths,
+      @Nonnull final Collection<String> excessFieldPaths) {
+    super(buildMessage(resourceCode, missingFieldPaths, excessFieldPaths));
+    this.resourceCode = resourceCode;
+  }
+
+  /**
    * Returns the resource type whose table is drifted.
    *
-   * @return the resource type code
+   * @return the resource type code, or null where it was not known
    */
-  @Nonnull
+  @Nullable
   public String getResourceCode() {
     return resourceCode;
+  }
+
+  /**
+   * Assembles the message for the two-direction form. Where neither direction yielded field paths -
+   * a recognised condition whose detail could not be interpreted - the condition is still named, so
+   * that the caller learns what kind of problem they have.
+   */
+  @Nonnull
+  private static String buildMessage(
+      @Nullable final String resourceCode,
+      @Nonnull final Collection<String> missingFieldPaths,
+      @Nonnull final Collection<String> excessFieldPaths) {
+    final String subject =
+        resourceCode == null
+            ? "A stored table"
+            : "The stored table for resource type '" + resourceCode + "'";
+
+    if (missingFieldPaths.isEmpty() && excessFieldPaths.isEmpty()) {
+      return subject
+          + " cannot be reconciled with this server's encoders. Compare the encoding configuration "
+          + "against the configuration the table was written with, in particular "
+          + "pathling.encoding.openTypes, and enable pathling.storage.schemaAutoMerge if the table "
+          + "is behind the encoders.";
+    }
+
+    final Stream<String> clauses =
+        Stream.of(
+                missingFieldPaths.isEmpty()
+                    ? null
+                    : " is missing fields that this server's encoders require ("
+                        + summarise(missingFieldPaths)
+                        + "). Enable pathling.storage.schemaAutoMerge and restart, or update a "
+                        + "resource of this type with the flag enabled, to migrate the table.",
+                excessFieldPaths.isEmpty()
+                    ? null
+                    : " carries fields that this server's encoders do not emit ("
+                        + summarise(excessFieldPaths)
+                        + "). These cannot be reconstructed: restore the encoding configuration the"
+                        + " table was written with, in particular pathling.encoding.openTypes, or"
+                        + " re-import the data at this server's schema.")
+            .filter(Objects::nonNull);
+
+    return subject + clauses.collect(Collectors.joining(" It also"));
+  }
+
+  /** Renders a bounded, comma-separated list of field paths. */
+  @Nonnull
+  private static String summarise(@Nonnull final Collection<String> fieldPaths) {
+    final String reported =
+        fieldPaths.stream().limit(MAX_REPORTED_PATHS).collect(Collectors.joining(", "));
+    final int remainder = fieldPaths.size() - MAX_REPORTED_PATHS;
+    return remainder > 0 ? reported + ", and " + remainder + " more" : reported;
   }
 }

--- a/server/src/main/java/au/csiro/pathling/io/SchemaMigrator.java
+++ b/server/src/main/java/au/csiro/pathling/io/SchemaMigrator.java
@@ -38,10 +38,19 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructType;
 
 /**
- * Detects Delta tables in the warehouse whose schemas are missing fields relative to the current
- * FHIR encoders, and migrates them at startup when {@code schemaAutoMerge} is enabled. Tables that
- * remain drifted (flag disabled, or migration failure) are reported so that requests against them
- * can fail with an actionable error instead of a generic one.
+ * Reports, at startup, every Delta table in the warehouse whose schema differs from the current
+ * FHIR encoders, in either direction, and migrates the migratable direction when {@code
+ * schemaAutoMerge} is enabled.
+ *
+ * <p>A table missing fields the encoders require is migrated by an additive schema evolution.
+ * Tables that remain in that state (flag disabled, or migration failure) are reported so that
+ * requests against them can fail with an actionable error instead of a generic one.
+ *
+ * <p>A table carrying fields the encoders do not emit cannot be migrated - the columns cannot be
+ * reconstructed - so it is reported and otherwise left alone. That condition is tolerated rather
+ * than fatal, so it does not enter the drifted set.
+ *
+ * <p>Neither direction ever fails startup.
  *
  * @author John Grimes
  */
@@ -103,6 +112,7 @@ public class SchemaMigrator {
       @Nonnull final String resourceCode, @Nonnull final Set<String> driftedTypes) {
     final String tablePath = safelyJoinPaths(databasePath, resourceCode + TABLE_EXTENSION);
     final SortedSet<String> missingFields;
+    final SortedSet<String> excessFields;
     try {
       if (!DeltaTable.isDeltaTable(spark, tablePath)) {
         return;
@@ -110,10 +120,28 @@ public class SchemaMigrator {
       final StructType encoderSchema = fhirEncoders.of(resourceCode).schema();
       final StructType tableSchema = spark.read().format("delta").load(tablePath).schema();
       missingFields = SchemaDrift.missingFieldPaths(encoderSchema, tableSchema);
+      excessFields = SchemaDrift.excessFieldPaths(encoderSchema, tableSchema);
     } catch (final Exception e) {
       // A table that cannot be inspected (for example, an unencodable name) is skipped.
       log.debug("Skipping schema drift check for {}: {}", resourceCode, e.getMessage());
       return;
+    }
+
+    if (!excessFields.isEmpty()) {
+      // This direction is not migratable: the columns cannot be reconstructed, and narrowing the
+      // table would discard data. It is reported so that a deployment state which is otherwise
+      // invisible - most often a narrowed pathling.encoding.openTypes against a populated warehouse
+      // - can be seen before it has any effect, and at INFO because it is tolerated: writes
+      // null-fill
+      // these columns and reads return what the encoder can represent. The type is deliberately not
+      // added to the drifted set, and no migration is attempted.
+      log.info(
+          "The {} table carries fields this server's encoders do not emit (extra fields: {}). These"
+              + " columns are preserved and written as null; reads return what the encoders can"
+              + " represent. To read them, restore the encoding configuration the table was written"
+              + " with, in particular pathling.encoding.openTypes.",
+          resourceCode,
+          excessFields);
     }
 
     if (missingFields.isEmpty()) {

--- a/server/src/main/java/au/csiro/pathling/operations/update/BatchProvider.java
+++ b/server/src/main/java/au/csiro/pathling/operations/update/BatchProvider.java
@@ -24,6 +24,7 @@ import static org.hl7.fhir.r4.model.Bundle.BundleType.BATCHRESPONSE;
 
 import au.csiro.pathling.FhirServer;
 import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.errors.ErrorHandlingInterceptor;
 import au.csiro.pathling.errors.InvalidUserInputError;
 import au.csiro.pathling.operations.delete.DeleteExecutor;
 import au.csiro.pathling.security.OperationAccess;
@@ -31,6 +32,7 @@ import au.csiro.pathling.security.PathlingAuthority;
 import au.csiro.pathling.security.ResourceAccess;
 import ca.uhn.fhir.rest.annotation.Transaction;
 import ca.uhn.fhir.rest.annotation.TransactionParam;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.ArrayList;
@@ -47,6 +49,9 @@ import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryRequestComponent;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryResponseComponent;
 import org.hl7.fhir.r4.model.Enumerations.ResourceType;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
 import org.hl7.fhir.r4.model.Resource;
 import org.springframework.stereotype.Component;
 
@@ -101,18 +106,20 @@ public class BatchProvider {
 
     final Map<ResourceType, List<IBaseResource>> resourcesForUpdate =
         new EnumMap<>(ResourceType.class);
+    final Map<ResourceType, List<BundleEntryComponent>> responsesForUpdate =
+        new EnumMap<>(ResourceType.class);
     final Bundle response = new Bundle();
     response.setType(BATCHRESPONSE);
 
     // Gather all the resources within the request bundle, categorised by their type. Also, prepare
     // the responses should these operations be successful.
     for (final BundleEntryComponent entry : bundle.getEntry()) {
-      processEntry(resourcesForUpdate, response, entry);
+      processEntry(resourcesForUpdate, responsesForUpdate, response, entry);
     }
 
     if (!resourcesForUpdate.isEmpty()) {
       // Merge in any updated resources into their respective tables.
-      update(resourcesForUpdate);
+      update(resourcesForUpdate, responsesForUpdate);
     }
 
     return response;
@@ -120,6 +127,7 @@ public class BatchProvider {
 
   private void processEntry(
       @Nonnull final Map<ResourceType, List<IBaseResource>> resourcesForUpdate,
+      @Nonnull final Map<ResourceType, List<BundleEntryComponent>> responsesForUpdate,
       @Nonnull final Bundle response,
       @Nonnull final BundleEntryComponent entry) {
     final Resource resource = entry.getResource();
@@ -133,12 +141,12 @@ public class BatchProvider {
       if (resource == null) {
         return;
       }
-      processCreateEntry(resourcesForUpdate, response, entry);
+      processCreateEntry(resourcesForUpdate, responsesForUpdate, response, entry);
     } else if ("PUT".equals(method)) {
       if (resource == null) {
         return;
       }
-      processUpdateEntry(resourcesForUpdate, response, entry);
+      processUpdateEntry(resourcesForUpdate, responsesForUpdate, response, entry);
     } else if ("DELETE".equals(method)) {
       processDeleteEntry(response, entry);
     } else {
@@ -150,6 +158,7 @@ public class BatchProvider {
 
   private void processCreateEntry(
       @Nonnull final Map<ResourceType, List<IBaseResource>> resourcesForUpdate,
+      @Nonnull final Map<ResourceType, List<BundleEntryComponent>> responsesForUpdate,
       @Nonnull final Bundle response,
       @Nonnull final BundleEntryComponent entry) {
     final Resource resource = entry.getResource();
@@ -179,11 +188,12 @@ public class BatchProvider {
 
     log.debug("Batch creating {} with generated ID: {}", resourceType.toCode(), generatedId);
     addToResourceMap(resourcesForUpdate, resourceType, resource);
-    addCreateResponse(response, resource);
+    trackResponse(responsesForUpdate, resourceType, addCreateResponse(response, resource));
   }
 
   private void processUpdateEntry(
       @Nonnull final Map<ResourceType, List<IBaseResource>> resourcesForUpdate,
+      @Nonnull final Map<ResourceType, List<BundleEntryComponent>> responsesForUpdate,
       @Nonnull final Bundle response,
       @Nonnull final BundleEntryComponent entry) {
     final Resource resource = entry.getResource();
@@ -211,7 +221,7 @@ public class BatchProvider {
 
     final IBaseResource preparedResource = prepareResourceForUpdate(resource, urlId);
     addToResourceMap(resourcesForUpdate, resourceType, preparedResource);
-    addUpdateResponse(response, preparedResource);
+    trackResponse(responsesForUpdate, resourceType, addUpdateResponse(response, preparedResource));
   }
 
   private void processDeleteEntry(
@@ -243,17 +253,79 @@ public class BatchProvider {
     addDeleteResponse(response);
   }
 
-  private void update(@Nonnull final Map<ResourceType, List<IBaseResource>> resourcesForUpdate) {
+  /**
+   * Merges the gathered resources, one resource type at a time. A batch's entries are independent
+   * of one another, so a type whose merge fails does not prevent the remaining types from being
+   * written: the failure is reported on that type's own response entries, and the rest of the
+   * bundle keeps its success statuses. Without this, a single unwritable type - a table that cannot
+   * be reconciled with this server's encoders, for instance - would fail the whole request and
+   * leave the client unable to tell which entry was at fault.
+   */
+  private void update(
+      @Nonnull final Map<ResourceType, List<IBaseResource>> resourcesForUpdate,
+      @Nonnull final Map<ResourceType, List<BundleEntryComponent>> responsesForUpdate) {
     if (configuration.getAuth().isEnabled()) {
       checkHasAuthority(PathlingAuthority.operationAccess("update"));
     }
     for (final var entry : resourcesForUpdate.entrySet()) {
+      final ResourceType resourceType = entry.getKey();
       log.debug(
           "Batch updating {} resource(s) of type {}",
           entry.getValue().size(),
-          entry.getKey().toCode());
-      updateExecutor.merge(entry.getKey(), entry.getValue());
+          resourceType.toCode());
+      try {
+        updateExecutor.merge(resourceType, entry.getValue());
+      } catch (final Exception e) {
+        log.error("Batch update of type {} failed", resourceType.toCode(), e);
+        reportFailure(
+            responsesForUpdate.getOrDefault(resourceType, List.of()), resourceType.toCode(), e);
+      }
     }
+  }
+
+  /**
+   * Rewrites the response entries of a resource type whose merge failed, so that each carries the
+   * status and the OperationOutcome the same failure would have produced had the entry been
+   * submitted on its own. The resource echo is dropped, because it was not written.
+   */
+  private static void reportFailure(
+      @Nonnull final List<BundleEntryComponent> responseEntries,
+      @Nonnull final String resourceCode,
+      @Nonnull final Exception error) {
+    final BaseServerResponseException converted =
+        ErrorHandlingInterceptor.convertError(error, resourceCode);
+    for (final BundleEntryComponent responseEntry : responseEntries) {
+      final BundleEntryResponseComponent responseElement = responseEntry.getResponse();
+      responseElement.setStatus(String.valueOf(converted.getStatusCode()));
+      responseElement.setOutcome(outcomeFor(converted));
+      responseEntry.setResource(null);
+    }
+  }
+
+  /**
+   * Returns the OperationOutcome a converted failure carries, synthesising one from its message
+   * where it carries none.
+   */
+  @Nonnull
+  private static Resource outcomeFor(@Nonnull final BaseServerResponseException converted) {
+    if (converted.getOperationOutcome() instanceof final OperationOutcome outcome) {
+      return outcome;
+    }
+    final OperationOutcome outcome = new OperationOutcome();
+    outcome
+        .addIssue()
+        .setSeverity(IssueSeverity.ERROR)
+        .setCode(IssueType.PROCESSING)
+        .setDiagnostics(converted.getMessage());
+    return outcome;
+  }
+
+  /** Records the response entry that a resource type's merge outcome will be reported on. */
+  private static void trackResponse(
+      @Nonnull final Map<ResourceType, List<BundleEntryComponent>> responsesForUpdate,
+      @Nonnull final ResourceType resourceType,
+      @Nonnull final BundleEntryComponent responseEntry) {
+    responsesForUpdate.computeIfAbsent(resourceType, k -> new ArrayList<>()).add(responseEntry);
   }
 
   @Nonnull
@@ -313,22 +385,26 @@ public class BatchProvider {
     resourcesForCreation.get(resourceType).add(resource);
   }
 
-  private void addCreateResponse(
+  @Nonnull
+  private BundleEntryComponent addCreateResponse(
       @Nonnull final Bundle response, @Nonnull final IBaseResource createdResource) {
     final BundleEntryComponent responseEntry = response.addEntry();
     final BundleEntryResponseComponent responseElement = new BundleEntryResponseComponent();
     responseElement.setStatus("201");
     responseEntry.setResponse(responseElement);
     responseEntry.setResource((Resource) createdResource);
+    return responseEntry;
   }
 
-  private void addUpdateResponse(
+  @Nonnull
+  private BundleEntryComponent addUpdateResponse(
       @Nonnull final Bundle response, @Nonnull final IBaseResource updatedResource) {
     final BundleEntryComponent responseEntry = response.addEntry();
     final BundleEntryResponseComponent responseElement = new BundleEntryResponseComponent();
     responseElement.setStatus("200");
     responseEntry.setResponse(responseElement);
     responseEntry.setResource((Resource) updatedResource);
+    return responseEntry;
   }
 
   private void addDeleteResponse(@Nonnull final Bundle response) {

--- a/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/update/UpdateExecutor.java
@@ -27,6 +27,7 @@ import au.csiro.pathling.io.DynamicDeltaSource;
 import au.csiro.pathling.io.SchemaDrift;
 import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
+import io.delta.tables.DeltaMergeBuilder;
 import io.delta.tables.DeltaTable;
 import jakarta.annotation.Nonnull;
 import java.util.Collections;
@@ -39,6 +40,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Enumerations.ResourceType;
 import org.springframework.beans.factory.annotation.Value;
@@ -237,21 +239,56 @@ public class UpdateExecutor {
       log.info("Evolved schema of {} table, added fields: {}", resourceCode, missingFields);
     }
 
-    // Perform a merge operation on the existing table.
-    table
-        .as("original")
-        .merge(updates.as("updates"), "original.id = updates.id")
-        .whenMatched()
-        .updateAll()
-        .whenNotMatched()
-        .insertAll()
-        .execute();
+    // Perform a merge operation on the existing table, tolerating a table that is wider than the
+    // encoder output.
+    DeltaMergeBuilder merge =
+        table
+            .as("original")
+            .merge(updates.as("updates"), "original.id = updates.id")
+            .whenMatched()
+            .updateAll()
+            .whenNotMatched()
+            .insertAll();
+    if (isPurelyNarrowing(updates, table)) {
+      merge = merge.withSchemaEvolution();
+    }
+    merge.execute();
 
     // After a schema-evolving write, refresh the dataset served for this resource type so that
     // all in-process consumers observe the evolved schema without a server restart.
     if (schemaEvolved && dataSource instanceof final DynamicDeltaSource dynamicDataSource) {
       dynamicDataSource.refresh(resourceCode);
     }
+  }
+
+  /**
+   * Returns true if the table carries field paths the encoder output lacks, and the encoder output
+   * carries none the table lacks.
+   *
+   * <p>Delta refuses to cast a source struct onto a target struct with a different field count
+   * unless schema evolution is enabled on the merge, so a table wider than the running encoder
+   * cannot be merged into at all without it. Enabling it makes Delta null-fill the fields the
+   * source cannot supply, which is what is wanted: the stored-only columns are preserved and
+   * written as null.
+   *
+   * <p>The same flag also lets the target schema grow to admit source fields the target lacks,
+   * which is emphatically not wanted here - that direction belongs to {@code
+   * pathling.storage.schemaAutoMerge}, settled above by the warmup write. Requiring the difference
+   * to be purely narrowing is what keeps the two apart: where a table differs in both directions at
+   * once, this returns false, the merge fails as it does today unless the flag permitted the warmup
+   * write, and after that write the remaining difference is purely narrowing and the tolerance
+   * applies. The table is re-resolved after the warmup write, so the comparison here sees the
+   * settled schema.
+   *
+   * @param updates the encoder output being merged
+   * @param table the target table, as resolved for this merge
+   * @return true if schema evolution can safely be enabled on the merge
+   */
+  private static boolean isPurelyNarrowing(
+      @Nonnull final Dataset<Row> updates, @Nonnull final DeltaTable table) {
+    final StructType tableSchema = table.toDF().schema();
+    return SchemaDrift.missingFieldPaths(updates.schema(), tableSchema).isEmpty()
+        && !SchemaDrift.excessFieldPaths(updates.schema(), tableSchema).isEmpty();
   }
 
   /**

--- a/server/src/test/java/au/csiro/pathling/errors/ErrorHandlingInterceptorTest.java
+++ b/server/src/test/java/au/csiro/pathling/errors/ErrorHandlingInterceptorTest.java
@@ -30,12 +30,15 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import jakarta.annotation.Nonnull;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import org.apache.spark.SparkException;
 import org.apache.spark.SparkRuntimeException;
+import org.apache.spark.sql.delta.DeltaAnalysisException;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.junit.jupiter.api.Test;
+import scala.Option;
 
 /**
  * Unit tests for {@link ErrorHandlingInterceptor}.
@@ -282,5 +285,152 @@ class ErrorHandlingInterceptorTest {
 
     assertThat(result).isInstanceOf(InvalidRequestException.class);
     assertThat(result.getStatusCode()).isEqualTo(400);
+  }
+
+  // ---- Delta schema mismatch translation (FR-001, FR-002, FR-003) ----
+
+  // A Delta schema mismatch where the source carries fields the table lacks must be translated into
+  // an actionable message naming the missing field paths and the remedy for that direction, rather
+  // than falling through to the generic "Unexpected error occurred" (FR-001).
+  @Test
+  void convertsDeltaSchemaMismatchWithMissingFieldsToActionableDiagnostics() {
+    final Throwable e = schemaMismatch("struct<path:string,forEach:string>", "struct<path:string>");
+
+    final BaseServerResponseException result = ErrorHandlingInterceptor.convertError(e);
+
+    assertThat(result.getStatusCode()).isEqualTo(500);
+    final String diagnostics = diagnosticsOf(result);
+    assertThat(diagnostics)
+        .contains("forEach")
+        .contains("schemaAutoMerge")
+        .doesNotContain("Unexpected error occurred");
+  }
+
+  // The resource type is not carried by the Delta exception, so it is supplied by the caller that
+  // knows it. When supplied it must appear in the diagnostics (FR-001).
+  @Test
+  void namesTheResourceTypeWhenItIsKnown() {
+    final Throwable e = schemaMismatch("struct<path:string,forEach:string>", "struct<path:string>");
+
+    final BaseServerResponseException result =
+        ErrorHandlingInterceptor.convertError(e, "ViewDefinition");
+
+    assertThat(diagnosticsOf(result)).contains("ViewDefinition").contains("forEach");
+  }
+
+  // A Delta schema mismatch where the table carries fields the encoder does not emit must name
+  // those paths and point at the encoding configuration rather than at schemaAutoMerge, because
+  // that direction is not migratable (FR-001).
+  @Test
+  void convertsDeltaSchemaMismatchWithExcessFieldsToActionableDiagnostics() {
+    final Throwable e =
+        schemaMismatch("struct<url:string>", "struct<url:string,valuePeriod:string>");
+
+    final BaseServerResponseException result = ErrorHandlingInterceptor.convertError(e, "Patient");
+
+    final String diagnostics = diagnosticsOf(result);
+    assertThat(diagnostics)
+        .contains("Patient")
+        .contains("valuePeriod")
+        .contains("openTypes")
+        .doesNotContain("Unexpected error occurred");
+  }
+
+  // Where the two schemas differ in both directions at once, both sets of paths are reported and
+  // the message distinguishes them.
+  @Test
+  void reportsBothDirectionsWhenTheyDifferAtOnce() {
+    final Throwable e =
+        schemaMismatch(
+            "struct<url:string,forEach:string>", "struct<url:string,valuePeriod:string>");
+
+    final BaseServerResponseException result = ErrorHandlingInterceptor.convertError(e, "Patient");
+
+    final String diagnostics = diagnosticsOf(result);
+    assertThat(diagnostics).contains("forEach").contains("valuePeriod");
+  }
+
+  // The translated message must not leak the raw exception text, which embeds the full struct
+  // definitions of both schemas, nor any warehouse path (FR-002, SC-003).
+  @Test
+  void translatedDiagnosticsExposeNoStructDefinitionOrWarehousePath() {
+    final Throwable e = schemaMismatch("struct<path:string,forEach:string>", "struct<path:string>");
+
+    final BaseServerResponseException result = ErrorHandlingInterceptor.convertError(e, "Patient");
+
+    final String diagnostics = diagnosticsOf(result);
+    assertThat(diagnostics)
+        .doesNotContain("struct<")
+        .doesNotContain("Cannot cast")
+        .doesNotContain("DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION")
+        .doesNotContain("file:/")
+        .doesNotContain(".parquet");
+  }
+
+  // A Delta exception carrying the recognised condition but no usable field detail must still
+  // produce a message naming the type and the condition, rather than the generic message.
+  @Test
+  void convertsDeltaSchemaMismatchWithoutFieldDetail() {
+    final Throwable e = schemaMismatch("not a parseable type", "also not parseable");
+
+    final BaseServerResponseException result = ErrorHandlingInterceptor.convertError(e, "Patient");
+
+    assertThat(result.getStatusCode()).isEqualTo(500);
+    final String diagnostics = diagnosticsOf(result);
+    assertThat(diagnostics)
+        .contains("Patient")
+        .contains("cannot be reconciled")
+        .doesNotContain("Unexpected error occurred");
+  }
+
+  // The translation is on the error path, so it applies to an exception surfaced from a read as
+  // readily as one from a write, including when Spark has wrapped it.
+  @Test
+  void translatesDeltaSchemaMismatchWrappedInSparkException() {
+    final Throwable cause =
+        schemaMismatch("struct<path:string,forEach:string>", "struct<path:string>");
+    final SparkException e = new SparkException("Job aborted", cause);
+
+    final BaseServerResponseException result = ErrorHandlingInterceptor.convertError(e, "Patient");
+
+    assertThat(diagnosticsOf(result)).contains("forEach").contains("Patient");
+  }
+
+  // A Delta exception carrying a different condition is not a schema mismatch, so it must continue
+  // to yield the existing generic message with no internal detail added (FR-003).
+  @Test
+  void otherDeltaConditionsStillYieldTheGenericMessage() {
+    final Throwable e =
+        new DeltaAnalysisException(
+            "DELTA_FAILED_TO_MERGE_FIELDS",
+            new String[] {"a", "b"},
+            Option.empty(),
+            Option.empty());
+
+    final BaseServerResponseException result = ErrorHandlingInterceptor.convertError(e, "Patient");
+
+    assertThat(result).isInstanceOf(InternalErrorException.class);
+    assertThat(result.getStatusCode()).isEqualTo(500);
+    assertThat(result.getMessage()).isEqualTo("Unexpected error occurred");
+  }
+
+  /** Builds the Delta exception raised when a MERGE cannot cast the source struct to the target. */
+  @Nonnull
+  private static Throwable schemaMismatch(
+      @Nonnull final String fromCatalog, @Nonnull final String toCatalog) {
+    return new DeltaAnalysisException(
+        "DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION",
+        new String[] {fromCatalog, toCatalog},
+        Option.empty(),
+        Option.empty());
+  }
+
+  /** Extracts the single OperationOutcome issue's diagnostics from a converted exception. */
+  @Nonnull
+  private static String diagnosticsOf(@Nonnull final BaseServerResponseException result) {
+    assertThat(result.getOperationOutcome()).isInstanceOf(OperationOutcome.class);
+    final OperationOutcome outcome = (OperationOutcome) result.getOperationOutcome();
+    assertThat(outcome.getIssue()).hasSize(1);
+    return outcome.getIssueFirstRep().getDiagnostics();
   }
 }

--- a/server/src/test/java/au/csiro/pathling/errors/ErrorHandlingInterceptorTest.java
+++ b/server/src/test/java/au/csiro/pathling/errors/ErrorHandlingInterceptorTest.java
@@ -414,6 +414,25 @@ class ErrorHandlingInterceptorTest {
     assertThat(result.getMessage()).isEqualTo("Unexpected error occurred");
   }
 
+  // A struct can carry hundreds of fields, and a response body is not the place to enumerate them
+  // all. The rendered list is bounded and the remainder summarised by a count, so a wide struct
+  // cannot produce an unbounded message (FR-002).
+  @Test
+  void boundsTheNumberOfFieldPathsReported() {
+    final StringBuilder wide = new StringBuilder("struct<kept:string");
+    for (int i = 0; i < 25; i++) {
+      wide.append(",field").append(i).append(":string");
+    }
+    final Throwable e = schemaMismatch(wide.append(">").toString(), "struct<kept:string>");
+
+    final BaseServerResponseException result = ErrorHandlingInterceptor.convertError(e, "Patient");
+
+    final String diagnostics = diagnosticsOf(result);
+    // Ten paths are named and the remaining fifteen are counted, not listed. The names are reported
+    // in lexicographic order, so field9 falls outside the reported ten.
+    assertThat(diagnostics).contains("and 15 more").contains("field0").doesNotContain("field9");
+  }
+
   /** Builds the Delta exception raised when a MERGE cannot cast the source struct to the target. */
   @Nonnull
   private static Throwable schemaMismatch(

--- a/server/src/test/java/au/csiro/pathling/io/SchemaDriftTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/SchemaDriftTest.java
@@ -31,9 +31,10 @@ import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit tests for {@link SchemaDrift}. The comparison must count only missing field paths as drift,
- * recursing through structs, arrays and maps, while ignoring nullability and column metadata
- * differences and tolerating extra fields that exist only in the target schema.
+ * Unit tests for {@link SchemaDrift}. Both comparisons recurse through structs, arrays and maps,
+ * and both ignore nullability and column metadata differences. Each reports only its own direction:
+ * a field present only in the target is not drift, and a field present only in the source is not
+ * excess, so a schema differing in both directions at once is described by the two together.
  *
  * @author John Grimes
  */
@@ -147,6 +148,129 @@ class SchemaDriftTest {
 
     assertThat(SchemaDrift.hasMissingFields(schema, schema)).isFalse();
     assertThat(SchemaDrift.missingFieldPaths(schema, schema)).isEmpty();
+  }
+
+  // ---- the excess direction: paths in the target absent from the source ----
+
+  // Verifies that a target field absent from the source at the top level is reported as excess.
+  @Test
+  void excessTopLevelFieldIsReported() {
+    final StructType source = struct(field("id", DataTypes.StringType));
+    final StructType target =
+        struct(
+            field("id", DataTypes.StringType), field("fieldFromTheFuture", DataTypes.StringType));
+
+    assertThat(SchemaDrift.excessFieldPaths(source, target)).containsExactly("fieldFromTheFuture");
+  }
+
+  // Verifies that a target field absent from the source inside a nested struct is reported.
+  @Test
+  void excessNestedStructFieldIsReported() {
+    final StructType sourceInner = struct(field("name", DataTypes.StringType));
+    final StructType targetInner =
+        struct(field("name", DataTypes.StringType), field("version", DataTypes.StringType));
+    final StructType source = struct(field("id", DataTypes.StringType), field("meta", sourceInner));
+    final StructType target = struct(field("id", DataTypes.StringType), field("meta", targetInner));
+
+    assertThat(SchemaDrift.excessFieldPaths(source, target)).containsExactly("meta.version");
+  }
+
+  // Verifies that a target field absent from the source inside a struct nested in an array element
+  // is reported. This is the shape the extension element takes, where the open-type value fields
+  // live inside an array of structs.
+  @Test
+  void excessFieldInsideArrayElementStructIsReported() {
+    final StructType sourceElement = struct(field("url", DataTypes.StringType));
+    final StructType targetElement =
+        struct(field("url", DataTypes.StringType), field("valuePeriod", DataTypes.StringType));
+    final StructType source = struct(field("_extension", ArrayType.apply(sourceElement)));
+    final StructType target = struct(field("_extension", ArrayType.apply(targetElement)));
+
+    assertThat(SchemaDrift.excessFieldPaths(source, target))
+        .containsExactly("_extension.valuePeriod");
+  }
+
+  // Verifies that a target field absent from the source inside a struct used as a map value type is
+  // reported.
+  @Test
+  void excessFieldInsideMapValueStructIsReported() {
+    final StructType sourceValue = struct(field("code", DataTypes.StringType));
+    final StructType targetValue =
+        struct(field("code", DataTypes.StringType), field("display", DataTypes.StringType));
+    final StructType source =
+        struct(field("codings", MapType.apply(DataTypes.StringType, sourceValue)));
+    final StructType target =
+        struct(field("codings", MapType.apply(DataTypes.StringType, targetValue)));
+
+    assertThat(SchemaDrift.excessFieldPaths(source, target)).containsExactly("codings.display");
+  }
+
+  // Verifies that when the two schemas differ in both directions at once, each comparison reports
+  // only its own direction. This is the state described in issue #2697, where a warehouse is both
+  // behind the encoder in one place and ahead of it in another.
+  @Test
+  void bothDirectionsAreReportedSeparately() {
+    final StructType source =
+        struct(field("id", DataTypes.StringType), field("encoderOnly", DataTypes.StringType));
+    final StructType target =
+        struct(field("id", DataTypes.StringType), field("tableOnly", DataTypes.StringType));
+
+    assertThat(SchemaDrift.missingFieldPaths(source, target)).containsExactly("encoderOnly");
+    assertThat(SchemaDrift.excessFieldPaths(source, target)).containsExactly("tableOnly");
+  }
+
+  // Verifies that a difference in nullability alone is not reported as excess, consistent with the
+  // missing-field comparison.
+  @Test
+  void nullabilityOnlyDifferenceIsNotExcess() {
+    final StructType source =
+        new StructType(
+            new StructField[] {
+              new StructField("id", DataTypes.StringType, false, Metadata.empty())
+            });
+    final StructType target =
+        new StructType(
+            new StructField[] {
+              new StructField("id", DataTypes.StringType, true, Metadata.empty())
+            });
+
+    assertThat(SchemaDrift.excessFieldPaths(source, target)).isEmpty();
+  }
+
+  // Verifies that a difference in column metadata alone is not reported as excess.
+  @Test
+  void metadataOnlyDifferenceIsNotExcess() {
+    final Metadata metadata = new MetadataBuilder().putString("comment", "annotated").build();
+    final StructType source =
+        new StructType(
+            new StructField[] {
+              new StructField("id", DataTypes.StringType, true, Metadata.empty())
+            });
+    final StructType target =
+        new StructType(
+            new StructField[] {new StructField("id", DataTypes.StringType, true, metadata)});
+
+    assertThat(SchemaDrift.excessFieldPaths(source, target)).isEmpty();
+  }
+
+  // Verifies that identical schemas produce no excess paths.
+  @Test
+  void identicalSchemasHaveNoExcess() {
+    final StructType schema =
+        struct(field("id", DataTypes.StringType), field("status", DataTypes.StringType));
+
+    assertThat(SchemaDrift.excessFieldPaths(schema, schema)).isEmpty();
+  }
+
+  // Verifies that a source field absent from the target is not reported as excess, so the two
+  // comparisons cannot be confused for one another.
+  @Test
+  void missingFieldIsNotReportedAsExcess() {
+    final StructType source =
+        struct(field("id", DataTypes.StringType), field("url", DataTypes.StringType));
+    final StructType target = struct(field("id", DataTypes.StringType));
+
+    assertThat(SchemaDrift.excessFieldPaths(source, target)).isEmpty();
   }
 
   // ---- helpers ----

--- a/server/src/test/java/au/csiro/pathling/io/SchemaMigratorTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/SchemaMigratorTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.encoders.ViewDefinitionResource;
 import au.csiro.pathling.test.SpringBootUnitTest;
+import au.csiro.pathling.util.FhirEncoderFixtures;
 import au.csiro.pathling.util.FhirServerTestConfiguration;
 import au.csiro.pathling.util.LogCapture;
 import ch.qos.logback.classic.Level;
@@ -223,12 +224,141 @@ class SchemaMigratorTest {
     }
   }
 
+  // ---- reporting the excess direction at startup (FR-005, SC-002) ----
+
+  // Verifies that a table carrying fields the encoder does not emit is reported at startup, naming
+  // the type and those paths, at a level reflecting that the condition is tolerated rather than
+  // fatal. The type is not added to the drifted set and no migration is attempted, because the
+  // columns cannot be reconstructed (US2 scenario 2).
+  @Test
+  void excessFieldsTableIsReportedAtStartup(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    seedWideOpenTypesPatientTable(databasePath);
+    final long versionBefore = latestTableVersion(databasePath, "Patient");
+
+    try (final LogCapture logCapture = LogCapture.forClass(SchemaMigrator.class)) {
+      final Set<String> drifted = newMigrator(databasePath, true, narrowEncoders()).migrate();
+
+      assertThat(drifted).isEmpty();
+      assertThat(latestTableVersion(databasePath, "Patient")).isEqualTo(versionBefore);
+      assertThat(logCapture.events())
+          .anySatisfy(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.INFO);
+                assertThat(event.getFormattedMessage())
+                    .contains("Patient")
+                    .contains("_extension.valuePeriod")
+                    .contains("_extension.valueQuantity");
+              });
+    }
+  }
+
+  // Verifies that the excess direction is reported regardless of the schemaAutoMerge flag, since
+  // the
+  // flag governs the migratable direction only.
+  @Test
+  void excessFieldsTableIsReportedWithFlagDisabled(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    seedWideOpenTypesPatientTable(databasePath);
+
+    try (final LogCapture logCapture = LogCapture.forClass(SchemaMigrator.class)) {
+      assertThat(newMigrator(databasePath, false, narrowEncoders()).migrate()).isEmpty();
+
+      assertThat(logCapture.events())
+          .anySatisfy(
+              event ->
+                  assertThat(event.getFormattedMessage())
+                      .contains("Patient")
+                      .contains("_extension.valuePeriod"));
+    }
+  }
+
+  // Verifies that a table differing in both directions at once produces both messages,
+  // distinguishably: the missing direction is migrated and logged as such, and the excess direction
+  // is reported separately (US2 edge case, FR-005).
+  @Test
+  void tableDifferingInBothDirectionsProducesBothMessages(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    // The ambient encoder's open types produce the excess direction against a narrowed migrator;
+    // dropping gender produces the missing direction.
+    FhirEncoderFixtures.encodeResources(sparkSession, fhirEncoders, "Patient", List.of(patient()))
+        .drop("gender")
+        .write()
+        .format("delta")
+        .mode(SaveMode.ErrorIfExists)
+        .save(databasePath + "/Patient.parquet");
+
+    try (final LogCapture logCapture = LogCapture.forClass(SchemaMigrator.class)) {
+      newMigrator(databasePath, true, narrowEncoders()).migrate();
+
+      // The missing direction is migrated, and says so, naming the field it added.
+      assertThat(logCapture.events())
+          .anySatisfy(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.INFO);
+                assertThat(event.getFormattedMessage()).contains("Patient").contains("gender");
+              });
+      // The excess direction is reported separately, naming its own paths and not gender.
+      assertThat(logCapture.events())
+          .anySatisfy(
+              event ->
+                  assertThat(event.getFormattedMessage())
+                      .contains("Patient")
+                      .contains("_extension.valuePeriod")
+                      .doesNotContain("gender"));
+    }
+  }
+
+  // Verifies that a warehouse whose tables all reconcile produces neither message (US2 scenario 3).
+  @Test
+  void reconcilingTableProducesNoMessage(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    seedCurrentSchemaViewDefinitionTable(databasePath);
+
+    try (final LogCapture logCapture = LogCapture.forClass(SchemaMigrator.class)) {
+      assertThat(newMigrator(databasePath, true).migrate()).isEmpty();
+
+      assertThat(logCapture.events())
+          .noneSatisfy(
+              event ->
+                  assertThat(event.getFormattedMessage())
+                      .containsAnyOf("missing fields", "does not emit", "Migrated schema"));
+    }
+  }
+
+  // Verifies that startup succeeds against any warehouse state, including one holding a table of
+  // each difference direction alongside entries that cannot be inspected at all (US2 scenario 4,
+  // FR-005).
+  @Test
+  void startupSucceedsForEveryWarehouseState(@TempDir final Path tempDir) throws IOException {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    seedOldSchemaViewDefinitionTable(databasePath);
+    seedWideOpenTypesPatientTable(databasePath);
+    Files.createDirectory(tempDir.resolve("Empty.parquet"));
+
+    assertThatNoException()
+        .isThrownBy(() -> newMigrator(databasePath, true, narrowEncoders()).migrate());
+  }
+
   // ---- helpers ----
 
   @Nonnull
   private SchemaMigrator newMigrator(
       @Nonnull final String databasePath, final boolean schemaAutoMerge) {
-    return new SchemaMigrator(sparkSession, fhirEncoders, databasePath, schemaAutoMerge);
+    return newMigrator(databasePath, schemaAutoMerge, fhirEncoders);
+  }
+
+  /**
+   * Builds a migrator running against nominated encoders rather than the ambient ones, so that a
+   * test can put the running encoder behind or ahead of a table's schema without depending on the
+   * encoding configuration the test profile happens to use.
+   */
+  @Nonnull
+  private SchemaMigrator newMigrator(
+      @Nonnull final String databasePath,
+      final boolean schemaAutoMerge,
+      @Nonnull final FhirEncoders encoders) {
+    return new SchemaMigrator(sparkSession, encoders, databasePath, schemaAutoMerge);
   }
 
   /**
@@ -249,16 +379,43 @@ class SchemaMigratorTest {
    * dropped, simulating a table written by an older encoder version.
    */
   private void seedOldSchemaPatientTable(@Nonnull final String databasePath) {
-    final Patient patient = new Patient();
-    patient.setId("test-patient");
     sparkSession
-        .createDataset(List.of(patient), fhirEncoders.of("Patient"))
+        .createDataset(List.of(patient()), fhirEncoders.of("Patient"))
         .toDF()
         .drop("gender")
         .write()
         .format("delta")
         .mode(SaveMode.ErrorIfExists)
         .save(databasePath + "/Patient.parquet");
+  }
+
+  /**
+   * Writes a Patient Delta table at the ambient encoder's schema. Paired with a migrator built on
+   * {@link #narrowEncoders()}, this simulates a warehouse written before {@code
+   * pathling.encoding.openTypes} was narrowed: the table carries extension value fields the running
+   * encoder no longer emits.
+   */
+  private void seedWideOpenTypesPatientTable(@Nonnull final String databasePath) {
+    FhirEncoderFixtures.seedTable(
+        sparkSession,
+        fhirEncoders,
+        "Patient",
+        List.of(patient()),
+        databasePath + "/Patient.parquet");
+  }
+
+  /** The ambient encoders with Period and Quantity dropped from their open types. */
+  @Nonnull
+  private FhirEncoders narrowEncoders() {
+    return FhirEncoderFixtures.narrow(fhirEncoders);
+  }
+
+  /** A minimal Patient, sufficient to give the encoder something to write. */
+  @Nonnull
+  private static Patient patient() {
+    final Patient patient = new Patient();
+    patient.setId("test-patient");
+    return patient;
   }
 
   /** Sets the writability of a directory, used to provoke migration write failures. */

--- a/server/src/test/java/au/csiro/pathling/operations/update/NarrowedOpenTypesIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/NarrowedOpenTypesIT.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.io.SchemaDrift;
+import au.csiro.pathling.util.TestDataSetup;
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * End-to-end test for user story 3 and quickstart scenario 3: a server whose {@code
+ * pathling.encoding.openTypes} has been narrowed against a populated warehouse can still write to
+ * and read from the affected resource types, with no configuration change.
+ *
+ * <p>The prebuilt Delta test data is written with the standard open types. This test starts the
+ * server with {@code Address} and {@code Identifier} removed from that set, so the Patient table
+ * carries the {@code valueAddress} and {@code valueIdentifier} fields inside its extension element
+ * while the running encoder does not emit them. The difference is purely narrowing, which is the
+ * state reported in issue #2697. {@code pathling.storage.schemaAutoMerge} is left disabled, so
+ * nothing here depends on the migratable direction being permitted.
+ *
+ * <p>Reading such a table back is only sound because of the core-side decode fix in {@code
+ * 048-name-based-nested-decode}, which resolves nested fields by name rather than by position. A
+ * server resolving {@code pathling.version} to a core build without it would decode these rows at
+ * the wrong offsets.
+ *
+ * @author John Grimes
+ */
+@Slf4j
+@Tag("IntegrationTest")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+      // The standard open types, less Address and Identifier. The warehouse on disk carries the
+      // full
+      // standard set, so the stored extension element is wider than this encoder's.
+      "pathling.encoding.openTypes=boolean,code,date,dateTime,decimal,integer,string,Coding,"
+          + "CodeableConcept,Reference",
+      "pathling.encoding.maxNestingLevel=3",
+      "pathling.encoding.enableExtensions=true",
+      // Left at the shipped default, so the tolerance cannot be mistaken for the widening policy.
+      "pathling.storage.schemaAutoMerge=false",
+      // Bind the Spark driver to localhost so that executor class fetches do not depend on the
+      // machine's LAN address being reachable (e.g. under a firewall or VPN).
+      "spark.driver.bindAddress=localhost",
+      "spark.driver.host=localhost"
+    })
+@ActiveProfiles({"integration-test"})
+@TestMethodOrder(OrderAnnotation.class)
+class NarrowedOpenTypesIT {
+
+  /** The extension value fields the stored table carries and the running encoder does not emit. */
+  private static final String[] STORED_ONLY_FIELDS = {
+    "_extension.valueAddress", "_extension.valueIdentifier"
+  };
+
+  /** A Patient id that exists in the prebuilt test data. */
+  private static final String EXISTING_PATIENT_ID = "72df0f76-2758-fac4-67cd-de33c4a2c95e";
+
+  private static final String NEW_PATIENT_ID = "narrowed-open-types-write";
+
+  private static final String IMPORTED_PATIENT_ID = "narrowed-open-types-import";
+
+  @LocalServerPort int port;
+
+  @Autowired WebTestClient webTestClient;
+
+  @Autowired SparkSession spark;
+
+  @Autowired FhirEncoders fhirEncoders;
+
+  @TempDir private static Path warehouseDir;
+
+  @TempDir private static Path ndjsonDir;
+
+  @DynamicPropertySource
+  static void configureProperties(final DynamicPropertyRegistry registry) throws IOException {
+    TestDataSetup.copyTestDataToTempDir(warehouseDir);
+    Files.writeString(
+        ndjsonDir.resolve("Patient.ndjson"),
+        """
+        {"resourceType":"Patient","id":"%s","active":true,\
+        "extension":[{"url":"http://example.org/string","valueString":"imported"}]}
+        """
+            .formatted(IMPORTED_PATIENT_ID),
+        StandardCharsets.UTF_8);
+    registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir.toAbsolutePath());
+    registry.add(
+        "pathling.import.allowableSources", () -> "file://" + ndjsonDir.toAbsolutePath() + "/");
+  }
+
+  @BeforeEach
+  void setUp() {
+    webTestClient =
+        webTestClient
+            .mutate()
+            .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024))
+            .responseTimeout(Duration.ofSeconds(120))
+            .build();
+  }
+
+  /**
+   * Confirms the premise of every test below: the stored table really is wider than the running
+   * encoder, and only wider. If this fails the configuration above no longer describes the #2697
+   * state, and the tests that follow would pass without exercising the tolerance at all.
+   */
+  @Test
+  @Order(1)
+  void theStoredTableIsWiderThanTheEncoderAndOnlyWider() {
+    final StructType tableSchema = patientTableSchema();
+    final StructType encoderSchema = encoderPatientSchema();
+
+    assertThat(SchemaDrift.excessFieldPaths(encoderSchema, tableSchema))
+        .contains(STORED_ONLY_FIELDS);
+    assertThat(SchemaDrift.missingFieldPaths(encoderSchema, tableSchema)).isEmpty();
+  }
+
+  /**
+   * US3 scenarios 1 and 3: a PUT under a new id succeeds, and a read returns the resource as sent.
+   * This is the reproduction that fails today with {@code 500 Unexpected error occurred} (SC-005).
+   */
+  @Test
+  @Order(2)
+  void putUnderNewIdSucceedsAndReadsBackAsSent() {
+    webTestClient
+        .put()
+        .uri("http://localhost:" + port + "/fhir/Patient/" + NEW_PATIENT_ID)
+        .header("Content-Type", "application/fhir+json")
+        .header("Accept", "application/fhir+json")
+        .bodyValue(patientJson(NEW_PATIENT_ID, "kept"))
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    webTestClient
+        .get()
+        .uri("http://localhost:" + port + "/fhir/Patient/" + NEW_PATIENT_ID)
+        .header("Accept", "application/fhir+json")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.id")
+        .isEqualTo(NEW_PATIENT_ID)
+        .jsonPath("$.active")
+        .isEqualTo(true)
+        .jsonPath("$.extension[0].valueString")
+        .isEqualTo("kept");
+  }
+
+  /**
+   * US3 scenario 2: a PUT over an existing id replaces the row rather than duplicating it, and the
+   * replacement reads back.
+   */
+  @Test
+  @Order(3)
+  void putOverExistingIdReplacesTheRow() {
+    webTestClient
+        .put()
+        .uri("http://localhost:" + port + "/fhir/Patient/" + EXISTING_PATIENT_ID)
+        .header("Content-Type", "application/fhir+json")
+        .header("Accept", "application/fhir+json")
+        .bodyValue(patientJson(EXISTING_PATIENT_ID, "replaced"))
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    webTestClient
+        .get()
+        .uri("http://localhost:" + port + "/fhir/Patient/" + EXISTING_PATIENT_ID)
+        .header("Accept", "application/fhir+json")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.extension[0].valueString")
+        .isEqualTo("replaced");
+  }
+
+  /**
+   * US3 scenario 4: the write leaves the table's wider schema in place, so a server later restarted
+   * with the original open types still reads the columns it wrote before. Narrowing the table here
+   * would have discarded data irrecoverably.
+   */
+  @Test
+  @Order(4)
+  void theTableKeepsItsWiderSchemaAfterTheWrite() {
+    assertThat(SchemaDrift.excessFieldPaths(encoderPatientSchema(), patientTableSchema()))
+        .contains(STORED_ONLY_FIELDS);
+  }
+
+  /**
+   * US3 scenario 7 and FR-010: {@code $import} in merge mode writes through the core Delta sink
+   * rather than through {@link UpdateExecutor}, so this verifies the core-side fix from {@code
+   * 048-name-based-nested-decode} rather than any server change.
+   */
+  @Test
+  @Order(5)
+  void importInMergeModeSucceeds() {
+    runImport("merge");
+
+    webTestClient
+        .get()
+        .uri("http://localhost:" + port + "/fhir/Patient/" + IMPORTED_PATIENT_ID)
+        .header("Accept", "application/fhir+json")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.extension[0].valueString")
+        .isEqualTo("imported");
+    // Merge mode has not narrowed the table either.
+    assertThat(SchemaDrift.excessFieldPaths(encoderPatientSchema(), patientTableSchema()))
+        .contains(STORED_ONLY_FIELDS);
+  }
+
+  /**
+   * US3 scenario 8: {@code $import} in overwrite mode still rewrites the table at the encoder's
+   * schema, as it does today, so the stored-only columns are gone afterwards. This runs last
+   * because it destroys the wider schema the tests above depend on.
+   */
+  @Test
+  @Order(6)
+  void importInOverwriteModeRewritesAtTheEncoderSchema() {
+    runImport("overwrite");
+
+    assertThat(SchemaDrift.excessFieldPaths(encoderPatientSchema(), patientTableSchema()))
+        .isEmpty();
+  }
+
+  // ---- helpers ----
+
+  /** Kicks off an asynchronous $import of the Patient NDJSON and waits for the job to complete. */
+  private void runImport(final String saveMode) {
+    final String body =
+        """
+        {
+          "inputFormat": "application/fhir+ndjson",
+          "inputSource": "https://example.org/source",
+          "input": [{"type": "Patient", "url": "%s"}],
+          "saveMode": "%s"
+        }
+        """
+            .formatted(ndjsonDir.resolve("Patient.ndjson").toUri(), saveMode);
+
+    final var result =
+        webTestClient
+            .post()
+            .uri("http://localhost:" + port + "/fhir/$import")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/fhir+json")
+            .header("Prefer", "respond-async")
+            .bodyValue(body)
+            .exchange()
+            .expectStatus()
+            .isAccepted()
+            .expectHeader()
+            .exists(HttpHeaders.CONTENT_LOCATION)
+            .returnResult(String.class);
+
+    final String contentLocation =
+        result.getResponseHeaders().getFirst(HttpHeaders.CONTENT_LOCATION);
+    assertThat(contentLocation).isNotNull();
+
+    // A job that failed on a schema mismatch never reaches 200 here.
+    await()
+        .atMost(120, TimeUnit.SECONDS)
+        .pollInterval(2, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                webTestClient
+                    .get()
+                    .uri(contentLocation)
+                    .header("Accept", "application/fhir+json")
+                    .exchange()
+                    .expectStatus()
+                    .isOk());
+  }
+
+  @Nonnull
+  private StructType patientTableSchema() {
+    final String tablePath =
+        warehouseDir.resolve("delta").resolve("Patient.parquet").toAbsolutePath().toString();
+    spark.catalog().refreshByPath(tablePath);
+    return spark.read().format("delta").load(tablePath).schema();
+  }
+
+  /** The schema the running server's encoder produces for Patient. */
+  @Nonnull
+  private StructType encoderPatientSchema() {
+    return fhirEncoders.of("Patient").schema();
+  }
+
+  @Nonnull
+  private static String patientJson(final String id, final String extensionValue) {
+    return """
+    {"resourceType":"Patient","id":"%s","active":true,
+     "extension":[{"url":"http://example.org/string","valueString":"%s"}]}
+    """
+        .formatted(id, extensionValue);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/update/SchemaEvolutionReadIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/SchemaEvolutionReadIT.java
@@ -41,12 +41,15 @@ import org.springframework.test.web.reactive.server.WebTestClient;
  * production incident where a server upgrade left the on-disk table schema behind the encoders.
  *
  * <p>The warehouse is prepared before the application context starts: the Patient Delta table's
- * schema is downgraded on disk by removing the {@code gender} field, simulating a table written by
- * an older server version whose encoder lacked that field.
+ * schema is downgraded on disk by removing the top-level {@code gender} field and the {@code
+ * prefix} and {@code suffix} fields nested inside the name element, simulating a table written by
+ * an older server version whose encoder lacked them.
  *
  * <p>Covers the acceptance scenarios of user stories 1 and 2: a resource of the drifted type is
  * readable from boot without any prior write (startup migration), and a PUT followed immediately by
- * a GET and a type-level search succeeds with no restart (runtime refresh).
+ * a GET and a type-level search succeeds with no restart (runtime refresh). The nested fields also
+ * cover the read path against a struct the migration actually had to evolve, which the top-level
+ * field alone does not.
  *
  * @author John Grimes
  */
@@ -70,6 +73,9 @@ class SchemaEvolutionReadIT {
 
   private static final String NEW_PATIENT_ID = "schema-drift-test-patient";
 
+  /** The id used to exercise the fields the migration added inside a nested struct. */
+  private static final String NESTED_PATIENT_ID = "schema-drift-nested-patient";
+
   @LocalServerPort int port;
 
   @Autowired WebTestClient webTestClient;
@@ -91,10 +97,14 @@ class SchemaEvolutionReadIT {
   @DynamicPropertySource
   static void configureProperties(final DynamicPropertyRegistry registry) throws Exception {
     // Copy the prebuilt Delta test data into a temporary warehouse, then downgrade the Patient
-    // table's schema on disk so it is missing the gender field relative to the current encoder.
+    // table's schema on disk. The top-level gender field covers the name-resolved case; prefix and
+    // suffix, which live inside the name element's nested structs, cover the case that startup
+    // migration actually has to evolve and that the decoder then has to read back at the right
+    // offsets.
     TestDataSetup.copyTestDataToTempDir(warehouseDir);
     DeltaSchemaFixtures.removeFieldsFromTableSchema(
-        warehouseDir.resolve("delta").resolve("Patient.parquet"), Set.of("gender"));
+        warehouseDir.resolve("delta").resolve("Patient.parquet"),
+        Set.of("gender", "prefix", "suffix"));
     registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir.toAbsolutePath());
   }
 
@@ -184,5 +194,86 @@ class SchemaEvolutionReadIT {
         .isEqualTo("Bundle")
         .jsonPath("$.entry[?(@.resource.id == '%s')]".formatted(NEW_PATIENT_ID))
         .exists();
+  }
+
+  /**
+   * The fields the startup migration added inside a nested struct must read back correctly, and so
+   * must the fields that already surrounded them.
+   *
+   * <p>This closes a gap in the existing coverage: drifting only the top-level {@code gender}
+   * column exercises nothing, because Delta resolves top-level columns by name and a table missing
+   * one is simply read as null. A field inside the {@code name} element's struct is different - the
+   * migration genuinely rewrites that struct's field list, and a decoder that resolved nested
+   * fields by position would then read this row at the wrong offsets, returning wrong values or
+   * faulting. That is the defect fixed in the core by {@code 048-name-based-nested-decode}, and
+   * this is the server-side confirmation that the fix reaches the read and search paths.
+   */
+  @Test
+  @Order(3)
+  void nestedFieldsAddedByMigrationReadBackCorrectly() {
+    final String patientJson =
+        """
+        {
+          "resourceType": "Patient",
+          "id": "%s",
+          "gender": "male",
+          "name": [
+            {
+              "prefix": ["Dr"],
+              "family": "Nested",
+              "given": ["Drift", "Field"],
+              "suffix": ["Jr"]
+            }
+          ]
+        }
+        """
+            .formatted(NESTED_PATIENT_ID);
+
+    webTestClient
+        .put()
+        .uri("http://localhost:" + port + "/fhir/Patient/" + NESTED_PATIENT_ID)
+        .header("Content-Type", "application/fhir+json")
+        .header("Accept", "application/fhir+json")
+        .bodyValue(patientJson)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    // Every field of the nested struct must come back as sent - the migrated ones and the ones that
+    // surrounded them, whose offsets shifted when the struct was evolved.
+    webTestClient
+        .get()
+        .uri("http://localhost:" + port + "/fhir/Patient/" + NESTED_PATIENT_ID)
+        .header("Accept", "application/fhir+json")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.name[0].prefix[0]")
+        .isEqualTo("Dr")
+        .jsonPath("$.name[0].family")
+        .isEqualTo("Nested")
+        .jsonPath("$.name[0].given[0]")
+        .isEqualTo("Drift")
+        .jsonPath("$.name[0].given[1]")
+        .isEqualTo("Field")
+        .jsonPath("$.name[0].suffix[0]")
+        .isEqualTo("Jr")
+        .jsonPath("$.gender")
+        .isEqualTo("male");
+
+    // A search reads the same rows through a different path, so it must agree.
+    webTestClient
+        .get()
+        .uri("http://localhost:" + port + "/fhir/Patient?_count=200")
+        .header("Accept", "application/fhir+json")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath(
+            "$.entry[?(@.resource.id == '%s')].resource.name[0].family"
+                .formatted(NESTED_PATIENT_ID))
+        .isEqualTo("Nested");
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/update/SchemaMismatchDiagnosticsIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/SchemaMismatchDiagnosticsIT.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import au.csiro.pathling.util.DeltaSchemaFixtures;
+import au.csiro.pathling.util.TestDataSetup;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * End-to-end test for the diagnostics served when a write cannot be reconciled with the stored
+ * table, covering quickstart scenario 1 and the acceptance scenarios of user story 1.
+ *
+ * <p>The warehouse is prepared before the application context starts: the Patient table's schema is
+ * downgraded on disk by removing the {@code prefix} and {@code suffix} fields from every nested
+ * struct, which is where the {@code name} element's fields live. That is the difference Delta's
+ * MERGE refuses to reconcile - a target struct with fewer fields than the corresponding source
+ * struct - and with {@code pathling.storage.schemaAutoMerge} left at its shipped default of
+ * disabled it is not migrated either, which is exactly the state that produces {@code 500
+ * Unexpected error occurred} today.
+ *
+ * <p>Removing a top-level column instead would not do: Delta 4 resolves top-level columns by name
+ * and silently tolerates extra ones in the source, which is why {@link SchemaEvolutionReadIT} can
+ * drift {@code gender} without provoking a failure at all.
+ *
+ * @author John Grimes
+ */
+@Slf4j
+@Tag("IntegrationTest")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+      "pathling.storage.schemaAutoMerge=false",
+      // Bind the Spark driver to localhost so that executor class fetches do not depend on the
+      // machine's LAN address being reachable (e.g. under a firewall or VPN).
+      "spark.driver.bindAddress=localhost",
+      "spark.driver.host=localhost"
+    })
+@ActiveProfiles({"integration-test"})
+class SchemaMismatchDiagnosticsIT {
+
+  /** The nested fields removed from the Patient table, which live inside the name element. */
+  private static final Set<String> REMOVED_FIELDS = Set.of("prefix", "suffix");
+
+  private static final String PATIENT_ID = "schema-mismatch-diagnostics-patient";
+
+  private static final String CONDITION_ID = "schema-mismatch-diagnostics-condition";
+
+  @LocalServerPort int port;
+
+  @Autowired WebTestClient webTestClient;
+
+  @TempDir private static java.nio.file.Path warehouseDir;
+
+  @BeforeEach
+  void setUp() {
+    webTestClient =
+        webTestClient
+            .mutate()
+            .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024))
+            .responseTimeout(Duration.ofSeconds(120))
+            .build();
+  }
+
+  @DynamicPropertySource
+  static void configureProperties(final DynamicPropertyRegistry registry) throws Exception {
+    TestDataSetup.copyTestDataToTempDir(warehouseDir);
+    DeltaSchemaFixtures.removeFieldsFromTableSchema(
+        warehouseDir.resolve("delta").resolve("Patient.parquet"), REMOVED_FIELDS);
+    registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir.toAbsolutePath());
+  }
+
+  /**
+   * User story 1, acceptance scenario 1: a PUT against the affected type returns a 500 whose
+   * OperationOutcome diagnostics name the resource type, the missing field paths and the remedy,
+   * and does not read {@code Unexpected error occurred} (FR-001, SC-001).
+   */
+  @Test
+  void putOfAffectedTypeReturnsActionableDiagnostics() {
+    final String body = responseBody(putPatient(PATIENT_ID).expectStatus().isEqualTo(500));
+
+    assertThat(body).contains("OperationOutcome");
+    assertThat(diagnostics(body))
+        .contains("Patient")
+        .contains("prefix")
+        .contains("suffix")
+        .contains("schemaAutoMerge")
+        .doesNotContain("Unexpected error occurred");
+  }
+
+  /**
+   * FR-002 and SC-003: the diagnostics must not expose the raw Delta message, which embeds both
+   * struct definitions in full, nor any warehouse path.
+   */
+  @Test
+  void diagnosticsExposeNoStructDefinitionOrWarehousePath() {
+    final String body = responseBody(putPatient(PATIENT_ID).expectStatus().isEqualTo(500));
+
+    assertThat(diagnostics(body))
+        .doesNotContain("struct<")
+        .doesNotContain("Cannot cast")
+        .doesNotContain("DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION")
+        .doesNotContain(warehouseDir.toAbsolutePath().toString())
+        .doesNotContain(".parquet");
+  }
+
+  /**
+   * User story 1, acceptance scenario 2: within a batch, the entry of the affected type carries the
+   * same diagnostics while the entry of an unaffected type succeeds. A batch's entries are
+   * independent, so one unwritable type must not fail the whole request.
+   */
+  @Test
+  void batchReportsTheAffectedEntryAndSucceedsForOthers() {
+    final String batch =
+        """
+        {
+          "resourceType": "Bundle",
+          "type": "batch",
+          "entry": [
+            {
+              "request": {"method": "PUT", "url": "Patient/%s"},
+              "resource": {
+                "resourceType": "Patient", "id": "%s", "active": true,
+                "name": [{"family": "Mismatch", "given": ["Schema"]}]
+              }
+            },
+            {
+              "request": {"method": "PUT", "url": "Condition/%s"},
+              "resource": {
+                "resourceType": "Condition", "id": "%s",
+                "subject": {"reference": "Patient/unaffected"}
+              }
+            }
+          ]
+        }
+        """
+            .formatted(PATIENT_ID, PATIENT_ID, CONDITION_ID, CONDITION_ID);
+
+    final String body =
+        responseBody(
+            webTestClient
+                .post()
+                .uri("http://localhost:" + port + "/fhir")
+                .header("Content-Type", "application/fhir+json")
+                .header("Accept", "application/fhir+json")
+                .bodyValue(batch)
+                .exchange()
+                .expectStatus()
+                .isOk());
+
+    // The Patient entry carries the failure, naming the type, the paths and the remedy.
+    assertThat(body).contains("\"status\":\"500\"");
+    assertThat(diagnostics(body))
+        .contains("Patient")
+        .contains("prefix")
+        .contains("schemaAutoMerge")
+        .doesNotContain("Unexpected error occurred");
+    // The Condition entry, whose table reconciles, still succeeds.
+    assertThat(body).contains("\"status\":\"200\"");
+  }
+
+  /**
+   * FR-006: a type whose table reconciles with the encoders is written exactly as it is today, so
+   * the translation has not changed write semantics for anything else.
+   */
+  @Test
+  void putOfUnaffectedTypeStillSucceeds() {
+    webTestClient
+        .put()
+        .uri("http://localhost:" + port + "/fhir/Condition/" + CONDITION_ID)
+        .header("Content-Type", "application/fhir+json")
+        .header("Accept", "application/fhir+json")
+        .bodyValue(
+            """
+            {"resourceType": "Condition", "id": "%s",
+             "subject": {"reference": "Patient/unaffected"}}
+            """
+                .formatted(CONDITION_ID))
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+
+  // ---- helpers ----
+
+  private WebTestClient.ResponseSpec putPatient(final String id) {
+    return webTestClient
+        .put()
+        .uri("http://localhost:" + port + "/fhir/Patient/" + id)
+        .header("Content-Type", "application/fhir+json")
+        .header("Accept", "application/fhir+json")
+        .bodyValue(
+            """
+            {"resourceType": "Patient", "id": "%s", "active": true,
+             "name": [{"family": "Mismatch", "given": ["Schema"]}]}
+            """
+                .formatted(id))
+        .exchange();
+  }
+
+  /**
+   * Returns the response body as a string, so that assertions can be made across the whole body.
+   */
+  private static String responseBody(final WebTestClient.ResponseSpec response) {
+    final byte[] bytes = response.expectBody().returnResult().getResponseBody();
+    assertThat(bytes).isNotNull();
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Extracts the diagnostics text from a body carrying an OperationOutcome, whether at the top
+   * level or nested inside a batch response entry's outcome.
+   */
+  private static String diagnostics(final String body) {
+    final int start = body.indexOf("\"diagnostics\":\"");
+    assertThat(start).as("body must carry a diagnostics field: %s", body).isNotNegative();
+    final int from = start + "\"diagnostics\":\"".length();
+    final int end = body.indexOf('"', from);
+    return body.substring(from, end);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorSchemaAutoMergeTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/update/UpdateExecutorSchemaAutoMergeTest.java
@@ -32,10 +32,12 @@ import au.csiro.pathling.encoders.ViewDefinitionResource;
 import au.csiro.pathling.encoders.ViewDefinitionResource.ColumnComponent;
 import au.csiro.pathling.encoders.ViewDefinitionResource.SelectComponent;
 import au.csiro.pathling.io.DynamicDeltaSource;
+import au.csiro.pathling.io.SchemaDrift;
 import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import au.csiro.pathling.util.DeltaSchemaFixtures;
+import au.csiro.pathling.util.FhirEncoderFixtures;
 import au.csiro.pathling.util.FhirServerTestConfiguration;
 import au.csiro.pathling.util.LogCapture;
 import ch.qos.logback.classic.Level;
@@ -45,8 +47,17 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.StructType;
 import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -78,6 +89,12 @@ import org.springframework.context.annotation.Import;
 class UpdateExecutorSchemaAutoMergeTest {
 
   private static final String VIEW_ID = "schema-compat-test";
+
+  /** The id of the row seeded at the wide schema, carrying a Period-valued extension. */
+  private static final String WIDE_PATIENT_ID = "wide-schema-patient";
+
+  /** The id written by the narrowed encoder after the table was seeded wide. */
+  private static final String NEW_PATIENT_ID = "narrowed-write-patient";
 
   @Autowired private PathlingContext pathlingContext;
 
@@ -180,6 +197,127 @@ class UpdateExecutorSchemaAutoMergeTest {
     verify(dataSource, never()).refresh(anyString());
   }
 
+  // ---- the narrowing direction: a table wider than the running encoder (US3, FR-008, FR-009) ----
+
+  /**
+   * US3 scenario 1: a merge into a table carrying fields the encoder does not emit succeeds, and
+   * the table keeps its wider schema. Without the tolerance this fails with {@code
+   * DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION}, which is the #2697 reproduction.
+   */
+  @Test
+  void mergeIntoWiderTable_succeedsAndLeavesTheSchemaUnchanged() {
+    seedWidePatientTable();
+    final StructType schemaBefore = patientTableSchema();
+
+    final UpdateExecutor executor = newNarrowExecutor(false);
+
+    assertThatNoException()
+        .isThrownBy(() -> executor.merge("Patient", narrowPatient(NEW_PATIENT_ID)));
+    assertThat(patientTableSchema()).isEqualTo(schemaBefore);
+  }
+
+  /**
+   * US3 scenario 1, the null-fill half: the row written by the narrow encoder carries nothing for
+   * the fields it cannot express, so reading it back with the wide encoder finds no Period
+   * extension.
+   */
+  @Test
+  void mergeIntoWiderTable_leavesStoredOnlyColumnsNull() {
+    seedWidePatientTable();
+
+    newNarrowExecutor(false).merge("Patient", narrowPatient(NEW_PATIENT_ID));
+
+    final Patient written = readPatientWithWideEncoder(NEW_PATIENT_ID);
+    assertThat(written.getExtension()).noneSatisfy(e -> assertThat(e.getValue()).isNotNull());
+  }
+
+  /**
+   * US3 scenario 4: the rows written before the configuration was narrowed are untouched, so a
+   * server later restarted with the original open types still reads the columns it wrote before.
+   */
+  @Test
+  void mergeIntoWiderTable_leavesEarlierWideRowsIntact() {
+    seedWidePatientTable();
+
+    newNarrowExecutor(false).merge("Patient", narrowPatient(NEW_PATIENT_ID));
+
+    final Patient existing = readPatientWithWideEncoder(WIDE_PATIENT_ID);
+    assertThat(existing.getExtension()).hasSize(1);
+    final Extension extension = existing.getExtension().get(0);
+    assertThat(extension.getValue()).isInstanceOf(Period.class);
+    assertThat(((Period) extension.getValue()).getStartElement().asStringValue())
+        .startsWith("2020-01-01");
+  }
+
+  /**
+   * US3 scenario 2: a merge matching an existing id replaces that row rather than duplicating it.
+   */
+  @Test
+  void mergeIntoWiderTable_replacesAMatchedRow() {
+    seedWidePatientTable();
+
+    final UpdateExecutor executor = newNarrowExecutor(false);
+    final Patient replacement = narrowPatient(WIDE_PATIENT_ID);
+    replacement.setGender(AdministrativeGender.OTHER);
+    executor.merge("Patient", replacement);
+
+    final Dataset<Row> table = readPatientTable();
+    assertThat(table.filter("id = '" + WIDE_PATIENT_ID + "'").count()).isEqualTo(1);
+    assertThat(readPatientWithWideEncoder(WIDE_PATIENT_ID).getGender())
+        .isEqualTo(AdministrativeGender.OTHER);
+  }
+
+  /**
+   * FR-009: where the table differs in both directions at once, the widening direction stays under
+   * the existing policy. With {@code schemaAutoMerge} disabled the merge still fails, so the
+   * tolerance has not quietly overridden the flag.
+   */
+  @Test
+  void mergeIntoBothDirectionsTable_withoutAutoMerge_stillFails() throws IOException {
+    seedWidePatientTableMissingNestedFields();
+
+    final UpdateExecutor executor = newNarrowExecutor(false);
+
+    assertThatThrownBy(() -> executor.merge("Patient", narrowPatient(NEW_PATIENT_ID)))
+        .hasMessageContaining("DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION");
+  }
+
+  /**
+   * FR-009: with {@code schemaAutoMerge} enabled the two directions are settled in order - the
+   * warmup write adds the fields the encoder requires, after which the remaining difference is
+   * purely narrowing and the tolerance applies.
+   */
+  @Test
+  void mergeIntoBothDirectionsTable_withAutoMerge_succeeds() throws IOException {
+    seedWidePatientTableMissingNestedFields();
+
+    final UpdateExecutor executor = newNarrowExecutor(true);
+
+    assertThatNoException()
+        .isThrownBy(() -> executor.merge("Patient", narrowPatient(NEW_PATIENT_ID)));
+    // The warmup write added the encoder's fields; the table's own wider fields are still there.
+    final StructType schema = patientTableSchema();
+    assertThat(SchemaDrift.missingFieldPaths(narrowEncoders().of("Patient").schema(), schema))
+        .isEmpty();
+    assertThat(SchemaDrift.excessFieldPaths(narrowEncoders().of("Patient").schema(), schema))
+        .isNotEmpty();
+  }
+
+  /**
+   * FR-007 and FR-009: a table that reconciles with the running encoder takes neither the warmup
+   * write nor the tolerance, so the ordinary write path is unchanged.
+   */
+  @Test
+  void mergeIntoReconcilingTable_isUnaffectedByTheTolerance() {
+    seedTable();
+    final DynamicDeltaSource dataSource = mock(DynamicDeltaSource.class);
+    final UpdateExecutor executor = newExecutor(true, dataSource);
+
+    executor.merge("ViewDefinition", createViewDefinition(VIEW_ID, "updated_view", "Patient"));
+
+    verify(dataSource, never()).refresh(anyString());
+  }
+
   // ---- helpers ----
 
   /**
@@ -218,15 +356,121 @@ class UpdateExecutorSchemaAutoMergeTest {
   @Nonnull
   private UpdateExecutor newExecutor(
       final boolean schemaAutoMerge, @Nonnull final QueryableDataSource dataSource) {
+    return newExecutor(schemaAutoMerge, dataSource, fhirEncoders);
+  }
+
+  /**
+   * Builds an executor running against the narrowed encoders, so that the table seeded at the
+   * ambient schema is wider than the encoder writing to it. This is the state a warehouse is in
+   * after {@code pathling.encoding.openTypes} has been narrowed, and it does not depend on which
+   * encoding configuration the test profile happens to use.
+   */
+  @Nonnull
+  private UpdateExecutor newNarrowExecutor(final boolean schemaAutoMerge) {
+    return newExecutor(schemaAutoMerge, mock(QueryableDataSource.class), narrowEncoders());
+  }
+
+  @Nonnull
+  private UpdateExecutor newExecutor(
+      final boolean schemaAutoMerge,
+      @Nonnull final QueryableDataSource dataSource,
+      @Nonnull final FhirEncoders encoders) {
     final StorageConfiguration storageConfiguration = new StorageConfiguration();
     storageConfiguration.setSchemaAutoMerge(schemaAutoMerge);
     return new UpdateExecutor(
         pathlingContext,
-        fhirEncoders,
+        encoders,
         tempDatabasePath.toAbsolutePath().toString(),
         cacheableDatabase,
         storageConfiguration,
         dataSource);
+  }
+
+  /** The ambient encoders with Period and Quantity dropped from their open types. */
+  @Nonnull
+  private FhirEncoders narrowEncoders() {
+    return FhirEncoderFixtures.narrow(fhirEncoders);
+  }
+
+  /**
+   * Seeds a Patient table at the ambient (wide) schema, holding one row whose extension carries a
+   * Period value. The narrowed encoder cannot express that value, so the table is wider than the
+   * encoder in a way that has real data behind it.
+   */
+  private void seedWidePatientTable() {
+    FhirEncoderFixtures.seedTable(
+        pathlingContext.getSpark(),
+        fhirEncoders,
+        "Patient",
+        List.of(widePatient()),
+        patientTablePath().toString());
+  }
+
+  /**
+   * Seeds the wide Patient table and then removes the nested {@code prefix} and {@code suffix}
+   * fields from its committed schema, so that it differs from the narrowed encoder in both
+   * directions at once.
+   */
+  private void seedWidePatientTableMissingNestedFields() throws IOException {
+    seedWidePatientTable();
+    DeltaSchemaFixtures.removeFieldsFromTableSchema(patientTablePath(), Set.of("prefix", "suffix"));
+    invalidateDeltaMetadataCache(patientTablePath());
+  }
+
+  /** A Patient carrying a Period-valued extension, which only the wide encoder can represent. */
+  @Nonnull
+  private static Patient widePatient() {
+    final Patient patient = new Patient();
+    patient.setId(WIDE_PATIENT_ID);
+    patient.setGender(AdministrativeGender.FEMALE);
+    final Period period = new Period();
+    period.setStartElement(new DateTimeType("2020-01-01T00:00:00Z"));
+    patient.addExtension("http://example.org/period", period);
+    return patient;
+  }
+
+  /** A Patient whose content the narrowed encoder can represent in full. */
+  @Nonnull
+  private static Patient narrowPatient(@Nonnull final String id) {
+    final Patient patient = new Patient();
+    patient.setId(id);
+    patient.setActive(true);
+    return patient;
+  }
+
+  @Nonnull
+  private Path patientTablePath() {
+    return tempDatabasePath.resolve("Patient.parquet");
+  }
+
+  @Nonnull
+  private Dataset<Row> readPatientTable() {
+    invalidateDeltaMetadataCache(patientTablePath());
+    return pathlingContext
+        .getSpark()
+        .read()
+        .format("delta")
+        .load(patientTablePath().toAbsolutePath().toString());
+  }
+
+  @Nonnull
+  private StructType patientTableSchema() {
+    return readPatientTable().schema();
+  }
+
+  /**
+   * Reads one Patient back through the wide encoder, which is what a server restarted with the
+   * original open types would do.
+   */
+  @Nonnull
+  private Patient readPatientWithWideEncoder(@Nonnull final String id) {
+    final List<Patient> patients =
+        readPatientTable()
+            .filter("id = '" + id + "'")
+            .as(fhirEncoders.<Patient>of("Patient"))
+            .collectAsList();
+    assertThat(patients).hasSize(1);
+    return patients.get(0);
   }
 
   @Nonnull

--- a/server/src/test/java/au/csiro/pathling/util/FhirEncoderFixtures.java
+++ b/server/src/test/java/au/csiro/pathling/util/FhirEncoderFixtures.java
@@ -56,14 +56,6 @@ public final class FhirEncoderFixtures {
   /** The open types the narrow encoder drops relative to the encoders it is derived from. */
   public static final Set<String> NARROWED_OPEN_TYPES = Set.of("Period", "Quantity");
 
-  /**
-   * The roots of the field subtrees that exist only in the wide encoder's schema. A narrow server
-   * sees these, and every path beneath them, as excess when it reads a table written by a wide one,
-   * so these are the paths its messages are expected to name.
-   */
-  public static final Set<String> WIDE_ONLY_FIELD_PATH_ROOTS =
-      Set.of("_extension.valuePeriod", "_extension.valueQuantity");
-
   private FhirEncoderFixtures() {}
 
   /**

--- a/server/src/test/java/au/csiro/pathling/util/FhirEncoderFixtures.java
+++ b/server/src/test/java/au/csiro/pathling/util/FhirEncoderFixtures.java
@@ -17,6 +17,7 @@
 
 package au.csiro.pathling.util;
 
+import au.csiro.pathling.config.EncodingConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
 import jakarta.annotation.Nonnull;
 import java.util.HashSet;
@@ -33,11 +34,17 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
  * so that a Delta table can be seeded at one encoder's schema and then written to or read by the
  * other.
  *
- * <p>The wide encoder adds {@code Period} and {@code Quantity} to the standard open types, which
- * gives the extension element struct the additional {@code valuePeriod} and {@code valueQuantity}
- * fields. A table seeded with the wide encoder is therefore wider than the narrow encoder's schema
- * in exactly the way a warehouse is when {@code pathling.encoding.openTypes} has been narrowed
- * against populated data, which is the state reported in issue #2697.
+ * <p>The pair is derived from the encoders under test rather than from a fixed configuration. The
+ * wide encoder is the one supplied; the narrow encoder is the same configuration with {@code
+ * Period} and {@code Quantity} removed from its open types, which drops the corresponding {@code
+ * valuePeriod} and {@code valueQuantity} fields from the extension element struct. Deriving the
+ * pair this way matters because the encoding configuration differs between the server's shipped
+ * defaults and the test profile, so a hardcoded pair would describe neither reliably.
+ *
+ * <p>A table seeded with the wide encoder is therefore wider than the narrow encoder's schema in
+ * exactly the way a warehouse is when {@code pathling.encoding.openTypes} has been narrowed against
+ * populated data, which is the state reported in issue #2697. The difference is purely narrowing:
+ * the narrow schema introduces nothing the wide one lacks.
  *
  * <p>This is the counterpart of {@link DeltaSchemaFixtures}, which produces the opposite direction
  * by rewriting a committed schema on disk to remove fields.
@@ -46,23 +53,8 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
  */
 public final class FhirEncoderFixtures {
 
-  /** The open types added by the wide encoder, on top of the standard set. */
-  public static final Set<String> ADDITIONAL_OPEN_TYPES = Set.of("Period", "Quantity");
-
-  /**
-   * The nesting level both encoders are built with, matching the default of {@code
-   * pathling.encoding.maxNestingLevel}. The encoder builder's own default is 0, so this must be set
-   * explicitly for the fixture to describe the same schema the server does.
-   */
-  private static final int MAX_NESTING_LEVEL = 3;
-
-  /**
-   * Both encoders are built with extensions enabled, matching the default of {@code
-   * pathling.encoding.enableExtensions}. This is what makes the open types observable at all: the
-   * open-type value fields live inside the {@code _extension} element, so with extensions disabled
-   * the two encoders would produce identical schemas.
-   */
-  private static final boolean ENABLE_EXTENSIONS = true;
+  /** The open types the narrow encoder drops relative to the encoders it is derived from. */
+  public static final Set<String> NARROWED_OPEN_TYPES = Set.of("Period", "Quantity");
 
   /**
    * The roots of the field subtrees that exist only in the wide encoder's schema. A narrow server
@@ -75,37 +67,28 @@ public final class FhirEncoderFixtures {
   private FhirEncoderFixtures() {}
 
   /**
-   * Returns encoders configured with the standard open types plus {@code Period} and {@code
-   * Quantity}. Every other setting matches the server's defaults, so the schema differs from {@link
-   * #narrowEncoders()} only in the extension value fields.
+   * Returns encoders matching the given ones except that {@code Period} and {@code Quantity} are
+   * removed from the open types. Every other setting is carried across unchanged, so the resulting
+   * schema differs only in the extension value fields.
    *
-   * @return the wide encoders
+   * @param encoders the encoders to narrow, typically the ones the application context provides
+   * @return the narrowed encoders
+   * @throws IllegalArgumentException if the given encoders carry neither of the narrowed open
+   *     types, in which case narrowing would produce no difference and the fixture would prove
+   *     nothing
    */
   @Nonnull
-  public static FhirEncoders wideEncoders() {
-    final Set<String> openTypes = new HashSet<>(FhirEncoders.STANDARD_OPEN_TYPES);
-    openTypes.addAll(ADDITIONAL_OPEN_TYPES);
-    return encoders(openTypes);
-  }
-
-  /**
-   * Returns encoders configured with the standard open types, which is the server's shipped
-   * default.
-   *
-   * @return the narrow encoders
-   */
-  @Nonnull
-  public static FhirEncoders narrowEncoders() {
-    return encoders(FhirEncoders.STANDARD_OPEN_TYPES);
-  }
-
-  /** Builds encoders for the given open types, with every other setting at the server's default. */
-  @Nonnull
-  private static FhirEncoders encoders(@Nonnull final Set<String> openTypes) {
+  public static FhirEncoders narrow(@Nonnull final FhirEncoders encoders) {
+    final EncodingConfiguration configuration = encoders.getConfiguration();
+    final Set<String> openTypes = new HashSet<>(configuration.getOpenTypes());
+    if (!openTypes.removeAll(NARROWED_OPEN_TYPES)) {
+      throw new IllegalArgumentException(
+          "The encoders to narrow must carry at least one of " + NARROWED_OPEN_TYPES);
+    }
     return FhirEncoders.forR4()
         .withOpenTypes(openTypes)
-        .withMaxNestingLevel(MAX_NESTING_LEVEL)
-        .withExtensionsEnabled(ENABLE_EXTENSIONS)
+        .withMaxNestingLevel(configuration.getMaxNestingLevel())
+        .withExtensionsEnabled(configuration.isEnableExtensions())
         .getOrCreate();
   }
 

--- a/server/src/test/java/au/csiro/pathling/util/FhirEncoderFixtures.java
+++ b/server/src/test/java/au/csiro/pathling/util/FhirEncoderFixtures.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.util;
+
+import au.csiro.pathling.encoders.FhirEncoders;
+import jakarta.annotation.Nonnull;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+/**
+ * Test fixtures that produce a pair of FHIR encoders differing only in their configured open types,
+ * so that a Delta table can be seeded at one encoder's schema and then written to or read by the
+ * other.
+ *
+ * <p>The wide encoder adds {@code Period} and {@code Quantity} to the standard open types, which
+ * gives the extension element struct the additional {@code valuePeriod} and {@code valueQuantity}
+ * fields. A table seeded with the wide encoder is therefore wider than the narrow encoder's schema
+ * in exactly the way a warehouse is when {@code pathling.encoding.openTypes} has been narrowed
+ * against populated data, which is the state reported in issue #2697.
+ *
+ * <p>This is the counterpart of {@link DeltaSchemaFixtures}, which produces the opposite direction
+ * by rewriting a committed schema on disk to remove fields.
+ *
+ * @author John Grimes
+ */
+public final class FhirEncoderFixtures {
+
+  /** The open types added by the wide encoder, on top of the standard set. */
+  public static final Set<String> ADDITIONAL_OPEN_TYPES = Set.of("Period", "Quantity");
+
+  /**
+   * The nesting level both encoders are built with, matching the default of {@code
+   * pathling.encoding.maxNestingLevel}. The encoder builder's own default is 0, so this must be set
+   * explicitly for the fixture to describe the same schema the server does.
+   */
+  private static final int MAX_NESTING_LEVEL = 3;
+
+  /**
+   * Both encoders are built with extensions enabled, matching the default of {@code
+   * pathling.encoding.enableExtensions}. This is what makes the open types observable at all: the
+   * open-type value fields live inside the {@code _extension} element, so with extensions disabled
+   * the two encoders would produce identical schemas.
+   */
+  private static final boolean ENABLE_EXTENSIONS = true;
+
+  /**
+   * The roots of the field subtrees that exist only in the wide encoder's schema. A narrow server
+   * sees these, and every path beneath them, as excess when it reads a table written by a wide one,
+   * so these are the paths its messages are expected to name.
+   */
+  public static final Set<String> WIDE_ONLY_FIELD_PATH_ROOTS =
+      Set.of("_extension.valuePeriod", "_extension.valueQuantity");
+
+  private FhirEncoderFixtures() {}
+
+  /**
+   * Returns encoders configured with the standard open types plus {@code Period} and {@code
+   * Quantity}. Every other setting matches the server's defaults, so the schema differs from {@link
+   * #narrowEncoders()} only in the extension value fields.
+   *
+   * @return the wide encoders
+   */
+  @Nonnull
+  public static FhirEncoders wideEncoders() {
+    final Set<String> openTypes = new HashSet<>(FhirEncoders.STANDARD_OPEN_TYPES);
+    openTypes.addAll(ADDITIONAL_OPEN_TYPES);
+    return encoders(openTypes);
+  }
+
+  /**
+   * Returns encoders configured with the standard open types, which is the server's shipped
+   * default.
+   *
+   * @return the narrow encoders
+   */
+  @Nonnull
+  public static FhirEncoders narrowEncoders() {
+    return encoders(FhirEncoders.STANDARD_OPEN_TYPES);
+  }
+
+  /** Builds encoders for the given open types, with every other setting at the server's default. */
+  @Nonnull
+  private static FhirEncoders encoders(@Nonnull final Set<String> openTypes) {
+    return FhirEncoders.forR4()
+        .withOpenTypes(openTypes)
+        .withMaxNestingLevel(MAX_NESTING_LEVEL)
+        .withExtensionsEnabled(ENABLE_EXTENSIONS)
+        .getOrCreate();
+  }
+
+  /**
+   * Seeds a Delta table at the schema of the nominated encoder, failing if a table already exists
+   * at the path.
+   *
+   * @param spark the Spark session
+   * @param encoders the encoders whose schema the table is written at
+   * @param resourceCode the resource type code being written
+   * @param resources the resources to write, which may be empty to seed an empty table
+   * @param tablePath the path to write the Delta table to
+   * @param <T> the resource type being written
+   */
+  public static <T extends IBaseResource> void seedTable(
+      @Nonnull final SparkSession spark,
+      @Nonnull final FhirEncoders encoders,
+      @Nonnull final String resourceCode,
+      @Nonnull final List<T> resources,
+      @Nonnull final String tablePath) {
+    encodeResources(spark, encoders, resourceCode, resources)
+        .write()
+        .format("delta")
+        .mode(SaveMode.ErrorIfExists)
+        .save(tablePath);
+  }
+
+  /**
+   * Encodes resources using the nominated encoder, without writing them anywhere. Useful for
+   * obtaining an encoder's schema, or for merging into an existing table.
+   *
+   * @param spark the Spark session
+   * @param encoders the encoders to use
+   * @param resourceCode the resource type code being encoded
+   * @param resources the resources to encode, which may be empty
+   * @param <T> the resource type being encoded
+   * @return the encoded dataset
+   */
+  @Nonnull
+  public static <T extends IBaseResource> Dataset<Row> encodeResources(
+      @Nonnull final SparkSession spark,
+      @Nonnull final FhirEncoders encoders,
+      @Nonnull final String resourceCode,
+      @Nonnull final List<T> resources) {
+    return spark.createDataset(resources, encoders.<T>of(resourceCode)).toDF();
+  }
+}

--- a/site/docs/server/configuration.md
+++ b/site/docs/server/configuration.md
@@ -213,6 +213,15 @@ This setting bounds the resolution of a query's dependency graph, for both
   profiles. In general, you will get the best query performance by encoding your
   data with the shortest possible list.
 
+  Shortening this list against a warehouse that already holds data, or pointing
+  a server at a warehouse written by a deployment with a longer list, leaves
+  stored columns that the running encoder no longer emits. Those columns are
+  preserved: they are not dropped from the table, and writes to the affected
+  resource types succeed with the columns written as null on the new rows. Reads
+  return what the running encoder can represent, so the values in those columns
+  are not visible until the original list is restored. Each affected table is
+  named in the log at startup, along with the field paths involved.
+
 ### Storage
 
 - `pathling.storage.warehouseUrl` - (default: `file:///usr/share/warehouse`) The
@@ -250,6 +259,15 @@ This setting bounds the resolution of a query's dependency graph, for both
   runtime schema evolution is only visible to the replica that performed it;
   other replicas require a restart, although redeploys (which replace all
   replicas and re-run startup migration) are self-correcting.
+
+  Where a stored table and the running encoders cannot be reconciled at all, the
+  request fails with an error that describes the condition rather than a generic
+  one. The message names the resource type, which direction the two schemas
+  differ in, the field paths involved, and the remedy - enabling this setting
+  where the table is behind the encoders, or restoring the encoding
+  configuration the table was written with where it is ahead of them. It
+  deliberately excludes the underlying schema definitions and warehouse paths,
+  so the full detail remains in the server log alone.
 
 Pathling will automatically detect AWS authentication details within the
 environment and use them to access S3 buckets. It uses a chain of authentication


### PR DESCRIPTION
Resolves #2697.

This is the whole server-side response to that issue: the diagnostics ask, visibility of the condition at startup, and tolerance for a table wider than the running encoder on the server's own merge path.

**Depends on core 9.9.0** (#2656), which carries the name-based nested decode fix. Without it the stored rows admitted by the write tolerance here would be decoded at the wrong offsets, so this must not be released ahead of that.

Three changes, sharing one comparison:

- A Delta schema mismatch reaching the error handler is translated into an `OperationOutcome` naming the resource type, the direction of the mismatch, the field paths involved and the remedy, instead of falling through to `Unexpected error occurred`. The raw Delta message cannot be returned in its place because it embeds both struct definitions in full. Every other failure keeps the generic message.
- Startup now reports both directions of difference per table. The direction where a table carries fields the encoders do not emit was previously not detected at all, so an operator who narrowed `encoding.openTypes` against a populated warehouse had no way to see it until a request failed. It is logged at INFO rather than WARN, because the condition is tolerated rather than fatal to the type.
- A merge into a table wider than the running encoder now succeeds, with the stored-only columns written as null and the table's schema left unchanged, so a server later restarted with the original configuration still reads what it wrote before. The gate is deliberately narrow: the same Delta flag would also widen the target to admit encoder-only fields, which belongs to `storage.schemaAutoMerge`, so it is set only when the difference is purely narrowing. Where a table differs in both directions the widening is settled first under the existing policy.

A batch now reports these failures per entry rather than failing the whole request. Its entries are independent of one another, but `BatchProvider` grouped resources by type and let any one type's failure throw out of the whole operation, so a client could not tell which entry was at fault.
