### PR TITLE
Reject an unbound SQL parameter with a 400

### DIFF
--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
@@ -17,12 +17,17 @@
 
 package au.csiro.pathling.operations.sqlquery;
 
+import au.csiro.pathling.operations.sql.SqlOperationError;
+import au.csiro.pathling.operations.sql.SqlOperationOutcomes;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +39,8 @@ import org.hl7.fhir.r4.model.DateType;
 import org.hl7.fhir.r4.model.DecimalType;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
+import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r4.model.PrimitiveType;
@@ -46,6 +53,10 @@ import org.springframework.stereotype.Component;
  * Validates and normalises the raw HTTP inputs of a {@code $sql-run} invocation into a {@link
  * SqlQueryRequest}. Has no Spark dependency; performs only structural FHIR-level validation and
  * parsing.
+ *
+ * <p>That validation includes the completeness of the runtime parameter bindings: every parameter
+ * the Library declares must be bound, and a request that leaves any of them unbound is rejected
+ * with a {@code 400} naming each one.
  *
  * @author John Grimes
  */
@@ -83,7 +94,8 @@ public class SqlQueryRequestParser {
    * @param limit optional row cap
    * @param parameters runtime parameter bindings as a {@code Parameters} resource
    * @return the validated request
-   * @throws InvalidRequestException if the inputs are not a valid SQLQuery invocation
+   * @throws InvalidRequestException if the inputs are not a valid SQLQuery invocation, including
+   *     where a parameter the Library declares has no runtime binding
    */
   @Nonnull
   @SuppressWarnings("java:S107")
@@ -149,20 +161,21 @@ public class SqlQueryRequestParser {
    * Validates the runtime parameter bindings against the declarations in {@code Library.parameter}
    * and converts each {@code value[x]} to a typed Java object.
    *
+   * <p>Every declared parameter requires a binding. The SQL engine has no parameter defaults, so an
+   * unbound declaration can only fail once the query is analysed, long after the point where the
+   * fault can be attributed to the request.
+   *
    * @param parameters the runtime bindings, may be {@code null}
    * @param declaredParameters the declarations from the SQLQuery Library
    * @return an ordered map of name → typed Java value
    * @throws InvalidRequestException if a binding is malformed, names a parameter that was not
-   *     declared, or supplies a value of the wrong FHIR type
+   *     declared, or supplies a value of the wrong FHIR type; or if a declared parameter has no
+   *     binding, in which case the outcome carries one issue per unbound parameter
    */
   @Nonnull
   private Map<String, Object> bindParameters(
       @Nullable final Parameters parameters,
-      @Nonnull final java.util.List<SqlParameterDeclaration> declaredParameters) {
-
-    if (parameters == null || parameters.getParameter().isEmpty()) {
-      return Map.of();
-    }
+      @Nonnull final List<SqlParameterDeclaration> declaredParameters) {
 
     final Map<String, String> declaredByName = new LinkedHashMap<>();
     for (final SqlParameterDeclaration declaration : declaredParameters) {
@@ -170,29 +183,53 @@ public class SqlQueryRequestParser {
     }
 
     final Map<String, Object> bindings = new LinkedHashMap<>();
-    for (final ParametersParameterComponent binding : parameters.getParameter()) {
-      final String name = binding.getName();
-      if (name == null || name.isBlank()) {
-        throw new InvalidRequestException(
-            "Each runtime parameter binding must have a non-empty name");
+    // A null or absent set of bindings skips the binding loop, but not the completeness check
+    // below: the absence of a binding for a declared parameter is precisely what that check
+    // reports.
+    if (parameters != null) {
+      for (final ParametersParameterComponent binding : parameters.getParameter()) {
+        final String name = binding.getName();
+        if (name == null || name.isBlank()) {
+          throw new InvalidRequestException(
+              "Each runtime parameter binding must have a non-empty name");
+        }
+        final String declaredType = declaredByName.get(name);
+        if (declaredType == null) {
+          throw new InvalidRequestException(
+              "Runtime parameter '"
+                  + name
+                  + "' is not declared in the SQLQuery Library's parameter list");
+        }
+        final Type value = binding.getValue();
+        if (value == null) {
+          throw new InvalidRequestException("Runtime parameter '" + name + "' has no value[x]");
+        }
+        if (bindings.containsKey(name)) {
+          throw new InvalidRequestException(
+              "Runtime parameter '" + name + "' is supplied more than once");
+        }
+        bindings.put(name, convertTypedValue(name, declaredType, value));
       }
-      final String declaredType = declaredByName.get(name);
-      if (declaredType == null) {
-        throw new InvalidRequestException(
-            "Runtime parameter '"
-                + name
-                + "' is not declared in the SQLQuery Library's parameter list");
-      }
-      final Type value = binding.getValue();
-      if (value == null) {
-        throw new InvalidRequestException("Runtime parameter '" + name + "' has no value[x]");
-      }
-      if (bindings.containsKey(name)) {
-        throw new InvalidRequestException(
-            "Runtime parameter '" + name + "' is supplied more than once");
-      }
-      bindings.put(name, convertTypedValue(name, declaredType, value));
     }
+
+    // Every unbound declaration is reported together, in declaration order, so that a request
+    // missing more than one binding can be corrected in a single round trip.
+    final List<OperationOutcomeIssueComponent> unbound = new ArrayList<>();
+    for (final String name : declaredByName.keySet()) {
+      if (!bindings.containsKey(name)) {
+        unbound.add(
+            SqlOperationError.issue(
+                IssueType.INVALID,
+                SqlOperationOutcomes.PARAMETERS_EXPRESSION,
+                "Runtime parameter '"
+                    + name
+                    + "' is declared by the SQLQuery Library but no binding was supplied"));
+      }
+    }
+    if (!unbound.isEmpty()) {
+      throw SqlOperationError.of(HttpServletResponse.SC_BAD_REQUEST, unbound);
+    }
+
     return bindings;
   }
 

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParser.java
@@ -188,27 +188,7 @@ public class SqlQueryRequestParser {
     // reports.
     if (parameters != null) {
       for (final ParametersParameterComponent binding : parameters.getParameter()) {
-        final String name = binding.getName();
-        if (name == null || name.isBlank()) {
-          throw new InvalidRequestException(
-              "Each runtime parameter binding must have a non-empty name");
-        }
-        final String declaredType = declaredByName.get(name);
-        if (declaredType == null) {
-          throw new InvalidRequestException(
-              "Runtime parameter '"
-                  + name
-                  + "' is not declared in the SQLQuery Library's parameter list");
-        }
-        final Type value = binding.getValue();
-        if (value == null) {
-          throw new InvalidRequestException("Runtime parameter '" + name + "' has no value[x]");
-        }
-        if (bindings.containsKey(name)) {
-          throw new InvalidRequestException(
-              "Runtime parameter '" + name + "' is supplied more than once");
-        }
-        bindings.put(name, convertTypedValue(name, declaredType, value));
+        bindOneValue(binding, declaredByName, bindings);
       }
     }
 
@@ -231,6 +211,43 @@ public class SqlQueryRequestParser {
     }
 
     return bindings;
+  }
+
+  /**
+   * Validates one runtime binding against the declared parameters and places it into the bindings
+   * map.
+   *
+   * @param binding the binding to validate
+   * @param declaredByName the declared parameters keyed by name
+   * @param bindings the map the validated binding is placed into
+   * @throws InvalidRequestException if the binding is malformed, names a parameter that was not
+   *     declared, or supplies a value of the wrong FHIR type
+   */
+  private void bindOneValue(
+      @Nonnull final ParametersParameterComponent binding,
+      @Nonnull final Map<String, String> declaredByName,
+      @Nonnull final Map<String, Object> bindings) {
+    final String name = binding.getName();
+    if (name == null || name.isBlank()) {
+      throw new InvalidRequestException(
+          "Each runtime parameter binding must have a non-empty name");
+    }
+    final String declaredType = declaredByName.get(name);
+    if (declaredType == null) {
+      throw new InvalidRequestException(
+          "Runtime parameter '"
+              + name
+              + "' is not declared in the SQLQuery Library's parameter list");
+    }
+    final Type value = binding.getValue();
+    if (value == null) {
+      throw new InvalidRequestException("Runtime parameter '" + name + "' has no value[x]");
+    }
+    if (bindings.containsKey(name)) {
+      throw new InvalidRequestException(
+          "Runtime parameter '" + name + "' is supplied more than once");
+    }
+    bindings.put(name, convertTypedValue(name, declaredType, value));
   }
 
   /**

--- a/server/src/test/java/au/csiro/pathling/operations/sql/SqlExportProviderIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sql/SqlExportProviderIT.java
@@ -374,12 +374,12 @@ class SqlExportProviderIT extends AbstractAsyncExportIT {
             .getResponseBodyContent();
 
     final Map<String, Object> outcome = parse(body);
-    assertThat(outcome.get("resourceType")).isEqualTo("OperationOutcome");
+    assertThat(outcome).containsEntry("resourceType", "OperationOutcome");
 
     final List<Map<String, Object>> issues = issuesOf(outcome);
     assertThat(issues).hasSize(1);
     assertThat(issues.get(0)).containsEntry("severity", "error").containsEntry("code", "invalid");
-    assertThat(issues.get(0).get("expression")).isEqualTo(List.of("parameters"));
+    assertThat(issues.get(0)).containsEntry("expression", List.of("parameters"));
     assertThat((String) issues.get(0).get("diagnostics")).contains("family");
 
     // Nothing was accepted, so the registry holds exactly what it held before the request.
@@ -411,8 +411,9 @@ class SqlExportProviderIT extends AbstractAsyncExportIT {
             .getResponseBodyContent();
 
     final List<Map<String, Object>> issues = issuesOf(parse(body));
-    assertThat(issues).hasSize(2);
-    assertThat(issues).allSatisfy(issue -> assertThat(issue).containsEntry("severity", "error"));
+    assertThat(issues)
+        .hasSize(2)
+        .allSatisfy(issue -> assertThat(issue).containsEntry("severity", "error"));
 
     // The first subject's own rejection: a ViewDefinition declares no parameters.
     assertThat((String) issues.get(0).get("diagnostics")).contains("ViewDefinition");
@@ -420,7 +421,7 @@ class SqlExportProviderIT extends AbstractAsyncExportIT {
     // The second subject's unbound declaration, carried through the accumulation with the shape it
     // was raised with: the parameters element named, and the parameter at fault in the diagnostics.
     assertThat(issues.get(1)).containsEntry("code", "invalid");
-    assertThat(issues.get(1).get("expression")).isEqualTo(List.of("parameters"));
+    assertThat(issues.get(1)).containsEntry("expression", List.of("parameters"));
     assertThat((String) issues.get(1).get("diagnostics")).contains("family");
   }
 

--- a/server/src/test/java/au/csiro/pathling/operations/sql/SqlExportProviderIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sql/SqlExportProviderIT.java
@@ -344,6 +344,90 @@ class SqlExportProviderIT extends AbstractAsyncExportIT {
     assertThat((List<?>) outcome.get("issue")).hasSize(1);
   }
 
+  // -------------------------------------------------------------------------
+  // Unbound parameters.
+  // -------------------------------------------------------------------------
+
+  // A parameter the subject declares but the request never binds is a client fault, and it is
+  // decidable without touching the data, so it is decided here. The operation promises that a job
+  // which starts will not be rejected later, so the kick-off is refused outright and no job is
+  // registered - the client is not left polling one that was doomed before it began.
+  @Test
+  void rejectsASubjectWhoseDeclaredParameterIsNotBound() {
+    final int jobsBefore = jobCount();
+
+    final byte[] body =
+        kickOff(
+                systemLevelUri(),
+                parameters(
+                    subject(
+                        nameOf("johnsons"),
+                        canonicalOf(
+                            SqlRunTestConfiguration.libraryUrl(
+                                SqlRunTestConfiguration.PATIENTS_BY_FAMILY_ID)))))
+            .expectStatus()
+            .isBadRequest()
+            .expectHeader()
+            .doesNotExist("Content-Location")
+            .expectBody()
+            .returnResult()
+            .getResponseBodyContent();
+
+    final Map<String, Object> outcome = parse(body);
+    assertThat(outcome.get("resourceType")).isEqualTo("OperationOutcome");
+
+    final List<Map<String, Object>> issues = issuesOf(outcome);
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0)).containsEntry("severity", "error").containsEntry("code", "invalid");
+    assertThat(issues.get(0).get("expression")).isEqualTo(List.of("parameters"));
+    assertThat((String) issues.get(0).get("diagnostics")).contains("family");
+
+    // Nothing was accepted, so the registry holds exactly what it held before the request.
+    assertThat(jobCount()).as("A rejected kick-off must not register a job").isEqualTo(jobsBefore);
+  }
+
+  // The missing binding is one subject's failure, so it joins the other subjects' kick-off issues
+  // in a single outcome rather than being thrown on its own: a body wrong in more than one way is
+  // answered once, naming every problem.
+  @Test
+  void reportsAnUnboundParameterAlongsideAnotherSubjectsKickOffIssue() {
+    final byte[] body =
+        kickOff(
+                systemLevelUri(),
+                parameters(
+                    subject(
+                        nameOf("demographics"),
+                        canonicalOf(SqlRunTestConfiguration.PATIENT_VIEW_URL),
+                        resourcePart("parameters", Map.of("resourceType", "Parameters"))),
+                    subject(
+                        nameOf("johnsons"),
+                        canonicalOf(
+                            SqlRunTestConfiguration.libraryUrl(
+                                SqlRunTestConfiguration.PATIENTS_BY_FAMILY_ID)))))
+            .expectStatus()
+            .isBadRequest()
+            .expectBody()
+            .returnResult()
+            .getResponseBodyContent();
+
+    final List<Map<String, Object>> issues = issuesOf(parse(body));
+    assertThat(issues).hasSize(2);
+    assertThat(issues).allSatisfy(issue -> assertThat(issue).containsEntry("severity", "error"));
+
+    // The first subject's own rejection: a ViewDefinition declares no parameters.
+    assertThat((String) issues.get(0).get("diagnostics")).contains("ViewDefinition");
+
+    // The second subject's unbound declaration, carried through the accumulation with the shape it
+    // was raised with: the parameters element named, and the parameter at fault in the diagnostics.
+    assertThat(issues.get(1)).containsEntry("code", "invalid");
+    assertThat(issues.get(1).get("expression")).isEqualTo(List.of("parameters"));
+    assertThat((String) issues.get(1).get("diagnostics")).contains("family");
+  }
+
+  // The fully bound case is unchanged, and is covered by exportsAMixedJobWithOneOutputPerSubject
+  // above: its SQLQuery subject binds the 'family' parameter the stored Library declares, kicks
+  // off with a 202, and completes with the narrowed result.
+
   // ---- helpers ----
 
   /** Builds a job mixing a ViewDefinition subject and a parameter-bound SQLQuery subject. */
@@ -449,6 +533,30 @@ class SqlExportProviderIT extends AbstractAsyncExportIT {
         .filter(o -> name.equals(partValue(o, "name", "valueString")))
         .findFirst()
         .orElseThrow(() -> new AssertionError("No output named " + name));
+  }
+
+  /** The issues of an OperationOutcome response body, in the order the server reported them. */
+  @SuppressWarnings("unchecked")
+  @Nonnull
+  private static List<Map<String, Object>> issuesOf(@Nonnull final Map<String, Object> outcome) {
+    final List<Map<String, Object>> issues = (List<Map<String, Object>>) outcome.get("issue");
+    return issues == null ? List.of() : issues;
+  }
+
+  /** The number of jobs the {@code $jobs} listing currently holds. */
+  private int jobCount() {
+    final byte[] body =
+        webTestClient
+            .get()
+            .uri("http://localhost:" + port + "/fhir/$jobs")
+            .header("Accept", "application/fhir+json")
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody()
+            .returnResult()
+            .getResponseBodyContent();
+    return paramsByName(parse(body), "job").size();
   }
 
   /** Kicks off a request expected to be rejected, asserting the status and the named parameter. */

--- a/server/src/test/java/au/csiro/pathling/operations/sql/SqlRunProviderIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sql/SqlRunProviderIT.java
@@ -25,9 +25,11 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import com.google.gson.Gson;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +40,8 @@ import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
 import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.ParameterDefinition;
+import org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType;
@@ -303,6 +307,34 @@ class SqlRunProviderIT {
   }
 
   // -------------------------------------------------------------------------
+  // Unbound parameters.
+  // -------------------------------------------------------------------------
+
+  // A parameter the subject declares but the request never binds is a client fault, not a server
+  // one. It is answered with a 400 naming the parameters element and the parameter at fault,
+  // rather than reaching the SQL engine and surfacing as an opaque 500.
+  @Test
+  void rejectsASubjectWhoseDeclaredParameterIsNotBound() {
+    final String body =
+        postExpectStatus(parameterisedSqlQueryRequest(null), 400, "application/fhir+json");
+
+    assertThat(body)
+        .contains("\"code\":\"invalid\"")
+        .contains("\"expression\":[\"parameters\"]")
+        .contains("family");
+  }
+
+  // The bound case is unchanged, so the rejection cannot be reached by declaring a parameter alone.
+  @Test
+  void runsASubjectWhoseDeclaredParameterIsBound() {
+    final String body = postOk(parameterisedSqlQueryRequest("Johnson"), SqlRunFormat.NDJSON);
+
+    final List<String> lines = body.lines().filter(line -> !line.isBlank()).toList();
+    assertThat(lines).hasSize(1);
+    assertThat(body).contains("\"family_name\":\"Johnson\"").contains("\"id\":\"p2\"");
+  }
+
+  // -------------------------------------------------------------------------
   // Analysis failures.
   // -------------------------------------------------------------------------
 
@@ -388,6 +420,32 @@ class SqlRunProviderIT {
                 jsonParser.encodeResourceToString(sqlQueryLibrary(sql, "adh", AD_HOC_VIEW_URL))),
             resourceParameter("context", adHocViewJson()),
             stringParameter("_format", SqlRunFormat.NDJSON.getCode())));
+    return GSON.toJson(parameters);
+  }
+
+  /**
+   * Builds a POST body carrying an inline SQLQuery Library that declares a {@code family}
+   * parameter, binding it to the given value, or supplying no bindings at all when it is null.
+   */
+  @Nonnull
+  private String parameterisedSqlQueryRequest(@Nullable final String family) {
+    final Library library =
+        sqlQueryLibrary(
+            "SELECT id, family_name FROM adh WHERE family_name = :family", "adh", AD_HOC_VIEW_URL);
+    library.addParameter(
+        new ParameterDefinition().setName("family").setUse(ParameterUse.IN).setType("string"));
+
+    final List<Map<String, Object>> parts = new ArrayList<>();
+    parts.add(resourceParameter("subjectResource", jsonParser.encodeResourceToString(library)));
+    parts.add(resourceParameter("context", adHocViewJson()));
+    parts.add(stringParameter("_format", SqlRunFormat.NDJSON.getCode()));
+    if (family != null) {
+      parts.add(boundParameters("family", family));
+    }
+
+    final Map<String, Object> parameters = new LinkedHashMap<>();
+    parameters.put("resourceType", "Parameters");
+    parameters.put("parameter", parts);
     return GSON.toJson(parameters);
   }
 

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParserTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParserTest.java
@@ -19,6 +19,7 @@ package au.csiro.pathling.operations.sqlquery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import java.math.BigDecimal;
@@ -26,7 +27,9 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Map;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.r4.model.Base64BinaryType;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.CodeableConcept;
@@ -37,6 +40,10 @@ import org.hl7.fhir.r4.model.DecimalType;
 import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
+import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
 import org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.StringType;
@@ -47,6 +54,8 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link SqlQueryRequestParser}, focused on the typed parameter binding path that
  * cross-checks runtime {@code value[x]} against {@code Library.parameter} declarations.
+ *
+ * @author John Grimes
  */
 class SqlQueryRequestParserTest {
 
@@ -275,6 +284,107 @@ class SqlQueryRequestParserTest {
   }
 
   // ---------------------------------------------------------------------------
+  // Unbound declared parameters.
+  //
+  // Every parameter declared by the Library requires a binding. The vacuous case (a Library
+  // declaring nothing, parsed with no bindings) is held by the two tests at the top of this class
+  // and by acceptsTopLevelSqlViewLibrary; the neighbouring rejections are held by the section
+  // above.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void rejectsDeclaredParameterWhenNoBindingsAreSuppliedAtAll() {
+    // The absence of the parameters resource is itself the fault, so the outcome still names it.
+    final Library library = libraryWithSql("SELECT * FROM t WHERE d < :period_end");
+    library.addParameter().setName("period_end").setType("date").setUse(ParameterUse.IN);
+
+    final List<OperationOutcomeIssueComponent> issues = rejectionIssues(library, null);
+
+    assertThat(issues).hasSize(1);
+    final OperationOutcomeIssueComponent issue = issues.get(0);
+    assertThat(issue.getSeverity()).isEqualTo(IssueSeverity.ERROR);
+    assertThat(issue.getCode()).isEqualTo(IssueType.INVALID);
+    assertThat(issue.getExpression())
+        .extracting(StringType::getValue)
+        .containsExactly("parameters");
+    assertThat(issue.getDiagnostics()).contains("period_end");
+  }
+
+  @Test
+  void rejectsDeclaredParameterWhenTheParametersResourceIsEmpty() {
+    // An empty Parameters resource binds nothing, so it is answered exactly as its absence is.
+    final Library library = libraryWithSql("SELECT * FROM t WHERE d < :period_end");
+    library.addParameter().setName("period_end").setType("date").setUse(ParameterUse.IN);
+
+    final List<OperationOutcomeIssueComponent> issues = rejectionIssues(library, new Parameters());
+
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).getCode()).isEqualTo(IssueType.INVALID);
+    assertThat(issues.get(0).getDiagnostics()).contains("period_end");
+  }
+
+  @Test
+  void namesOnlyTheUnboundParameterWhenSomeAreBound() {
+    // A partially bound request reports the parameter at fault and not the one already supplied.
+    final Library library =
+        libraryWithSql("SELECT * FROM t WHERE d >= :period_start AND d < :period_end");
+    library.addParameter().setName("period_start").setType("date").setUse(ParameterUse.IN);
+    library.addParameter().setName("period_end").setType("date").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    params.addParameter().setName("period_start").setValue(new DateType("2026-01-01"));
+
+    final List<OperationOutcomeIssueComponent> issues = rejectionIssues(library, params);
+
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).getDiagnostics())
+        .contains("period_end")
+        .doesNotContain("period_start");
+  }
+
+  @Test
+  void reportsEveryUnboundParameterInDeclarationOrder() {
+    // Several faults are reported in one outcome, so a single correction round trip suffices.
+    final Library library =
+        libraryWithSql("SELECT * FROM t WHERE d >= :period_start AND d < :period_end");
+    library.addParameter().setName("period_start").setType("date").setUse(ParameterUse.IN);
+    library.addParameter().setName("period_end").setType("date").setUse(ParameterUse.IN);
+
+    final List<OperationOutcomeIssueComponent> issues = rejectionIssues(library, null);
+
+    assertThat(issues).hasSize(2);
+    assertThat(issues)
+        .allSatisfy(
+            issue -> {
+              assertThat(issue.getSeverity()).isEqualTo(IssueSeverity.ERROR);
+              assertThat(issue.getCode()).isEqualTo(IssueType.INVALID);
+              assertThat(issue.getExpression())
+                  .extracting(StringType::getValue)
+                  .containsExactly("parameters");
+            });
+    assertThat(issues.get(0).getDiagnostics()).contains("period_start");
+    assertThat(issues.get(1).getDiagnostics()).contains("period_end");
+  }
+
+  @Test
+  void bindsEveryDeclaredParameterWhenAllAreSupplied() {
+    // The happy path is unchanged: a fully bound request parses with every value present.
+    final Library library =
+        libraryWithSql("SELECT * FROM t WHERE d >= :period_start AND d < :period_end");
+    library.addParameter().setName("period_start").setType("date").setUse(ParameterUse.IN);
+    library.addParameter().setName("period_end").setType("date").setUse(ParameterUse.IN);
+    final Parameters params = new Parameters();
+    params.addParameter().setName("period_start").setValue(new DateType("2026-01-01"));
+    params.addParameter().setName("period_end").setValue(new DateType("2026-12-31"));
+
+    final SqlQueryRequest request = parser.parse(library, null, null, null, null, params);
+
+    assertThat(request.getParameterBindings())
+        .containsExactly(
+            Map.entry("period_start", LocalDate.of(2026, 1, 1)),
+            Map.entry("period_end", LocalDate.of(2026, 12, 31)));
+  }
+
+  // ---------------------------------------------------------------------------
   // Output-format selection: strict for explicit _format, lenient for Accept.
   // ---------------------------------------------------------------------------
 
