### PR TITLE
See resource types created after server startup through filtered reads

### DIFF
--- a/server/src/main/java/au/csiro/pathling/Dependencies.java
+++ b/server/src/main/java/au/csiro/pathling/Dependencies.java
@@ -100,6 +100,7 @@ public class Dependencies {
             .migrate();
     final QueryableDataSource baseSource = pathlingContext.read().delta(databaseLocation);
     return new DynamicDeltaSource(
+        pathlingContext,
         baseSource,
         pathlingContext.getSpark(),
         databaseLocation,

--- a/server/src/main/java/au/csiro/pathling/io/DerivedSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DerivedSource.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.io;
+
+import au.csiro.pathling.io.source.DataSource;
+import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.AbstractSource;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
+import au.csiro.pathling.library.query.FhirViewQuery;
+import au.csiro.pathling.views.FhirView;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+
+/**
+ * A source derived from another by a row transformation, a resource-type filter, or both, which
+ * resolves every read through the source it was derived from.
+ *
+ * <p>Deferring resolution is what makes the derivation see the same data its parent does. A source
+ * built eagerly over the parent's resource map is frozen at the moment of derivation, so a type
+ * whose table appears later - or whose dataset the parent replaces on refresh - is invisible to it.
+ * Because a read here calls the parent's own {@code read}, the parent's dynamic discovery,
+ * empty-dataset fallback and schema drift guard all apply, and they apply equally to a source
+ * derived from a derived source.
+ *
+ * <p>Extending {@link AbstractSource} gives this source a query dispatcher and sink builder over
+ * itself, so view queries and writes resolve their datasets through this class's {@code read}
+ * rather than the parent's.
+ *
+ * @author John Grimes
+ */
+public class DerivedSource extends AbstractSource {
+
+  /** A row operator that leaves the dataset untouched, for a derivation that only filters types. */
+  static final BiFunction<String, Dataset<Row>, Dataset<Row>> IDENTITY_OPERATOR =
+      (resourceType, dataset) -> dataset;
+
+  /** A type predicate that retains every type, for a derivation that only transforms rows. */
+  static final Predicate<String> RETAIN_ALL_TYPES = resourceType -> true;
+
+  @Nonnull private final QueryableDataSource parent;
+
+  @Nonnull private final BiFunction<String, Dataset<Row>, Dataset<Row>> operator;
+
+  @Nonnull private final Predicate<String> typePredicate;
+
+  @Nonnull private final Set<String> driftedTypes;
+
+  /**
+   * Constructs a new DerivedSource.
+   *
+   * @param context the Pathling context
+   * @param parent the source this one is derived from, through which all reads are resolved
+   * @param operator the transformation applied to each dataset read from the parent
+   * @param typePredicate the types this source retains from the parent
+   * @param driftedTypes the resource types whose tables are drifted and unmigrated; held by
+   *     reference so that guard decisions reflect the parent's current state
+   */
+  DerivedSource(
+      @Nonnull final PathlingContext context,
+      @Nonnull final QueryableDataSource parent,
+      @Nonnull final BiFunction<String, Dataset<Row>, Dataset<Row>> operator,
+      @Nonnull final Predicate<String> typePredicate,
+      @Nonnull final Set<String> driftedTypes) {
+    super(context);
+    this.parent = parent;
+    this.operator = operator;
+    this.typePredicate = typePredicate;
+    this.driftedTypes = driftedTypes;
+  }
+
+  @Override
+  @Nonnull
+  public Dataset<Row> read(@Nullable final String resourceCode) {
+    if (resourceCode == null) {
+      throw new IllegalArgumentException("Resource code must not be null");
+    }
+    if (!typePredicate.test(resourceCode)) {
+      // A type removed by the predicate fails exactly as it does when a source is filtered
+      // eagerly, so that compartment semantics are unchanged by the deferred resolution.
+      throw new IllegalArgumentException("No data found for resource type: " + resourceCode);
+    }
+    return operator.apply(resourceCode, parent.read(resourceCode));
+  }
+
+  @Override
+  @Nonnull
+  public Set<String> getResourceTypes() {
+    return parent.getResourceTypes().stream().filter(typePredicate).collect(Collectors.toSet());
+  }
+
+  @Override
+  @Nonnull
+  public FhirViewQuery view(@Nullable final String subjectResource) {
+    checkNotDrifted(subjectResource);
+    return super.view(subjectResource);
+  }
+
+  @Override
+  @Nonnull
+  public FhirViewQuery view(@Nullable final FhirView view) {
+    if (view != null) {
+      checkNotDrifted(view.getResource());
+    }
+    return super.view(view);
+  }
+
+  @Override
+  @Nonnull
+  public QueryableDataSource map(
+      @Nonnull final BiFunction<String, Dataset<Row>, Dataset<Row>> operator) {
+    return new DerivedSource(context, this, operator, RETAIN_ALL_TYPES, driftedTypes);
+  }
+
+  @Override
+  @Nonnull
+  public QueryableDataSource filterByResourceType(
+      @Nonnull final Predicate<String> resourceTypePredicate) {
+    return new DerivedSource(context, this, IDENTITY_OPERATOR, resourceTypePredicate, driftedTypes);
+  }
+
+  @Override
+  @Nonnull
+  public DataSource cache() {
+    return new DerivedSource(
+        context, this, (resourceType, dataset) -> dataset.cache(), RETAIN_ALL_TYPES, driftedTypes);
+  }
+
+  /**
+   * Fails with a {@link SchemaDriftError} if the given resource type is marked as drifted. A read
+   * inherits this check from the parent, but a view query is only executed later, so its subject is
+   * checked when the query is constructed - as {@link DriftGuardedSource} does.
+   *
+   * @param resourceCode the resource type code to check, or null to skip the check
+   */
+  private void checkNotDrifted(@Nullable final String resourceCode) {
+    if (resourceCode != null && driftedTypes.contains(resourceCode)) {
+      throw new SchemaDriftError(resourceCode);
+    }
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/io/DriftGuardedSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DriftGuardedSource.java
@@ -32,12 +32,17 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
 /**
- * A {@link QueryableDataSource} wrapper that guards reads against schema drift, and carries that
- * guard into sources derived from it through {@code map} or {@code filterByResourceType}. Reads of
- * a drifted type fail with {@link SchemaDriftError} instead of an opaque Spark analysis failure.
- * View queries are guarded on their subject resource type when the query is constructed, because
- * the executed query resolves datasets through the wrapped source's own dispatcher rather than the
- * guarded {@code read}.
+ * A {@link QueryableDataSource} wrapper that guards reads against schema drift. Reads of a drifted
+ * type fail with {@link SchemaDriftError} instead of an opaque Spark analysis failure. View queries
+ * are guarded on their subject resource type when the query is constructed, because the executed
+ * query resolves datasets through the wrapped source's own dispatcher rather than the guarded
+ * {@code read}.
+ *
+ * <p>Deriving through {@code map}, {@code filterByResourceType} or {@code cache} produces a {@link
+ * DerivedSource} over this source rather than over the delegate. The derived source therefore reads
+ * through this class's guarded {@code read}, so the guard propagates without being re-applied, and
+ * so does whatever read behaviour a subclass adds - dynamic discovery, an empty-dataset fallback, a
+ * pinned version.
  *
  * <p>The drifted types set is held by reference, so guard decisions reflect its current contents.
  * This allows a mutable set shared with a refreshing source to clear the guard when a type is
@@ -112,24 +117,26 @@ public class DriftGuardedSource implements QueryableDataSource {
   @Nonnull
   public QueryableDataSource map(
       @Nonnull final BiFunction<String, Dataset<Row>, Dataset<Row>> operator) {
-    return new DriftGuardedSource(context, delegate.map(operator), driftedTypes);
+    return new DerivedSource(context, this, operator, DerivedSource.RETAIN_ALL_TYPES, driftedTypes);
   }
 
   @Override
   @Nonnull
   public QueryableDataSource filterByResourceType(
       @Nonnull final Predicate<String> resourceTypePredicate) {
-    return new DriftGuardedSource(
-        context, delegate.filterByResourceType(resourceTypePredicate), driftedTypes);
+    return new DerivedSource(
+        context, this, DerivedSource.IDENTITY_OPERATOR, resourceTypePredicate, driftedTypes);
   }
 
   @Override
   @Nonnull
   public DataSource cache() {
-    final DataSource cached = delegate.cache();
-    return cached instanceof final QueryableDataSource queryable
-        ? new DriftGuardedSource(context, queryable, driftedTypes)
-        : cached;
+    return new DerivedSource(
+        context,
+        this,
+        (resourceType, dataset) -> dataset.cache(),
+        DerivedSource.RETAIN_ALL_TYPES,
+        driftedTypes);
   }
 
   /**

--- a/server/src/main/java/au/csiro/pathling/io/DriftGuardedSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DriftGuardedSource.java
@@ -18,6 +18,7 @@
 package au.csiro.pathling.io;
 
 import au.csiro.pathling.io.source.DataSource;
+import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.sink.DataSinkBuilder;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.library.query.FhirViewQuery;
@@ -46,6 +47,9 @@ import org.apache.spark.sql.Row;
  */
 public class DriftGuardedSource implements QueryableDataSource {
 
+  /** The Pathling context, used to construct sources derived from this one. */
+  @Nonnull protected final PathlingContext context;
+
   /** The underlying QueryableDataSource that guarded operations delegate to. */
   @Nonnull protected final QueryableDataSource delegate;
 
@@ -55,12 +59,16 @@ public class DriftGuardedSource implements QueryableDataSource {
   /**
    * Constructs a new DriftGuardedSource.
    *
+   * @param context the Pathling context, used to construct derived sources
    * @param delegate the underlying QueryableDataSource to delegate to
    * @param driftedTypes the resource types whose tables are drifted and unmigrated; held by
    *     reference so that mutations are reflected in guard decisions
    */
   public DriftGuardedSource(
-      @Nonnull final QueryableDataSource delegate, @Nonnull final Set<String> driftedTypes) {
+      @Nonnull final PathlingContext context,
+      @Nonnull final QueryableDataSource delegate,
+      @Nonnull final Set<String> driftedTypes) {
+    this.context = context;
     this.delegate = delegate;
     this.driftedTypes = driftedTypes;
   }
@@ -104,7 +112,7 @@ public class DriftGuardedSource implements QueryableDataSource {
   @Nonnull
   public QueryableDataSource map(
       @Nonnull final BiFunction<String, Dataset<Row>, Dataset<Row>> operator) {
-    return new DriftGuardedSource(delegate.map(operator), driftedTypes);
+    return new DriftGuardedSource(context, delegate.map(operator), driftedTypes);
   }
 
   @Override
@@ -112,7 +120,7 @@ public class DriftGuardedSource implements QueryableDataSource {
   public QueryableDataSource filterByResourceType(
       @Nonnull final Predicate<String> resourceTypePredicate) {
     return new DriftGuardedSource(
-        delegate.filterByResourceType(resourceTypePredicate), driftedTypes);
+        context, delegate.filterByResourceType(resourceTypePredicate), driftedTypes);
   }
 
   @Override
@@ -120,7 +128,7 @@ public class DriftGuardedSource implements QueryableDataSource {
   public DataSource cache() {
     final DataSource cached = delegate.cache();
     return cached instanceof final QueryableDataSource queryable
-        ? new DriftGuardedSource(queryable, driftedTypes)
+        ? new DriftGuardedSource(context, queryable, driftedTypes)
         : cached;
   }
 

--- a/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
@@ -46,6 +46,11 @@ import org.apache.spark.sql.SparkSession;
  * Delegates to the underlying data source for known types, and attempts on-demand discovery for
  * unknown types by checking if a Delta table exists at the expected path.
  *
+ * <p>Discovery on read is matched by discovery on enumeration: {@link #getResourceTypes} also lists
+ * the warehouse database directory, so a table that exists but has never been read is still
+ * enumerable. Reads and enumeration therefore agree, and an unnarrowed export cannot silently omit
+ * a type merely because nothing happened to read it first.
+ *
  * <p>The drift guard behaviour, including its propagation into derived sources, is inherited from
  * {@link DriftGuardedSource}. The drifted types set is mutable so that a successful {@link
  * #refresh} clears the guard for the refreshed type.
@@ -205,12 +210,56 @@ public class DynamicDeltaSource extends DriftGuardedSource {
     }
   }
 
+  /**
+   * Returns every resource type this source can serve: those the delegate knew at startup, those
+   * discovered on demand since, and those whose table directory is present in the warehouse
+   * database directory.
+   *
+   * <p>The directory listing is what makes a table created after startup - by this server or by
+   * another process sharing the warehouse - enumerable before anything has read it. Without it, an
+   * unnarrowed export would silently omit such a type until an unrelated request happened to read
+   * it. Listed names are filtered to supported resource types, so an unrelated directory in the
+   * warehouse is not mistaken for one; whether a listed table is actually readable is left to
+   * {@link #read}, which falls back to an empty dataset.
+   *
+   * @return the resource types this source can serve
+   */
   @Override
   @Nonnull
   public Set<String> getResourceTypes() {
     final Set<String> types = new HashSet<>(delegate.getResourceTypes());
     types.addAll(dynamicallyDiscoveredTypes);
+    types.addAll(listTableDirectories());
     return types;
+  }
+
+  /**
+   * Lists the resource types with a table directory in the database directory. A listing failure is
+   * an enhancement lost rather than a request lost: it is logged and the caller falls back to the
+   * types already known.
+   */
+  @Nonnull
+  private Set<String> listTableDirectories() {
+    final Set<String> listed = new HashSet<>();
+    try {
+      final Path databaseDir = new Path(databasePath);
+      final FileSystem fileSystem =
+          databaseDir.getFileSystem(spark.sparkContext().hadoopConfiguration());
+      if (fileSystem.exists(databaseDir)) {
+        for (final FileStatus status : fileSystem.listStatus(databaseDir)) {
+          final String name = status.getPath().getName();
+          if (status.isDirectory() && name.endsWith(TABLE_SUFFIX)) {
+            final String resourceType = name.substring(0, name.length() - TABLE_SUFFIX.length());
+            if (context.isResourceTypeSupported(resourceType)) {
+              listed.add(resourceType);
+            }
+          }
+        }
+      }
+    } catch (final IOException e) {
+      log.warn("Failed to list the database directory while enumerating resource types", e);
+    }
+    return listed;
   }
 
   /**
@@ -229,7 +278,7 @@ public class DynamicDeltaSource extends DriftGuardedSource {
     final Map<String, Dataset<Row>> pinnedDatasets = new HashMap<>();
     final Map<String, Long> pinnedVersions = new HashMap<>();
 
-    for (final String resourceType : snapshotCandidateTypes()) {
+    for (final String resourceType : getResourceTypes()) {
       final String tablePath = getTablePath(resourceType);
       if (!DeltaTable.isDeltaTable(spark, tablePath)) {
         continue;
@@ -246,34 +295,6 @@ public class DynamicDeltaSource extends DriftGuardedSource {
     log.debug("Pinned {} resource-type tables for a snapshot read", pinnedVersions.size());
     return SnapshotDeltaSource.of(
         context, spark, fhirEncoders, pinnedDatasets, pinnedVersions, driftedTypes);
-  }
-
-  /**
-   * Determines the resource types to consider for a snapshot: those the source already knows about,
-   * plus any Delta table present in the database directory. The directory listing catches a table
-   * created after startup that has never been read, which dynamic discovery would not yet know
-   * about.
-   */
-  @Nonnull
-  private Set<String> snapshotCandidateTypes() {
-    final Set<String> candidates = new HashSet<>(getResourceTypes());
-    try {
-      final Path databaseDir = new Path(databasePath);
-      final FileSystem fileSystem =
-          databaseDir.getFileSystem(spark.sparkContext().hadoopConfiguration());
-      if (fileSystem.exists(databaseDir)) {
-        for (final FileStatus status : fileSystem.listStatus(databaseDir)) {
-          final String name = status.getPath().getName();
-          if (status.isDirectory() && name.endsWith(TABLE_SUFFIX)) {
-            candidates.add(name.substring(0, name.length() - TABLE_SUFFIX.length()));
-          }
-        }
-      }
-    } catch (final IOException e) {
-      // The listing is an enhancement over the known types; if it fails, fall back to those.
-      log.warn("Failed to list the database directory while taking a snapshot", e);
-    }
-    return candidates;
   }
 
   /** Reads the current version of a Delta table from its transaction log. */

--- a/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/DynamicDeltaSource.java
@@ -71,6 +71,8 @@ public class DynamicDeltaSource extends DriftGuardedSource {
   /**
    * Constructs a new DynamicDeltaSource with no drifted types.
    *
+   * @param context the Pathling context, used to construct derived sources and to check whether a
+   *     listed table directory names a supported resource type
    * @param delegate the underlying QueryableDataSource to delegate to
    * @param spark the Spark session for Delta table operations
    * @param databasePath the path to the Delta database
@@ -78,17 +80,20 @@ public class DynamicDeltaSource extends DriftGuardedSource {
    * @param storageConfiguration the storage configuration
    */
   public DynamicDeltaSource(
+      @Nonnull final PathlingContext context,
       @Nonnull final QueryableDataSource delegate,
       @Nonnull final SparkSession spark,
       @Nonnull final String databasePath,
       @Nonnull final FhirEncoders fhirEncoders,
       @Nonnull final StorageConfiguration storageConfiguration) {
-    this(delegate, spark, databasePath, fhirEncoders, storageConfiguration, Set.of());
+    this(context, delegate, spark, databasePath, fhirEncoders, storageConfiguration, Set.of());
   }
 
   /**
    * Constructs a new DynamicDeltaSource.
    *
+   * @param context the Pathling context, used to construct derived sources and to check whether a
+   *     listed table directory names a supported resource type
    * @param delegate the underlying QueryableDataSource to delegate to
    * @param spark the Spark session for Delta table operations
    * @param databasePath the path to the Delta database
@@ -96,14 +101,16 @@ public class DynamicDeltaSource extends DriftGuardedSource {
    * @param storageConfiguration the storage configuration
    * @param driftedTypes the resource types left drifted and unmigrated at startup
    */
+  @SuppressWarnings("java:S107")
   public DynamicDeltaSource(
+      @Nonnull final PathlingContext context,
       @Nonnull final QueryableDataSource delegate,
       @Nonnull final SparkSession spark,
       @Nonnull final String databasePath,
       @Nonnull final FhirEncoders fhirEncoders,
       @Nonnull final StorageConfiguration storageConfiguration,
       @Nonnull final Set<String> driftedTypes) {
-    super(delegate, concurrentCopyOf(driftedTypes));
+    super(context, delegate, concurrentCopyOf(driftedTypes));
     this.spark = spark;
     this.databasePath = databasePath;
     this.fhirEncoders = fhirEncoders;
@@ -215,11 +222,10 @@ public class DynamicDeltaSource extends DriftGuardedSource {
    * single-snapshot guarantee requires. Pinning reads only each table's Delta log, so no data is
    * copied and reads stay lazy.
    *
-   * @param context the Pathling context used to hold the pinned datasets
    * @return a snapshot source pinned at the current instant
    */
   @Nonnull
-  public SnapshotDeltaSource snapshot(@Nonnull final PathlingContext context) {
+  public SnapshotDeltaSource snapshot() {
     final Map<String, Dataset<Row>> pinnedDatasets = new HashMap<>();
     final Map<String, Long> pinnedVersions = new HashMap<>();
 

--- a/server/src/main/java/au/csiro/pathling/io/SnapshotDeltaSource.java
+++ b/server/src/main/java/au/csiro/pathling/io/SnapshotDeltaSource.java
@@ -59,6 +59,7 @@ public class SnapshotDeltaSource extends DriftGuardedSource {
   /**
    * Constructs a new SnapshotDeltaSource over datasets already pinned to their captured versions.
    *
+   * @param context the Pathling context, used to construct derived sources
    * @param pinned a source holding one {@code versionAsOf} dataset per resource type
    * @param spark the Spark session, used to build empty datasets for unpinned types
    * @param fhirEncoders the FHIR encoders, used to build empty datasets for unpinned types
@@ -67,12 +68,13 @@ public class SnapshotDeltaSource extends DriftGuardedSource {
    *     reference so the guard tracks the live source's current state
    */
   SnapshotDeltaSource(
+      @Nonnull final PathlingContext context,
       @Nonnull final QueryableDataSource pinned,
       @Nonnull final SparkSession spark,
       @Nonnull final FhirEncoders fhirEncoders,
       @Nonnull final Map<String, Long> pinnedVersions,
       @Nonnull final Set<String> driftedTypes) {
-    super(pinned, driftedTypes);
+    super(context, pinned, driftedTypes);
     this.spark = spark;
     this.fhirEncoders = fhirEncoders;
     this.pinnedVersions = Map.copyOf(pinnedVersions);
@@ -123,6 +125,7 @@ public class SnapshotDeltaSource extends DriftGuardedSource {
       @Nonnull final Set<String> driftedTypes) {
     final DatasetSource pinned = new DatasetSource(context);
     pinnedDatasets.forEach(pinned::dataset);
-    return new SnapshotDeltaSource(pinned, spark, fhirEncoders, pinnedVersions, driftedTypes);
+    return new SnapshotDeltaSource(
+        context, pinned, spark, fhirEncoders, pinnedVersions, driftedTypes);
   }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sql/SqlExportExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sql/SqlExportExecutor.java
@@ -19,7 +19,6 @@ package au.csiro.pathling.operations.sql;
 
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.io.DynamicDeltaSource;
-import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.operations.ParquetSchemaValidator;
 import au.csiro.pathling.operations.export.ExportDataSourceBuilder;
@@ -63,8 +62,6 @@ public class SqlExportExecutor {
 
   @Nonnull private final QueryableDataSource deltaLake;
 
-  @Nonnull private final PathlingContext pathlingContext;
-
   @Nonnull private final FhirContext fhirContext;
 
   @Nonnull private final ServerConfiguration serverConfiguration;
@@ -78,7 +75,6 @@ public class SqlExportExecutor {
    *
    * @param pipeline the SQL evaluation engine
    * @param deltaLake the server's data source, snapshotted at execution start
-   * @param pathlingContext the Pathling context, used to hold the snapshot's pinned datasets
    * @param fhirContext the FHIR context, used to build view query plans
    * @param serverConfiguration the server configuration, consulted for the query configuration
    * @param dataSourceBuilder applies the job's filters to the snapshot
@@ -89,14 +85,12 @@ public class SqlExportExecutor {
   public SqlExportExecutor(
       @Nonnull final SqlQueryPipeline pipeline,
       @Nonnull final QueryableDataSource deltaLake,
-      @Nonnull final PathlingContext pathlingContext,
       @Nonnull final FhirContext fhirContext,
       @Nonnull final ServerConfiguration serverConfiguration,
       @Nonnull final ExportDataSourceBuilder dataSourceBuilder,
       @Nonnull final ExportFileWriter fileWriter) {
     this.pipeline = pipeline;
     this.deltaLake = deltaLake;
-    this.pathlingContext = pathlingContext;
     this.fhirContext = fhirContext;
     this.serverConfiguration = serverConfiguration;
     this.dataSourceBuilder = dataSourceBuilder;
@@ -139,7 +133,7 @@ public class SqlExportExecutor {
   @Nonnull
   private QueryableDataSource snapshot() {
     if (deltaLake instanceof final DynamicDeltaSource dynamic) {
-      return dynamic.snapshot(pathlingContext);
+      return dynamic.snapshot();
     }
     log.debug("Data source {} cannot be pinned; reading it live", deltaLake.getClass().getName());
     return deltaLake;

--- a/server/src/test/java/au/csiro/pathling/io/DerivedSourceTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/DerivedSourceTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import au.csiro.pathling.config.StorageConfiguration;
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.sink.FileInformation;
+import au.csiro.pathling.library.io.sink.WriteDetails;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
+import au.csiro.pathling.test.SpringBootUnitTest;
+import au.csiro.pathling.util.FhirServerTestConfiguration;
+import au.csiro.pathling.util.TestDataSetup;
+import au.csiro.pathling.views.FhirView;
+import jakarta.annotation.Nonnull;
+import java.nio.file.Path;
+import java.util.Set;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.storage.StorageLevel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Unit tests for {@link DerivedSource}, the source produced by {@code map}, {@code
+ * filterByResourceType} and {@code cache} on a {@link DriftGuardedSource}.
+ *
+ * <p>Every test creates the resource type's table <b>after</b> the parent source is constructed,
+ * because that is the case the derivation used to get wrong: a source derived eagerly over the
+ * parent's startup resource map could not see a type discovered later, so a filtered read failed
+ * while the equivalent unfiltered read succeeded.
+ *
+ * @author John Grimes
+ */
+@Import(FhirServerTestConfiguration.class)
+@SpringBootUnitTest
+class DerivedSourceTest {
+
+  /** A resource type that has no table in any of the warehouses used here. */
+  private static final String ABSENT_TYPE = "ImmunizationEvaluation";
+
+  /** The number of Patient resources in the copied test table. */
+  private static final long PATIENT_COUNT = 125;
+
+  @Autowired private SparkSession sparkSession;
+
+  @Autowired private PathlingContext pathlingContext;
+
+  @Autowired private FhirEncoders fhirEncoders;
+
+  // A source derived through map() must read a type whose table appeared after the parent was
+  // constructed, and must apply the row operator to what it reads (FR-001).
+  @Test
+  void mapDerivedReadSeesTypeCreatedAfterConstruction(@TempDir final Path tempDir) {
+    final DynamicDeltaSource parent = emptyWarehouseSource(tempDir);
+    createPatientTable(tempDir);
+
+    final QueryableDataSource derived = parent.map((resourceType, dataset) -> dataset.limit(3));
+
+    assertThat(derived.read("Patient").count()).isEqualTo(3);
+    assertThat(parent.read("Patient").count()).isEqualTo(PATIENT_COUNT);
+  }
+
+  // The same for a source derived through filterByResourceType(): a retained type created after
+  // construction is readable (FR-001).
+  @Test
+  void filterDerivedReadSeesTypeCreatedAfterConstruction(@TempDir final Path tempDir) {
+    final DynamicDeltaSource parent = emptyWarehouseSource(tempDir);
+    createPatientTable(tempDir);
+
+    final QueryableDataSource derived = parent.filterByResourceType("Patient"::equals);
+
+    assertThat(derived.read("Patient").count()).isEqualTo(PATIENT_COUNT);
+  }
+
+  // A type removed by the predicate keeps the failure behaviour it has today, so that compartment
+  // semantics are not silently changed by this fix (FR-009).
+  @Test
+  void filterDerivedReadOfExcludedTypeFails(@TempDir final Path tempDir) {
+    final DynamicDeltaSource parent = emptyWarehouseSource(tempDir);
+    createPatientTable(tempDir);
+
+    final QueryableDataSource derived = parent.filterByResourceType(resourceType -> false);
+
+    assertThatThrownBy(() -> derived.read("Patient"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No data found for resource type: Patient");
+  }
+
+  // Derivation composes: chaining map, filterByResourceType and map again applies every stage to a
+  // type discovered after construction (FR-002).
+  @Test
+  void chainedDerivationAppliesEveryStage(@TempDir final Path tempDir) {
+    final DynamicDeltaSource parent = emptyWarehouseSource(tempDir);
+    createPatientTable(tempDir);
+
+    final QueryableDataSource derived =
+        parent
+            .map((resourceType, dataset) -> dataset.limit(10))
+            .filterByResourceType("Patient"::equals)
+            .map((resourceType, dataset) -> dataset.limit(4));
+
+    assertThat(derived.read("Patient").count()).isEqualTo(4);
+    // The excluded type is still excluded further down the chain.
+    assertThatThrownBy(() -> derived.read("Observation"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  // A derived read of a type with no table anywhere returns an empty dataset with the type's
+  // schema, exactly as the unfiltered read does, rather than failing (FR-003).
+  @Test
+  void derivedReadOfAbsentTypeReturnsEmptyDataset(@TempDir final Path tempDir) {
+    final DynamicDeltaSource parent = emptyWarehouseSource(tempDir);
+
+    final Dataset<Row> result = parent.map((resourceType, dataset) -> dataset).read(ABSENT_TYPE);
+
+    assertThat(result.count()).isZero();
+    assertThat(result.schema().fieldNames()).contains("id", "status");
+  }
+
+  // Deriving a source must not weaken the schema drift guard: a drifted, unmigrated type still
+  // fails with the actionable error through any derivation chain (FR-004).
+  @Test
+  void derivedReadOfDriftedTypeThrowsSchemaDriftError(@TempDir final Path tempDir) {
+    final DynamicDeltaSource parent = emptyWarehouseSource(tempDir, false, Set.of("Patient"));
+    createPatientTable(tempDir);
+
+    final QueryableDataSource derived =
+        parent.map((resourceType, dataset) -> dataset).filterByResourceType(resourceType -> true);
+
+    assertThatThrownBy(() -> derived.read("Patient")).isInstanceOf(SchemaDriftError.class);
+    // Constructing a view over a drifted subject fails up front, as it does on the parent.
+    assertThatThrownBy(() -> derived.view("Patient")).isInstanceOf(SchemaDriftError.class);
+  }
+
+  // A derived source enumerates its parent's types minus the ones its predicates removed (FR-007).
+  @Test
+  void derivedResourceTypesAreParentTypesMinusExcluded(@TempDir final Path tempDir) {
+    final DynamicDeltaSource parent = emptyWarehouseSource(tempDir);
+    createPatientTable(tempDir);
+    createTable(tempDir, "Observation");
+    // Reading brings both post-startup types into the parent's enumeration through dynamic
+    // discovery; enumeration of never-read tables is covered separately in DynamicDeltaSourceTest.
+    parent.read("Patient");
+    parent.read("Observation");
+
+    assertThat(parent.map((resourceType, dataset) -> dataset).getResourceTypes())
+        .containsExactlyInAnyOrder("Patient", "Observation");
+    assertThat(parent.filterByResourceType("Patient"::equals).getResourceTypes())
+        .containsExactly("Patient");
+  }
+
+  // cache() is a derivation like any other, so it must also see a post-startup type, and must
+  // still mark the datasets it serves for caching (FR-001).
+  @Test
+  void cacheDerivationReadsPostStartupTypeAndMarksForCaching(@TempDir final Path tempDir) {
+    final DynamicDeltaSource parent = emptyWarehouseSource(tempDir);
+    createPatientTable(tempDir);
+
+    final Dataset<Row> result = ((QueryableDataSource) parent.cache()).read("Patient");
+
+    try {
+      assertThat(result.count()).isEqualTo(PATIENT_COUNT);
+      assertThat(result.storageLevel()).isEqualTo(StorageLevel.MEMORY_AND_DISK());
+    } finally {
+      result.unpersist();
+    }
+  }
+
+  // A write through a derived source enumerates and reads through that source, so the output
+  // carries the derivation's transformations and only its retained types.
+  @Test
+  void writeThroughDerivedSourceWritesTransformedDatasets(
+      @TempDir final Path tempDir, @TempDir final Path outputDir) {
+    final DynamicDeltaSource parent = emptyWarehouseSource(tempDir);
+    createPatientTable(tempDir);
+    createTable(tempDir, "Observation");
+    parent.read("Patient");
+    parent.read("Observation");
+
+    final WriteDetails written =
+        parent
+            .filterByResourceType("Patient"::equals)
+            .map((resourceType, dataset) -> dataset.limit(2))
+            .write()
+            .saveMode("overwrite")
+            .ndjson(outputDir.toAbsolutePath().toString());
+
+    // Only the retained type is written, and its file carries the row limit the derivation
+    // applied.
+    assertThat(written.fileInfos())
+        .extracting(FileInformation::fhirResourceType)
+        .containsOnly("Patient");
+    final long lines =
+        written.fileInfos().stream()
+            .mapToLong(info -> sparkSession.read().text(info.absoluteUrl()).count())
+            .sum();
+    assertThat(lines).isEqualTo(2);
+  }
+
+  // A view over a derived source resolves its subject through the derived read, so it too sees a
+  // post-startup type and observes the derivation's row filtering.
+  @Test
+  void viewOverDerivedSourceResolvesThroughDerivedRead(@TempDir final Path tempDir) {
+    final DynamicDeltaSource parent = emptyWarehouseSource(tempDir);
+    createPatientTable(tempDir);
+    final FhirView view =
+        FhirView.ofResource("Patient")
+            .select(FhirView.columns(FhirView.column("id", "id")))
+            .build();
+
+    final Dataset<Row> result =
+        parent.map((resourceType, dataset) -> dataset.limit(5)).view(view).execute();
+
+    assertThat(result.count()).isEqualTo(5);
+    assertThat(result.schema().fieldNames()).containsExactly("id");
+  }
+
+  // ---- helpers ----
+
+  /** Builds a live source over an empty warehouse, so every table used is created after it. */
+  @Nonnull
+  private DynamicDeltaSource emptyWarehouseSource(@Nonnull final Path databaseDir) {
+    return emptyWarehouseSource(databaseDir, false, Set.of());
+  }
+
+  @Nonnull
+  private DynamicDeltaSource emptyWarehouseSource(
+      @Nonnull final Path databaseDir,
+      final boolean cacheDatasets,
+      @Nonnull final Set<String> driftedTypes) {
+    final String databasePath = databaseDir.toAbsolutePath().toString();
+    final StorageConfiguration storageConfiguration = new StorageConfiguration();
+    storageConfiguration.setCacheDatasets(cacheDatasets);
+    final QueryableDataSource baseSource = pathlingContext.read().delta(databasePath);
+    return new DynamicDeltaSource(
+        pathlingContext,
+        baseSource,
+        sparkSession,
+        databasePath,
+        fhirEncoders,
+        storageConfiguration,
+        driftedTypes);
+  }
+
+  /** Creates the Patient table in the warehouse, from the encoded test data. */
+  private void createPatientTable(@Nonnull final Path databaseDir) {
+    TestDataSetup.copyTestDataToTempDir(databaseDir, "Patient");
+  }
+
+  /** Creates a table for another resource type in the warehouse. */
+  private void createTable(@Nonnull final Path databaseDir, @Nonnull final String resourceType) {
+    TestDataSetup.copyTestDataToTempDir(databaseDir, resourceType);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
@@ -24,11 +24,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import au.csiro.pathling.config.StorageConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
 import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.DatasetSource;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import au.csiro.pathling.util.FhirServerTestConfiguration;
 import au.csiro.pathling.views.FhirView;
 import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
@@ -268,6 +271,72 @@ class DynamicDeltaSourceTest {
     source.refresh("ImmunizationEvaluation");
 
     assertThat(source.read("ImmunizationEvaluation").count()).isZero();
+  }
+
+  // Verifies that a table written into the warehouse after the source was built is enumerated even
+  // though nothing has read it. Writing the table directly rather than through the source also
+  // stands in for a table created by another process sharing the warehouse (FR-006).
+  @Test
+  void enumeratesNeverReadTableCreatedAfterConstruction(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    final DynamicDeltaSource source = newTempDirSource(databasePath, false);
+    assertThat(source.getResourceTypes()).isEmpty();
+
+    writePatientTable(databasePath, "id");
+
+    assertThat(source.getResourceTypes()).containsExactly("Patient");
+  }
+
+  // Verifies that a directory whose name does not correspond to a supported resource type is not
+  // reported as one, and that a stray file alongside the tables does not disturb enumeration.
+  @Test
+  void enumerationIgnoresUnsupportedNamesAndStrayFiles(@TempDir final Path tempDir)
+      throws IOException {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    final DynamicDeltaSource source = newTempDirSource(databasePath, false);
+    writePatientTable(databasePath, "id");
+    Files.createDirectories(tempDir.resolve("NotAType.parquet"));
+    Files.createDirectories(tempDir.resolve("jobs"));
+    Files.writeString(tempDir.resolve("stray.txt"), "not a table");
+
+    assertThat(source.getResourceTypes()).containsExactly("Patient");
+  }
+
+  // Verifies that a failure to list the database directory falls back to the types already known,
+  // logs a warning and does not fail the caller (FR-008).
+  @Test
+  void enumerationFallsBackWhenListingFails() {
+    // A scheme with no registered filesystem makes the listing throw an IOException.
+    final DatasetSource delegate = new DatasetSource(pathlingContext);
+    delegate.dataset("Patient", patientDataset(1, "id"));
+    final StorageConfiguration storageConfiguration = new StorageConfiguration();
+    storageConfiguration.setCacheDatasets(false);
+    final DynamicDeltaSource source =
+        new DynamicDeltaSource(
+            pathlingContext,
+            delegate,
+            sparkSession,
+            "nosuchscheme://host/database",
+            fhirEncoders,
+            storageConfiguration,
+            Set.of());
+
+    assertThatNoException().isThrownBy(source::getResourceTypes);
+    assertThat(source.getResourceTypes()).containsExactly("Patient");
+  }
+
+  // Verifies that a snapshot pins and serves a table that exists in the warehouse but has never
+  // been read, which is the behaviour the enumeration refactor has to preserve.
+  @Test
+  void snapshotPinsNeverReadTable(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    final DynamicDeltaSource source = newTempDirSource(databasePath, false);
+    writePatientTable(databasePath, "id");
+
+    final SnapshotDeltaSource snapshot = source.snapshot();
+
+    assertThat(snapshot.getPinnedVersions()).containsKey("Patient");
+    assertThat(snapshot.read("Patient").count()).isEqualTo(1);
   }
 
   // ---- helpers ----

--- a/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/DynamicDeltaSourceTest.java
@@ -292,7 +292,13 @@ class DynamicDeltaSourceTest {
     storageConfiguration.setCacheDatasets(cacheDatasets);
     final QueryableDataSource baseSource = pathlingContext.read().delta(databasePath);
     return new DynamicDeltaSource(
-        baseSource, sparkSession, databasePath, fhirEncoders, storageConfiguration, driftedTypes);
+        pathlingContext,
+        baseSource,
+        sparkSession,
+        databasePath,
+        fhirEncoders,
+        storageConfiguration,
+        driftedTypes);
   }
 
   /** Writes a single-row Patient Delta table whose schema has only the given string columns. */

--- a/server/src/test/java/au/csiro/pathling/io/SnapshotDeltaSourceTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/SnapshotDeltaSourceTest.java
@@ -109,6 +109,24 @@ class SnapshotDeltaSourceTest {
     assertThat(filtered.read("Patient").count()).isEqualTo(2);
   }
 
+  // A snapshot's empty-dataset fallback for a type with no table at the pinned instant has to
+  // survive derivation too, or an $sql-export narrowed by patient would fail on a view that
+  // references such a type instead of yielding no rows for it (FR-005).
+  @Test
+  void derivedSourceKeepsTheEmptyDatasetFallback(@TempDir final Path tempDir) {
+    final String databasePath = tempDir.toAbsolutePath().toString();
+    writeTable(databasePath, "Patient", 1);
+    final SnapshotDeltaSource snapshot = newLiveSource(databasePath).snapshot();
+
+    final QueryableDataSource derived =
+        snapshot.map((resourceType, dataset) -> dataset).filterByResourceType(resourceType -> true);
+
+    // ImmunizationEvaluation had no table at the pinned instant.
+    final Dataset<Row> result = derived.read("ImmunizationEvaluation");
+    assertThat(result.count()).isZero();
+    assertThat(result.schema().fieldNames()).contains("id", "status");
+  }
+
   // Every table is pinned at the same instant, so a write to a second type after snapshot creation
   // is equally invisible.
   @Test

--- a/server/src/test/java/au/csiro/pathling/io/SnapshotDeltaSourceTest.java
+++ b/server/src/test/java/au/csiro/pathling/io/SnapshotDeltaSourceTest.java
@@ -69,7 +69,7 @@ class SnapshotDeltaSourceTest {
     final String databasePath = tempDir.toAbsolutePath().toString();
     writeTable(databasePath, "Patient", 2);
     final DynamicDeltaSource live = newLiveSource(databasePath);
-    final SnapshotDeltaSource snapshot = live.snapshot(pathlingContext);
+    final SnapshotDeltaSource snapshot = live.snapshot();
     assertThat(snapshot.read("Patient").count()).isEqualTo(2);
 
     // A concurrent writer appends two more rows, advancing the table's Delta version.
@@ -86,7 +86,7 @@ class SnapshotDeltaSourceTest {
   void repeatedReadsWithinSnapshotAreConsistent(@TempDir final Path tempDir) {
     final String databasePath = tempDir.toAbsolutePath().toString();
     writeTable(databasePath, "Patient", 3);
-    final SnapshotDeltaSource snapshot = newLiveSource(databasePath).snapshot(pathlingContext);
+    final SnapshotDeltaSource snapshot = newLiveSource(databasePath).snapshot();
 
     final long first = snapshot.read("Patient").count();
     appendToTable(databasePath, "Patient", 5);
@@ -101,7 +101,7 @@ class SnapshotDeltaSourceTest {
   void derivedSourcePreservesPinnedVersion(@TempDir final Path tempDir) {
     final String databasePath = tempDir.toAbsolutePath().toString();
     writeTable(databasePath, "Patient", 2);
-    final SnapshotDeltaSource snapshot = newLiveSource(databasePath).snapshot(pathlingContext);
+    final SnapshotDeltaSource snapshot = newLiveSource(databasePath).snapshot();
     final QueryableDataSource filtered = snapshot.map((resourceType, dataset) -> dataset);
 
     appendToTable(databasePath, "Patient", 3);
@@ -116,7 +116,7 @@ class SnapshotDeltaSourceTest {
     final String databasePath = tempDir.toAbsolutePath().toString();
     writeTable(databasePath, "Patient", 1);
     writeTable(databasePath, "Observation", 1);
-    final SnapshotDeltaSource snapshot = newLiveSource(databasePath).snapshot(pathlingContext);
+    final SnapshotDeltaSource snapshot = newLiveSource(databasePath).snapshot();
 
     appendToTable(databasePath, "Patient", 4);
     appendToTable(databasePath, "Observation", 7);
@@ -132,7 +132,7 @@ class SnapshotDeltaSourceTest {
   void typesCreatedAfterSnapshotAreInvisible(@TempDir final Path tempDir) {
     final String databasePath = tempDir.toAbsolutePath().toString();
     writeTable(databasePath, "Patient", 1);
-    final SnapshotDeltaSource snapshot = newLiveSource(databasePath).snapshot(pathlingContext);
+    final SnapshotDeltaSource snapshot = newLiveSource(databasePath).snapshot();
 
     writeTable(databasePath, "Condition", 3);
 
@@ -152,7 +152,7 @@ class SnapshotDeltaSourceTest {
     assertThat(cached.storageLevel()).isEqualTo(StorageLevel.MEMORY_AND_DISK());
 
     try {
-      final SnapshotDeltaSource snapshot = live.snapshot(pathlingContext);
+      final SnapshotDeltaSource snapshot = live.snapshot();
 
       assertThat(snapshot.read("Patient").storageLevel()).isEqualTo(StorageLevel.NONE());
       assertThat(snapshot.read("Patient").count()).isEqualTo(2);
@@ -169,7 +169,7 @@ class SnapshotDeltaSourceTest {
     writeTable(databasePath, "Patient", 1);
     final DynamicDeltaSource live = newLiveSource(databasePath, false, Set.of("Patient"));
 
-    final SnapshotDeltaSource snapshot = live.snapshot(pathlingContext);
+    final SnapshotDeltaSource snapshot = live.snapshot();
 
     assertThatThrownBy(() -> snapshot.read("Patient"))
         .isInstanceOf(SchemaDriftError.class)
@@ -192,7 +192,13 @@ class SnapshotDeltaSourceTest {
     storageConfiguration.setCacheDatasets(cacheDatasets);
     final QueryableDataSource baseSource = pathlingContext.read().delta(databasePath);
     return new DynamicDeltaSource(
-        baseSource, sparkSession, databasePath, fhirEncoders, storageConfiguration, driftedTypes);
+        pathlingContext,
+        baseSource,
+        sparkSession,
+        databasePath,
+        fhirEncoders,
+        storageConfiguration,
+        driftedTypes);
   }
 
   /** Writes a new single-column Delta table with the given number of rows. */

--- a/server/src/test/java/au/csiro/pathling/operations/export/ExportDataSourceBuilderDynamicTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/export/ExportDataSourceBuilderDynamicTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import au.csiro.pathling.config.StorageConfiguration;
+import au.csiro.pathling.encoders.FhirEncoders;
+import au.csiro.pathling.io.DynamicDeltaSource;
+import au.csiro.pathling.library.PathlingContext;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
+import au.csiro.pathling.operations.compartment.PatientCompartmentService;
+import au.csiro.pathling.test.SpringBootUnitTest;
+import au.csiro.pathling.util.FhirServerTestConfiguration;
+import au.csiro.pathling.util.TestDataSetup;
+import ca.uhn.fhir.context.FhirContext;
+import jakarta.annotation.Nonnull;
+import java.nio.file.Path;
+import java.util.Set;
+import org.apache.spark.sql.SparkSession;
+import org.hl7.fhir.r4.model.InstantType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Tests the export filter chain built by {@link ExportDataSourceBuilder} over a live source whose
+ * Patient table appeared after the source was constructed.
+ *
+ * <p>This is the same defect as the filtered {@code $sql-run}, reached at the export boundary: the
+ * {@code _since} map and the patient-compartment filter each derive a source, and a derivation that
+ * captured the parent's startup resource map could not see the table. These are regression tests -
+ * the fix is in the derivation itself, not in this builder.
+ *
+ * @author John Grimes
+ */
+@Import(FhirServerTestConfiguration.class)
+@SpringBootUnitTest
+class ExportDataSourceBuilderDynamicTest {
+
+  @Autowired private SparkSession sparkSession;
+
+  @Autowired private PathlingContext pathlingContext;
+
+  @Autowired private FhirEncoders fhirEncoders;
+
+  @Autowired private FhirContext fhirContext;
+
+  // The _since filter alone derives the source, so it too must see the post-startup table.
+  @Test
+  void sinceFilteredSourceSeesPostStartupTable(@TempDir final Path tempDir) {
+    final DynamicDeltaSource base = emptyWarehouseSource(tempDir);
+    TestDataSetup.copyTestDataToTempDir(tempDir, "Patient");
+
+    final QueryableDataSource filtered =
+        builder().build(base, new InstantType("2000-01-01T00:00:00Z"), Set.of());
+
+    assertThat(filtered.read("Patient").count()).isPositive();
+  }
+
+  // The patient-compartment filter narrows to the named patient, over a table the source did not
+  // know about when it was built.
+  @Test
+  void patientFilteredSourceSeesPostStartupTable(@TempDir final Path tempDir) {
+    final DynamicDeltaSource base = emptyWarehouseSource(tempDir);
+    TestDataSetup.copyTestDataToTempDir(tempDir, "Patient");
+    final String patientId = base.read("Patient").select("id").first().getString(0);
+
+    final QueryableDataSource filtered = builder().build(base, null, Set.of(patientId));
+
+    assertThat(filtered.read("Patient").count()).isEqualTo(1);
+  }
+
+  // A patient id that matches nothing yields an empty result rather than a failure: the type is
+  // visible, the filter simply removes every row.
+  @Test
+  void patientFilterWithNoMatchesYieldsEmptyResult(@TempDir final Path tempDir) {
+    final DynamicDeltaSource base = emptyWarehouseSource(tempDir);
+    TestDataSetup.copyTestDataToTempDir(tempDir, "Patient");
+
+    final QueryableDataSource filtered = builder().build(base, null, Set.of("no-such-patient"));
+
+    assertThat(filtered.read("Patient").count()).isZero();
+  }
+
+  // Both filters together compose over the post-startup table.
+  @Test
+  void chainedFiltersSeePostStartupTable(@TempDir final Path tempDir) {
+    final DynamicDeltaSource base = emptyWarehouseSource(tempDir);
+    TestDataSetup.copyTestDataToTempDir(tempDir, "Patient");
+    final String patientId = base.read("Patient").select("id").first().getString(0);
+
+    final QueryableDataSource filtered =
+        builder().build(base, new InstantType("2000-01-01T00:00:00Z"), Set.of(patientId));
+
+    assertThat(filtered.read("Patient").count()).isEqualTo(1);
+  }
+
+  // ---- helpers ----
+
+  @Nonnull
+  private ExportDataSourceBuilder builder() {
+    return new ExportDataSourceBuilder(new PatientCompartmentService(fhirContext));
+  }
+
+  /** Builds a live source over an empty warehouse, so the Patient table is created after it. */
+  @Nonnull
+  private DynamicDeltaSource emptyWarehouseSource(@Nonnull final Path databaseDir) {
+    final String databasePath = databaseDir.toAbsolutePath().toString();
+    final StorageConfiguration storageConfiguration = new StorageConfiguration();
+    storageConfiguration.setCacheDatasets(false);
+    final QueryableDataSource baseSource = pathlingContext.read().delta(databasePath);
+    return new DynamicDeltaSource(
+        pathlingContext,
+        baseSource,
+        sparkSession,
+        databasePath,
+        fhirEncoders,
+        storageConfiguration,
+        Set.of());
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sql/SqlExportExecutorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sql/SqlExportExecutorTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.when;
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.io.DynamicDeltaSource;
 import au.csiro.pathling.io.SnapshotDeltaSource;
-import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.operations.export.ExportDataSourceBuilder;
 import au.csiro.pathling.operations.export.ExportFileWriter;
@@ -84,7 +83,7 @@ class SqlExportExecutorTest {
     fileWriter = mock(ExportFileWriter.class);
     filteredSource = mock(QueryableDataSource.class);
 
-    when(deltaLake.snapshot(any())).thenReturn(snapshot);
+    when(deltaLake.snapshot()).thenReturn(snapshot);
     when(dataSourceBuilder.build(any(), any(), any())).thenReturn(filteredSource);
     when(fileWriter.createJobDirectory(any())).thenReturn(new Path("/tmp/" + JOB_ID));
     when(fileWriter.writeNdjson(any(), any(), any())).thenReturn(List.of("file.ndjson"));
@@ -105,7 +104,6 @@ class SqlExportExecutorTest {
         new SqlExportExecutor(
             pipeline,
             deltaLake,
-            mock(PathlingContext.class),
             mock(FhirContext.class),
             mock(ServerConfiguration.class, org.mockito.Answers.RETURNS_DEEP_STUBS),
             dataSourceBuilder,
@@ -143,7 +141,7 @@ class SqlExportExecutorTest {
   void readsEverySubjectThroughOneSnapshotCapturedAtStart() {
     executor.execute(request(sqlSubject("first"), sqlSubject("second")), JOB_ID);
 
-    verify(deltaLake, times(1)).snapshot(any());
+    verify(deltaLake, times(1)).snapshot();
 
     final ArgumentCaptor<QueryableDataSource> base =
         ArgumentCaptor.forClass(QueryableDataSource.class);
@@ -163,7 +161,6 @@ class SqlExportExecutorTest {
         new SqlExportExecutor(
             pipeline,
             plainSource,
-            mock(PathlingContext.class),
             mock(FhirContext.class),
             mock(ServerConfiguration.class, org.mockito.Answers.RETURNS_DEEP_STUBS),
             dataSourceBuilder,

--- a/server/src/test/java/au/csiro/pathling/test/integration/DynamicTypeVisibilityIT.java
+++ b/server/src/test/java/au/csiro/pathling/test/integration/DynamicTypeVisibilityIT.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -64,7 +63,6 @@ import org.springframework.test.web.reactive.server.WebTestClient;
  *
  * @author John Grimes
  */
-@Slf4j
 @Tag("IntegrationTest")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ResourceLock(value = "wiremock", mode = ResourceAccessMode.READ_WRITE)

--- a/server/src/test/java/au/csiro/pathling/test/integration/DynamicTypeVisibilityIT.java
+++ b/server/src/test/java/au/csiro/pathling/test/integration/DynamicTypeVisibilityIT.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.test.integration;
+
+import static au.csiro.pathling.util.ExportOperationUtil.doPolling;
+import static au.csiro.pathling.util.ExportOperationUtil.kickOffRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import au.csiro.pathling.util.TestDataSetup;
+import com.google.gson.Gson;
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * End-to-end reproduction of issue #2709: a resource type whose Delta table is created after the
+ * server started must be visible to reads that narrow by {@code patient}, {@code group} or {@code
+ * _since}, and to bulk exports, without a restart.
+ *
+ * <p>The server starts against an <b>empty</b> warehouse, so every table these tests read is
+ * created after startup. Before the fix, the unfiltered {@code $sql-run} returned the row while
+ * every narrowed variant failed with {@code No data found for resource type: Patient}.
+ *
+ * @author John Grimes
+ */
+@Slf4j
+@Tag("IntegrationTest")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ResourceLock(value = "wiremock", mode = ResourceAccessMode.READ_WRITE)
+@ActiveProfiles({"integration-test"})
+class DynamicTypeVisibilityIT {
+
+  private static final Gson GSON = new Gson();
+
+  private static final String PATIENT_ID = "dynamic-visibility-patient";
+
+  private static final String OTHER_PATIENT_ID = "dynamic-visibility-other-patient";
+
+  private static final String GROUP_ID = "dynamic-visibility-group";
+
+  /**
+   * A type used only by the enumeration scenario, so that no other test in this class reads it and
+   * brings it into the source's type set through dynamic discovery.
+   */
+  private static final String NEVER_READ_TYPE = "Organization";
+
+  @TempDir private static Path warehouseDir;
+
+  @LocalServerPort int port;
+
+  @Autowired WebTestClient webTestClient;
+
+  @DynamicPropertySource
+  static void configureProperties(final DynamicPropertyRegistry registry) throws IOException {
+    // An empty database directory: the server starts knowing about no resource types at all.
+    Files.createDirectories(warehouseDir.resolve("delta"));
+    registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir.toAbsolutePath());
+  }
+
+  @BeforeEach
+  void setUp() {
+    webTestClient =
+        webTestClient
+            .mutate()
+            .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(100 * 1024 * 1024))
+            .responseTimeout(Duration.ofSeconds(60))
+            .build();
+    putPatient(PATIENT_ID);
+  }
+
+  // -------------------------------------------------------------------------
+  // User story 1: filtered $sql-run.
+  // -------------------------------------------------------------------------
+
+  // The baseline: without narrowing, the post-startup type is already visible, because the live
+  // source discovers its table on demand.
+  @Test
+  void unfilteredRunSeesPostStartupType() {
+    assertThat(runIds()).contains(PATIENT_ID);
+  }
+
+  // The defect as reported: narrowing by patient used to fail because the derived source was built
+  // over the startup resource map.
+  @Test
+  void patientFilteredRunSeesPostStartupType() {
+    assertThat(runIds(referencePart("patient", "Patient/" + PATIENT_ID)))
+        .containsExactly(PATIENT_ID);
+  }
+
+  // The narrowing still narrows: with a second Patient stored, filtering to the first returns only
+  // that one. A patient id naming nothing is not used here, because the operation answers that
+  // with a 400 by design rather than an empty result.
+  @Test
+  void patientFilteredRunExcludesOtherPatients() {
+    putPatient(OTHER_PATIENT_ID);
+
+    assertThat(runIds()).contains(PATIENT_ID, OTHER_PATIENT_ID);
+    assertThat(runIds(referencePart("patient", "Patient/" + PATIENT_ID)))
+        .containsExactly(PATIENT_ID);
+  }
+
+  // The _since variant of the same defect.
+  @Test
+  void sinceFilteredRunSeesPostStartupType() {
+    assertThat(runIds(simplePart("_since", "valueInstant", "2000-01-01T00:00:00Z")))
+        .contains(PATIENT_ID);
+  }
+
+  // The group variant of the same defect: the group's member resolves to the patient, and the
+  // compartment filter is applied over a type discovered after startup.
+  @Test
+  void groupFilteredRunSeesPostStartupType() {
+    putGroup();
+
+    assertThat(runIds(referencePart("group", "Group/" + GROUP_ID))).containsExactly(PATIENT_ID);
+  }
+
+  // -------------------------------------------------------------------------
+  // User story 2: filtered bulk export.
+  // -------------------------------------------------------------------------
+
+  // A patient-level export derives the source through the compartment filter, so it reached the
+  // same defect.
+  @Test
+  void patientLevelExportIncludesPostStartupType() {
+    final Map<String, List<String>> output =
+        exportToCompletion(
+            "http://localhost:"
+                + port
+                + "/fhir/Patient/"
+                + PATIENT_ID
+                + "/$export?_outputFormat=application/fhir+ndjson");
+
+    assertThat(output).containsKey("Patient");
+    assertThat(downloadAll(output.get("Patient"))).contains(PATIENT_ID);
+  }
+
+  // -------------------------------------------------------------------------
+  // User story 3: enumeration of a never-read type.
+  // -------------------------------------------------------------------------
+
+  // A table written straight into the warehouse by another process, which this server has never
+  // read, must still appear in an unnarrowed system-level export.
+  @Test
+  void systemLevelExportIncludesNeverReadType() {
+    // Stands in for another process sharing the warehouse: the table appears on disk without the
+    // server having created or read it.
+    TestDataSetup.copyTestDataToTempDir(warehouseDir.resolve("delta"), NEVER_READ_TYPE);
+
+    final Map<String, List<String>> output =
+        exportToCompletion(
+            "http://localhost:" + port + "/fhir/$export?_outputFormat=application/fhir+ndjson");
+
+    assertThat(output).containsKey(NEVER_READ_TYPE);
+    assertThat(downloadAll(output.get(NEVER_READ_TYPE)))
+        .contains("\"resourceType\":\"Organization\"");
+  }
+
+  // ---- helpers ----
+
+  /** Creates a Patient, in a table that appears only after the server has started. */
+  private void putPatient(@Nonnull final String id) {
+    final String patient =
+        """
+        {
+          "resourceType": "Patient",
+          "id": "%s",
+          "gender": "female"
+        }
+        """
+            .formatted(id);
+    webTestClient
+        .put()
+        .uri("http://localhost:" + port + "/fhir/Patient/" + id)
+        .header("Content-Type", "application/fhir+json")
+        .header("Accept", "application/fhir+json")
+        .bodyValue(patient)
+        .exchange()
+        .expectStatus()
+        .is2xxSuccessful();
+  }
+
+  /** Creates a Group whose only member is the Patient created in setup. */
+  private void putGroup() {
+    final String group =
+        """
+        {
+          "resourceType": "Group",
+          "id": "%s",
+          "type": "person",
+          "actual": true,
+          "member": [ { "entity": { "reference": "Patient/%s" } } ]
+        }
+        """
+            .formatted(GROUP_ID, PATIENT_ID);
+    webTestClient
+        .put()
+        .uri("http://localhost:" + port + "/fhir/Group/" + GROUP_ID)
+        .header("Content-Type", "application/fhir+json")
+        .header("Accept", "application/fhir+json")
+        .bodyValue(group)
+        .exchange()
+        .expectStatus()
+        .is2xxSuccessful();
+  }
+
+  /**
+   * Runs an inline ViewDefinition over Patient through {@code $sql-run} with the given narrowing
+   * parameters, and returns the ids it projected.
+   */
+  @SafeVarargs
+  @Nonnull
+  private List<String> runIds(@Nonnull final Map<String, Object>... narrowing) {
+    final List<Map<String, Object>> params = new ArrayList<>();
+    params.add(resourcePart("subjectResource", patientView()));
+    params.add(simplePart("_format", "valueString", "ndjson"));
+    params.addAll(List.of(narrowing));
+    final Map<String, Object> body = new LinkedHashMap<>();
+    body.put("resourceType", "Parameters");
+    body.put("parameter", params);
+
+    final EntityExchangeResult<byte[]> result =
+        webTestClient
+            .post()
+            .uri("http://localhost:" + port + "/fhir/$sql-run")
+            .header("Content-Type", "application/fhir+json")
+            .header("Accept", "application/x-ndjson")
+            .bodyValue(GSON.toJson(body))
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody()
+            .returnResult();
+    final String text =
+        new String(
+            Objects.requireNonNullElse(result.getResponseBodyContent(), new byte[0]),
+            StandardCharsets.UTF_8);
+    return text.lines()
+        .filter(line -> !line.isBlank())
+        .map(line -> (String) GSON.fromJson(line, Map.class).get("id"))
+        .toList();
+  }
+
+  /** A minimal ViewDefinition projecting the id of every Patient. */
+  @Nonnull
+  private static Map<String, Object> patientView() {
+    return Map.of(
+        "resourceType",
+        "ViewDefinition",
+        "status",
+        "active",
+        "resource",
+        "Patient",
+        "select",
+        List.of(Map.of("column", List.of(Map.of("name", "id", "path", "id")))));
+  }
+
+  @Nonnull
+  private static Map<String, Object> simplePart(
+      @Nonnull final String name, @Nonnull final String valueKey, @Nonnull final Object value) {
+    final Map<String, Object> part = new LinkedHashMap<>();
+    part.put("name", name);
+    part.put(valueKey, value);
+    return part;
+  }
+
+  @Nonnull
+  private static Map<String, Object> referencePart(
+      @Nonnull final String name, @Nonnull final String reference) {
+    final Map<String, Object> part = new LinkedHashMap<>();
+    part.put("name", name);
+    part.put("valueReference", Map.of("reference", reference));
+    return part;
+  }
+
+  @Nonnull
+  private static Map<String, Object> resourcePart(
+      @Nonnull final String name, @Nonnull final Map<String, Object> resource) {
+    final Map<String, Object> part = new LinkedHashMap<>();
+    part.put("name", name);
+    part.put("resource", resource);
+    return part;
+  }
+
+  /**
+   * Kicks off a bulk export, polls it to completion, and returns the download URLs of the output
+   * files grouped by resource type.
+   */
+  @Nonnull
+  private Map<String, List<String>> exportToCompletion(@Nonnull final String uri) {
+    final String pollUrl = kickOffRequest(webTestClient, uri);
+    final AtomicReference<Map<String, List<String>>> outputs = new AtomicReference<>();
+    await()
+        .atMost(120, TimeUnit.SECONDS)
+        .pollInterval(1, TimeUnit.SECONDS)
+        .until(
+            () ->
+                doPolling(
+                    webTestClient,
+                    pollUrl,
+                    result -> outputs.set(outputsOf(result.getResponseBody()))));
+    return outputs.get();
+  }
+
+  /** Extracts the {@code output} parameters of a completion manifest, grouped by resource type. */
+  @SuppressWarnings("unchecked")
+  @Nonnull
+  private static Map<String, List<String>> outputsOf(@Nonnull final String manifest) {
+    final Map<String, Object> parsed = GSON.fromJson(manifest, Map.class);
+    final List<Map<String, Object>> parameters =
+        (List<Map<String, Object>>) parsed.get("parameter");
+    final Map<String, List<String>> outputs = new LinkedHashMap<>();
+    for (final Map<String, Object> parameter : parameters) {
+      if (!"output".equals(parameter.get("name"))) {
+        continue;
+      }
+      final List<Map<String, Object>> parts = (List<Map<String, Object>>) parameter.get("part");
+      String type = null;
+      String url = null;
+      for (final Map<String, Object> part : parts) {
+        if ("type".equals(part.get("name"))) {
+          type =
+              (String) Objects.requireNonNullElse(part.get("valueCode"), part.get("valueString"));
+        } else if ("url".equals(part.get("name"))) {
+          url = (String) part.get("valueUri");
+        }
+      }
+      if (type != null && url != null) {
+        outputs.computeIfAbsent(type, key -> new ArrayList<>()).add(url);
+      }
+    }
+    return outputs;
+  }
+
+  /** Downloads and concatenates every file at the given URLs. */
+  @Nonnull
+  private String downloadAll(@Nonnull final List<String> urls) {
+    final StringBuilder content = new StringBuilder();
+    for (final String url : urls) {
+      final byte[] bytes =
+          webTestClient
+              .get()
+              .uri(url)
+              .exchange()
+              .expectStatus()
+              .isOk()
+              .expectBody()
+              .returnResult()
+              .getResponseBodyContent();
+      content.append(
+          new String(Objects.requireNonNullElse(bytes, new byte[0]), StandardCharsets.UTF_8));
+    }
+    return content.toString();
+  }
+}


### PR DESCRIPTION
Resolves #2709.

A read narrowed by `patient`, `group` or `_since` resolved against the resource types the data source knew at server startup, so a type whose Delta table was created later was invisible to it. The same read without a filter worked.

`DriftGuardedSource.map` and `filterByResourceType` re-wrapped the result in a plain `DriftGuardedSource`, discarding the dynamic table discovery that `DynamicDeltaSource.read` provides, and `DatasetSource` derived both from the fixed resource map captured at construction. The derived sources now keep the dynamic behaviour, so filtered reads and the export filter chain see post-startup types.

Also fixes enumeration of warehouse tables that have never been read.

Targets `sql-run-export` rather than `main`, as it builds on that branch.
