### PR TITLE
Tolerate concurrent job deletion in integration test teardown

### DIFF
--- a/server/src/test/java/au/csiro/pathling/operations/JobListIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/JobListIT.java
@@ -23,13 +23,13 @@ import static org.awaitility.Awaitility.await;
 
 import au.csiro.pathling.shaded.com.fasterxml.jackson.databind.JsonNode;
 import au.csiro.pathling.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import au.csiro.pathling.util.DirectoryCleanup;
 import au.csiro.pathling.util.TestDataSetup;
 import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
@@ -74,16 +74,16 @@ class JobListIT {
 
   @AfterEach
   void cleanup() throws IOException {
-    // Only clean up the jobs directory, preserving the delta tables for reuse.
+    // Only clean up the jobs directory, preserving the delta tables for reuse. Cancelling a job
+    // deletes its directory asynchronously, so the cleanup must tolerate entries disappearing
+    // underneath it (issue #2711).
     final Path jobsDir = warehouseDir.resolve("delta").resolve("jobs");
-    if (jobsDir.toFile().exists()) {
-      FileUtils.cleanDirectory(jobsDir.toFile());
-    }
+    DirectoryCleanup.cleanDirectoryTolerantly(jobsDir);
   }
 
   @AfterAll
   static void cleanupAll() throws IOException {
-    FileUtils.cleanDirectory(warehouseDir.toFile());
+    DirectoryCleanup.cleanDirectoryTolerantly(warehouseDir);
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/operations/bulkexport/ExportOperationCacheIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkexport/ExportOperationCacheIT.java
@@ -21,12 +21,12 @@ import static au.csiro.pathling.util.ExportOperationUtil.doPolling;
 import static au.csiro.pathling.util.ExportOperationUtil.kickOffRequest;
 import static org.awaitility.Awaitility.await;
 
+import au.csiro.pathling.util.DirectoryCleanup;
 import au.csiro.pathling.util.TestDataSetup;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -67,11 +67,10 @@ class ExportOperationCacheIT {
 
   @AfterEach
   void cleanup() throws IOException {
-    // Only clean up the jobs directory, preserving the delta tables for reuse.
+    // Only clean up the jobs directory, preserving the delta tables for reuse. The cleanup
+    // tolerates entries disappearing underneath it (issue #2711).
     final Path jobsDir = warehouseDir.resolve("delta").resolve("jobs");
-    if (jobsDir.toFile().exists()) {
-      FileUtils.cleanDirectory(jobsDir.toFile());
-    }
+    DirectoryCleanup.cleanDirectoryTolerantly(jobsDir);
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/operations/bulkexport/ExportOperationIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkexport/ExportOperationIT.java
@@ -32,6 +32,7 @@ import au.csiro.pathling.library.io.source.DataSourceBuilder;
 import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.shaded.com.fasterxml.jackson.databind.JsonNode;
 import au.csiro.pathling.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import au.csiro.pathling.util.DirectoryCleanup;
 import au.csiro.pathling.util.ExportOperationUtil;
 import au.csiro.pathling.util.TestDataSetup;
 import ca.uhn.fhir.context.FhirContext;
@@ -48,7 +49,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FileUtils;
 import org.apache.spark.sql.SparkSession;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Encounter;
@@ -128,18 +128,18 @@ class ExportOperationIT {
 
   @AfterEach
   void cleanup() throws IOException {
-    // Only clean up the jobs directory, preserving the delta tables for reuse.
+    // Only clean up the jobs directory, preserving the delta tables for reuse. Cancelling a job
+    // deletes its directory asynchronously, so the cleanup must tolerate entries disappearing
+    // underneath it (issue #2711).
     final Path jobsDir = warehouseDir.resolve("delta").resolve("jobs");
-    if (jobsDir.toFile().exists()) {
-      FileUtils.cleanDirectory(jobsDir.toFile());
-    }
+    DirectoryCleanup.cleanDirectoryTolerantly(jobsDir);
   }
 
   @AfterAll
   static void cleanupAll() throws IOException {
     // Clean the entire temp directory before JUnit's @TempDir cleanup runs.
     // This ensures Spark/Delta file handles don't prevent directory deletion.
-    FileUtils.cleanDirectory(warehouseDir.toFile());
+    DirectoryCleanup.cleanDirectoryTolerantly(warehouseDir);
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/util/DirectoryCleanup.java
+++ b/server/src/test/java/au/csiro/pathling/util/DirectoryCleanup.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.util;
+
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Teardown helper for integration tests whose working directories are also deleted asynchronously
+ * by the server. Cancelling a job causes the server to delete that job's directory in the
+ * background, so a teardown running {@code FileUtils.cleanDirectory} over the enclosing jobs
+ * directory can find entries vanishing underneath it and fail with {@link NoSuchFileException} (see
+ * issue #2711). This helper treats a concurrently deleted entry as already cleaned up.
+ *
+ * @author John Grimes
+ */
+public final class DirectoryCleanup {
+
+  private DirectoryCleanup() {}
+
+  /**
+   * Deletes the contents of a directory, preserving the directory itself. Entries that disappear
+   * while the cleanup is running, or a directory that does not exist at all, are treated as already
+   * cleaned up rather than as failures.
+   *
+   * @param directory the directory whose contents should be removed
+   * @throws IOException if an entry could not be deleted for a reason other than it disappearing
+   */
+  public static void cleanDirectoryTolerantly(@Nonnull final Path directory) throws IOException {
+    for (final Path entry : listChildrenTolerantly(directory)) {
+      deleteRecursivelyTolerantly(entry);
+    }
+  }
+
+  /**
+   * Lists the children of a directory, returning an empty list if the directory has disappeared.
+   *
+   * @param directory the directory to list
+   * @return the children present at the time of listing, or an empty list if the directory is gone
+   * @throws IOException if the listing failed for a reason other than the directory disappearing
+   */
+  @Nonnull
+  private static List<Path> listChildrenTolerantly(@Nonnull final Path directory)
+      throws IOException {
+    try (final Stream<Path> children = Files.list(directory)) {
+      return children.toList();
+    } catch (final NoSuchFileException e) {
+      return List.of();
+    }
+  }
+
+  /**
+   * Deletes a file or directory tree, tolerating any part of it disappearing concurrently. Symbolic
+   * links are deleted without following them.
+   *
+   * @param path the file or directory to delete
+   * @throws IOException if a deletion failed for a reason other than the entry disappearing
+   */
+  private static void deleteRecursivelyTolerantly(@Nonnull final Path path) throws IOException {
+    if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+      for (final Path child : listChildrenTolerantly(path)) {
+        deleteRecursivelyTolerantly(child);
+      }
+    }
+    Files.deleteIfExists(path);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/util/DirectoryCleanupTest.java
+++ b/server/src/test/java/au/csiro/pathling/util/DirectoryCleanupTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link DirectoryCleanup}, the teardown helper that tolerates entries being deleted
+ * concurrently by the server (see issue #2711).
+ *
+ * @author John Grimes
+ */
+class DirectoryCleanupTest {
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void deletesNestedContentsAndPreservesRoot() throws IOException {
+    // Build a structure with nested directories and files, mirroring a jobs directory containing
+    // job subdirectories with output files.
+    final Path jobDir = Files.createDirectories(tempDir.resolve("job-1").resolve("output"));
+    Files.writeString(jobDir.resolve("result.ndjson"), "{}");
+    Files.writeString(tempDir.resolve("stray-file.txt"), "stray");
+    Files.createDirectory(tempDir.resolve("empty-dir"));
+
+    DirectoryCleanup.cleanDirectoryTolerantly(tempDir);
+
+    // The root must survive, but all of its contents must be gone.
+    assertThat(tempDir).isEmptyDirectory();
+  }
+
+  @Test
+  void missingDirectoryIsANoOp() {
+    // A directory that has already been deleted underneath us is a normal outcome, not a failure.
+    // This exercises the same tolerance branch that a mid-walk concurrent deletion hits.
+    final Path missing = tempDir.resolve("does-not-exist");
+
+    assertThatCode(() -> DirectoryCleanup.cleanDirectoryTolerantly(missing))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void emptyDirectoryIsANoOp() {
+    assertThatCode(() -> DirectoryCleanup.cleanDirectoryTolerantly(tempDir))
+        .doesNotThrowAnyException();
+
+    assertThat(tempDir).exists();
+  }
+}


### PR DESCRIPTION
Resolves #2711.

`ExportOperationIT.cleanup` swept the jobs directory with `FileUtils.cleanDirectory` while the server deleted a cancelled job's directory asynchronously, so overlapping deletions failed the teardown intermittently with `NoSuchFileException`. This adds a teardown helper that treats an entry disappearing mid-cleanup as already cleaned up, and switches `ExportOperationIT`, `JobListIT` (which cancels jobs and shares the identical race) and `ExportOperationCacheIT` (same pattern) over to it.