### PR TITLE
Make the accepted JWS signing algorithms configurable

### DIFF
--- a/server/src/main/java/au/csiro/pathling/config/AuthorizationConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/AuthorizationConfiguration.java
@@ -28,7 +28,11 @@ import java.util.Optional;
 import lombok.Data;
 import lombok.ToString;
 
-/** Represents configuration specific to authorisation. */
+/**
+ * Represents configuration specific to authorisation.
+ *
+ * @author John Grimes
+ */
 @Data
 @ToString(doNotUseGetters = true)
 public class AuthorizationConfiguration {

--- a/server/src/main/java/au/csiro/pathling/config/AuthorizationConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/AuthorizationConfiguration.java
@@ -77,6 +77,12 @@ public class AuthorizationConfiguration {
   @Nonnull private List<String> codeChallengeMethodsSupported = Collections.singletonList("S256");
 
   /**
+   * The JWS signing algorithms accepted within incoming bearer tokens. When empty, the accepted
+   * algorithms are derived from the keys published in the issuer's JWKS.
+   */
+  @Nonnull private List<String> tokenSigningAlgorithms = Collections.emptyList();
+
+  /**
    * Returns the configured issuer.
    *
    * @return the issuer, or empty if not configured
@@ -124,6 +130,17 @@ public class AuthorizationConfiguration {
   @Nonnull
   public List<String> getCodeChallengeMethodsSupported() {
     return codeChallengeMethodsSupported;
+  }
+
+  /**
+   * Returns the configured token signing algorithms.
+   *
+   * @return the list of accepted JWS signing algorithms, empty if they are to be derived from the
+   *     issuer's JWKS
+   */
+  @Nonnull
+  public List<String> getTokenSigningAlgorithms() {
+    return tokenSigningAlgorithms;
   }
 
   /**

--- a/server/src/main/java/au/csiro/pathling/config/AuthorizationConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/AuthorizationConfiguration.java
@@ -21,6 +21,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -31,6 +32,13 @@ import lombok.ToString;
 @Data
 @ToString(doNotUseGetters = true)
 public class AuthorizationConfiguration {
+
+  /**
+   * The JWS algorithm names that can verify a signature against a public key, and are therefore the
+   * only values usable for verifying tokens against an issuer's JWKS.
+   */
+  private static final String ASYMMETRIC_ALGORITHMS =
+      "RS256|RS384|RS512|PS256|PS384|PS512|ES256|ES256K|ES384|ES512|EdDSA";
 
   /** Enables authorization. */
   @NotNull private boolean enabled;
@@ -78,9 +86,25 @@ public class AuthorizationConfiguration {
 
   /**
    * The JWS signing algorithms accepted within incoming bearer tokens. When empty, the accepted
-   * algorithms are derived from the keys published in the issuer's JWKS.
+   * algorithms are derived from the keys published in the issuer's JWKS; when non-empty, only the
+   * listed algorithms are accepted, regardless of what the JWKS publishes.
+   *
+   * <p>Tokens are verified against a public JWKS, so only asymmetric algorithm names are permitted.
+   * Symmetric algorithms could never verify a token, and configuring one would produce a deployment
+   * that silently rejects every request.
+   *
+   * @see <a href="https://datatracker.ietf.org/doc/html/rfc7518#section-3.1">JSON Web
+   *     Algorithms</a>
    */
-  @Nonnull private List<String> tokenSigningAlgorithms = Collections.emptyList();
+  @Nonnull
+  private List<
+          @Pattern(
+              regexp = ASYMMETRIC_ALGORITHMS,
+              message =
+                  "tokenSigningAlgorithms must contain only asymmetric JWS algorithms: RS256,"
+                      + " RS384, RS512, PS256, PS384, PS512, ES256, ES256K, ES384, ES512, EdDSA")
+          String>
+      tokenSigningAlgorithms = Collections.emptyList();
 
   /**
    * Returns the configured issuer.

--- a/server/src/main/java/au/csiro/pathling/security/PathlingJwtDecoderBuilder.java
+++ b/server/src/main/java/au/csiro/pathling/security/PathlingJwtDecoderBuilder.java
@@ -49,6 +49,9 @@ import java.security.Key;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpHeaders;
@@ -61,6 +64,7 @@ import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoderProviderConfigurationUtilsProxy;
 import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.stereotype.Component;
@@ -75,19 +79,34 @@ import org.springframework.web.client.RestTemplate;
 @Component
 @ConditionalOnProperty(prefix = "pathling", name = "auth.enabled", havingValue = "true")
 @Primary
+@Slf4j
 public class PathlingJwtDecoderBuilder implements JWTClaimsSetAwareJWSKeySelector<SecurityContext> {
 
   @Nonnull private final OidcConfiguration oidcConfiguration;
 
-  @Nonnull private final RestOperations restOperations = new RestTemplate();
+  @Nonnull private final RestOperations restOperations;
 
   /**
    * Creates a new PathlingJwtDecoderBuilder.
    *
    * @param oidcConfiguration configuration used to instantiate the builder
    */
+  @Autowired
   public PathlingJwtDecoderBuilder(@Nonnull final OidcConfiguration oidcConfiguration) {
+    this(oidcConfiguration, new RestTemplate());
+  }
+
+  /**
+   * Creates a new PathlingJwtDecoderBuilder with an explicit HTTP client, for use in tests.
+   *
+   * @param oidcConfiguration configuration used to instantiate the builder
+   * @param restOperations the HTTP client used to retrieve the JWKS
+   */
+  PathlingJwtDecoderBuilder(
+      @Nonnull final OidcConfiguration oidcConfiguration,
+      @Nonnull final RestOperations restOperations) {
     this.oidcConfiguration = oidcConfiguration;
+    this.restOperations = restOperations;
   }
 
   /**
@@ -129,11 +148,35 @@ public class PathlingJwtDecoderBuilder implements JWTClaimsSetAwareJWSKeySelecto
       @SuppressWarnings("deprecation")
       final JWKSource<SecurityContext> jwkSource =
           new RemoteJWKSet<>(URI.create(jwksUri).toURL(), new JwksRetriever(restOperations));
+      final Set<JWSAlgorithm> acceptedAlgorithms = resolveAcceptedAlgorithms(jwkSource);
+      log.debug("Accepted JWS signing algorithms: {}", acceptedAlgorithms);
       final JWSKeySelector<SecurityContext> keySelector =
-          new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, jwkSource);
+          new JWSVerificationKeySelector<>(acceptedAlgorithms, jwkSource);
       return keySelector.selectJWSKeys(header, context);
     } catch (final IOException e) {
       throw new KeySourceException("Failed to retrieve keys from " + jwksUri, e);
+    }
+  }
+
+  /**
+   * Resolves the set of JWS signing algorithms that will be accepted within a token header. The
+   * accepted set is derived from the keys published by the issuer.
+   *
+   * @param jwkSource the source of the issuer's published keys
+   * @return the accepted algorithms
+   * @throws KeySourceException if the algorithms could not be derived from the published keys
+   */
+  @Nonnull
+  private Set<JWSAlgorithm> resolveAcceptedAlgorithms(
+      @Nonnull final JWKSource<SecurityContext> jwkSource) throws KeySourceException {
+    try {
+      return JwtDecoderProviderConfigurationUtilsProxy.getJwsAlgorithms(jwkSource);
+    } catch (final IllegalStateException | IllegalArgumentException e) {
+      // The Spring utility wraps key retrieval failures in an IllegalStateException, and signals an
+      // empty key set with an IllegalArgumentException. Both are token verification failures rather
+      // than server errors, so they are reported as such to preserve the 401 failure mode.
+      throw new KeySourceException(
+          "Failed to derive accepted signing algorithms from the published keys", e);
     }
   }
 

--- a/server/src/main/java/au/csiro/pathling/security/PathlingJwtDecoderBuilder.java
+++ b/server/src/main/java/au/csiro/pathling/security/PathlingJwtDecoderBuilder.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -87,26 +88,41 @@ public class PathlingJwtDecoderBuilder implements JWTClaimsSetAwareJWSKeySelecto
   @Nonnull private final RestOperations restOperations;
 
   /**
+   * The JWS signing algorithms that the operator has pinned, or empty when the accepted algorithms
+   * are to be derived from the issuer's JWKS.
+   */
+  @Nonnull private final Set<JWSAlgorithm> configuredAlgorithms;
+
+  /**
    * Creates a new PathlingJwtDecoderBuilder.
    *
    * @param oidcConfiguration configuration used to instantiate the builder
+   * @param serverConfiguration configuration supplying any pinned signing algorithms
    */
   @Autowired
-  public PathlingJwtDecoderBuilder(@Nonnull final OidcConfiguration oidcConfiguration) {
-    this(oidcConfiguration, new RestTemplate());
+  public PathlingJwtDecoderBuilder(
+      @Nonnull final OidcConfiguration oidcConfiguration,
+      @Nonnull final ServerConfiguration serverConfiguration) {
+    this(oidcConfiguration, serverConfiguration, new RestTemplate());
   }
 
   /**
    * Creates a new PathlingJwtDecoderBuilder with an explicit HTTP client, for use in tests.
    *
    * @param oidcConfiguration configuration used to instantiate the builder
+   * @param serverConfiguration configuration supplying any pinned signing algorithms
    * @param restOperations the HTTP client used to retrieve the JWKS
    */
   PathlingJwtDecoderBuilder(
       @Nonnull final OidcConfiguration oidcConfiguration,
+      @Nonnull final ServerConfiguration serverConfiguration,
       @Nonnull final RestOperations restOperations) {
     this.oidcConfiguration = oidcConfiguration;
     this.restOperations = restOperations;
+    this.configuredAlgorithms =
+        serverConfiguration.getAuth().getTokenSigningAlgorithms().stream()
+            .map(JWSAlgorithm::parse)
+            .collect(Collectors.toUnmodifiableSet());
   }
 
   /**
@@ -159,8 +175,9 @@ public class PathlingJwtDecoderBuilder implements JWTClaimsSetAwareJWSKeySelecto
   }
 
   /**
-   * Resolves the set of JWS signing algorithms that will be accepted within a token header. The
-   * accepted set is derived from the keys published by the issuer.
+   * Resolves the set of JWS signing algorithms that will be accepted within a token header. Any
+   * algorithms pinned by configuration are used as-is; otherwise the accepted set is derived from
+   * the keys published by the issuer.
    *
    * @param jwkSource the source of the issuer's published keys
    * @return the accepted algorithms
@@ -169,6 +186,9 @@ public class PathlingJwtDecoderBuilder implements JWTClaimsSetAwareJWSKeySelecto
   @Nonnull
   private Set<JWSAlgorithm> resolveAcceptedAlgorithms(
       @Nonnull final JWKSource<SecurityContext> jwkSource) throws KeySourceException {
+    if (!configuredAlgorithms.isEmpty()) {
+      return configuredAlgorithms;
+    }
     try {
       return JwtDecoderProviderConfigurationUtilsProxy.getJwsAlgorithms(jwkSource);
     } catch (final IllegalStateException | IllegalArgumentException e) {

--- a/server/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoderProviderConfigurationUtilsProxy.java
+++ b/server/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoderProviderConfigurationUtilsProxy.java
@@ -17,8 +17,12 @@
 
 package org.springframework.security.oauth2.jwt;
 
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
 import jakarta.annotation.Nonnull;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Provides access to functionality within the package-private {@link
@@ -39,5 +43,22 @@ public class JwtDecoderProviderConfigurationUtilsProxy {
   public static Map<String, Object> getConfigurationForIssuerLocation(
       @Nonnull final String issuer) {
     return JwtDecoderProviderConfigurationUtils.getConfigurationForIssuerLocation(issuer);
+  }
+
+  /**
+   * Derives the set of JWS signing algorithms that the keys published by a JWK source can verify.
+   * Each key's {@code alg} value is used when present; otherwise the algorithms implied by the key
+   * type are contributed.
+   *
+   * @param <C> the type of security context used when retrieving keys
+   * @param jwkSource the source of the published keys
+   * @return the set of derivable JWS algorithms
+   * @throws IllegalStateException if the keys cannot be retrieved
+   * @throws IllegalArgumentException if no algorithms could be derived from the published keys
+   */
+  @Nonnull
+  public static <C extends SecurityContext> Set<JWSAlgorithm> getJwsAlgorithms(
+      @Nonnull final JWKSource<C> jwkSource) {
+    return JwtDecoderProviderConfigurationUtils.getJWSAlgorithms(jwkSource);
   }
 }

--- a/server/src/test/java/au/csiro/pathling/config/AuthorizationConfigurationTest.java
+++ b/server/src/test/java/au/csiro/pathling/config/AuthorizationConfigurationTest.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Unit tests for {@link AuthorizationConfiguration} validation.
@@ -108,6 +110,73 @@ class AuthorizationConfigurationTest {
 
     // Should have two violations: missing S256 and has plain.
     assertThat(violations).hasSize(2);
+  }
+
+  // -------------------------------------------------------------------------
+  // Token signing algorithm validation tests
+  // -------------------------------------------------------------------------
+
+  @ParameterizedTest
+  @ValueSource(strings = {"HS256", "HS384", "HS512", "none", "RS999", "rs256", ""})
+  void rejectsNonAsymmetricTokenSigningAlgorithm(final String algorithm) {
+    // Verification runs against a public JWKS, so only asymmetric algorithm names are usable.
+    final AuthorizationConfiguration config = new AuthorizationConfiguration();
+    config.setTokenSigningAlgorithms(List.of(algorithm));
+
+    final Set<ConstraintViolation<AuthorizationConfiguration>> violations =
+        validator.validate(config);
+
+    assertThat(violations).hasSize(1);
+    final ConstraintViolation<AuthorizationConfiguration> violation = violations.iterator().next();
+    assertThat(violation.getPropertyPath()).hasToString("tokenSigningAlgorithms[0].<list element>");
+    assertThat(violation.getInvalidValue()).isEqualTo(algorithm);
+    assertThat(violation.getMessage())
+        .isEqualTo(
+            "tokenSigningAlgorithms must contain only asymmetric JWS algorithms: RS256, RS384, "
+                + "RS512, PS256, PS384, PS512, ES256, ES256K, ES384, ES512, EdDSA");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES256", "ES256K", "ES384", "ES512",
+        "EdDSA"
+      })
+  void acceptsAsymmetricTokenSigningAlgorithm(final String algorithm) {
+    // Every asymmetric JWS algorithm name is accepted.
+    final AuthorizationConfiguration config = new AuthorizationConfiguration();
+    config.setTokenSigningAlgorithms(List.of(algorithm));
+
+    final Set<ConstraintViolation<AuthorizationConfiguration>> violations =
+        validator.validate(config);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void reportsTheIndexOfEachOffendingAlgorithm() {
+    // The violation must identify which element of the list was rejected.
+    final AuthorizationConfiguration config = new AuthorizationConfiguration();
+    config.setTokenSigningAlgorithms(List.of("RS256", "HS256"));
+
+    final Set<ConstraintViolation<AuthorizationConfiguration>> violations =
+        validator.validate(config);
+
+    assertThat(violations).hasSize(1);
+    assertThat(violations.iterator().next().getPropertyPath())
+        .hasToString("tokenSigningAlgorithms[1].<list element>");
+  }
+
+  @Test
+  void acceptsEmptyTokenSigningAlgorithms() {
+    // An empty list is valid, and means the algorithms are derived from the issuer's JWKS.
+    final AuthorizationConfiguration config = new AuthorizationConfiguration();
+    config.setTokenSigningAlgorithms(List.of());
+
+    final Set<ConstraintViolation<AuthorizationConfiguration>> violations =
+        validator.validate(config);
+
+    assertThat(violations).isEmpty();
   }
 
   // -------------------------------------------------------------------------

--- a/server/src/test/java/au/csiro/pathling/config/AuthorizationConfigurationTest.java
+++ b/server/src/test/java/au/csiro/pathling/config/AuthorizationConfigurationTest.java
@@ -18,16 +18,26 @@
 package au.csiro.pathling.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.context.properties.bind.BindException;
+import org.springframework.boot.context.properties.bind.BindHandler;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.bind.validation.BindValidationException;
+import org.springframework.boot.context.properties.bind.validation.ValidationBindHandler;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
 
 /**
  * Unit tests for {@link AuthorizationConfiguration} validation.
@@ -165,6 +175,51 @@ class AuthorizationConfigurationTest {
     assertThat(violations).hasSize(1);
     assertThat(violations.iterator().next().getPropertyPath())
         .hasToString("tokenSigningAlgorithms[1].<list element>");
+  }
+
+  @Test
+  void bindingFailsForNonAsymmetricTokenSigningAlgorithm() {
+    // Binding is the mechanism Spring Boot uses to populate configuration properties at startup, so
+    // a rejected value here is what prevents the server from starting.
+    final MapConfigurationPropertySource source =
+        new MapConfigurationPropertySource(
+            Map.of(
+                "pathling.auth.enabled", "true",
+                "pathling.auth.tokenSigningAlgorithms[0]", "HS256"));
+    final BindHandler handler =
+        new ValidationBindHandler(
+            new SpringValidatorAdapter(Validation.buildDefaultValidatorFactory().getValidator()));
+
+    assertThatThrownBy(
+            () ->
+                new Binder(source)
+                    .bind("pathling.auth", Bindable.of(AuthorizationConfiguration.class), handler))
+        .isInstanceOf(BindException.class)
+        .rootCause()
+        .isInstanceOf(BindValidationException.class)
+        .hasMessageContaining("tokenSigningAlgorithms[0]")
+        .hasMessageContaining("HS256")
+        .hasMessageContaining("asymmetric JWS algorithms");
+  }
+
+  @Test
+  void bindingSucceedsForAsymmetricTokenSigningAlgorithm() {
+    // The same binding path accepts a valid asymmetric algorithm name.
+    final MapConfigurationPropertySource source =
+        new MapConfigurationPropertySource(
+            Map.of(
+                "pathling.auth.enabled", "true",
+                "pathling.auth.tokenSigningAlgorithms[0]", "ES384"));
+    final BindHandler handler =
+        new ValidationBindHandler(
+            new SpringValidatorAdapter(Validation.buildDefaultValidatorFactory().getValidator()));
+
+    final AuthorizationConfiguration bound =
+        new Binder(source)
+            .bind("pathling.auth", Bindable.of(AuthorizationConfiguration.class), handler)
+            .get();
+
+    assertThat(bound.getTokenSigningAlgorithms()).containsExactly("ES384");
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/security/JwsTestFixtures.java
+++ b/server/src/test/java/au/csiro/pathling/security/JwsTestFixtures.java
@@ -40,6 +40,7 @@ import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -70,7 +71,7 @@ final class JwsTestFixtures {
    * @throws JOSEException if key generation fails
    */
   @Nonnull
-  static RSAKey generateRsaKey(@Nonnull final String keyId, final JWSAlgorithm algorithm)
+  static RSAKey generateRsaKey(@Nonnull final String keyId, @Nullable final JWSAlgorithm algorithm)
       throws JOSEException {
     final JWKGenerator<RSAKey> generator =
         new RSAKeyGenerator(2048).keyID(keyId).keyUse(KeyUse.SIGNATURE);
@@ -89,7 +90,7 @@ final class JwsTestFixtures {
    * @throws JOSEException if key generation fails
    */
   @Nonnull
-  static ECKey generateEcKey(@Nonnull final String keyId, final JWSAlgorithm algorithm)
+  static ECKey generateEcKey(@Nonnull final String keyId, @Nullable final JWSAlgorithm algorithm)
       throws JOSEException {
     final JWKGenerator<ECKey> generator =
         new ECKeyGenerator(Curve.P_384).keyID(keyId).keyUse(KeyUse.SIGNATURE);
@@ -145,7 +146,7 @@ final class JwsTestFixtures {
    * @return the header
    */
   @Nonnull
-  static JWSHeader header(@Nonnull final JWSAlgorithm algorithm, final String keyId) {
+  static JWSHeader header(@Nonnull final JWSAlgorithm algorithm, @Nullable final String keyId) {
     final JWSHeader.Builder builder = new JWSHeader.Builder(algorithm);
     if (keyId != null) {
       builder.keyID(keyId);

--- a/server/src/test/java/au/csiro/pathling/security/JwsTestFixtures.java
+++ b/server/src/test/java/au/csiro/pathling/security/JwsTestFixtures.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.security;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.JWKGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import jakarta.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestOperations;
+
+/**
+ * Test fixtures for exercising JWS signing algorithm selection: real key generation, real token
+ * signing, and a mocked HTTP client that serves a JWKS document.
+ *
+ * @author John Grimes
+ */
+final class JwsTestFixtures {
+
+  /** The JWKS URI used by tests, matching the one configured into the test OIDC configuration. */
+  static final String JWKS_URI = "http://localhost/.well-known/jwks.json";
+
+  private JwsTestFixtures() {}
+
+  /**
+   * Generates an RSA key pair suitable for signing.
+   *
+   * @param keyId the key identifier to assign
+   * @param algorithm the algorithm to advertise in the key's {@code alg} field, or null to omit it
+   * @return a new RSA JWK containing the private key
+   * @throws JOSEException if key generation fails
+   */
+  @Nonnull
+  static RSAKey generateRsaKey(@Nonnull final String keyId, final JWSAlgorithm algorithm)
+      throws JOSEException {
+    final JWKGenerator<RSAKey> generator =
+        new RSAKeyGenerator(2048).keyID(keyId).keyUse(KeyUse.SIGNATURE);
+    if (algorithm != null) {
+      generator.algorithm(algorithm);
+    }
+    return generator.generate();
+  }
+
+  /**
+   * Generates an EC P-384 key pair suitable for signing with ES384.
+   *
+   * @param keyId the key identifier to assign
+   * @param algorithm the algorithm to advertise in the key's {@code alg} field, or null to omit it
+   * @return a new EC JWK containing the private key
+   * @throws JOSEException if key generation fails
+   */
+  @Nonnull
+  static ECKey generateEcKey(@Nonnull final String keyId, final JWSAlgorithm algorithm)
+      throws JOSEException {
+    final JWKGenerator<ECKey> generator =
+        new ECKeyGenerator(Curve.P_384).keyID(keyId).keyUse(KeyUse.SIGNATURE);
+    if (algorithm != null) {
+      generator.algorithm(algorithm);
+    }
+    return generator.generate();
+  }
+
+  /**
+   * Renders the public halves of the supplied keys as a JWKS document.
+   *
+   * @param keys the keys to publish
+   * @return the JSON representation of the JWKS
+   */
+  @Nonnull
+  static String jwksBody(@Nonnull final JWK... keys) {
+    final List<JWK> publicKeys = Arrays.stream(keys).map(JWK::toPublicJWK).toList();
+    return new JWKSet(publicKeys).toString();
+  }
+
+  /**
+   * Signs a JWT with the supplied key and algorithm.
+   *
+   * @param key the key to sign with, which must contain the private key material
+   * @param algorithm the JWS algorithm to name in the header
+   * @return the serialised, signed JWT
+   * @throws JOSEException if signing fails
+   */
+  @Nonnull
+  static String signToken(@Nonnull final JWK key, @Nonnull final JWSAlgorithm algorithm)
+      throws JOSEException {
+    final JWSSigner signer =
+        key instanceof final ECKey ecKey ? new ECDSASigner(ecKey) : new RSASSASigner((RSAKey) key);
+    final JWTClaimsSet claims =
+        new JWTClaimsSet.Builder()
+            .subject("test-subject")
+            .issuer("http://issuer.example.com")
+            .audience("http://audience.example.com")
+            .expirationTime(new Date(System.currentTimeMillis() + 3600_000))
+            .build();
+    final SignedJWT jwt =
+        new SignedJWT(new JWSHeader.Builder(algorithm).keyID(key.getKeyID()).build(), claims);
+    jwt.sign(signer);
+    return jwt.serialize();
+  }
+
+  /**
+   * Builds a JWS header naming the supplied algorithm and key.
+   *
+   * @param algorithm the JWS algorithm
+   * @param keyId the key identifier, or null to omit it
+   * @return the header
+   */
+  @Nonnull
+  static JWSHeader header(@Nonnull final JWSAlgorithm algorithm, final String keyId) {
+    final JWSHeader.Builder builder = new JWSHeader.Builder(algorithm);
+    if (keyId != null) {
+      builder.keyID(keyId);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Builds a minimal claims set for driving key selection.
+   *
+   * @return the claims set
+   */
+  @Nonnull
+  static JWTClaimsSet claims() {
+    return new JWTClaimsSet.Builder().subject("test-subject").build();
+  }
+
+  /**
+   * Creates a mocked HTTP client that serves the supplied JWKS body for the test JWKS URI.
+   *
+   * @param body the JWKS document to return
+   * @return the mocked client
+   */
+  @Nonnull
+  static RestOperations mockJwksTransport(@Nonnull final String body) {
+    final RestOperations restOperations = mock(RestOperations.class);
+    when(restOperations.exchange(any(RequestEntity.class), eq(String.class)))
+        .thenReturn(new ResponseEntity<>(body, HttpStatus.OK));
+    return restOperations;
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/security/PathlingJwtDecoderBuilderTest.java
+++ b/server/src/test/java/au/csiro/pathling/security/PathlingJwtDecoderBuilderTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
 
 /**
  * Tests for {@link PathlingJwtDecoderBuilder} covering auth configuration validation, decoder
@@ -62,7 +63,7 @@ class PathlingJwtDecoderBuilderTest {
     // Create an OidcConfiguration with a test JWKS URI.
     final OidcConfiguration oidcConfig =
         new OidcConfiguration(Map.of("jwks_uri", "http://localhost/.well-known/jwks.json"));
-    builder = new PathlingJwtDecoderBuilder(oidcConfig);
+    builder = new PathlingJwtDecoderBuilder(oidcConfig, configuration(List.of()));
   }
 
   // -- getAuthConfiguration --
@@ -212,19 +213,117 @@ class PathlingJwtDecoderBuilderTest {
     assertThat(jwt.getSubject()).isEqualTo("test-subject");
   }
 
+  // -- selectKeys: algorithms pinned by configuration --
+
+  @Test
+  void configuredAlgorithmsExcludeOthersPublishedByTheJwks() throws Exception {
+    // Pinning RS256 must reject ES384 even though the JWKS publishes a matching EC key.
+    final RSAKey rsaKey = generateRsaKey("rsa-1", JWSAlgorithm.RS256);
+    final ECKey ecKey = generateEcKey("ec-1", JWSAlgorithm.ES384);
+    final PathlingJwtDecoderBuilder decoderBuilder = builderFor(List.of("RS256"), rsaKey, ecKey);
+
+    final List<? extends Key> keys =
+        decoderBuilder.selectKeys(header(JWSAlgorithm.ES384, "ec-1"), claims(), null);
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void configuredAlgorithmsAcceptListedAlgorithm() throws Exception {
+    // Pinning RS256 must continue to accept RS256 tokens.
+    final RSAKey rsaKey = generateRsaKey("rsa-1", JWSAlgorithm.RS256);
+    final ECKey ecKey = generateEcKey("ec-1", JWSAlgorithm.ES384);
+    final PathlingJwtDecoderBuilder decoderBuilder = builderFor(List.of("RS256"), rsaKey, ecKey);
+
+    final List<? extends Key> keys =
+        decoderBuilder.selectKeys(header(JWSAlgorithm.RS256, "rsa-1"), claims(), null);
+
+    assertThat(keys).hasSize(1);
+    assertThat(keys.get(0)).isInstanceOf(RSAPublicKey.class);
+  }
+
+  @Test
+  void configuredEcAlgorithmSelectsMatchingKey() throws Exception {
+    // Pinning ES384 accepts an ES384 token backed by a published EC key.
+    final ECKey key = generateEcKey("ec-1", JWSAlgorithm.ES384);
+    final PathlingJwtDecoderBuilder decoderBuilder = builderFor(List.of("ES384"), key);
+
+    final List<? extends Key> keys =
+        decoderBuilder.selectKeys(header(JWSAlgorithm.ES384, "ec-1"), claims(), null);
+
+    assertThat(keys).hasSize(1);
+    assertThat(keys.get(0)).isInstanceOf(ECPublicKey.class);
+  }
+
+  @Test
+  void emptyConfiguredAlgorithmsFallBackToDerivation() throws Exception {
+    // An explicitly empty list behaves identically to the property being unset.
+    final ECKey key = generateEcKey("ec-1", JWSAlgorithm.ES384);
+    final PathlingJwtDecoderBuilder decoderBuilder = builderFor(List.of(), key);
+
+    final List<? extends Key> keys =
+        decoderBuilder.selectKeys(header(JWSAlgorithm.ES384, "ec-1"), claims(), null);
+
+    assertThat(keys).hasSize(1);
+  }
+
+  @Test
+  void decoderRejectsTokenSignedWithUnpinnedAlgorithm() throws Exception {
+    // End-to-end: a validly signed ES384 token is rejected when only RS256 is pinned.
+    final RSAKey rsaKey = generateRsaKey("rsa-1", JWSAlgorithm.RS256);
+    final ECKey ecKey = generateEcKey("ec-1", JWSAlgorithm.ES384);
+    final PathlingJwtDecoderBuilder decoderBuilder = builderFor(List.of("RS256"), rsaKey, ecKey);
+    final JwtDecoder decoder = decoderBuilder.build(authEnabledConfiguration());
+    final String token = signToken(ecKey, JWSAlgorithm.ES384);
+
+    assertThrows(JwtException.class, () -> decoder.decode(token));
+  }
+
   // -- Helpers --
 
   /**
-   * Builds a decoder builder whose JWKS endpoint publishes the supplied keys.
+   * Builds a decoder builder whose JWKS endpoint publishes the supplied keys, with no pinned
+   * algorithms.
    *
    * @param keys the keys to publish
    * @return the builder
    */
   @Nonnull
   private static PathlingJwtDecoderBuilder builderFor(@Nonnull final JWK... keys) {
+    return builderFor(List.of(), keys);
+  }
+
+  /**
+   * Builds a decoder builder whose JWKS endpoint publishes the supplied keys, with the supplied
+   * pinned algorithms.
+   *
+   * @param algorithms the value of the tokenSigningAlgorithms property
+   * @param keys the keys to publish
+   * @return the builder
+   */
+  @Nonnull
+  private static PathlingJwtDecoderBuilder builderFor(
+      @Nonnull final List<String> algorithms, @Nonnull final JWK... keys) {
     final OidcConfiguration oidcConfig =
         new OidcConfiguration(Map.of("jwks_uri", JwsTestFixtures.JWKS_URI));
-    return new PathlingJwtDecoderBuilder(oidcConfig, mockJwksTransport(jwksBody(keys)));
+    return new PathlingJwtDecoderBuilder(
+        oidcConfig, configuration(algorithms), mockJwksTransport(jwksBody(keys)));
+  }
+
+  /**
+   * Builds a server configuration with auth enabled and the supplied pinned algorithms.
+   *
+   * @param algorithms the value of the tokenSigningAlgorithms property
+   * @return the configuration
+   */
+  @Nonnull
+  private static ServerConfiguration configuration(@Nonnull final List<String> algorithms) {
+    final ServerConfiguration config = new ServerConfiguration();
+    final AuthorizationConfiguration authConfig = new AuthorizationConfiguration();
+    authConfig.setEnabled(true);
+    authConfig.setTokenSigningAlgorithms(algorithms);
+    config.setAuth(authConfig);
+    return config;
   }
 
   /**
@@ -235,12 +334,9 @@ class PathlingJwtDecoderBuilderTest {
    */
   @Nonnull
   private static ServerConfiguration authEnabledConfiguration() {
-    final ServerConfiguration config = new ServerConfiguration();
-    final AuthorizationConfiguration authConfig = new AuthorizationConfiguration();
-    authConfig.setEnabled(true);
-    authConfig.setIssuer("http://issuer.example.com");
-    authConfig.setAudience("http://audience.example.com");
-    config.setAuth(authConfig);
+    final ServerConfiguration config = configuration(List.of());
+    config.getAuth().setIssuer("http://issuer.example.com");
+    config.getAuth().setAudience("http://audience.example.com");
     return config;
   }
 }

--- a/server/src/test/java/au/csiro/pathling/security/PathlingJwtDecoderBuilderTest.java
+++ b/server/src/test/java/au/csiro/pathling/security/PathlingJwtDecoderBuilderTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import au.csiro.pathling.config.AuthorizationConfiguration;
 import au.csiro.pathling.config.ServerConfiguration;
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.KeySourceException;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.RSAKey;
@@ -211,6 +212,17 @@ class PathlingJwtDecoderBuilderTest {
     final Jwt jwt = decoder.decode(signToken(key, JWSAlgorithm.RS256));
 
     assertThat(jwt.getSubject()).isEqualTo("test-subject");
+  }
+
+  @Test
+  void reportsEmptyJwksAsAKeySourceFailure() {
+    // A JWKS with no usable keys must fail as a key source problem, so that the request is
+    // rejected with a 401 rather than reported as a server error.
+    final PathlingJwtDecoderBuilder decoderBuilder = builderFor();
+
+    assertThrows(
+        KeySourceException.class,
+        () -> decoderBuilder.selectKeys(header(JWSAlgorithm.RS256, "rsa-1"), claims(), null));
   }
 
   // -- selectKeys: algorithms pinned by configuration --

--- a/server/src/test/java/au/csiro/pathling/security/PathlingJwtDecoderBuilderTest.java
+++ b/server/src/test/java/au/csiro/pathling/security/PathlingJwtDecoderBuilderTest.java
@@ -17,15 +17,33 @@
 
 package au.csiro.pathling.security;
 
+import static au.csiro.pathling.security.JwsTestFixtures.claims;
+import static au.csiro.pathling.security.JwsTestFixtures.generateEcKey;
+import static au.csiro.pathling.security.JwsTestFixtures.generateRsaKey;
+import static au.csiro.pathling.security.JwsTestFixtures.header;
+import static au.csiro.pathling.security.JwsTestFixtures.jwksBody;
+import static au.csiro.pathling.security.JwsTestFixtures.mockJwksTransport;
+import static au.csiro.pathling.security.JwsTestFixtures.signToken;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import au.csiro.pathling.config.AuthorizationConfiguration;
 import au.csiro.pathling.config.ServerConfiguration;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import jakarta.annotation.Nonnull;
+import java.security.Key;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 /**
@@ -115,5 +133,114 @@ class PathlingJwtDecoderBuilderTest {
   void selectKeysThrowsForNullClaimsSet() {
     // A null claims set should throw an IllegalArgumentException.
     assertThrows(IllegalArgumentException.class, () -> builder.selectKeys(null, null, null));
+  }
+
+  // -- selectKeys: algorithms derived from the JWKS --
+
+  @Test
+  void derivesEcAlgorithmFromJwksWithEcKey() throws Exception {
+    // An EC P-384 key published with alg ES384 means ES384 tokens must be verifiable.
+    final ECKey key = generateEcKey("ec-1", JWSAlgorithm.ES384);
+    final PathlingJwtDecoderBuilder decoderBuilder = builderFor(key);
+
+    final List<? extends Key> keys =
+        decoderBuilder.selectKeys(header(JWSAlgorithm.ES384, "ec-1"), claims(), null);
+
+    assertThat(keys).hasSize(1);
+    assertThat(keys.get(0)).isInstanceOf(ECPublicKey.class);
+  }
+
+  @Test
+  void derivesRsaAlgorithmFromJwksWithRsaKey() throws Exception {
+    // Existing behaviour: an RSA key published with alg RS256 verifies RS256 tokens.
+    final RSAKey key = generateRsaKey("rsa-1", JWSAlgorithm.RS256);
+    final PathlingJwtDecoderBuilder decoderBuilder = builderFor(key);
+
+    final List<? extends Key> keys =
+        decoderBuilder.selectKeys(header(JWSAlgorithm.RS256, "rsa-1"), claims(), null);
+
+    assertThat(keys).hasSize(1);
+    assertThat(keys.get(0)).isInstanceOf(RSAPublicKey.class);
+  }
+
+  @Test
+  void rejectsAlgorithmAbsentFromJwks() throws Exception {
+    // A JWKS publishing only an RSA key must not accept an ES384 token.
+    final RSAKey key = generateRsaKey("rsa-1", JWSAlgorithm.RS256);
+    final PathlingJwtDecoderBuilder decoderBuilder = builderFor(key);
+
+    final List<? extends Key> keys =
+        decoderBuilder.selectKeys(header(JWSAlgorithm.ES384, "rsa-1"), claims(), null);
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void derivesAlgorithmsFromKeyTypeWhenAlgAbsent() throws Exception {
+    // A key that omits alg still contributes the algorithms implied by its key type.
+    final ECKey key = generateEcKey("ec-1", null);
+    final PathlingJwtDecoderBuilder decoderBuilder = builderFor(key);
+
+    final List<? extends Key> keys =
+        decoderBuilder.selectKeys(header(JWSAlgorithm.ES384, "ec-1"), claims(), null);
+
+    assertThat(keys).hasSize(1);
+    assertThat(keys.get(0)).isInstanceOf(ECPublicKey.class);
+  }
+
+  @Test
+  void decoderVerifiesEs384SignedToken() throws Exception {
+    // End-to-end: a real ES384 signature verifies through the built decoder.
+    final ECKey key = generateEcKey("ec-1", JWSAlgorithm.ES384);
+    final PathlingJwtDecoderBuilder decoderBuilder = builderFor(key);
+    final JwtDecoder decoder = decoderBuilder.build(authEnabledConfiguration());
+
+    final Jwt jwt = decoder.decode(signToken(key, JWSAlgorithm.ES384));
+
+    assertThat(jwt.getSubject()).isEqualTo("test-subject");
+  }
+
+  @Test
+  void decoderVerifiesRs256SignedToken() throws Exception {
+    // End-to-end regression guard: RS256 verification is unchanged.
+    final RSAKey key = generateRsaKey("rsa-1", JWSAlgorithm.RS256);
+    final PathlingJwtDecoderBuilder decoderBuilder = builderFor(key);
+    final JwtDecoder decoder = decoderBuilder.build(authEnabledConfiguration());
+
+    final Jwt jwt = decoder.decode(signToken(key, JWSAlgorithm.RS256));
+
+    assertThat(jwt.getSubject()).isEqualTo("test-subject");
+  }
+
+  // -- Helpers --
+
+  /**
+   * Builds a decoder builder whose JWKS endpoint publishes the supplied keys.
+   *
+   * @param keys the keys to publish
+   * @return the builder
+   */
+  @Nonnull
+  private static PathlingJwtDecoderBuilder builderFor(@Nonnull final JWK... keys) {
+    final OidcConfiguration oidcConfig =
+        new OidcConfiguration(Map.of("jwks_uri", JwsTestFixtures.JWKS_URI));
+    return new PathlingJwtDecoderBuilder(oidcConfig, mockJwksTransport(jwksBody(keys)));
+  }
+
+  /**
+   * Builds a server configuration with auth enabled and the issuer and audience asserted by the
+   * fixture tokens.
+   *
+   * @return the configuration
+   */
+  @Nonnull
+  private static ServerConfiguration authEnabledConfiguration() {
+    final ServerConfiguration config = new ServerConfiguration();
+    final AuthorizationConfiguration authConfig = new AuthorizationConfiguration();
+    authConfig.setEnabled(true);
+    authConfig.setIssuer("http://issuer.example.com");
+    authConfig.setAudience("http://audience.example.com");
+    config.setAuth(authConfig);
+    return config;
   }
 }

--- a/site/docs/server/configuration.md
+++ b/site/docs/server/configuration.md
@@ -459,6 +459,18 @@ spark:
 - `pathling.auth.codeChallengeMethodsSupported` - (default: `S256`) A list of
   PKCE code challenge methods supported. Must include `S256` and must not
   include `plain` as per the SMART specification.
+- `pathling.auth.tokenSigningAlgorithms` - (default: empty) A list of the
+  [JWS signing algorithms](https://datatracker.ietf.org/doc/html/rfc7518#section-3.1)
+  accepted within incoming bearer tokens. When empty, the accepted algorithms
+  are derived from the keys published in the issuer's JWKS: a key's `alg` value
+  is used when present, otherwise the algorithms implied by its key type. This
+  derivation happens at token verification time, so key rotation at the identity
+  provider takes effect without a restart. When one or more values are
+  configured, only tokens whose header algorithm is in that list are accepted,
+  regardless of what the JWKS publishes. Tokens are verified against a public
+  JWKS, so only the asymmetric algorithm names `RS256`, `RS384`, `RS512`,
+  `PS256`, `PS384`, `PS512`, `ES256`, `ES256K`, `ES384`, `ES512` and `EdDSA` are
+  permitted; any other value fails validation at startup.
 
 ### Admin UI
 


### PR DESCRIPTION
Resolves #2704.

The server hardcoded RS256 when verifying incoming bearer tokens, so any identity provider signing with a different asymmetric algorithm was rejected outright regardless of what its JWKS advertised.

The accepted algorithms are now derived from the keys the issuer publishes, using Spring Security's own derivation semantics: a key's `alg` value when present, otherwise the algorithms implied by its key type. Derivation happens at verification time, so key rotation at the identity provider takes effect without a restart.

Deployments that need to constrain the accepted set can pin it with the new `pathling.auth.tokenSigningAlgorithms` property, which replaces derivation entirely rather than widening it. Because verification runs against a public JWKS, only asymmetric algorithm names are permitted; a symmetric or unrecognised value fails validation at startup with a message naming the offending element.

Note that derivation intentionally widens acceptance relative to the previous behaviour: an issuer publishing an RSA key may now verify RS384 or PS256 tokens that were previously rejected. Operators who require exact pinning use the new property.