### PR TITLE
Allow $translate on Quantity

### DIFF
--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/collection/QuantityCollection.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/collection/QuantityCollection.java
@@ -17,11 +17,15 @@
 
 package au.csiro.pathling.fhirpath.collection;
 
+import static org.apache.spark.sql.functions.lit;
+import static org.apache.spark.sql.functions.struct;
+
 import au.csiro.pathling.errors.UnsupportedFhirPathFeatureError;
 import au.csiro.pathling.fhirpath.FhirPathQuantity;
 import au.csiro.pathling.fhirpath.FhirPathType;
 import au.csiro.pathling.fhirpath.Numeric;
 import au.csiro.pathling.fhirpath.StringCoercible;
+import au.csiro.pathling.fhirpath.TerminologyConcepts;
 import au.csiro.pathling.fhirpath.column.ColumnRepresentation;
 import au.csiro.pathling.fhirpath.column.DefaultRepresentation;
 import au.csiro.pathling.fhirpath.column.QuantityValue;
@@ -32,6 +36,7 @@ import au.csiro.pathling.fhirpath.definition.ElementDefinition;
 import au.csiro.pathling.fhirpath.definition.NodeDefinition;
 import au.csiro.pathling.fhirpath.definition.defaults.DefaultCompositeDefinition;
 import au.csiro.pathling.fhirpath.definition.defaults.DefaultPrimitiveDefinition;
+import au.csiro.pathling.fhirpath.encoding.CodingSchema;
 import au.csiro.pathling.fhirpath.encoding.QuantityEncoding;
 import au.csiro.pathling.sql.misc.QuantityToLiteral;
 import jakarta.annotation.Nonnull;
@@ -39,6 +44,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import org.apache.spark.sql.Column;
+import org.apache.spark.sql.types.DataTypes;
 import org.hl7.fhir.r4.model.Enumerations.FHIRDefinedType;
 
 /**
@@ -147,6 +153,50 @@ public class QuantityCollection extends Collection implements Comparable, String
     // by using UCUM '1' unit.
     return QuantityCollection.build(
         columnRepresentation.transform(QuantityEncoding::encodeNumeric), Optional.empty());
+  }
+
+  /**
+   * Projects a Coding structure from the coded unit of a single quantity value.
+   *
+   * <p>The unit name is carried across as the display, as it is the human-readable rendering of the
+   * unit in the same way that a display is the human-readable rendering of a code. The original
+   * code is used rather than the canonicalised one, as a ConceptMap is authored against the codes
+   * that appear within the data.
+   *
+   * <p>The result is cast to the canonical Coding schema, as the terminology UDFs decode the
+   * structure using positional indices into that schema.
+   *
+   * @param quantity The column containing a single quantity value
+   * @return A column containing a Coding structure
+   */
+  @Nonnull
+  private static Column toCoding(@Nonnull final Column quantity) {
+    return struct(
+            lit(null).cast(DataTypes.StringType).as(CodingSchema.ID_FIELD),
+            quantity.getField(QuantityEncoding.SYSTEM_COLUMN).as(CodingSchema.SYSTEM_FIELD),
+            lit(null).cast(DataTypes.StringType).as(CodingSchema.VERSION_FIELD),
+            quantity.getField(QuantityEncoding.CODE_COLUMN).as(CodingSchema.CODE_FIELD),
+            quantity.getField(QuantityEncoding.UNIT_COLUMN).as(CodingSchema.DISPLAY_FIELD),
+            lit(null).cast(DataTypes.BooleanType).as(CodingSchema.USER_SELECTED_FIELD),
+            lit(null).cast(DataTypes.IntegerType).as(CodingSchema.FID_FIELD))
+        .cast(CodingSchema.DATA_TYPE);
+  }
+
+  /**
+   * A quantity identifies a concept through its coded unit, so it can be used as the input to the
+   * terminology functions that operate upon concepts. Each quantity carries a single concept, and
+   * so the result is a set of independent concepts rather than a union.
+   *
+   * <p>Quantities that carry a free-text unit without a system and code yield a Coding that the
+   * terminology functions treat as invalid, and which is excluded from the operation.
+   *
+   * @return A {@link TerminologyConcepts} representation of this collection
+   */
+  @Nonnull
+  @Override
+  public Optional<TerminologyConcepts> toConcepts() {
+    final ColumnRepresentation codings = getColumn().transform(QuantityCollection::toCoding);
+    return Optional.of(TerminologyConcepts.set(codings, CodingCollection.build(codings)));
   }
 
   /**

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/collection/QuantityCollection.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/collection/QuantityCollection.java
@@ -188,7 +188,8 @@ public class QuantityCollection extends Collection implements Comparable, String
    * so the result is a set of independent concepts rather than a union.
    *
    * <p>Quantities that carry a free-text unit without a system and code yield a Coding that the
-   * terminology functions treat as invalid, and which is excluded from the operation.
+   * terminology functions treat as invalid; it yields {@code false} from the boolean functions and
+   * no output from {@code translate}.
    *
    * @return A {@link TerminologyConcepts} representation of this collection
    */

