### PR TITLE
Record the true source scale in decimal _scale fields

### DIFF
--- a/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/DecimalCustomCoder.scala
+++ b/encoders/src/main/scala/au/csiro/pathling/encoders/datatypes/DecimalCustomCoder.scala
@@ -38,6 +38,11 @@ import org.hl7.fhir.r4.model.DecimalType
  * an additional IntegerType column with `_scale` suffix storing the scale of the
  * original FHIR decimal value.
  *
+ * The scale is written without any cap, so a stored scale greater than the scale of the value
+ * column identifies a value that was rounded during encoding. The cap is applied when reading,
+ * where the scale set on the reconstructed value is the lesser of the stored scale and the scale
+ * of the value column.
+ *
  * @param elementName the name of the element that this will be used to encode
  */
 case class DecimalCustomCoder(elementName: String) extends CustomCoder {
@@ -82,24 +87,35 @@ case class DecimalCustomCoder(elementName: String) extends CustomCoder {
       StructField(scaleFieldName, encode(IntegerType)))
   }
 
+  /**
+   * Decodes the value column into a DecimalType, setting the scale to the lesser of the stored
+   * scale and the scale of the value column. The stored scale can exceed the scale of the value
+   * column, in which case the additional digits are no longer available and must not be
+   * reinstated.
+   */
   private def decimalExpression(addToPath: String => Expression) = {
+    val clampedScale = Catalyst.staticInvoke(classOf[Math],
+      IntegerType,
+      "min", Literal(decimalType.scale) :: addToPath(scaleFieldName) :: Nil
+    )
     NewInstance(primitiveClass,
       Invoke(
         Invoke(addToPath(elementName), "toJavaBigDecimal",
           ObjectType(classOf[java.math.BigDecimal])),
-        "setScale", ObjectType(classOf[java.math.BigDecimal]), addToPath(scaleFieldName) :: Nil
+        "setScale", ObjectType(classOf[java.math.BigDecimal]), clampedScale :: Nil
       ) :: Nil,
       ObjectType(primitiveClass)
     )
   }
 
+  /**
+   * Encodes the scale of the original FHIR decimal value, without any cap, so that a stored scale
+   * greater than the scale of the value column identifies a value that lost precision during
+   * encoding.
+   */
   private def scaleExpression(inputObject: Expression) = {
-    Catalyst.staticInvoke(classOf[Math],
-      IntegerType,
-      "min", Literal(decimalType.scale) ::
-        Invoke(Invoke(inputObject, "getValue", ObjectType(classOf[java.math.BigDecimal])),
-          "scale", DataTypes.IntegerType) :: Nil
-    )
+    Invoke(Invoke(inputObject, "getValue", ObjectType(classOf[java.math.BigDecimal])),
+      "scale", DataTypes.IntegerType)
   }
 
 }
@@ -134,14 +150,19 @@ object DecimalCustomCoder {
 
 
   /**
-   * Need a way to zip two arrays so that they can be decoded to an arrays of DecimalTYpe
+   * Zips the value and scale arrays so that they can be decoded to an array of DecimalType.
+   *
+   * The scale applied to each element is the lesser of the stored scale and the scale of the value
+   * column, as the stored scale records the scale of the original FHIR decimal value and can
+   * exceed what the value column represents.
    */
   def zipToDecimal(values: ArrayData, scales: ArrayData): Array[DecimalType] = {
     assert(values.numElements() == scales.numElements(),
       "Values and scales must have the same length")
     Array.tabulate(values.numElements()) { i =>
       new DecimalType(
-        values.getDecimal(i, precision, scale).toJavaBigDecimal.setScale(scales.getInt(i)))
+        values.getDecimal(i, precision, scale).toJavaBigDecimal
+          .setScale(Math.min(scales.getInt(i), scale)))
     }
   }
 }

