### PR TITLE
Refresh served datasets after an import

### DIFF
--- a/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/bulkimport/ImportExecutor.java
@@ -21,12 +21,14 @@ import au.csiro.pathling.cache.CacheableDatabase;
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.config.UrlAllowlist;
 import au.csiro.pathling.errors.AccessDeniedError;
+import au.csiro.pathling.io.DynamicDeltaSource;
 import au.csiro.pathling.io.source.DataSource;
 import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.sink.DataSinkBuilder;
 import au.csiro.pathling.library.io.sink.WriteDetails;
 import au.csiro.pathling.library.io.source.NdjsonSource;
 import au.csiro.pathling.library.io.source.ParquetSource;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.security.PathlingAuthority;
 import au.csiro.pathling.security.ResourceAccess.AccessType;
 import au.csiro.pathling.security.SecurityAspect;
@@ -64,6 +66,8 @@ public class ImportExecutor {
 
   private final boolean allowInsecureUrls;
 
+  @Nonnull private final QueryableDataSource dataSource;
+
   /**
    * Creates a new ImportExecutor.
    *
@@ -74,6 +78,8 @@ public class ImportExecutor {
    * @param cacheableDatabase the cacheable database for cache invalidation
    * @param allowInsecureUrls whether plain-http URLs are accepted; defaults to false so that
    *     outgoing requests use TLS by default.
+   * @param dataSource the data source serving queries, refreshed after an import so that reads do
+   *     not continue to be served from a dataset pinned before the import
    */
   public ImportExecutor(
       @Nonnull final Optional<AccessRules> accessRules,
@@ -82,13 +88,15 @@ public class ImportExecutor {
           final String databasePath,
       final ServerConfiguration serverConfiguration,
       @Nonnull final CacheableDatabase cacheableDatabase,
-      @Value("${pathling.allowInsecureUrls:false}") final boolean allowInsecureUrls) {
+      @Value("${pathling.allowInsecureUrls:false}") final boolean allowInsecureUrls,
+      @Nonnull final QueryableDataSource dataSource) {
     this.accessRules = accessRules;
     this.pathlingContext = pathlingContext;
     this.databasePath = databasePath;
     this.serverConfiguration = serverConfiguration;
     this.cacheableDatabase = cacheableDatabase;
     this.allowInsecureUrls = allowInsecureUrls;
+    this.dataSource = dataSource;
   }
 
   /**
@@ -134,7 +142,7 @@ public class ImportExecutor {
         checkAuthority(request, customAllowableSources);
 
     // Create the appropriate data source based on the import format.
-    final DataSource dataSource =
+    final DataSource importSource =
         switch (request.importFormat()) {
           case NDJSON -> new NdjsonSource(pathlingContext, resourcesWithAuthority, "ndjson");
           case PARQUET ->
@@ -144,12 +152,20 @@ public class ImportExecutor {
 
     // Always write to Delta format regardless of source format.
     final WriteDetails writeDetails =
-        new DataSinkBuilder(pathlingContext, dataSource)
+        new DataSinkBuilder(pathlingContext, importSource)
             .saveMode(request.saveMode().getCode())
             .delta(databasePath);
 
     // Invalidate the cache to ensure subsequent requests see the updated data.
     cacheableDatabase.invalidate();
+
+    // Refresh the dataset served for each imported resource type, so that reads are not answered
+    // from a cached plan pinned before the import. Without this, an overwrite import leaves the
+    // pre-import table snapshot in service, and a schema-changing rewrite makes any recache of
+    // that stale plan fail.
+    if (dataSource instanceof final DynamicDeltaSource dynamicDataSource) {
+      request.input().keySet().forEach(dynamicDataSource::refresh);
+    }
 
     return writeDetails;
   }

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportExecutorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportExecutorTest.java
@@ -20,15 +20,20 @@ package au.csiro.pathling.operations.bulkimport;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import au.csiro.pathling.cache.CacheableDatabase;
 import au.csiro.pathling.config.ImportConfiguration;
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.errors.AccessDeniedError;
+import au.csiro.pathling.io.DynamicDeltaSource;
 import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.SaveMode;
 import au.csiro.pathling.library.io.sink.FileInformation;
 import au.csiro.pathling.library.io.sink.WriteDetails;
+import au.csiro.pathling.library.io.source.QueryableDataSource;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import au.csiro.pathling.util.FhirServerTestConfiguration;
 import java.io.IOException;
@@ -70,6 +75,7 @@ class ImportExecutorTest {
 
   private Path uniqueTempDir;
   private ImportExecutor importExecutor;
+  private DynamicDeltaSource dataSource;
 
   @BeforeEach
   void setUp() throws IOException {
@@ -77,6 +83,7 @@ class ImportExecutorTest {
     Files.createDirectories(uniqueTempDir);
 
     final String databasePath = "file://" + uniqueTempDir.toAbsolutePath();
+    dataSource = mock(DynamicDeltaSource.class);
     importExecutor =
         new ImportExecutor(
             Optional.empty(), // No access rules for most tests
@@ -84,7 +91,8 @@ class ImportExecutorTest {
             databasePath,
             serverConfiguration,
             cacheableDatabase,
-            true);
+            true,
+            dataSource);
   }
 
   // ========================================
@@ -408,7 +416,8 @@ class ImportExecutorTest {
             "file://" + uniqueTempDir.toAbsolutePath(),
             serverConfiguration,
             cacheableDatabase,
-            true);
+            true,
+            dataSource);
 
     final String patientUrl = "file://" + TEST_DATA_PATH.resolve("Patient.ndjson").toAbsolutePath();
     final ImportRequest request =
@@ -439,7 +448,8 @@ class ImportExecutorTest {
             "file://" + uniqueTempDir.toAbsolutePath(),
             serverConfiguration,
             cacheableDatabase,
-            true);
+            true,
+            dataSource);
 
     final String deniedUrl = "s3://denied-bucket/Patient.ndjson";
     final ImportRequest request =
@@ -489,7 +499,8 @@ class ImportExecutorTest {
             "file://" + uniqueTempDir.toAbsolutePath(),
             serverConfiguration,
             cacheableDatabase,
-            true);
+            true,
+            dataSource);
 
     final String allowedUrl = "file://" + TEST_DATA_PATH.resolve("Patient.ndjson").toAbsolutePath();
     final String deniedUrl = "s3://denied-bucket/Condition.ndjson";
@@ -568,7 +579,8 @@ class ImportExecutorTest {
             "file://" + uniqueTempDir.toAbsolutePath(),
             serverConfiguration,
             cacheableDatabase,
-            true);
+            true,
+            dataSource);
 
     final String patientUrl = "file://" + TEST_DATA_PATH.resolve("Patient.ndjson").toAbsolutePath();
     final List<String> customAllowableSources = List.of("file://");
@@ -710,6 +722,110 @@ class ImportExecutorTest {
       // Reset Spark configuration to default
       pathlingContext.getSpark().conf().unset("spark.sql.files.maxRecordsPerFile");
     }
+  }
+
+  // ========================================
+  // Data Source Refresh Tests
+  // ========================================
+
+  /**
+   * After an overwrite import, the dataset served for each imported resource type must be
+   * refreshed, so that reads do not continue to be answered from a cached plan pinned before the
+   * import (see issue #2714).
+   */
+  @Test
+  void overwriteImportRefreshesDataSourceForEachImportedType() {
+    // Given - an overwrite import covering two resource types.
+    final ImportRequest request =
+        new ImportRequest(
+            "http://example.com/fhir/$import",
+            Map.of(
+                "Patient",
+                List.of("file://" + TEST_DATA_PATH.resolve("Patient.ndjson").toAbsolutePath()),
+                "Condition",
+                List.of("file://" + TEST_DATA_PATH.resolve("Condition.ndjson").toAbsolutePath())),
+            SaveMode.OVERWRITE,
+            ImportFormat.NDJSON);
+
+    // When
+    importExecutor.execute(request, JOB_ID);
+
+    // Then - the data source is refreshed for every imported type.
+    verify(dataSource).refresh("Patient");
+    verify(dataSource).refresh("Condition");
+  }
+
+  /** Non-overwrite imports also modify the table, so they must refresh the data source too. */
+  @Test
+  void appendImportRefreshesDataSource() {
+    // Given - an append import.
+    final String patientUrl = "file://" + TEST_DATA_PATH.resolve("Patient.ndjson").toAbsolutePath();
+    final ImportRequest request =
+        new ImportRequest(
+            "http://example.com/fhir/$import",
+            Map.of("Patient", List.of(patientUrl)),
+            SaveMode.APPEND,
+            ImportFormat.NDJSON);
+
+    // When
+    importExecutor.execute(request, JOB_ID);
+
+    // Then
+    verify(dataSource).refresh("Patient");
+  }
+
+  /** An import that is rejected before writing anything must not refresh the data source. */
+  @Test
+  void failedImportDoesNotRefreshDataSource() {
+    // Given - an import whose source URL is not allowed.
+    final String deniedUrl = "s3://denied-bucket/Patient.ndjson";
+    final ImportRequest request =
+        new ImportRequest(
+            "http://example.com/fhir/$import",
+            Map.of("Patient", List.of(deniedUrl)),
+            SaveMode.OVERWRITE,
+            ImportFormat.NDJSON);
+
+    // When - the import is rejected by the custom allowable sources.
+    assertThatThrownBy(() -> importExecutor.execute(request, JOB_ID, List.of("https://trusted/")))
+        .isInstanceOf(AccessDeniedError.class);
+
+    // Then - nothing was written, so nothing is refreshed.
+    verifyNoInteractions(dataSource);
+  }
+
+  /**
+   * When the injected data source is not a {@link DynamicDeltaSource}, the import must still
+   * complete successfully; there is simply no pinned dataset to refresh.
+   */
+  @Test
+  void importSucceedsWhenDataSourceIsNotDynamic() {
+    // Given - an executor built over a data source that cannot be refreshed.
+    final QueryableDataSource plainDataSource = mock(QueryableDataSource.class);
+    final ImportExecutor executorWithPlainSource =
+        new ImportExecutor(
+            Optional.empty(),
+            pathlingContext,
+            "file://" + uniqueTempDir.toAbsolutePath(),
+            serverConfiguration,
+            cacheableDatabase,
+            true,
+            plainDataSource);
+
+    final String patientUrl = "file://" + TEST_DATA_PATH.resolve("Patient.ndjson").toAbsolutePath();
+    final ImportRequest request =
+        new ImportRequest(
+            "http://example.com/fhir/$import",
+            Map.of("Patient", List.of(patientUrl)),
+            SaveMode.OVERWRITE,
+            ImportFormat.NDJSON);
+
+    // When
+    final ImportResponse response = executorWithPlainSource.execute(request, JOB_ID);
+
+    // Then
+    assertThat(response).isNotNull();
+    assertThat(response.getInputUrls()).containsExactly(patientUrl);
   }
 
   // ========================================

--- a/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportLockTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/bulkimport/ImportLockTest.java
@@ -19,9 +19,11 @@ package au.csiro.pathling.operations.bulkimport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import au.csiro.pathling.cache.CacheableDatabase;
 import au.csiro.pathling.config.ServerConfiguration;
+import au.csiro.pathling.io.DynamicDeltaSource;
 import au.csiro.pathling.library.PathlingContext;
 import au.csiro.pathling.library.io.SaveMode;
 import au.csiro.pathling.test.SpringBootUnitTest;
@@ -81,7 +83,8 @@ class ImportLockTest {
             databasePath,
             serverConfiguration,
             cacheableDatabase,
-            true);
+            true,
+            mock(DynamicDeltaSource.class));
   }
 
   @Test


### PR DESCRIPTION
Resolves #2714. An overwrite $import left the dataset pinned and cached at startup in service, so reads could be answered from a plan predating the import, and a schema-changing rewrite made any recache of that stale plan fail - the cause of the intermittent `DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS` failure in `NarrowedOpenTypesIT.importInOverwriteModeRewritesAtTheEncoderSchema`. The import path now calls `DynamicDeltaSource.refresh()` for each imported resource type on completion, as updates already do, unpersisting the stale cached dataset and re-pinning the current table.