@@ -345,6 +455,20 @@ class SqlQueryRequestParserTest {
 
     assertThatThrownBy(() -> parser.parse(library, null, null, null, null, null))
         .isInstanceOf(InvalidRequestException.class);
+  }
+
+  /**
+   * Parses the given inputs expecting a rejection, and returns the issues its OperationOutcome
+   * carries.
+   */
+  private List<OperationOutcomeIssueComponent> rejectionIssues(
+      final Library library, final Parameters parameters) {
+    final Throwable thrown =
+        catchThrowable(() -> parser.parse(library, null, null, null, null, parameters));
+    assertThat(thrown).isInstanceOf(InvalidRequestException.class);
+    final IBaseOperationOutcome outcome = ((InvalidRequestException) thrown).getOperationOutcome();
+    assertThat(outcome).isInstanceOf(OperationOutcome.class);
+    return ((OperationOutcome) outcome).getIssue();
   }
 
   /** Builds a minimal SQLQuery-typed Library carrying the given SQL. */

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParserTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryRequestParserTest.java
@@ -351,8 +351,8 @@ class SqlQueryRequestParserTest {
 
     final List<OperationOutcomeIssueComponent> issues = rejectionIssues(library, null);
 
-    assertThat(issues).hasSize(2);
     assertThat(issues)
+        .hasSize(2)
         .allSatisfy(
             issue -> {
               assertThat(issue.getSeverity()).isEqualTo(IssueSeverity.ERROR);

--- a/site/docs/server/operations/sql-export.md
+++ b/site/docs/server/operations/sql-export.md
@@ -36,7 +36,7 @@ rejected rather than answered synchronously.
 | `subject.subjectCanonical` | 0..1        | canonical  | The subject's canonical URL, honouring a `\|version` pin.                                          |
 | `subject.subjectReference` | 0..1        | Reference  | A relative reference naming its type: `ViewDefinition/[id]` or `Library/[id]`.                     |
 | `subject.subjectResource`  | 0..1        | Resource   | An inline ViewDefinition, SQLQuery or SQLView.                                                     |
-| `subject.parameters`       | 0..1        | Parameters | Runtime bindings, for a SQL subject only.                                                          |
+| `subject.parameters`       | 0..1        | Parameters | Runtime bindings, for a SQL subject only. Every declared parameter must be bound.                  |
 | `context`                  | 0..\*       | Resource   | Job-wide inline supporting artefacts, matched by canonical URL. These produce no output.           |
 | `clientTrackingId`         | 0..1        | string     | Echoed in the completion manifest.                                                                 |
 | `_format`                  | 0..1        | code       | `ndjson` (default), `csv` or `parquet`.                                                            |
@@ -165,6 +165,13 @@ per file, all under the one `name`.
 | `404 Not Found`             | A subject's canonical or reference resolves to nothing; the status URL of a cancelled job.                    |
 | `422 Unprocessable Entity`  | A subject is of no admitted kind, or is conformant but cannot be processed.                                   |
 | `500 Internal Server Error` | An unexpected fault, or - on the result URL - the job's own failure outcome.                                  |
+
+A subject whose `parameters` part leaves a parameter its Library declares
+unbound is refused at kick-off with a `400`, before any job is created: the
+fault is decidable from the request alone, so there is no status URL to poll and
+nothing to clean up. Each unbound declaration is its own `invalid` issue naming
+`parameters`, as on [`$sql-run`](sql-run.md), and with several subjects those
+issues join the rest of the kick-off issues in the one outcome.
 
 A subject whose SQL only Spark's analyser can fault - an unresolved column, an
 unknown function, a missing `GROUP BY`, an ambiguous reference - fails the job

--- a/site/docs/server/operations/sql-run.md
+++ b/site/docs/server/operations/sql-run.md
@@ -45,7 +45,7 @@ server; supplying a resource-valued parameter over `GET` is rejected with a
 | `subjectCanonical` | 0..1        | canonical  | The subject's canonical URL, honouring a `\|version` pin. Matched against both `ViewDefinition.url` and `Library.url`.               |
 | `subjectReference` | 0..1        | Reference  | A relative reference naming its type: `ViewDefinition/[id]` or `Library/[id]`.                                                       |
 | `subjectResource`  | 0..1        | Resource   | An inline ViewDefinition, SQLQuery or SQLView.                                                                                       |
-| `parameters`       | 0..1        | Parameters | Runtime bindings for a SQL subject. Each entry's name must match a `Library.parameter` declaration and its `value[x]` its type.      |
+| `parameters`       | 0..1        | Parameters | Runtime bindings for a SQL subject. Every `Library.parameter` declaration must be bound by an entry matching it in name and type.    |
 | `context`          | 0..\*       | Resource   | Inline supporting artefacts (ViewDefinition or SQLView) for dependencies the server cannot resolve. Matched by canonical URL.        |
 | `resource`         | 0..\*       | string     | FHIR resources to project instead of server data, for a ViewDefinition subject. Each is a serialised resource or a Bundle to unwrap. |
 | `_format`          | 0..1        | code       | Output format; see below. Takes precedence over the `Accept` header.                                                                 |
@@ -177,6 +177,14 @@ Every 4xx and 5xx response carries an
 name the parameter at fault in `expression`. A request that is wrong in more
 than one way is answered with one outcome naming every problem, so it can be
 corrected in a single round trip.
+
+Every parameter the subject declares must be bound. The SQL engine has no
+parameter defaults, so an unbound declaration cannot be executed at all, and
+leaving one out is a `400` rather than a query run over a missing value. Each
+unbound declaration is reported as its own `invalid` issue, so a request short
+of several bindings is answered naming all of them, and `expression` names
+`parameters` even when the request carried no `parameters` resource - its
+absence is the fault.
 
 A fault in the subject's own SQL that only Spark's analyser can catch - an
 unresolved column, an unknown function, a missing `GROUP BY`, an ambiguous


### PR DESCRIPTION
Addresses #2732.

A SQLQuery subject that declares a parameter but receives no binding for it
currently reaches Spark, which raises an internal analysis failure and the
client sees an opaque `500 Internal Server Error`. The missing binding is a
client mistake, yet nothing in the response says so or names the parameter at
fault.

This change adds one validation to the shared request parser: after the
runtime bindings are collected, every parameter declared in `Library.parameter`
must have a binding, and each missing one contributes an issue (`severity =
error`, `code = invalid`, expression `parameters`) to a single 400 whose
OperationOutcome names every unbound parameter. Both `$sql-run` and
`$sql-export` validate subjects through this parser at kick-off, so one check
point covers both operations, and the export rejects before any job is
accepted.

Every declared parameter is now required, including one declared but never
referenced in the SQL - a deliberate behaviour change that keeps the rule
simple and free of SQL text scanning.

Docs updated for both operations.

## Summary

- `SqlQueryRequestParser.bindParameters` rejects a declared parameter with no
  binding as a 400 with one `invalid` issue per unbound parameter.
- Unit and integration tests cover the run and export paths, edge cases, and
  the unchanged happy paths.
- `site/docs/server/operations/sql-run.md` and `sql-export.md` document the
  rejection.