--- a/encoders/src/test/java/au/csiro/pathling/encoders/FhirEncodersTest.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/FhirEncodersTest.java
@@ -48,6 +48,7 @@ import java.util.stream.Stream;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -370,6 +371,126 @@ class FhirEncodersTest {
     assertEquals(
         TestData.TEST_VERY_SMALL_DECIMAL_SCALE_6,
         decodedObservation.getReferenceRange().getFirst().getLow().getValue());
+  }
+
+  @Test
+  void bigDecimalStoredScaleRecordsSourceScale() {
+    // The stored scale must record the scale of the source FHIR decimal without any cap, so that a
+    // consumer can tell whether the stored value lost precision.
+    final Row scales =
+        observationsDataset
+            .select(
+                col("valueQuantity.value_scale"),
+                col("referenceRange").getItem(0).getField("low").getField("value_scale"))
+            .head();
+
+    // The control is a source scale of 2, which is within the storage scale and therefore
+    // unaffected by the cap.
+    assertEquals(TestData.TEST_SMALL_DECIMAL.scale(), scales.getInt(0));
+    // The source scale of 7 exceeds the storage scale of 6, and must still be recorded exactly.
+    assertEquals(TestData.TEST_VERY_SMALL_DECIMAL.scale(), scales.getInt(1));
+
+    // The value itself is still stored rounded to the storage scale of 6.
+    final BigDecimal storedLow =
+        (BigDecimal)
+            observationsDataset
+                .select(col("referenceRange").getItem(0).getField("low").getField("value"))
+                .head()
+                .get(0);
+    assertEquals(0, TestData.TEST_VERY_SMALL_DECIMAL_SCALE_6.compareTo(storedLow));
+  }
+
+  @Test
+  void bigDecimalStoredScaleRecordsHighSourceScales() {
+    // Reproduces the source scales reported in the issue: 16 and 17 decimal places.
+    final Observation highScaleObservation = new Observation();
+    highScaleObservation.setId("high-scale");
+    highScaleObservation.setStatus(Observation.ObservationStatus.FINAL);
+
+    final Quantity quantity = new Quantity();
+    quantity.setValue(TestData.TEST_SCALE_16_DECIMAL);
+    quantity.setUnit("mL/h");
+    highScaleObservation.setValue(quantity);
+    highScaleObservation.addReferenceRange().getLow().setValue(TestData.TEST_SCALE_17_DECIMAL);
+
+    final Dataset<Observation> highScaleDataset =
+        spark.createDataset(List.of(highScaleObservation), ENCODERS_L0.of(Observation.class));
+
+    final Row row =
+        highScaleDataset
+            .select(
+                col("valueQuantity.value_scale"),
+                col("referenceRange").getItem(0).getField("low").getField("value_scale"),
+                col("valueQuantity.value"),
+                col("referenceRange").getItem(0).getField("low").getField("value"))
+            .head();
+
+    assertEquals(TestData.TEST_SCALE_16_DECIMAL.scale(), row.getInt(0));
+    assertEquals(TestData.TEST_SCALE_17_DECIMAL.scale(), row.getInt(1));
+
+    // The values are stored rounded to the storage scale of 6.
+    assertEquals(0, TestData.TEST_SCALE_16_DECIMAL_SCALE_6.compareTo((BigDecimal) row.get(2)));
+    assertEquals(0, TestData.TEST_SCALE_17_DECIMAL_SCALE_6.compareTo((BigDecimal) row.get(3)));
+  }
+
+  @Test
+  void bigDecimalStoredScaleIdentifiesTruncatedValues() {
+    // The high value has a source scale of exactly 6 and was not truncated, whereas the low value
+    // has a source scale of 7 and was. The predicate `_scale > 6` must separate the two.
+    final Column highScale =
+        col("referenceRange").getItem(0).getField("high").getField("value_scale");
+    final Column lowScale =
+        col("referenceRange").getItem(0).getField("low").getField("value_scale");
+
+    final Row scales = observationsDataset.select(highScale, lowScale).head();
+    assertEquals(6, scales.getInt(0));
+    assertEquals(7, scales.getInt(1));
+
+    assertEquals(
+        0, observationsDataset.select(highScale.as("scale")).filter(col("scale").gt(6)).count());
+    assertEquals(
+        1, observationsDataset.select(lowScale.as("scale")).filter(col("scale").gt(6)).count());
+  }
+
+  @Test
+  void bigDecimalDecodeClampsHighStoredScales() {
+    // A stored scale greater than the storage scale of 6 must not reinstate precision on decode.
+    // The decoded value carries the storage scale, not the source scale, so that no digits are
+    // asserted that the stored value no longer holds.
+    final Observation highScaleObservation = new Observation();
+    highScaleObservation.setId("high-scale-decode");
+    highScaleObservation.setStatus(Observation.ObservationStatus.FINAL);
+
+    final Quantity quantity = new Quantity();
+    quantity.setValue(TestData.TEST_SCALE_16_DECIMAL);
+    quantity.setUnit("mL/h");
+    highScaleObservation.setValue(quantity);
+    highScaleObservation.addReferenceRange().getLow().setValue(TestData.TEST_SCALE_17_DECIMAL);
+
+    final Observation decoded =
+        spark
+            .createDataset(List.of(highScaleObservation), ENCODERS_L0.of(Observation.class))
+            .head();
+
+    // The scale-16 source decodes to its value rounded HALF_UP to a scale of 6. The comparison uses
+    // `equals` rather than `compareTo`, so that the scale is checked along with the value.
+    final BigDecimal decodedValue = ((Quantity) decoded.getValue()).getValue();
+    assertEquals(TestData.TEST_SCALE_16_DECIMAL_SCALE_6, decodedValue);
+    assertEquals(6, decodedValue.scale());
+
+    // The scale-17 source decodes at a scale of 6 in the same way.
+    final BigDecimal decodedLow = decoded.getReferenceRange().getFirst().getLow().getValue();
+    assertEquals(TestData.TEST_SCALE_17_DECIMAL_SCALE_6, decodedLow);
+    assertEquals(6, decodedLow.scale());
+  }
+
+  @Test
+  void bigDecimalDecodePreservesScalesWithinStorageScale() {
+    // A source scale within the storage scale of 6 is preserved exactly on decode, so the
+    // read-time clamp is a no-op for these values. The source here has a scale of 2.
+    final BigDecimal decodedValue = ((Quantity) decodedObservation.getValue()).getValue();
+    assertEquals(TestData.TEST_SMALL_DECIMAL, decodedValue);
+    assertEquals(2, decodedValue.scale());
   }
 
   @Test