--- a/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/TerminologyFunctions.java
+++ b/fhirpath/src/main/java/au/csiro/pathling/fhirpath/function/provider/TerminologyFunctions.java
@@ -196,14 +196,14 @@ public abstract class TerminologyFunctions {
   }
 
   /**
-   * This function can be invoked on a collection of {@code Coding} or {@code CodeableConcept}
-   * values, returning a collection of {@code Boolean} values based on whether each concept is a
-   * member of the ValueSet with the specified url.
+   * This function can be invoked on a collection of {@code Coding}, {@code CodeableConcept} or
+   * {@code Quantity} values, returning a collection of {@code Boolean} values based on whether each
+   * concept is a member of the ValueSet with the specified url.
    *
    * <p>For a {@code CodeableConcept}, the function will return true if any of the codings are
-   * members of the value set.
+   * members of the value set. For a {@code Quantity}, the concept is the coded unit.
    *
-   * @param input The input collection of Codings or CodeableConcepts
+   * @param input The input collection of Codings, CodeableConcepts or Quantities
    * @param valueSetUrl The URL of the ValueSet to check membership against
    * @return A collection of boolean values
    * @see <a href="https://pathling.csiro.au/docs/fhirpath/functions.html#memberof">Pathling
@@ -217,13 +217,13 @@ public abstract class TerminologyFunctions {
   }
 
   /**
-   * This function takes a collection of {@code Coding} or {@code CodeableConcept} elements as
-   * input, and another collection as the argument. The result is a collection with a {@code
-   * Boolean} value for each source concept, each value being {@code true} if the concept subsumes
-   * any of the concepts within the argument collection, and {@code false} otherwise.
+   * This function takes a collection of {@code Coding}, {@code CodeableConcept} or {@code Quantity}
+   * elements as input, and another collection as the argument. The result is a collection with a
+   * {@code Boolean} value for each source concept, each value being {@code true} if the concept
+   * subsumes any of the concepts within the argument collection, and {@code false} otherwise.
    *
-   * @param input The input collection of Codings or CodeableConcepts
-   * @param codes The collection of Codings or CodeableConcepts to check against
+   * @param input The input collection of Codings, CodeableConcepts or Quantities
+   * @param codes The collection of Codings, CodeableConcepts or Quantities to check against
    * @return A collection of boolean values
    * @see <a href="https://hl7.org/fhir/R4/fhirpath.html#functions">FHIR specification - Additional
    *     functions</a>
@@ -242,8 +242,8 @@ public abstract class TerminologyFunctions {
    * This is the inverse of the {@link #subsumes} function, examining whether each input concept is
    * subsumed by any of the argument concepts.
    *
-   * @param input The input collection of Codings or CodeableConcepts
-   * @param codes The collection of Codings or CodeableConcepts to check against
+   * @param input The input collection of Codings, CodeableConcepts or Quantities
+   * @param codes The collection of Codings, CodeableConcepts or Quantities to check against
    * @return A collection of boolean values
    * @see <a href="https://hl7.org/fhir/R4/fhirpath.html#functions">FHIR specification - Additional
    *     functions</a>
@@ -258,7 +258,8 @@ public abstract class TerminologyFunctions {
 
   /**
    * When invoked on a {@code Coding}, returns any matching concepts using the ConceptMap specified
-   * using {@code conceptMapUrl}.
+   * using {@code conceptMapUrl}. It can also be invoked on a {@code CodeableConcept}, or on a
+   * {@code Quantity}, where the coded unit is translated.
    *
    * <p>The {@code reverse} parameter controls the direction to traverse the map - {@code false}
    * results in "source to target" mappings, while {@code true} results in "target to source".
@@ -270,7 +271,7 @@ public abstract class TerminologyFunctions {
    * <p>The {@code target} parameter identifies the value set in which a translation is sought — a
    * scope for the translation.
    *
-   * @param input The input collection of Codings
+   * @param input The input collection of Codings, CodeableConcepts or Quantities
    * @param conceptMapUrl The URL of the ConceptMap to use
    * @param reverse The optional reverse parameter
    * @param equivalence The optional equivalence parameter

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/dsl/TerminologyFunctionsDslTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/dsl/TerminologyFunctionsDslTest.java
@@ -20,7 +20,9 @@ package au.csiro.pathling.fhirpath.dsl;
 import static au.csiro.pathling.test.yaml.FhirTypedLiteral.toCoding;
 import static au.csiro.pathling.test.yaml.FhirTypedLiteral.toInteger;
 import static org.hl7.fhir.r4.model.Enumerations.FHIRDefinedType.CODEABLECONCEPT;
+import static org.hl7.fhir.r4.model.Enumerations.FHIRDefinedType.QUANTITY;
 
+import au.csiro.pathling.fhirpath.unit.UcumUnit;
 import au.csiro.pathling.terminology.TerminologyService;
 import au.csiro.pathling.test.SharedMocks;
 import au.csiro.pathling.test.dsl.FhirPathDslTestBase;
@@ -683,6 +685,124 @@ public class TerminologyFunctionsDslTest extends FhirPathDslTestBase {
         .testError(
             "loinc.translate('" + conceptMap1 + "', false, 'equivalent', 'target', 'extra')",
             "translate() throws an error when called with more than four parameters")
+        .build();
+  }
+
+  @FhirPathTest
+  public Stream<DynamicTest> testTerminologyFunctionsWithQuantity() {
+    // Reset mocks and setup terminology service expectations
+    SharedMocks.resetAll();
+
+    // Create the codings that identify the units of the quantities under test.
+    final Coding milligrams = new Coding(UcumUnit.UCUM_SYSTEM_URI, "mg", "mg");
+    final Coding kilograms = new Coding(UcumUnit.UCUM_SYSTEM_URI, "kg", "kg");
+
+    // Create the codings that the units translate to.
+    final Coding localMilligrams = new Coding("http://example.org/units", "MILLIGRAM", "Milligram");
+    final Coding localKilograms = new Coding("http://example.org/units", "KILOGRAM", "Kilogram");
+
+    // Create a unit that subsumes another unit. Subsumption is decided by the terminology server,
+    // and is only tested between codings of the same system, so this relationship is a fiction of
+    // the mock that exists to exercise the conversion.
+    final Coding grams = new Coding(UcumUnit.UCUM_SYSTEM_URI, "g", "g");
+
+    // Define the concept map and value set URLs.
+    final String unitMap = "http://example.org/fhir/ConceptMap/ucum-to-local";
+    final String massUnitsValueSet = "http://example.org/fhir/ValueSet/mass-units";
+
+    TerminologyServiceHelpers.setupTranslate(terminologyService)
+        .withTranslations(
+            milligrams,
+            unitMap,
+            false,
+            TerminologyService.Translation.of(ConceptMapEquivalence.EQUIVALENT, localMilligrams))
+        .withTranslations(
+            kilograms,
+            unitMap,
+            false,
+            TerminologyService.Translation.of(ConceptMapEquivalence.EQUIVALENT, localKilograms))
+        // Reverse translation, from a local unit back to the UCUM unit.
+        .withTranslations(
+            localMilligrams,
+            unitMap,
+            true,
+            TerminologyService.Translation.of(ConceptMapEquivalence.EQUIVALENT, milligrams));
+
+    TerminologyServiceHelpers.setupValidate(terminologyService)
+        .withValueSet(massUnitsValueSet, milligrams, kilograms);
+
+    TerminologyServiceHelpers.setupSubsumes(terminologyService).withSubsumes(grams, milligrams);
+
+    return builder()
+        .withSubject(
+            sb ->
+                sb.quantity("mass", "10.5 'mg'")
+                    .quantity("weight", "70 'kg'")
+                    .quantity("distance", "30.5 'cm'")
+                    .quantityArray("measurements", "10.5 'mg'", "70 'kg'")
+                    .quantityEmpty("emptyQuantity")
+                    // A quantity carrying a free-text unit, without a coded unit.
+                    .element(
+                        "freeTextQuantity",
+                        quantity ->
+                            quantity
+                                .fhirType(QUANTITY)
+                                .decimal("value", 10.0)
+                                .string("unit", "widgets")
+                                .stringEmpty("system")
+                                .stringEmpty("code"))
+                    .coding("localMilligrams", "http://example.org/units|MILLIGRAM||'Milligram'"))
+        .group("translate() function with Quantity")
+        .testEquals(
+            toCoding("http://example.org/units|MILLIGRAM||'Milligram'"),
+            "mass.translate('" + unitMap + "')",
+            "translate() returns the translation of the coded unit of a quantity")
+        .testEquals(
+            toCoding("http://example.org/units|KILOGRAM||'Kilogram'"),
+            "weight.translate('" + unitMap + "')",
+            "translate() returns the translation of the coded unit of another quantity")
+        .testEmpty(
+            "distance.translate('" + unitMap + "')",
+            "translate() returns empty for a quantity with an untranslatable unit")
+        .testEmpty(
+            "emptyQuantity.translate('" + unitMap + "')",
+            "translate() returns empty for an empty quantity")
+        .testEmpty(
+            "freeTextQuantity.translate('" + unitMap + "')",
+            "translate() returns empty for a quantity with a free-text unit")
+        .group("translate() function with collections of Quantities")
+        .testEquals(
+            List.of(
+                toCoding("http://example.org/units|MILLIGRAM||'Milligram'"),
+                toCoding("http://example.org/units|KILOGRAM||'Kilogram'")),
+            "measurements.translate('" + unitMap + "')",
+            "translate() returns translations for a collection of quantities")
+        .group("translate() function with Quantity and the reverse parameter")
+        .testEquals(
+            toCoding(UcumUnit.UCUM_SYSTEM_URI + "|mg||'mg'"),
+            "localMilligrams.translate('" + unitMap + "', true)",
+            "translate() with reverse=true returns the UCUM unit for a local unit")
+        .group("memberOf() function with Quantity")
+        .testTrue(
+            "mass.memberOf('" + massUnitsValueSet + "')",
+            "memberOf() returns true for a quantity whose unit is in the value set")
+        .testFalse(
+            "distance.memberOf('" + massUnitsValueSet + "')",
+            "memberOf() returns false for a quantity whose unit is not in the value set")
+        .testEmpty(
+            "emptyQuantity.memberOf('" + massUnitsValueSet + "')",
+            "memberOf() returns empty for an empty quantity")
+        .testEquals(
+            List.of(true, true),
+            "measurements.memberOf('" + massUnitsValueSet + "')",
+            "memberOf() returns a result for each quantity within a collection")
+        .group("subsumedBy() function with Quantity")
+        .testTrue(
+            "mass.subsumedBy(http://unitsofmeasure.org|g)",
+            "subsumedBy() returns true for a quantity whose unit is subsumed by the argument")
+        .testFalse(
+            "distance.subsumedBy(http://unitsofmeasure.org|g)",
+            "subsumedBy() returns false for a quantity whose unit is not subsumed by the argument")
         .build();
   }
 

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/dsl/TerminologyFunctionsDslTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/dsl/TerminologyFunctionsDslTest.java
@@ -738,6 +738,7 @@ public class TerminologyFunctionsDslTest extends FhirPathDslTestBase {
             sb ->
                 sb.quantity("mass", "10.5 'mg'")
                     .quantity("weight", "70 'kg'")
+                    .quantity("bulk", "500 'g'")
                     .quantity("distance", "30.5 'cm'")
                     .quantityArray("measurements", "10.5 'mg'", "70 'kg'")
                     .quantityEmpty("emptyQuantity")
@@ -796,6 +797,19 @@ public class TerminologyFunctionsDslTest extends FhirPathDslTestBase {
             List.of(true, true),
             "measurements.memberOf('" + massUnitsValueSet + "')",
             "memberOf() returns a result for each quantity within a collection")
+        .group("subsumes() function with Quantity")
+        .testTrue(
+            "bulk.subsumes(http://unitsofmeasure.org|mg)",
+            "subsumes() returns true for a quantity whose unit subsumes the argument")
+        .testFalse(
+            "distance.subsumes(http://unitsofmeasure.org|mg)",
+            "subsumes() returns false for a quantity whose unit does not subsume the argument")
+        .testEmpty(
+            "emptyQuantity.subsumes(http://unitsofmeasure.org|mg)",
+            "subsumes() returns empty for an empty quantity")
+        .testTrue(
+            "bulk.subsumes(mass)",
+            "subsumes() accepts a quantity as the argument as well as the input")
         .group("subsumedBy() function with Quantity")
         .testTrue(
             "mass.subsumedBy(http://unitsofmeasure.org|g)",

--- a/fhirpath/src/test/java/au/csiro/pathling/fhirpath/dsl/TerminologyFunctionsDslTest.java
+++ b/fhirpath/src/test/java/au/csiro/pathling/fhirpath/dsl/TerminologyFunctionsDslTest.java
@@ -793,6 +793,11 @@ public class TerminologyFunctionsDslTest extends FhirPathDslTestBase {
         .testEmpty(
             "emptyQuantity.memberOf('" + massUnitsValueSet + "')",
             "memberOf() returns empty for an empty quantity")
+        // A quantity with a free-text unit yields a Coding that the terminology functions treat
+        // as invalid, which is false rather than empty for the boolean functions.
+        .testFalse(
+            "freeTextQuantity.memberOf('" + massUnitsValueSet + "')",
+            "memberOf() returns false for a quantity with a free-text unit")
         .testEquals(
             List.of(true, true),
             "measurements.memberOf('" + massUnitsValueSet + "')",
@@ -810,6 +815,12 @@ public class TerminologyFunctionsDslTest extends FhirPathDslTestBase {
         .testTrue(
             "bulk.subsumes(mass)",
             "subsumes() accepts a quantity as the argument as well as the input")
+        .testFalse(
+            "freeTextQuantity.subsumes(http://unitsofmeasure.org|mg)",
+            "subsumes() returns false for a quantity with a free-text unit as the input")
+        .testFalse(
+            "bulk.subsumes(freeTextQuantity)",
+            "subsumes() returns false for a quantity with a free-text unit as the argument")
         .group("subsumedBy() function with Quantity")
         .testTrue(
             "mass.subsumedBy(http://unitsofmeasure.org|g)",
@@ -817,6 +828,9 @@ public class TerminologyFunctionsDslTest extends FhirPathDslTestBase {
         .testFalse(
             "distance.subsumedBy(http://unitsofmeasure.org|g)",
             "subsumedBy() returns false for a quantity whose unit is not subsumed by the argument")
+        .testFalse(
+            "freeTextQuantity.subsumedBy(http://unitsofmeasure.org|g)",
+            "subsumedBy() returns false for a quantity with a free-text unit")
         .build();
   }
 

--- a/site/docs/fhirpath/extension-functions.md
+++ b/site/docs/fhirpath/extension-functions.md
@@ -147,11 +147,16 @@ currently unique to the Pathling implementation.
 ## translate
 
 ```
-collection<Coding|CodeableConcept> -> translate(conceptMapUrl: String, reverse: Boolean = false, equivalence: String = 'equivalent', target?: String) : collection<Coding>
+collection<Coding|CodeableConcept|Quantity> -> translate(conceptMapUrl: String, reverse: Boolean = false, equivalence: String = 'equivalent', target?: String) : collection<Coding>
 ```
 
 When invoked on a [Coding](#coding), returns any
 matching concepts using the ConceptMap specified using `conceptMapUrl`.
+
+When invoked on a
+[Quantity](https://hl7.org/fhir/R4/datatypes.html#Quantity), the coded unit is
+translated &mdash; see
+[Quantity as a concept](fhir-functions.md#quantity-as-a-concept).
 
 The `reverse` parameter controls the direction to traverse the map - `false`
 results in "source to target" mappings, while `true` results in "target to

--- a/site/docs/fhirpath/fhir-functions.md
+++ b/site/docs/fhirpath/fhir-functions.md
@@ -75,12 +75,13 @@ function instead. See [Extension functions](extension-functions.md) for details.
 ## memberOf
 
 ```
-collection<Coding|CodeableConcept> -> memberOf(valueSetUrl: String) : collection<Boolean>
+collection<Coding|CodeableConcept|Quantity> -> memberOf(valueSetUrl: String) : collection<Boolean>
 ```
 
 The `memberOf` function can be invoked on a collection of
-[Coding](/docs/fhirpath/extension-functions#coding) or
-[CodeableConcept](https://hl7.org/fhir/R4/datatypes.html#CodeableConcept)
+[Coding](/docs/fhirpath/extension-functions#coding),
+[CodeableConcept](https://hl7.org/fhir/R4/datatypes.html#CodeableConcept) or
+[Quantity](https://hl7.org/fhir/R4/datatypes.html#Quantity)
 values, returning a collection of Boolean values
 based on whether each concept is a member of the
 [ValueSet](https://hl7.org/fhir/R4/valueset.html) with the specified
@@ -88,6 +89,9 @@ based on whether each concept is a member of the
 
 For a `CodeableConcept`, the function will return `true` if any of
 the codings are members of the value set.
+
+For a `Quantity`, the concept is the coded unit &mdash; see
+[Quantity as a concept](#quantity-as-a-concept).
 
 :::note
 The `memberOf` function is a terminology function, which means that it requires
@@ -99,11 +103,12 @@ a configured
 ## subsumes
 
 ```
-collection<Coding|CodeableConcept> -> subsumes(code: Coding|CodeableConcept) : collection<Boolean>
+collection<Coding|CodeableConcept|Quantity> -> subsumes(code: Coding|CodeableConcept|Quantity) : collection<Boolean>
 ```
 
-This function takes a collection of [Coding](/docs/fhirpath/extension-functions#coding) or
-[CodeableConcept](https://hl7.org/fhir/R4/datatypes.html#CodeableConcept)
+This function takes a collection of [Coding](/docs/fhirpath/extension-functions#coding),
+[CodeableConcept](https://hl7.org/fhir/R4/datatypes.html#CodeableConcept) or
+[Quantity](https://hl7.org/fhir/R4/datatypes.html#Quantity)
 elements as input, and another collection as the argument. The result is a
 collection with a Boolean value for each source concept, each value being true
 if the concept subsumes any of the concepts within the argument collection, and
@@ -125,7 +130,7 @@ a configured
 ## subsumedBy
 
 ```
-collection<Coding|CodeableConcept> -> subsumedBy(code: Coding|CodeableConcept) : collection<Boolean>
+collection<Coding|CodeableConcept|Quantity> -> subsumedBy(code: Coding|CodeableConcept|Quantity) : collection<Boolean>
 ```
 
 The `subsumedBy` function is the inverse of the [subsumes](#subsumes) function,
@@ -144,3 +149,27 @@ requires a configured
 [terminology service](https://hl7.org/fhir/R4/terminology-service.html). See
 [Terminology functions](/docs/libraries/terminology) for details.
 :::
+
+## Quantity as a concept
+
+The terminology functions that operate upon concepts &mdash; `memberOf`,
+`subsumes`, `subsumedBy` and
+[translate](extension-functions.md#translate) &mdash; can also be invoked on a
+[Quantity](https://hl7.org/fhir/R4/datatypes.html#Quantity). The concept is the
+coded unit of the quantity, taken from its `system` and `code`, with the `unit`
+as the display. The value of the quantity plays no part.
+
+This allows units of measure to be checked against a value set, or mapped to
+another set of unit codes:
+
+```
+Observation.value.ofType(Quantity).translate('https://csiro.au/fhir/ConceptMap/units')
+```
+
+The original unit code is used, rather than the canonical form that Pathling
+derives for the purposes of comparison, as a ConceptMap or ValueSet is authored
+against the codes that appear within the data.
+
+A quantity that carries only a free-text `unit`, without a `system` and `code`,
+does not identify a concept. Such a quantity is excluded from the operation, in
+the same way as a Coding without a system and code.

--- a/site/docs/fhirpath/fhir-functions.md
+++ b/site/docs/fhirpath/fhir-functions.md
@@ -171,5 +171,6 @@ derives for the purposes of comparison, as a ConceptMap or ValueSet is authored
 against the codes that appear within the data.
 
 A quantity that carries only a free-text `unit`, without a `system` and `code`,
-does not identify a concept. Such a quantity is excluded from the operation, in
-the same way as a Coding without a system and code.
+does not identify a concept. Such a quantity yields `false` from `memberOf`,
+`subsumes` and `subsumedBy`, and an empty result from `translate` &mdash; the
+same behaviour as a Coding without a system and code.


### PR DESCRIPTION
Allows the terminology functions that operate upon concepts - `memberOf`, `subsumes`, `subsumedBy` and `translate` - to be invoked on a Quantity, taking the concept from the quantity's coded unit.

Fixes #2727