### PR TITLE
Give the read interaction its own operation authority

### DIFF
--- a/server/src/main/java/au/csiro/pathling/read/ReadProvider.java
+++ b/server/src/main/java/au/csiro/pathling/read/ReadProvider.java
@@ -83,11 +83,17 @@ public class ReadProvider implements IResourceProvider {
   /**
    * Implements the FHIR read operation.
    *
+   * <p>Requires the {@code pathling:read-resource} operation authority, checked by the security
+   * aspect before method entry, in addition to read data authority for the resource type, checked
+   * inline below. The operation authority is deliberately named apart from the {@code
+   * pathling:read} data authority, so that a subject can be granted instance read on one resource
+   * type without being granted read access to every type.
+   *
    * @param id the ID of the resource to read
    * @return the resource with the specified ID
    */
   @Read
-  @OperationAccess("read")
+  @OperationAccess("read-resource")
   @SuppressWarnings("UnusedReturnValue")
   public IBaseResource read(@Nullable @IdParam final IdType id) {
     checkUserInput(id != null && !id.isEmpty(), "ID must be supplied");

--- a/server/src/main/java/au/csiro/pathling/read/ReadProviderFactory.java
+++ b/server/src/main/java/au/csiro/pathling/read/ReadProviderFactory.java
@@ -24,15 +24,20 @@ import ca.uhn.fhir.context.FhirContext;
 import jakarta.annotation.Nonnull;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Enumerations.ResourceType;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 /**
- * Factory for creating resource-specific ReadProvider instances.
+ * Factory for creating resource-specific ReadProvider instances. Uses the application context to
+ * create instances so that they are Spring beans and can be detected by Spring AOP for security
+ * interception.
  *
  * @author John Grimes
  */
 @Component
 public class ReadProviderFactory {
+
+  @Nonnull private final ApplicationContext applicationContext;
 
   @Nonnull private final ServerConfiguration configuration;
 
@@ -45,16 +50,19 @@ public class ReadProviderFactory {
   /**
    * Constructs a new ReadProviderFactory.
    *
+   * @param applicationContext the Spring application context for bean creation
    * @param configuration the server configuration
    * @param fhirContext the FHIR context for resource definitions
    * @param dataSource the data source containing the resources to read
    * @param fhirEncoders the encoders for converting Spark rows to FHIR resources
    */
   public ReadProviderFactory(
+      @Nonnull final ApplicationContext applicationContext,
       @Nonnull final ServerConfiguration configuration,
       @Nonnull final FhirContext fhirContext,
       @Nonnull final DataSource dataSource,
       @Nonnull final FhirEncoders fhirEncoders) {
+    this.applicationContext = applicationContext;
     this.configuration = configuration;
     this.fhirContext = fhirContext;
     this.dataSource = dataSource;
@@ -62,7 +70,7 @@ public class ReadProviderFactory {
   }
 
   /**
-   * Creates a ReadProvider for the given resource type.
+   * Creates a ReadProvider bean for the given resource type.
    *
    * @param resourceType the type of resource to create the provider for
    * @return a ReadProvider configured for the specified resource type
@@ -73,12 +81,13 @@ public class ReadProviderFactory {
         fhirContext.getResourceDefinition(resourceType.name()).getImplementingClass();
 
     final ReadExecutor readExecutor = new ReadExecutor(dataSource, fhirEncoders);
-    return new ReadProvider(configuration, readExecutor, fhirContext, resourceTypeClass);
+    return applicationContext.getBean(
+        ReadProvider.class, configuration, readExecutor, fhirContext, resourceTypeClass);
   }
 
   /**
-   * Creates a ReadProvider for the given resource type code. This method supports custom resource
-   * types like ViewDefinition that are not part of the standard FHIR ResourceType enum.
+   * Creates a ReadProvider bean for the given resource type code. This method supports custom
+   * resource types like ViewDefinition that are not part of the standard FHIR ResourceType enum.
    *
    * @param resourceTypeCode the type code of the resource (e.g., "Patient", "ViewDefinition")
    * @return a ReadProvider configured for the specified resource type
@@ -89,6 +98,7 @@ public class ReadProviderFactory {
         fhirContext.getResourceDefinition(resourceTypeCode).getImplementingClass();
 
     final ReadExecutor readExecutor = new ReadExecutor(dataSource, fhirEncoders);
-    return new ReadProvider(configuration, readExecutor, fhirContext, resourceTypeClass);
+    return applicationContext.getBean(
+        ReadProvider.class, configuration, readExecutor, fhirContext, resourceTypeClass);
   }
 }

--- a/server/src/test/java/au/csiro/pathling/read/ReadProviderAuthTest.java
+++ b/server/src/test/java/au/csiro/pathling/read/ReadProviderAuthTest.java
@@ -40,7 +40,10 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 /**
- * Security tests for {@link ReadProvider} verifying per-resource read authority enforcement.
+ * Security tests for {@link ReadProvider} verifying per-resource read authority enforcement. The
+ * provider is constructed directly here, so only the inline data authority check applies; the
+ * operation authority check that also guards the interaction is covered by {@code
+ * SecurityEnabledReadOperationTest}.
  *
  * @author John Grimes
  */
@@ -85,7 +88,7 @@ class ReadProviderAuthTest {
   @Test
   void readSucceedsWithCorrectResourceAuthority() {
     authConfig.setEnabled(true);
-    setSecurityContext("pathling:read", "pathling:read:Patient");
+    setSecurityContext("pathling:read:Patient");
     when(readExecutor.read("Patient", "patient-1")).thenReturn(new Patient());
     assertThat(readProvider.read(new IdType("Patient/patient-1"))).isNotNull();
   }

--- a/server/src/test/java/au/csiro/pathling/read/ReadProviderFactoryTest.java
+++ b/server/src/test/java/au/csiro/pathling/read/ReadProviderFactoryTest.java
@@ -36,6 +36,7 @@ import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -43,7 +44,9 @@ import org.springframework.context.annotation.Import;
  *
  * @author John Grimes
  */
-@Import(FhirServerTestConfiguration.class)
+// ReadProvider is imported so the context carries its (prototype-scoped) bean definition, which
+// is what the factory asks for.
+@Import({FhirServerTestConfiguration.class, ReadProvider.class})
 @SpringBootUnitTest
 class ReadProviderFactoryTest {
 
@@ -57,6 +60,8 @@ class ReadProviderFactoryTest {
 
   @Autowired private au.csiro.pathling.config.ServerConfiguration configuration;
 
+  @Autowired private ApplicationContext applicationContext;
+
   private ReadProviderFactory readProviderFactory;
 
   @BeforeEach
@@ -67,7 +72,8 @@ class ReadProviderFactoryTest {
         new CustomObjectDataSource(sparkSession, pathlingContext, fhirEncoders, resources);
 
     readProviderFactory =
-        new ReadProviderFactory(configuration, fhirContext, dataSource, fhirEncoders);
+        new ReadProviderFactory(
+            applicationContext, configuration, fhirContext, dataSource, fhirEncoders);
   }
 
   // -------------------------------------------------------------------------

--- a/server/src/test/java/au/csiro/pathling/read/ReadProviderTest.java
+++ b/server/src/test/java/au/csiro/pathling/read/ReadProviderTest.java
@@ -178,9 +178,11 @@ class ReadProviderTest {
     final Method readMethod = ReadProvider.class.getMethod("read", IdType.class);
     final OperationAccess operationAccess = readMethod.getAnnotation(OperationAccess.class);
 
-    // Then: the annotation should be present with value "read".
+    // Then: the annotation should be present with value "read-resource". The operation authority
+    // is deliberately named apart from the "read" data authority, so that instance read can be
+    // granted for a single resource type.
     assertThat(operationAccess).isNotNull();
-    assertThat(operationAccess.value()).containsExactly("read");
+    assertThat(operationAccess.value()).containsExactly("read-resource");
   }
 
   // -------------------------------------------------------------------------

--- a/server/src/test/java/au/csiro/pathling/security/PathlingAuthorityTest.java
+++ b/server/src/test/java/au/csiro/pathling/security/PathlingAuthorityTest.java
@@ -64,6 +64,7 @@ class PathlingAuthorityTest {
     PathlingAuthority.fromAuthority("pathling:import-pnp");
     PathlingAuthority.fromAuthority("pathling:create");
     PathlingAuthority.fromAuthority("pathling:update");
+    PathlingAuthority.fromAuthority("pathling:read-resource");
     for (final ResourceType resourceType : ResourceType.values()) {
       PathlingAuthority.fromAuthority("pathling:read:" + resourceType.toCode());
       PathlingAuthority.fromAuthority("pathling:write:" + resourceType.toCode());
@@ -79,6 +80,10 @@ class PathlingAuthorityTest {
     assertFailsValidation("pathling::");
     assertFailsValidation("pathling::Patient");
     assertFailsValidation("pathling:search:Patient", "Subject not supported for action: search");
+    // The new read interaction operation authority is operation-only: a subject is legal only
+    // after the read and write data access actions.
+    assertFailsValidation(
+        "pathling:read-resource:Patient", "Subject not supported for action: read-resource");
     assertFailsValidation("pathling:se_arch");
     assertFailsValidation("pathling:read:Clinical_Impression");
   }
@@ -117,6 +122,29 @@ class PathlingAuthorityTest {
     assertFalse(search.subsumedBy(auth("pathling:import")));
     assertFalse(search.subsumedBy(auth("pathling:read")));
     assertFalse(search.subsumedBy(auth("pathling:write:ClinicalImpression")));
+  }
+
+  /**
+   * The read interaction's operation authority and the all-types read data authority must remain
+   * distinct: neither subsumes the other, so granting read data access does not grant the
+   * interaction, and vice versa. Only the root authority covers both.
+   */
+  @Test
+  void testReadResourceAndReadDoNotSubsumeOneAnother() {
+    final PathlingAuthority readResource =
+        PathlingAuthority.fromAuthority("pathling:read-resource");
+    final PathlingAuthority read = PathlingAuthority.fromAuthority("pathling:read");
+    final PathlingAuthority patientRead = PathlingAuthority.fromAuthority("pathling:read:Patient");
+
+    // The root authority subsumes the new operation authority.
+    assertTrue(readResource.subsumedBy(auth("pathling")));
+    assertTrue(readResource.subsumedBy(auth("pathling:read-resource")));
+
+    // Neither direction of subsumption holds between the two names.
+    assertFalse(readResource.subsumedBy(auth("pathling:read")));
+    assertFalse(readResource.subsumedBy(auth("pathling:read:Patient")));
+    assertFalse(read.subsumedBy(auth("pathling:read-resource")));
+    assertFalse(patientRead.subsumedBy(auth("pathling:read-resource")));
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/security/SecurityEnabledReadOperationTest.java
+++ b/server/src/test/java/au/csiro/pathling/security/SecurityEnabledReadOperationTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import au.csiro.pathling.errors.AccessDeniedError;
-import au.csiro.pathling.read.ReadExecutor;
 import au.csiro.pathling.read.ReadProvider;
 import au.csiro.pathling.read.ReadProviderFactory;
 import au.csiro.pathling.util.FhirServerTestConfiguration;
@@ -57,7 +56,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 @MockitoBean(types = OidcConfiguration.class)
 @MockitoBean(types = JwtDecoder.class)
 @MockitoBean(types = JwtAuthenticationConverter.class)
-@Import({FhirServerTestConfiguration.class, ReadExecutor.class, ReadProviderFactory.class})
+@Import({FhirServerTestConfiguration.class, ReadProviderFactory.class})
 class SecurityEnabledReadOperationTest extends SecurityTest {
 
   private static final String ERROR_MSG_TEMPLATE = "Missing authority: 'pathling:%s'";

--- a/server/src/test/java/au/csiro/pathling/security/SecurityEnabledReadOperationTest.java
+++ b/server/src/test/java/au/csiro/pathling/security/SecurityEnabledReadOperationTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import au.csiro.pathling.errors.AccessDeniedError;
+import au.csiro.pathling.read.ReadExecutor;
+import au.csiro.pathling.read.ReadProvider;
+import au.csiro.pathling.read.ReadProviderFactory;
+import au.csiro.pathling.util.FhirServerTestConfiguration;
+import jakarta.annotation.Nonnull;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.IdType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Security tests for the FHIR read interaction. Verifies that both checks that guard the
+ * interaction fire together: the operation authority check applied by {@link SecurityAspect} before
+ * method entry, and the per-resource-type data authority check applied inline by the provider.
+ *
+ * <p>Providers are obtained from {@link ReadProviderFactory}, which is the path {@code FhirServer}
+ * uses to register them. Exercising that path is what makes the operation check observable: the
+ * check is applied by AspectJ {@code @Before} advice that only fires when the provider is a Spring
+ * bean, so a test that constructs the provider directly cannot see it.
+ *
+ * @author John Grimes
+ */
+@TestPropertySource(
+    properties = {
+      "pathling.auth.enabled=true",
+      "pathling.auth.issuer=https://pathling.acme.com/fhir"
+    })
+@MockitoBean(types = OidcConfiguration.class)
+@MockitoBean(types = JwtDecoder.class)
+@MockitoBean(types = JwtAuthenticationConverter.class)
+@Import({FhirServerTestConfiguration.class, ReadExecutor.class, ReadProviderFactory.class})
+class SecurityEnabledReadOperationTest extends SecurityTest {
+
+  private static final String ERROR_MSG_TEMPLATE = "Missing authority: 'pathling:%s'";
+
+  /** An identifier present in the Patient delta table backing the test data source. */
+  private static final String PATIENT_ID = "72df0f76-2758-fac4-67cd-de33c4a2c95e";
+
+  /** An identifier present in the Observation delta table backing the test data source. */
+  private static final String OBSERVATION_ID = "88d6aa70-4187-2360-9da6-3113decd1c21";
+
+  @Autowired private ReadProviderFactory readProviderFactory;
+
+  // -------------------------------------------------------------------------
+  // User story 1: narrow per-type instance read.
+  // -------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("US1: read-resource plus read:Observation reads an Observation by id")
+  @WithMockJwt(
+      username = "user",
+      authorities = {"pathling:read-resource", "pathling:read:Observation"})
+  void readAllowedWithOperationAuthorityAndMatchingTypeAuthority() {
+    final IBaseResource resource = read("Observation", OBSERVATION_ID);
+
+    assertThat(resource).isNotNull();
+    assertThat(resource.getIdElement().getIdPart()).isEqualTo(OBSERVATION_ID);
+  }
+
+  @Test
+  @DisplayName("US1: read-resource plus read:Observation is refused a Patient read")
+  @WithMockJwt(
+      username = "user",
+      authorities = {"pathling:read-resource", "pathling:read:Observation"})
+  void readDeniedWithOperationAuthorityButWrongTypeAuthority() {
+    // The operation check passes and the inline data check refuses, naming the type it wanted.
+    assertThatThrownBy(() -> read("Patient", PATIENT_ID))
+        .isExactlyInstanceOf(AccessDeniedError.class)
+        .hasMessage(ERROR_MSG_TEMPLATE.formatted("read:Patient"));
+  }
+
+  @Test
+  @DisplayName("US1: read:Observation alone is refused, naming the missing operation authority")
+  @WithMockJwt(
+      username = "user",
+      authorities = {"pathling:read:Observation"})
+  void readDeniedWithoutOperationAuthority() {
+    assertThatThrownBy(() -> read("Observation", OBSERVATION_ID))
+        .isExactlyInstanceOf(AccessDeniedError.class)
+        .hasMessage(ERROR_MSG_TEMPLATE.formatted("read-resource"));
+  }
+
+  @Test
+  @DisplayName("US1: read-resource plus all-types read reads any type by id")
+  @WithMockJwt(
+      username = "user",
+      authorities = {"pathling:read-resource", "pathling:read"})
+  void readAllowedWithOperationAuthorityAndAllTypesDataAuthority() {
+    assertThat(read("Observation", OBSERVATION_ID).getIdElement().getIdPart())
+        .isEqualTo(OBSERVATION_ID);
+    assertThat(read("Patient", PATIENT_ID).getIdElement().getIdPart()).isEqualTo(PATIENT_ID);
+  }
+
+  // -------------------------------------------------------------------------
+  // User story 2: the data authority no longer grants the operation.
+  // -------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("US2: the all-types read data authority alone no longer permits the interaction")
+  @WithMockJwt(
+      username = "user",
+      authorities = {"pathling:read"})
+  void readDeniedWithDataAuthorityOnly() {
+    assertThatThrownBy(() -> read("Patient", PATIENT_ID))
+        .isExactlyInstanceOf(AccessDeniedError.class)
+        .hasMessage(ERROR_MSG_TEMPLATE.formatted("read-resource"));
+    assertThatThrownBy(() -> read("Observation", OBSERVATION_ID))
+        .isExactlyInstanceOf(AccessDeniedError.class)
+        .hasMessage(ERROR_MSG_TEMPLATE.formatted("read-resource"));
+  }
+
+  @Test
+  @DisplayName("US2: the root authority subsumes both the operation and the data authority")
+  @WithMockJwt(
+      username = "user",
+      authorities = {"pathling"})
+  void readAllowedWithRootAuthority() {
+    assertThat(read("Patient", PATIENT_ID).getIdElement().getIdPart()).isEqualTo(PATIENT_ID);
+  }
+
+  // -------------------------------------------------------------------------
+  // Helper methods.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Reads a resource through a provider obtained from the factory, so that both the operation
+   * authority check and the inline data authority check apply.
+   *
+   * @param resourceType the type code of the resource to read
+   * @param id the logical identifier of the resource to read
+   * @return the resource
+   */
+  @Nonnull
+  private IBaseResource read(@Nonnull final String resourceType, @Nonnull final String id) {
+    final ReadProvider provider = readProviderFactory.createReadProvider(resourceType);
+    return provider.read(new IdType(resourceType + "/" + id));
+  }
+}

--- a/site/docs/server/authorization.md
+++ b/site/docs/server/authorization.md
@@ -41,18 +41,23 @@ graph TB
 
     subgraph Resources[" "]
         direction LR
-        read-resource["pathling:read:[resource type]"]
+        read-type["pathling:read:[resource type]"]
         read[pathling:read]
         write[pathling:write]
-        write-resource["pathling:write:[resource type]"]
+        write-type["pathling:write:[resource type]"]
     end
 
     pathling --> operation
     pathling --> read
     pathling --> write
-    read --> read-resource
-    write --> write-resource
+    read --> read-type
+    write --> write-type
 ```
+
+Note that `pathling:read-resource`, which gates the read interaction, is an
+operation authority and so belongs to the `pathling:[operation]` family above.
+It is distinct from the `pathling:read` data authority: neither implies the
+other, and only the root `pathling` authority implies both.
 
 → includes
 
@@ -63,6 +68,7 @@ graph TB
 | `pathling:read:[resource type]`  | Provides read access to only a specified resource type.                         |
 | `pathling:write`                 | Provides write access to all resource types.                                    |
 | `pathling:write:[resource type]` | Provides write access to only a specified resource type.                        |
+| `pathling:read-resource`         | Provides access to the read interaction.                                        |
 | `pathling:import`                | Provides access to the import operation.                                        |
 | `pathling:import-pnp`            | Provides access to the ping and pull import operation.                          |
 | `pathling:search`                | Provides access to the search operation.                                        |
@@ -82,6 +88,13 @@ In order to enable access to an operation, an operation authority (e.g.
 Where expressions within a request reference multiple different resource types
 (e.g. through resource references), authority for read access to all those
 resources must be present within the token.
+
+The read interaction follows this pattern like any other: reading a resource by
+id requires the `pathling:read-resource` operation authority, plus read
+authority for the type being read (`pathling:read:[resource type]`, or
+`pathling:read` for all types). A token holding only `pathling:read` can no
+longer perform an instance read, which is a breaking change introduced in
+version 3.0.0 of the server.
 
 The import, delete, batch, and bulk submit operations require `write` authority
 for all resource types that are referenced within the request.

--- a/site/docs/server/authorization.md
+++ b/site/docs/server/authorization.md
@@ -72,6 +72,7 @@ other, and only the root `pathling` authority implies both.
 | `pathling:import`                | Provides access to the import operation.                                        |
 | `pathling:import-pnp`            | Provides access to the ping and pull import operation.                          |
 | `pathling:search`                | Provides access to the search operation.                                        |
+| `pathling:create`                | Provides access to the create operation.                                        |
 | `pathling:update`                | Provides access to the update operation.                                        |
 | `pathling:delete`                | Provides access to the delete operation.                                        |
 | `pathling:batch`                 | Provides access to the batch operation.                                         |
@@ -79,6 +80,8 @@ other, and only the root `pathling` authority implies both.
 | `pathling:export`                | Provides access to the export operation.                                        |
 | `pathling:view-run`              | Provides access to the $viewdefinition-run operation.                           |
 | `pathling:view-export`           | Provides access to the $viewdefinition-export operation.                        |
+| `pathling:sqlquery-run`          | Provides access to the $sqlquery-run operation.                                 |
+| `pathling:sqlquery-export`       | Provides access to the $sqlquery-export operation.                              |
 | `pathling:jobs`                  | Provides access to the [jobs](operations/jobs) list operation.                  |
 
 In order to enable access to an operation, an operation authority (e.g.

--- a/site/docs/server/authorization.md
+++ b/site/docs/server/authorization.md
@@ -54,12 +54,12 @@ graph TB
     write --> write-type
 ```
 
+→ includes
+
 Note that `pathling:read-resource`, which gates the read interaction, is an
 operation authority and so belongs to the `pathling:[operation]` family above.
 It is distinct from the `pathling:read` data authority: neither implies the
 other, and only the root `pathling` authority implies both.
-
-→ includes
 
 | Authority                        | Description                                                                     |
 | -------------------------------- | ------------------------------------------------------------------------------- |


### PR DESCRIPTION
Resolves #2702.

The read interaction's operation authority was named `pathling:read`, the same string as the all-types read data authority, and the authority model cannot distinguish the two. No authority set could therefore permit reading a single resource type by id without also granting read access to every resource type. This renames the operation authority to `pathling:read-resource`, taking it out of the data namespace and giving the read interaction an operation authority alongside `search`, `create`, `update` and `delete`.

While building this it emerged that the operation check could not fire at all. `ReadProviderFactory` constructed providers with `new` rather than obtaining them from the application context, so they were never Spring beans and the security aspect never saw them, leaving `@OperationAccess` on the read method inert. The factory now follows the same shape as the update and delete factories, which is what makes the operation authority enforceable in the first place.

This is a breaking change, and is targeted at the 3.0.0 server release for that reason: a token carrying only `pathling:read` can no longer perform an instance read, and now needs `pathling:read-resource` alongside its read data authority. No compatibility alias accepts the old name for the operation check.

The authorisation documentation gains the new authority and describes the read interaction's requirements in the same terms as the other interactions. It also gains rows for `pathling:create`, `pathling:sqlquery-run` and `pathling:sqlquery-export`, which were already enforced but had no entry in the authorities table.