--- a/encoders/src/test/java/au/csiro/pathling/encoders/LightweightFhirEncodersTest.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/LightweightFhirEncodersTest.java
@@ -44,6 +44,7 @@ import org.hl7.fhir.r4.model.BaseResource;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.DecimalType;
 import org.hl7.fhir.r4.model.Device;
 import org.hl7.fhir.r4.model.Expression;
 import org.hl7.fhir.r4.model.IdType;
@@ -136,6 +137,86 @@ public class LightweightFhirEncodersTest implements JsonMethods {
     rocComponent.addSensitivity(new BigDecimal("0.100").setScale(6, RoundingMode.UNNECESSARY));
     rocComponent.addSensitivity(new BigDecimal("1.23").setScale(3, RoundingMode.UNNECESSARY));
     assertSerDeIsIdentity(encoder, molecularSequence);
+  }
+
+  @Test
+  void testDecimalCollectionRecordsSourceScales() {
+    // A repeated decimal element records the source scale of each value element-wise, without any
+    // cap, so that truncated elements can be identified individually.
+    final ExpressionEncoder<MolecularSequence> encoder = fhirEncoders.of(MolecularSequence.class);
+
+    final MolecularSequence molecularSequence = new MolecularSequence();
+    molecularSequence.setId("someId");
+    final MolecularSequenceQualityRocComponent rocComponent =
+        molecularSequence.getQualityFirstRep().getRoc();
+
+    // Source scales of 3, 7 and 17; only the first is within the storage scale of 6.
+    rocComponent.addSensitivity(new BigDecimal("1.23").setScale(3, RoundingMode.UNNECESSARY));
+    rocComponent.addSensitivity(TestData.TEST_VERY_SMALL_DECIMAL);
+    rocComponent.addSensitivity(TestData.TEST_SCALE_17_DECIMAL);
+
+    final ExpressionEncoder<MolecularSequence> resolvedEncoder =
+        EncoderUtils.defaultResolveAndBind(encoder);
+    final InternalRow serializedRow = resolvedEncoder.createSerializer().apply(molecularSequence);
+
+    // Deserialize the InternalRow to a Row with explicit schema, so that the companion scale array
+    // can be inspected directly.
+    final ExpressionEncoder<Row> rowEncoder =
+        EncoderUtils.defaultResolveAndBind(ExpressionEncoder.apply(encoder.schema()));
+    final Row sequenceRow = rowEncoder.createDeserializer().apply(serializedRow);
+
+    final List<Row> quality = sequenceRow.getList(sequenceRow.fieldIndex("quality"));
+    final Row qualityRow = quality.getFirst();
+    final Row rocRow = qualityRow.getStruct(qualityRow.fieldIndex("roc"));
+    final List<Integer> scales = rocRow.getList(rocRow.fieldIndex("sensitivity_scale"));
+
+    assertEquals(3, scales.size());
+    assertEquals(3, scales.get(0).intValue());
+    assertEquals(7, scales.get(1).intValue());
+    assertEquals(17, scales.get(2).intValue());
+  }
+
+  @Test
+  void testDecimalCollectionDecodeClampsScales() {
+    // Decoding a repeated decimal element applies the storage scale of 6 as a ceiling element-wise.
+    // A stored scale above 6 must not reinstate precision that the stored value no longer carries.
+    final ExpressionEncoder<MolecularSequence> encoder = fhirEncoders.of(MolecularSequence.class);
+
+    final MolecularSequence molecularSequence = new MolecularSequence();
+    molecularSequence.setId("someId");
+    final MolecularSequenceQualityRocComponent rocComponent =
+        molecularSequence.getQualityFirstRep().getRoc();
+
+    // Source scales of 3, 7 and 17; only the first is within the storage scale of 6.
+    rocComponent.addSensitivity(new BigDecimal("1.23").setScale(3, RoundingMode.UNNECESSARY));
+    rocComponent.addSensitivity(TestData.TEST_VERY_SMALL_DECIMAL);
+    rocComponent.addSensitivity(TestData.TEST_SCALE_17_DECIMAL);
+
+    // The round trip is performed explicitly, because `assertSerDeIsIdentity` cannot be used for
+    // values that lose precision during encoding.
+    final ExpressionEncoder<MolecularSequence> resolvedEncoder =
+        EncoderUtils.defaultResolveAndBind(encoder);
+    final MolecularSequence decoded =
+        resolvedEncoder
+            .createDeserializer()
+            .apply(resolvedEncoder.createSerializer().apply(molecularSequence));
+
+    // The expected resource is constructed explicitly, with each element rounded HALF_UP to the
+    // lesser of its source scale and the storage scale of 6.
+    final MolecularSequence expected = new MolecularSequence();
+    expected.setId("someId");
+    final MolecularSequenceQualityRocComponent expectedRoc = expected.getQualityFirstRep().getRoc();
+    expectedRoc.addSensitivity(new BigDecimal("1.230"));
+    expectedRoc.addSensitivity(TestData.TEST_VERY_SMALL_DECIMAL_SCALE_6);
+    expectedRoc.addSensitivity(TestData.TEST_SCALE_17_DECIMAL_SCALE_6);
+    assertResourceEquals(expected, decoded);
+
+    // The decoded scales are the lesser of the source scale and 6, element-wise.
+    final List<DecimalType> sensitivity = decoded.getQualityFirstRep().getRoc().getSensitivity();
+    assertEquals(3, sensitivity.size());
+    assertEquals(3, sensitivity.get(0).getValue().scale());
+    assertEquals(6, sensitivity.get(1).getValue().scale());
+    assertEquals(6, sensitivity.get(2).getValue().scale());
   }
 
   @Test

--- a/encoders/src/test/java/au/csiro/pathling/encoders/TestData.java
+++ b/encoders/src/test/java/au/csiro/pathling/encoders/TestData.java
@@ -77,6 +77,14 @@ public class TestData {
       new java.math.BigDecimal("0.1234567");
   public static final java.math.BigDecimal TEST_VERY_SMALL_DECIMAL_SCALE_6 =
       new java.math.BigDecimal("0.123457");
+  public static final java.math.BigDecimal TEST_SCALE_16_DECIMAL =
+      new java.math.BigDecimal("4.0460004806518555");
+  public static final java.math.BigDecimal TEST_SCALE_16_DECIMAL_SCALE_6 =
+      new java.math.BigDecimal("4.046000");
+  public static final java.math.BigDecimal TEST_SCALE_17_DECIMAL =
+      new java.math.BigDecimal("0.10000000894069672");
+  public static final java.math.BigDecimal TEST_SCALE_17_DECIMAL_SCALE_6 =
+      new java.math.BigDecimal("0.100000");
 
   /** Returns a FHIR Condition for testing purposes. */
   public static Condition newCondition() {

--- a/site/docs/libraries/io/schema.md
+++ b/site/docs/libraries/io/schema.md
@@ -115,6 +115,11 @@ In addition, an `INT32` field SHALL be included with the suffix `_scale`. This
 field SHALL be used to store the scale of the decimal value from the original
 FHIR data.
 
+A value with more than 6 decimal places is stored in the `DECIMAL` field
+rounded to a scale of 6, while the `_scale` field retains the scale of the
+original FHIR data. A `_scale` value greater than 6 therefore identifies a
+value that lost precision during encoding.
+
 ### ID type
 
 An element of type `id` SHALL be represented as a `BINARY (UTF8)` field. This


### PR DESCRIPTION
Fixes #2737.

The `_scale` companion field recorded `min(6, sourceScale)` rather than the scale of the source FHIR decimal, so a value that lost precision on encoding was indistinguishable from an exact one. The scale is now written uncapped and the cap is applied on read instead, for both single and repeated decimal elements.

Decoded values and their scales are unchanged: `setScale` on read takes the lesser of the stored scale and the storage scale of 6, and `zipToDecimal` does the same element-wise. The reproduction from the issue now yields scales of 16, 17 and 2 against stored values of `4.046000`, `0.100000` and `1.250000`, so `value_scale > 6` separates rounded values from exact ones.

`_scale` now records the true source scale rather than the storage scale, so a consumer that reads it as a storage scale must clamp it at 6. Data written by this version and read by an older Pathling version will decode truncated values with padded zero digits.