### PR TITLE
Substitute dependency labels only where they name a table

### DIFF
--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlEdit.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlEdit.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import jakarta.annotation.Nonnull;
+import lombok.Value;
+
+/**
+ * A single character-span replacement within a SQL query, produced by {@link SqlLabelRewriter} from
+ * the parse origin of a relation reference.
+ *
+ * @author John Grimes
+ */
+@Value
+class SqlEdit {
+
+  /** The offset of the first character the edit replaces. */
+  int start;
+
+  /** The offset just past the last character the edit replaces. */
+  int end;
+
+  /** The text that replaces the span. */
+  @Nonnull String replacement;
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriter.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriter.java
@@ -23,6 +23,7 @@ import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,8 +37,10 @@ import org.apache.spark.sql.catalyst.parser.ParserInterface;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.Sample;
 import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
+import org.apache.spark.sql.catalyst.plans.logical.UnresolvedWith;
 import org.apache.spark.sql.catalyst.trees.Origin;
 import org.apache.spark.sql.execution.command.DescribeQueryCommand;
+import scala.Tuple2;
 import scala.collection.immutable.Seq;
 import scala.jdk.javaapi.CollectionConverters;
 
@@ -51,6 +54,10 @@ import scala.jdk.javaapi.CollectionConverters;
  * injected after it. The rewritten query then behaves as if a real table existed under the label's
  * own name, so a column qualified by the label (for example {@code SELECT age.age FROM age})
  * continues to resolve.
+ *
+ * <p>A reference is left alone when a common table expression of the same name is in scope: the
+ * query author's definition shadows the label, per standard SQL scoping. Scope follows Spark's own
+ * {@code CTESubstitution}, and the names are compared case-sensitively, exactly as the labels are.
  *
  * @author John Grimes
  */
@@ -94,7 +101,7 @@ public final class SqlLabelRewriter {
 
     final List<SqlEdit> edits = new ArrayList<>();
     final Set<LogicalPlan> visited = Collections.newSetFromMap(new IdentityHashMap<>());
-    collectEdits(sql, plan, labelToViewName, false, NO_WRAPPER, visited, edits);
+    collectEdits(sql, plan, labelToViewName, Set.of(), false, NO_WRAPPER, visited, edits);
     return applyEdits(sql, edits);
   }
 
@@ -104,6 +111,8 @@ public final class SqlLabelRewriter {
    * @param sql the original SQL query
    * @param plan the plan node to visit
    * @param labelToViewName the mapping from dependency labels to temporary view names
+   * @param cteScope the names of the common table expressions in scope at this node, each of which
+   *     shadows a label of the same name
    * @param aliased whether an alias has already been seen between this node and the relation
    *     primary it belongs to
    * @param wrapperStop the last character offset of the outermost relation-primary wrapper seen so
@@ -116,6 +125,7 @@ public final class SqlLabelRewriter {
       @Nonnull final String sql,
       @Nonnull final LogicalPlan plan,
       @Nonnull final Map<String, String> labelToViewName,
+      @Nonnull final Set<String> cteScope,
       final boolean aliased,
       final int wrapperStop,
       @Nonnull final Set<LogicalPlan> visited,
@@ -126,34 +136,43 @@ public final class SqlLabelRewriter {
     }
 
     if (plan instanceof final UnresolvedRelation relation) {
-      collectRelationEdit(sql, relation, labelToViewName, aliased, wrapperStop, edits);
+      collectRelationEdit(sql, relation, labelToViewName, cteScope, aliased, wrapperStop, edits);
     } else if (plan instanceof final UnresolvedTableOrView target) {
       collectDescribeTargetEdit(target, labelToViewName, edits);
     }
 
     // A subquery expression holds its plan outside the tree's children.
     for (final Expression expression : CollectionConverters.asJava(plan.expressions())) {
-      collectEditsInExpression(sql, expression, labelToViewName, visited, edits);
+      collectEditsInExpression(sql, expression, labelToViewName, cteScope, visited, edits);
     }
 
     // DESCRIBE QUERY holds the query it describes as a constructor argument, so neither the child
     // walk nor the inner-child walk below reaches it.
     if (plan instanceof final DescribeQueryCommand describeQuery) {
-      collectEdits(sql, describeQuery.plan(), labelToViewName, false, NO_WRAPPER, visited, edits);
+      collectEdits(
+          sql, describeQuery.plan(), labelToViewName, cteScope, false, NO_WRAPPER, visited, edits);
     }
 
-    // The definition bodies of a WITH clause are inner children rather than children, so the
-    // generic child walk never reaches them.
+    // A WITH clause gives each of its subtrees a different scope, so it is walked explicitly
+    // instead of through the generic inner-child and child walks below.
+    if (plan instanceof final UnresolvedWith with) {
+      collectEditsInWith(sql, with, labelToViewName, cteScope, visited, edits);
+      return;
+    }
+
+    // Any plan a node holds outside its children is exposed as an inner child. The scope is
+    // carried into the descent so that a plan first reached this way keeps it.
     for (final Object innerChild : CollectionConverters.asJava(plan.innerChildren())) {
       if (innerChild instanceof final LogicalPlan innerPlan) {
-        collectEdits(sql, innerPlan, labelToViewName, false, NO_WRAPPER, visited, edits);
+        collectEdits(sql, innerPlan, labelToViewName, cteScope, false, NO_WRAPPER, visited, edits);
       }
     }
 
     final boolean childAliased = isAliasWrapper(plan) || (plan instanceof Sample && aliased);
     final int childWrapperStop = childWrapperStop(plan, wrapperStop);
     for (final LogicalPlan child : CollectionConverters.asJava(plan.children())) {
-      collectEdits(sql, child, labelToViewName, childAliased, childWrapperStop, visited, edits);
+      collectEdits(
+          sql, child, labelToViewName, cteScope, childAliased, childWrapperStop, visited, edits);
     }
   }
 
@@ -162,32 +181,69 @@ public final class SqlLabelRewriter {
       @Nonnull final String sql,
       @Nonnull final Expression expression,
       @Nonnull final Map<String, String> labelToViewName,
+      @Nonnull final Set<String> cteScope,
       @Nonnull final Set<LogicalPlan> visited,
       @Nonnull final List<SqlEdit> edits) {
 
     if (expression instanceof final SubqueryExpression subquery) {
-      collectEdits(sql, subquery.plan(), labelToViewName, false, NO_WRAPPER, visited, edits);
+      collectEdits(
+          sql, subquery.plan(), labelToViewName, cteScope, false, NO_WRAPPER, visited, edits);
     }
     for (final Expression child : CollectionConverters.asJava(expression.children())) {
-      collectEditsInExpression(sql, child, labelToViewName, visited, edits);
+      collectEditsInExpression(sql, child, labelToViewName, cteScope, visited, edits);
     }
   }
 
   /**
+   * Walks the definitions and the main query of a {@code WITH} clause, mirroring the scoping of
+   * Spark's own {@code CTESubstitution}: the i-th definition sees the names in scope around the
+   * clause plus the definitions declared before it, and the main query sees every definition. A
+   * definition referencing its own name therefore resolves outward to a label of that name, because
+   * a {@code WITH} without {@code RECURSIVE} cannot refer to itself.
+   *
+   * <p>The definitions are taken from {@code cteRelations} rather than {@code innerChildren}
+   * because only the former pairs each body with the name it is bound to. The scope is accumulated
+   * in place, each descent completing before the next name is added.
+   */
+  private static void collectEditsInWith(
+      @Nonnull final String sql,
+      @Nonnull final UnresolvedWith with,
+      @Nonnull final Map<String, String> labelToViewName,
+      @Nonnull final Set<String> cteScope,
+      @Nonnull final Set<LogicalPlan> visited,
+      @Nonnull final List<SqlEdit> edits) {
+
+    final List<Tuple2<String, SubqueryAlias>> ctes =
+        CollectionConverters.asJava(with.cteRelations());
+    final Set<String> scope = new HashSet<>(cteScope);
+    for (final Tuple2<String, SubqueryAlias> cte : ctes) {
+      if (with.allowRecursion()) {
+        // A RECURSIVE clause puts a definition's own name in scope for its body, so a
+        // self-reference there is the recursion rather than a label of the same name.
+        scope.add(cte._1());
+      }
+      collectEdits(sql, cte._2(), labelToViewName, scope, false, NO_WRAPPER, visited, edits);
+      scope.add(cte._1());
+    }
+    collectEdits(sql, with.child(), labelToViewName, scope, false, NO_WRAPPER, visited, edits);
+  }
+
+  /**
    * Collects the edit for a relation reference. A reference whose identifier is not a single-part
-   * label is left alone; static validation has already rejected anything that could not have been a
-   * declared label.
+   * label, or which names a common table expression in scope, is left alone; static validation has
+   * already rejected anything that could not have been a declared label.
    */
   private static void collectRelationEdit(
       @Nonnull final String sql,
       @Nonnull final UnresolvedRelation relation,
       @Nonnull final Map<String, String> labelToViewName,
+      @Nonnull final Set<String> cteScope,
       final boolean aliased,
       final int wrapperStop,
       @Nonnull final List<SqlEdit> edits) {
 
     final String label = singlePartLabel(relation.multipartIdentifier(), labelToViewName);
-    if (label == null) {
+    if (label == null || cteScope.contains(label)) {
       return;
     }
     final String viewName = labelToViewName.get(label);

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriter.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriter.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression;
 import org.apache.spark.sql.catalyst.parser.ParserInterface;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
-import org.apache.spark.sql.catalyst.plans.logical.Sample;
 import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
 import org.apache.spark.sql.catalyst.plans.logical.UnresolvedWith;
 import org.apache.spark.sql.catalyst.trees.Origin;
@@ -53,7 +52,9 @@ import scala.jdk.javaapi.CollectionConverters;
  * <p>Where a substituted relation reference carries no alias of its own, {@code AS <label>} is
  * injected after it. The rewritten query then behaves as if a real table existed under the label's
  * own name, so a column qualified by the label (for example {@code SELECT age.age FROM age})
- * continues to resolve.
+ * continues to resolve. Where the alias goes, and whether the grammar admits one at all, is decided
+ * from the query's tokens by {@code SqlSource.aliasInsertionPoint}. The target of a {@code
+ * DESCRIBE} never takes one.
  *
  * <p>A reference is left alone when a common table expression of the same name is in scope: the
  * query author's definition shadows the label, per standard SQL scoping. Scope follows Spark's own
@@ -62,9 +63,6 @@ import scala.jdk.javaapi.CollectionConverters;
  * @author John Grimes
  */
 public final class SqlLabelRewriter {
-
-  /** Sentinel meaning that no relation-primary wrapper is in effect. */
-  private static final int NO_WRAPPER = -1;
 
   private SqlLabelRewriter() {
     // This class is not intended to be instantiated.
@@ -99,35 +97,33 @@ public final class SqlLabelRewriter {
       throw new InvalidRequestException("Invalid SQL syntax: " + e.getMessage());
     }
 
+    final SqlSource source = new SqlSource(sql);
     final List<SqlEdit> edits = new ArrayList<>();
     final Set<LogicalPlan> visited = Collections.newSetFromMap(new IdentityHashMap<>());
-    collectEdits(sql, plan, labelToViewName, Set.of(), false, NO_WRAPPER, visited, edits);
+    collectEdits(source, plan, labelToViewName, Set.of(), false, visited, edits);
     return applyEdits(sql, edits);
   }
 
   /**
    * Walks the parsed plan, collecting one edit per relation reference that names a label.
    *
-   * @param sql the original SQL query
+   * @param sql the original SQL query, and the token view over it
    * @param plan the plan node to visit
    * @param labelToViewName the mapping from dependency labels to temporary view names
    * @param cteScope the names of the common table expressions in scope at this node, each of which
    *     shadows a label of the same name
    * @param aliased whether an alias has already been seen between this node and the relation
    *     primary it belongs to
-   * @param wrapperStop the last character offset of the outermost relation-primary wrapper seen so
-   *     far, or {@link #NO_WRAPPER} when there is none
    * @param visited the plan nodes already visited, compared by identity because a subquery plan is
    *     reachable both as an inner child and through its subquery expression
    * @param edits the edits collected so far
    */
   private static void collectEdits(
-      @Nonnull final String sql,
+      @Nonnull final SqlSource sql,
       @Nonnull final LogicalPlan plan,
       @Nonnull final Map<String, String> labelToViewName,
       @Nonnull final Set<String> cteScope,
       final boolean aliased,
-      final int wrapperStop,
       @Nonnull final Set<LogicalPlan> visited,
       @Nonnull final List<SqlEdit> edits) {
 
@@ -136,7 +132,7 @@ public final class SqlLabelRewriter {
     }
 
     if (plan instanceof final UnresolvedRelation relation) {
-      collectRelationEdit(sql, relation, labelToViewName, cteScope, aliased, wrapperStop, edits);
+      collectRelationEdit(sql, relation, labelToViewName, cteScope, aliased, edits);
     } else if (plan instanceof final UnresolvedTableOrView target) {
       collectDescribeTargetEdit(target, labelToViewName, edits);
     }
@@ -149,8 +145,7 @@ public final class SqlLabelRewriter {
     // DESCRIBE QUERY holds the query it describes as a constructor argument, so neither the child
     // walk nor the inner-child walk below reaches it.
     if (plan instanceof final DescribeQueryCommand describeQuery) {
-      collectEdits(
-          sql, describeQuery.plan(), labelToViewName, cteScope, false, NO_WRAPPER, visited, edits);
+      collectEdits(sql, describeQuery.plan(), labelToViewName, cteScope, false, visited, edits);
     }
 
     // A WITH clause gives each of its subtrees a different scope, so it is walked explicitly
@@ -164,21 +159,22 @@ public final class SqlLabelRewriter {
     // carried into the descent so that a plan first reached this way keeps it.
     for (final Object innerChild : CollectionConverters.asJava(plan.innerChildren())) {
       if (innerChild instanceof final LogicalPlan innerPlan) {
-        collectEdits(sql, innerPlan, labelToViewName, cteScope, false, NO_WRAPPER, visited, edits);
+        collectEdits(sql, innerPlan, labelToViewName, cteScope, false, visited, edits);
       }
     }
 
-    final boolean childAliased = isAliasWrapper(plan) || (plan instanceof Sample && aliased);
-    final int childWrapperStop = childWrapperStop(plan, wrapperStop);
+    // The parser wraps an aliased relation in its alias wrapper before any sample clause, so the
+    // wrapper is always the relation's immediate parent and the flag never has to survive another
+    // node. Every other node ends the relation primary, so the flag resets.
+    final boolean childAliased = isAliasWrapper(plan);
     for (final LogicalPlan child : CollectionConverters.asJava(plan.children())) {
-      collectEdits(
-          sql, child, labelToViewName, cteScope, childAliased, childWrapperStop, visited, edits);
+      collectEdits(sql, child, labelToViewName, cteScope, childAliased, visited, edits);
     }
   }
 
   /** Recurses through expression trees to reach the plans held by subquery expressions. */
   private static void collectEditsInExpression(
-      @Nonnull final String sql,
+      @Nonnull final SqlSource sql,
       @Nonnull final Expression expression,
       @Nonnull final Map<String, String> labelToViewName,
       @Nonnull final Set<String> cteScope,
@@ -186,8 +182,7 @@ public final class SqlLabelRewriter {
       @Nonnull final List<SqlEdit> edits) {
 
     if (expression instanceof final SubqueryExpression subquery) {
-      collectEdits(
-          sql, subquery.plan(), labelToViewName, cteScope, false, NO_WRAPPER, visited, edits);
+      collectEdits(sql, subquery.plan(), labelToViewName, cteScope, false, visited, edits);
     }
     for (final Expression child : CollectionConverters.asJava(expression.children())) {
       collectEditsInExpression(sql, child, labelToViewName, cteScope, visited, edits);
@@ -206,7 +201,7 @@ public final class SqlLabelRewriter {
    * in place, each descent completing before the next name is added.
    */
   private static void collectEditsInWith(
-      @Nonnull final String sql,
+      @Nonnull final SqlSource sql,
       @Nonnull final UnresolvedWith with,
       @Nonnull final Map<String, String> labelToViewName,
       @Nonnull final Set<String> cteScope,
@@ -222,10 +217,10 @@ public final class SqlLabelRewriter {
         // self-reference there is the recursion rather than a label of the same name.
         scope.add(cte._1());
       }
-      collectEdits(sql, cte._2(), labelToViewName, scope, false, NO_WRAPPER, visited, edits);
+      collectEdits(sql, cte._2(), labelToViewName, scope, false, visited, edits);
       scope.add(cte._1());
     }
-    collectEdits(sql, with.child(), labelToViewName, scope, false, NO_WRAPPER, visited, edits);
+    collectEdits(sql, with.child(), labelToViewName, scope, false, visited, edits);
   }
 
   /**
@@ -234,12 +229,11 @@ public final class SqlLabelRewriter {
    * already rejected anything that could not have been a declared label.
    */
   private static void collectRelationEdit(
-      @Nonnull final String sql,
+      @Nonnull final SqlSource sql,
       @Nonnull final UnresolvedRelation relation,
       @Nonnull final Map<String, String> labelToViewName,
       @Nonnull final Set<String> cteScope,
       final boolean aliased,
-      final int wrapperStop,
       @Nonnull final List<SqlEdit> edits) {
 
     final String label = singlePartLabel(relation.multipartIdentifier(), labelToViewName);
@@ -250,17 +244,19 @@ public final class SqlLabelRewriter {
     final int start = spanStart(relation.origin(), label);
     final int stop = spanStop(relation.origin(), label);
 
-    if (aliased) {
-      // The reference already carries an alias, so only the identifier is replaced. Standard SQL
-      // scoping makes the original name unavailable as a qualifier once an alias is present.
+    final int insertion = aliased ? SqlSource.NO_ALIAS : sql.aliasInsertionPoint(start, stop);
+    if (insertion == SqlSource.NO_ALIAS) {
+      // Only the identifier is replaced, because no alias can be added here. Either the reference
+      // already carries one, in which case standard SQL scoping makes the original name unavailable
+      // as a qualifier anyway, or the grammar offers no alias slot at all.
       edits.add(new SqlEdit(start, stop + 1, viewName));
       return;
     }
-    // The alias must follow any relation-primary clause the grammar orders before it, which among
-    // the constructs validation permits is the TABLESAMPLE clause.
-    final int end = Math.max(stop, wrapperStop);
+    // Any options and sample clauses between the identifier and the alias slot are carried over
+    // unchanged, because the grammar orders the alias after them.
     edits.add(
-        new SqlEdit(start, end + 1, viewName + sql.substring(stop + 1, end + 1) + " AS " + label));
+        new SqlEdit(
+            start, insertion, viewName + sql.substring(stop + 1, insertion) + " AS " + label));
   }
 
   /**
@@ -303,25 +299,6 @@ public final class SqlLabelRewriter {
   /** Returns true when the node is one of the wrappers the parser builds for a relation alias. */
   private static boolean isAliasWrapper(@Nonnull final LogicalPlan plan) {
     return plan instanceof SubqueryAlias || plan instanceof UnresolvedSubqueryColumnAliases;
-  }
-
-  /**
-   * Returns the wrapper extent to pass to a node's children. A {@code Sample} node carries the span
-   * of the TABLESAMPLE clause, which an injected alias must follow; any other node ends the
-   * relation primary, so the extent resets.
-   */
-  private static int childWrapperStop(@Nonnull final LogicalPlan plan, final int wrapperStop) {
-    if (plan instanceof final Sample sample) {
-      final Origin origin = sample.origin();
-      if (origin.stopIndex().isDefined()) {
-        return Math.max(wrapperStop, (Integer) origin.stopIndex().get());
-      }
-      return wrapperStop;
-    }
-    if (isAliasWrapper(plan)) {
-      return wrapperStop;
-    }
-    return NO_WRAPPER;
   }
 
   /** Returns the offset of the first character of a matched node's span. */

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriter.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriter.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation;
+import org.apache.spark.sql.catalyst.analysis.UnresolvedSubqueryColumnAliases;
+import org.apache.spark.sql.catalyst.analysis.UnresolvedTableOrView;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.SubqueryExpression;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.Sample;
+import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
+import org.apache.spark.sql.catalyst.trees.Origin;
+import org.apache.spark.sql.execution.command.DescribeQueryCommand;
+import scala.collection.immutable.Seq;
+import scala.jdk.javaapi.CollectionConverters;
+
+/**
+ * Substitutes dependency table labels within a SQL query with the request-scoped temporary view
+ * names the dependencies are materialised under. The substitution is parse-guided: the SQL is
+ * parsed and only the character spans of relation references are rewritten, so column references,
+ * aliases, function names, string literals and comments cannot be touched.
+ *
+ * <p>Where a substituted relation reference carries no alias of its own, {@code AS <label>} is
+ * injected after it. The rewritten query then behaves as if a real table existed under the label's
+ * own name, so a column qualified by the label (for example {@code SELECT age.age FROM age})
+ * continues to resolve.
+ *
+ * @author John Grimes
+ */
+public final class SqlLabelRewriter {
+
+  /** Sentinel meaning that no relation-primary wrapper is in effect. */
+  private static final int NO_WRAPPER = -1;
+
+  private SqlLabelRewriter() {
+    // This class is not intended to be instantiated.
+  }
+
+  /**
+   * Rewrites the table references within the supplied SQL that name a dependency label, replacing
+   * each with the temporary view name the dependency is registered under.
+   *
+   * @param parser the SQL parser used to locate relation references
+   * @param sql the original SQL query
+   * @param labelToViewName the mapping from dependency labels to temporary view names
+   * @return the rewritten SQL query
+   * @throws InvalidRequestException if the SQL cannot be parsed
+   */
+  @Nonnull
+  public static String rewrite(
+      @Nonnull final ParserInterface parser,
+      @Nonnull final String sql,
+      @Nonnull final Map<String, String> labelToViewName) {
+
+    if (labelToViewName.isEmpty()) {
+      return sql;
+    }
+
+    final LogicalPlan plan;
+    try {
+      plan = parser.parsePlan(sql);
+    } catch (final Exception e) {
+      // Static validation parses the same text first, so in the server pipeline this is
+      // unreachable; direct callers still get the invalid-syntax error the validator would raise.
+      throw new InvalidRequestException("Invalid SQL syntax: " + e.getMessage());
+    }
+
+    final List<SqlEdit> edits = new ArrayList<>();
+    final Set<LogicalPlan> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+    collectEdits(sql, plan, labelToViewName, false, NO_WRAPPER, visited, edits);
+    return applyEdits(sql, edits);
+  }
+
+  /**
+   * Walks the parsed plan, collecting one edit per relation reference that names a label.
+   *
+   * @param sql the original SQL query
+   * @param plan the plan node to visit
+   * @param labelToViewName the mapping from dependency labels to temporary view names
+   * @param aliased whether an alias has already been seen between this node and the relation
+   *     primary it belongs to
+   * @param wrapperStop the last character offset of the outermost relation-primary wrapper seen so
+   *     far, or {@link #NO_WRAPPER} when there is none
+   * @param visited the plan nodes already visited, compared by identity because a subquery plan is
+   *     reachable both as an inner child and through its subquery expression
+   * @param edits the edits collected so far
+   */
+  private static void collectEdits(
+      @Nonnull final String sql,
+      @Nonnull final LogicalPlan plan,
+      @Nonnull final Map<String, String> labelToViewName,
+      final boolean aliased,
+      final int wrapperStop,
+      @Nonnull final Set<LogicalPlan> visited,
+      @Nonnull final List<SqlEdit> edits) {
+
+    if (!visited.add(plan)) {
+      return;
+    }
+
+    if (plan instanceof final UnresolvedRelation relation) {
+      collectRelationEdit(sql, relation, labelToViewName, aliased, wrapperStop, edits);
+    } else if (plan instanceof final UnresolvedTableOrView target) {
+      collectDescribeTargetEdit(target, labelToViewName, edits);
+    }
+
+    // A subquery expression holds its plan outside the tree's children.
+    for (final Expression expression : CollectionConverters.asJava(plan.expressions())) {
+      collectEditsInExpression(sql, expression, labelToViewName, visited, edits);
+    }
+
+    // DESCRIBE QUERY holds the query it describes as a constructor argument, so neither the child
+    // walk nor the inner-child walk below reaches it.
+    if (plan instanceof final DescribeQueryCommand describeQuery) {
+      collectEdits(sql, describeQuery.plan(), labelToViewName, false, NO_WRAPPER, visited, edits);
+    }
+
+    // The definition bodies of a WITH clause are inner children rather than children, so the
+    // generic child walk never reaches them.
+    for (final Object innerChild : CollectionConverters.asJava(plan.innerChildren())) {
+      if (innerChild instanceof final LogicalPlan innerPlan) {
+        collectEdits(sql, innerPlan, labelToViewName, false, NO_WRAPPER, visited, edits);
+      }
+    }
+
+    final boolean childAliased = isAliasWrapper(plan) || (plan instanceof Sample && aliased);
+    final int childWrapperStop = childWrapperStop(plan, wrapperStop);
+    for (final LogicalPlan child : CollectionConverters.asJava(plan.children())) {
+      collectEdits(sql, child, labelToViewName, childAliased, childWrapperStop, visited, edits);
+    }
+  }
+
+  /** Recurses through expression trees to reach the plans held by subquery expressions. */
+  private static void collectEditsInExpression(
+      @Nonnull final String sql,
+      @Nonnull final Expression expression,
+      @Nonnull final Map<String, String> labelToViewName,
+      @Nonnull final Set<LogicalPlan> visited,
+      @Nonnull final List<SqlEdit> edits) {
+
+    if (expression instanceof final SubqueryExpression subquery) {
+      collectEdits(sql, subquery.plan(), labelToViewName, false, NO_WRAPPER, visited, edits);
+    }
+    for (final Expression child : CollectionConverters.asJava(expression.children())) {
+      collectEditsInExpression(sql, child, labelToViewName, visited, edits);
+    }
+  }
+
+  /**
+   * Collects the edit for a relation reference. A reference whose identifier is not a single-part
+   * label is left alone; static validation has already rejected anything that could not have been a
+   * declared label.
+   */
+  private static void collectRelationEdit(
+      @Nonnull final String sql,
+      @Nonnull final UnresolvedRelation relation,
+      @Nonnull final Map<String, String> labelToViewName,
+      final boolean aliased,
+      final int wrapperStop,
+      @Nonnull final List<SqlEdit> edits) {
+
+    final String label = singlePartLabel(relation.multipartIdentifier(), labelToViewName);
+    if (label == null) {
+      return;
+    }
+    final String viewName = labelToViewName.get(label);
+    final int start = spanStart(relation.origin(), label);
+    final int stop = spanStop(relation.origin(), label);
+
+    if (aliased) {
+      // The reference already carries an alias, so only the identifier is replaced. Standard SQL
+      // scoping makes the original name unavailable as a qualifier once an alias is present.
+      edits.add(new SqlEdit(start, stop + 1, viewName));
+      return;
+    }
+    // The alias must follow any relation-primary clause the grammar orders before it, which among
+    // the constructs validation permits is the TABLESAMPLE clause.
+    final int end = Math.max(stop, wrapperStop);
+    edits.add(
+        new SqlEdit(start, end + 1, viewName + sql.substring(stop + 1, end + 1) + " AS " + label));
+  }
+
+  /**
+   * Collects the edit for the target of a {@code DESCRIBE [TABLE] <label>} statement. No alias is
+   * injected: the grammar does not permit one there, and there is nothing to qualify.
+   */
+  private static void collectDescribeTargetEdit(
+      @Nonnull final UnresolvedTableOrView target,
+      @Nonnull final Map<String, String> labelToViewName,
+      @Nonnull final List<SqlEdit> edits) {
+
+    final String label = singlePartLabel(target.multipartIdentifier(), labelToViewName);
+    if (label == null) {
+      return;
+    }
+    edits.add(
+        new SqlEdit(
+            spanStart(target.origin(), label),
+            spanStop(target.origin(), label) + 1,
+            labelToViewName.get(label)));
+  }
+
+  /**
+   * Returns the label named by a relation identifier that is a single part matching a declared
+   * label, or null when the identifier is multi-part or names no label. Matching is case-sensitive,
+   * as it is in the validator.
+   */
+  @Nullable
+  private static String singlePartLabel(
+      @Nonnull final Seq<String> multipartIdentifier,
+      @Nonnull final Map<String, String> labelToViewName) {
+
+    final List<String> parts = CollectionConverters.asJava(multipartIdentifier);
+    if (parts.size() != 1 || !labelToViewName.containsKey(parts.get(0))) {
+      return null;
+    }
+    return parts.get(0);
+  }
+
+  /** Returns true when the node is one of the wrappers the parser builds for a relation alias. */
+  private static boolean isAliasWrapper(@Nonnull final LogicalPlan plan) {
+    return plan instanceof SubqueryAlias || plan instanceof UnresolvedSubqueryColumnAliases;
+  }
+
+  /**
+   * Returns the wrapper extent to pass to a node's children. A {@code Sample} node carries the span
+   * of the TABLESAMPLE clause, which an injected alias must follow; any other node ends the
+   * relation primary, so the extent resets.
+   */
+  private static int childWrapperStop(@Nonnull final LogicalPlan plan, final int wrapperStop) {
+    if (plan instanceof final Sample sample) {
+      final Origin origin = sample.origin();
+      if (origin.stopIndex().isDefined()) {
+        return Math.max(wrapperStop, (Integer) origin.stopIndex().get());
+      }
+      return wrapperStop;
+    }
+    if (isAliasWrapper(plan)) {
+      return wrapperStop;
+    }
+    return NO_WRAPPER;
+  }
+
+  /** Returns the offset of the first character of a matched node's span. */
+  private static int spanStart(@Nonnull final Origin origin, @Nonnull final String label) {
+    if (origin.startIndex().isEmpty()) {
+      throw new IllegalStateException(
+          "Parsed relation reference for label '" + label + "' carries no start position");
+    }
+    return (Integer) origin.startIndex().get();
+  }
+
+  /** Returns the offset of the last character of a matched node's span. */
+  private static int spanStop(@Nonnull final Origin origin, @Nonnull final String label) {
+    if (origin.stopIndex().isEmpty()) {
+      throw new IllegalStateException(
+          "Parsed relation reference for label '" + label + "' carries no end position");
+    }
+    return (Integer) origin.stopIndex().get();
+  }
+
+  /** Applies the collected edits to the original text in order, rejecting any overlap. */
+  @Nonnull
+  private static String applyEdits(@Nonnull final String sql, @Nonnull final List<SqlEdit> edits) {
+
+    edits.sort(Comparator.comparingInt(SqlEdit::getStart));
+    final StringBuilder out = new StringBuilder(sql.length());
+    int cursor = 0;
+    for (final SqlEdit edit : edits) {
+      if (edit.getStart() < cursor) {
+        // Relation references occupy disjoint spans of the query text, so an overlap here is an
+        // internal invariant violation rather than anything a client could provoke.
+        throw new IllegalStateException(
+            "Overlapping label substitutions at offset " + edit.getStart());
+      }
+      out.append(sql, cursor, edit.getStart()).append(edit.getReplacement());
+      cursor = edit.getEnd();
+    }
+    out.append(sql, cursor, sql.length());
+    return out.toString();
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlSource.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlSource.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Token;
+import org.apache.spark.sql.catalyst.parser.SqlBaseLexer;
+import org.apache.spark.sql.catalyst.parser.UpperCaseCharStream;
+
+/**
+ * The text of a SQL query, together with a view of the tokens Spark's own lexer produces for it.
+ * {@link SqlLabelRewriter} uses the tokens to place the table alias it injects after a substituted
+ * relation reference, which is the one thing the parsed plan cannot tell it.
+ *
+ * <p>The query is lexed at most once per instance, and only if the tokens are actually asked for.
+ *
+ * @author John Grimes
+ */
+class SqlSource {
+
+  /** Returned by {@link #aliasInsertionPoint} when the grammar admits no table alias. */
+  static final int NO_ALIAS = -1;
+
+  @Nonnull private final String text;
+
+  /** The default-channel tokens of the query, lexed on first use. */
+  @Nullable private List<Token> tokens;
+
+  SqlSource(@Nonnull final String text) {
+    this.text = text;
+  }
+
+  /**
+   * Returns the run of query text between two offsets.
+   *
+   * @param beginIndex the offset of the first character, inclusive
+   * @param endIndex the offset just past the last character
+   * @return the text between the offsets
+   */
+  @Nonnull
+  String substring(final int beginIndex, final int endIndex) {
+    return text.substring(beginIndex, endIndex);
+  }
+
+  /**
+   * Returns the offset at which a table alias may be inserted for the relation reference occupying
+   * the given span, or {@link #NO_ALIAS} when the grammar admits no alias for that reference.
+   *
+   * <p>The rule is {@code identifierReference temporalClause? optionsClause? sampleClause?
+   * tableAlias}, so the alias goes last, after any options and sample clauses. Neither clause can
+   * be measured from a plan node: the options end up in a field of the relation and produce no node
+   * at all, and {@code TABLESAMPLE (n ROWS)} produces a limit rather than a {@code Sample}. Both
+   * are therefore measured here as a keyword immediately followed by a balanced parenthesis group.
+   * Demanding that parenthesis is what stops the {@code WITH} of a common table expression being
+   * taken for an options clause.
+   *
+   * <p>Two positions admit no alias at all. The target of a {@code TABLE} query primary, whose rule
+   * is {@code TABLE identifierReference}, has no alias slot; the form is invisible in the parsed
+   * plan, because {@code TABLE age} and {@code FROM age} yield the same relation node under the
+   * same parents, so it is recognised from the preceding token instead. A temporal clause ({@code
+   * VERSION AS OF} and its variants) is refused rather than measured: time travel is rejected
+   * before the rewriter runs, and declining an alias costs only the resolution of a label-qualified
+   * column, whereas guessing an insertion point could produce text that does not parse.
+   *
+   * <p>Whitespace and both comment forms are lexed onto the hidden channel, so working over the
+   * default channel steps across them in both directions: a comment between {@code TABLE} and the
+   * identifier does not hide the keyword, and the word {@code TABLE} within a comment is never
+   * mistaken for it.
+   *
+   * @param start the offset of the first character of the relation identifier
+   * @param stop the offset of the last character of the relation identifier
+   * @return the offset just past the end of the relation primary, or {@link #NO_ALIAS}
+   */
+  int aliasInsertionPoint(final int start, final int stop) {
+    final List<Token> tokenList = tokens();
+    Token preceding = null;
+    int next = tokenList.size();
+    for (int i = 0; i < tokenList.size(); i++) {
+      final Token token = tokenList.get(i);
+      if (token.getStopIndex() < start) {
+        preceding = token;
+      } else if (token.getStartIndex() > stop) {
+        next = i;
+        break;
+      }
+    }
+    if (preceding != null && preceding.getType() == SqlBaseLexer.TABLE) {
+      return NO_ALIAS;
+    }
+
+    int insertion = stop + 1;
+    int index = next;
+    while (index < tokenList.size()) {
+      final int type = tokenList.get(index).getType();
+      if (startsTemporalClause(type)) {
+        return NO_ALIAS;
+      }
+      if ((type != SqlBaseLexer.WITH && type != SqlBaseLexer.TABLESAMPLE)
+          || index + 1 >= tokenList.size()
+          || tokenList.get(index + 1).getType() != SqlBaseLexer.LEFT_PAREN) {
+        break;
+      }
+      final int close = closingParenthesis(tokenList, index + 1);
+      if (close == NO_ALIAS) {
+        // The text has already been parsed, so the group is balanced; an unbalanced one can only
+        // mean the token view disagrees with the parse, and stopping short is the safe response.
+        break;
+      }
+      insertion = tokenList.get(close).getStopIndex() + 1;
+      index = close + 1;
+    }
+    return insertion;
+  }
+
+  /** Reports whether the token type opens the temporal clause of a relation primary. */
+  private static boolean startsTemporalClause(final int type) {
+    return type == SqlBaseLexer.FOR
+        || type == SqlBaseLexer.VERSION
+        || type == SqlBaseLexer.SYSTEM_VERSION
+        || type == SqlBaseLexer.TIMESTAMP
+        || type == SqlBaseLexer.SYSTEM_TIME;
+  }
+
+  /**
+   * Returns the index of the token closing the parenthesis group opened at the given index, or
+   * {@link #NO_ALIAS} when the group is not closed.
+   */
+  private static int closingParenthesis(@Nonnull final List<Token> tokenList, final int openIndex) {
+    int depth = 0;
+    for (int i = openIndex; i < tokenList.size(); i++) {
+      final int type = tokenList.get(i).getType();
+      if (type == SqlBaseLexer.LEFT_PAREN) {
+        depth++;
+      } else if (type == SqlBaseLexer.RIGHT_PAREN) {
+        depth--;
+        if (depth == 0) {
+          return i;
+        }
+      }
+    }
+    return NO_ALIAS;
+  }
+
+  /**
+   * Lexes the query on first use. The lexer is Spark's own, over the same upper-casing character
+   * stream Spark itself wraps the input in, because the grammar's keyword rules match uppercase
+   * text only. Error listeners are removed because the caller has already parsed the same text
+   * successfully, so there is nothing left to report.
+   */
+  @Nonnull
+  private List<Token> tokens() {
+    if (tokens == null) {
+      final SqlBaseLexer lexer =
+          new SqlBaseLexer(new UpperCaseCharStream(CharStreams.fromString(text)));
+      lexer.removeErrorListeners();
+      final CommonTokenStream stream = new CommonTokenStream(lexer);
+      stream.fill();
+      final List<Token> defaultChannel = new ArrayList<>();
+      for (final Token token : stream.getTokens()) {
+        if (token.getChannel() == Token.DEFAULT_CHANNEL) {
+          defaultChannel.add(token);
+        }
+      }
+      tokens = defaultChannel;
+    }
+    return tokens;
+  }
+}

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
@@ -174,12 +174,12 @@ public class ViewRegistrationService {
   }
 
   /**
-   * Rewrites SQL table references to use the prefixed temporary view names. Each unquoted
-   * identifier token whose text equals a label is replaced with the corresponding temporary view
-   * name; backtick-quoted identifiers matching a label are also rewritten. Single-quoted and
-   * double-quoted string literals, line comments ({@code -- ...}), and block comments ({@code /*
-   * ... *}{@code /}) are left untouched, so a literal value happening to equal a label (e.g. {@code
-   * WHERE x = 'patients'}) is preserved.
+   * Rewrites the table references within the given SQL to use the request-scoped temporary view
+   * names. The rewrite is parse-guided: only the character spans that the SQL parser reports as
+   * relation references are substituted, so a column, column alias, table alias, function name,
+   * string literal or comment that happens to share a label's name is left untouched. Where a
+   * substituted reference carries no alias of its own, {@code AS <label>} is injected after it so
+   * that a column qualified by the label continues to resolve.
    *
    * @param sql the original SQL query
    * @param labelToViewName the mapping from labels to temporary view names
@@ -188,164 +188,7 @@ public class ViewRegistrationService {
   @Nonnull
   public String rewriteSql(
       @Nonnull final String sql, @Nonnull final Map<String, String> labelToViewName) {
-
-    if (labelToViewName.isEmpty()) {
-      return sql;
-    }
-
-    final int n = sql.length();
-    final StringBuilder out = new StringBuilder(n);
-    int i = 0;
-    while (i < n) {
-      i = consumeNextToken(sql, n, i, labelToViewName, out);
-    }
-    return out.toString();
-  }
-
-  /** Consumes one token starting at {@code i} and returns the index after it. */
-  private static int consumeNextToken(
-      @Nonnull final String sql,
-      final int n,
-      final int i,
-      @Nonnull final Map<String, String> labelToViewName,
-      @Nonnull final StringBuilder out) {
-    final char c = sql.charAt(i);
-    if (c == '\'' || c == '"') {
-      return copyStringLiteral(sql, i, c, out);
-    }
-    if (c == '`') {
-      return copyOrRewriteBacktickIdentifier(sql, i, labelToViewName, out);
-    }
-    if (c == '-' && i + 1 < n && sql.charAt(i + 1) == '-') {
-      return copyLineComment(sql, i, out);
-    }
-    if (c == '/' && i + 1 < n && sql.charAt(i + 1) == '*') {
-      return copyBlockComment(sql, i, out);
-    }
-    if (Character.isLetter(c) || c == '_') {
-      return copyOrRewriteIdentifier(sql, i, labelToViewName, out);
-    }
-    out.append(c);
-    return i + 1;
-  }
-
-  /**
-   * Copies a {@code '...'} or {@code "..."} string literal verbatim, honouring both doubled-quote
-   * and backslash escapes (Spark accepts either). Returns the position after the closing quote.
-   */
-  private static int copyStringLiteral(
-      @Nonnull final String sql,
-      final int start,
-      final char quote,
-      @Nonnull final StringBuilder out) {
-    final int n = sql.length();
-    out.append(quote);
-    int i = start + 1;
-    while (i < n) {
-      final char d = sql.charAt(i);
-      if (d == '\\' && i + 1 < n) {
-        out.append(d).append(sql.charAt(i + 1));
-        i += 2;
-      } else if (d == quote && i + 1 < n && sql.charAt(i + 1) == quote) {
-        // Doubled quote inside the literal — Spark treats this as an escaped quote.
-        out.append(d).append(d);
-        i += 2;
-      } else if (d == quote) {
-        out.append(d);
-        return i + 1;
-      } else {
-        out.append(d);
-        i++;
-      }
-    }
-    return i;
-  }
-
-  /**
-   * A backtick-quoted identifier is a delimited identifier in Spark SQL. If its text matches a
-   * label, rewrite it to the (unquoted) temp view name; otherwise copy it verbatim.
-   */
-  private static int copyOrRewriteBacktickIdentifier(
-      @Nonnull final String sql,
-      final int start,
-      @Nonnull final Map<String, String> labelToViewName,
-      @Nonnull final StringBuilder out) {
-    final int n = sql.length();
-    int j = start + 1;
-    while (j < n && sql.charAt(j) != '`') {
-      j++;
-    }
-    if (j >= n) {
-      // Unterminated backtick — copy the rest verbatim and stop.
-      out.append(sql, start, n);
-      return n;
-    }
-    final String inner = sql.substring(start + 1, j);
-    final String replacement = labelToViewName.get(inner);
-    if (replacement != null) {
-      out.append(replacement);
-    } else {
-      out.append(sql, start, j + 1);
-    }
-    return j + 1;
-  }
-
-  /** Copies a {@code -- ...} line comment up to (and including) the terminating newline. */
-  private static int copyLineComment(
-      @Nonnull final String sql, final int start, @Nonnull final StringBuilder out) {
-    final int n = sql.length();
-    int i = start;
-    while (i < n && sql.charAt(i) != '\n') {
-      out.append(sql.charAt(i));
-      i++;
-    }
-    return i;
-  }
-
-  /** Copies a {@code /* ... *}{@code /} block comment verbatim. */
-  private static int copyBlockComment(
-      @Nonnull final String sql, final int start, @Nonnull final StringBuilder out) {
-    final int n = sql.length();
-    out.append("/*");
-    int i = start + 2;
-    while (i + 1 < n) {
-      if (sql.charAt(i) == '*' && sql.charAt(i + 1) == '/') {
-        out.append("*/");
-        return i + 2;
-      }
-      out.append(sql.charAt(i));
-      i++;
-    }
-    while (i < n) {
-      out.append(sql.charAt(i));
-      i++;
-    }
-    return i;
-  }
-
-  /**
-   * Reads an unquoted identifier starting at {@code start} and replaces it with the matching temp
-   * view name if the token equals a known label.
-   */
-  private static int copyOrRewriteIdentifier(
-      @Nonnull final String sql,
-      final int start,
-      @Nonnull final Map<String, String> labelToViewName,
-      @Nonnull final StringBuilder out) {
-    final int n = sql.length();
-    int j = start;
-    while (j < n) {
-      final char ch = sql.charAt(j);
-      if (Character.isLetterOrDigit(ch) || ch == '_') {
-        j++;
-      } else {
-        break;
-      }
-    }
-    final String token = sql.substring(start, j);
-    final String replacement = labelToViewName.get(token);
-    out.append(replacement != null ? replacement : token);
-    return j;
+    return SqlLabelRewriter.rewrite(sparkSession.sessionState().sqlParser(), sql, labelToViewName);
   }
 
   /**

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriterTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriterTest.java
@@ -212,13 +212,113 @@ class SqlLabelRewriterTest {
   }
 
   // ---------------------------------------------------------------------------
+  // String literals and comments.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void preservesSingleQuotedLiteralContainingALabel() {
+    // The parse spans cover relation identifiers only, so a literal that happens to contain the
+    // label text cannot be touched.
+    assertThat(rewriteAge("SELECT * FROM age WHERE label = 'age'"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " AS age WHERE label = 'age'");
+  }
+
+  @Test
+  void preservesDoubleQuotedLiteralContainingALabel() {
+    assertThat(rewriteAge("SELECT * FROM age WHERE note = \"age of patient\""))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " AS age WHERE note = \"age of patient\"");
+  }
+
+  @Test
+  void preservesDoubledQuoteEscapedLiteralContainingALabel() {
+    // Spark accepts a doubled single quote as an embedded apostrophe, and the label text inside
+    // such a literal must survive along with the escape.
+    assertThat(rewriteAge("SELECT * FROM age WHERE label = 'pat''s age'"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " AS age WHERE label = 'pat''s age'");
+  }
+
+  @Test
+  void preservesLineCommentMentioningALabel() {
+    assertThat(rewriteAge("SELECT * FROM age -- age comment\nWHERE x = 1"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " AS age -- age comment\nWHERE x = 1");
+  }
+
+  @Test
+  void preservesBlockCommentMentioningALabel() {
+    assertThat(rewriteAge("SELECT /* age in here */ * FROM age"))
+        .isEqualTo("SELECT /* age in here */ * FROM " + AGE_VIEW + " AS age");
+  }
+
+  @Test
+  void preservesLineCommentMentioningALabelAheadOfARewrittenRelation() {
+    // A comment ahead of the reference pins that the rewrite offsets are counted over the
+    // submitted text, newline and comment included, rather than over any normalised form of it.
+    assertThat(rewriteAge("-- age comment\nSELECT * FROM age"))
+        .isEqualTo("-- age comment\nSELECT * FROM " + AGE_VIEW + " AS age");
+  }
+
+  @Test
+  void leavesBacktickQuotedIdentifierThatIsNotALabelAlone() {
+    assertThat(rewriteAge("SELECT * FROM age WHERE `random col` = 'x'"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " AS age WHERE `random col` = 'x'");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Named parameters.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void preservesNamedParameterMarkersAndTheSpansAroundThem() {
+    // A named parameter marker is not an identifier, so it survives; the marker before the relation
+    // reference also proves the rewrite spans are offsets into the submitted text.
+    assertThat(rewriteAge("SELECT :threshold AS t FROM age WHERE v > :threshold"))
+        .isEqualTo("SELECT :threshold AS t FROM " + AGE_VIEW + " AS age WHERE v > :threshold");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Case sensitivity.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void doesNotRewriteARelationDifferingFromTheLabelOnlyByCase() {
+    // Label matching is case-sensitive, as it is in the validator, which rejects the reference as
+    // an undeclared table before execution.
+    final String sql = "SELECT * FROM AGE";
+    assertThat(rewriteAge(sql)).isEqualTo(sql);
+  }
+
+  // ---------------------------------------------------------------------------
+  // DESCRIBE statements.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void rewritesDescribeTargetWithoutInjectingAnAlias() {
+    // The grammar permits no alias on a DESCRIBE target, and there is nothing to qualify.
+    assertThat(rewriteAge("DESCRIBE age")).isEqualTo("DESCRIBE " + AGE_VIEW);
+  }
+
+  @Test
+  void rewritesDescribeTableTargetWithoutInjectingAnAlias() {
+    assertThat(rewriteAge("DESCRIBE TABLE age")).isEqualTo("DESCRIBE TABLE " + AGE_VIEW);
+  }
+
+  @Test
+  void rewritesOnlyTheRelationWithinDescribeQuery() {
+    // The described query is a constructor argument of the command rather than a tree child, so
+    // this also pins that the walk reaches it.
+    assertThat(rewriteAge("DESCRIBE QUERY SELECT age FROM age"))
+        .isEqualTo("DESCRIBE QUERY SELECT age FROM " + AGE_VIEW + " AS age");
+  }
+
+  // ---------------------------------------------------------------------------
   // Degenerate inputs.
   // ---------------------------------------------------------------------------
 
   @Test
   void returnsInputUnchangedWhenThereAreNoLabels() {
     final String sql = "SELECT age FROM age";
-    assertThat(rewrite(sql, Map.of())).isEqualTo(sql);
+    // With nothing to substitute the input is returned as-is, without even being parsed.
+    assertThat(rewrite(sql, Map.of())).isSameAs(sql);
   }
 
   /** Rewrites the given SQL against the single {@code age} label. */

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriterTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriterTest.java
@@ -311,6 +311,88 @@ class SqlLabelRewriterTest {
   }
 
   // ---------------------------------------------------------------------------
+  // Common table expression scoping.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void leavesReferenceShadowedByACteOfTheSameName() {
+    // The definition is in scope throughout the main query, so both occurrences of "age" name the
+    // CTE rather than the labelled table, and the label is simply unused.
+    final String sql = "WITH age AS (SELECT 99 AS v) SELECT v FROM age";
+    assertThat(rewriteAge(sql)).isEqualTo(sql);
+  }
+
+  @Test
+  void rewritesOnlyTheSelfReferenceWithinACteBodyNamedAfterALabel() {
+    // A CTE without RECURSIVE cannot refer to itself, so the reference inside the body resolves
+    // outward to the labelled table while the reference in the main query resolves to the CTE.
+    assertThat(rewriteAge("WITH age AS (SELECT * FROM age) SELECT * FROM age"))
+        .isEqualTo("WITH age AS (SELECT * FROM " + AGE_VIEW + " AS age) SELECT * FROM age");
+  }
+
+  @Test
+  void rewritesLabelReferenceInsideADifferentlyNamedCteBody() {
+    // Nothing named "age" is in scope, so the body's reference is a reference to the label.
+    assertThat(rewriteAge("WITH c AS (SELECT * FROM age) SELECT * FROM c"))
+        .isEqualTo("WITH c AS (SELECT * FROM " + AGE_VIEW + " AS age) SELECT * FROM c");
+  }
+
+  @Test
+  void leavesReferenceToAnEarlierSiblingCteNamedAfterALabel() {
+    // A definition sees the definitions declared before it, so "age" within the body of c names
+    // the first CTE.
+    final String sql = "WITH age AS (SELECT 1 AS v), c AS (SELECT * FROM age) SELECT * FROM c";
+    assertThat(rewriteAge(sql)).isEqualTo(sql);
+  }
+
+  @Test
+  void rewritesLabelReferenceInASubqueryOutsideACollidingCteScope() {
+    // The CTE defined within the first derived table is out of scope in the second, so the
+    // sibling's reference is still a reference to the labelled table.
+    assertThat(
+            rewriteAge(
+                "SELECT * FROM (WITH age AS (SELECT 1 AS v) SELECT v FROM age) AS a"
+                    + " JOIN (SELECT v FROM age) AS b ON a.v = b.v"))
+        .isEqualTo(
+            "SELECT * FROM (WITH age AS (SELECT 1 AS v) SELECT v FROM age) AS a"
+                + " JOIN (SELECT v FROM "
+                + AGE_VIEW
+                + " AS age) AS b ON a.v = b.v");
+  }
+
+  @Test
+  void leavesReferenceShadowedByACteDefinedWithinAnEnclosingCteBody() {
+    // An inner WITH shadows the label for the remainder of the enclosing definition's body.
+    final String sql = "WITH c AS (WITH age AS (SELECT 1 AS v) SELECT v FROM age) SELECT * FROM c";
+    assertThat(rewriteAge(sql)).isEqualTo(sql);
+  }
+
+  @Test
+  void leavesReferenceShadowedByACteFromWithinASubqueryOfTheMainQuery() {
+    // A definition's scope covers the whole main query, nested subqueries included.
+    final String sql = "WITH age AS (SELECT 1 AS v) SELECT * FROM (SELECT v FROM age) AS t";
+    assertThat(rewriteAge(sql)).isEqualTo(sql);
+  }
+
+  @Test
+  void rewritesReferenceMatchingACteNameOnlyByCase() {
+    // CTE names are compared case-sensitively, exactly as labels are, so a CTE named AGE does not
+    // shadow a reference that matches the label "age" exactly.
+    assertThat(rewriteAge("WITH AGE AS (SELECT 99 AS v) SELECT v FROM age"))
+        .isEqualTo("WITH AGE AS (SELECT 99 AS v) SELECT v FROM " + AGE_VIEW + " AS age");
+  }
+
+  @Test
+  void leavesSelfReferenceWithinARecursiveCteNamedAfterALabel() {
+    // RECURSIVE puts a definition's own name in scope for its body, so there the self-reference
+    // is the recursion rather than the labelled table.
+    final String sql =
+        "WITH RECURSIVE age AS (SELECT 1 AS v UNION ALL SELECT v + 1 FROM age WHERE v < 3)"
+            + " SELECT v FROM age";
+    assertThat(rewriteAge(sql)).isEqualTo(sql);
+  }
+
+  // ---------------------------------------------------------------------------
   // Degenerate inputs.
   // ---------------------------------------------------------------------------
 

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriterTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriterTest.java
@@ -18,6 +18,7 @@
 package au.csiro.pathling.operations.sqlquery;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import au.csiro.pathling.test.SpringBootUnitTest;
 import jakarta.annotation.Nonnull;
@@ -178,21 +179,145 @@ class SqlLabelRewriterTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Relation-primary wrappers.
+  // Options and sample clauses of a relation primary.
   // ---------------------------------------------------------------------------
 
   @Test
-  void injectsAliasAfterSampleClauseWhenRelationIsNotAliased() {
-    // The grammar orders the clauses as identifier, sample, alias, so the injected alias must
-    // follow the TABLESAMPLE clause rather than the identifier.
+  void injectsAliasAfterPercentageSampleClauseWhenRelationIsNotAliased() {
+    // The grammar orders the clauses as identifier, options, sample, alias, so the injected alias
+    // must follow the TABLESAMPLE clause rather than the identifier.
     assertThat(rewriteAge("SELECT * FROM age TABLESAMPLE (10 PERCENT)"))
         .isEqualTo("SELECT * FROM " + AGE_VIEW + " TABLESAMPLE (10 PERCENT) AS age");
   }
 
   @Test
-  void doesNotInjectAliasAfterSampleClauseWhenRelationIsAliased() {
+  void doesNotInjectAliasAfterPercentageSampleClauseWhenRelationIsAliased() {
     assertThat(rewriteAge("SELECT * FROM age TABLESAMPLE (10 PERCENT) AS t"))
         .isEqualTo("SELECT * FROM " + AGE_VIEW + " TABLESAMPLE (10 PERCENT) AS t");
+  }
+
+  @Test
+  void injectsAliasAfterRowCountSampleClauseWhenRelationIsNotAliased() {
+    // A row-count sample builds a limit rather than a Sample, so the clause is invisible as a
+    // sample node and its extent can only be taken from the tokens.
+    assertThat(rewriteAge("SELECT * FROM age TABLESAMPLE (2 ROWS)"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " TABLESAMPLE (2 ROWS) AS age");
+  }
+
+  @Test
+  void doesNotInjectAliasAfterRowCountSampleClauseWhenRelationIsAliased() {
+    // The alias sits above the limit nodes the row-count sample builds, so the flag marking the
+    // reference as aliased has to survive them.
+    assertThat(rewriteAge("SELECT * FROM age TABLESAMPLE (2 ROWS) AS t"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " TABLESAMPLE (2 ROWS) AS t");
+  }
+
+  @Test
+  void doesNotInjectAliasAfterRowCountSampleClauseWhenRelationCarriesColumnAliases() {
+    assertThat(rewriteAge("SELECT * FROM age TABLESAMPLE (2 ROWS) AS t(a, b)"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " TABLESAMPLE (2 ROWS) AS t(a, b)");
+  }
+
+  @Test
+  void injectsAliasAfterBucketSampleClauseWhenRelationIsNotAliased() {
+    assertThat(rewriteAge("SELECT * FROM age TABLESAMPLE (BUCKET 1 OUT OF 2)"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " TABLESAMPLE (BUCKET 1 OUT OF 2) AS age");
+  }
+
+  @Test
+  void injectsAliasAfterOptionsClauseWhenRelationIsNotAliased() {
+    // The options clause builds no plan node at all, the options landing in a field of the
+    // relation, so its extent likewise comes from the tokens.
+    assertThat(rewriteAge("SELECT * FROM age WITH (`k` = 'v')"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " WITH (`k` = 'v') AS age");
+  }
+
+  @Test
+  void doesNotInjectAliasAfterOptionsClauseWhenRelationIsAliased() {
+    assertThat(rewriteAge("SELECT * FROM age WITH (`k` = 'v') AS t"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " WITH (`k` = 'v') AS t");
+  }
+
+  @Test
+  void injectsAliasAfterBothOptionsAndSampleClausesWhenRelationIsNotAliased() {
+    assertThat(rewriteAge("SELECT * FROM age WITH (`k` = 'v') TABLESAMPLE (2 ROWS)"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " WITH (`k` = 'v') TABLESAMPLE (2 ROWS) AS age");
+  }
+
+  @Test
+  void doesNotInjectAliasAfterBothOptionsAndSampleClausesWhenRelationIsAliased() {
+    assertThat(rewriteAge("SELECT * FROM age WITH (`k` = 'v') TABLESAMPLE (2 ROWS) AS t"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " WITH (`k` = 'v') TABLESAMPLE (2 ROWS) AS t");
+  }
+
+  @Test
+  void injectsAliasAfterASampleClauseSeparatedFromTheIdentifierByAComment() {
+    // The clauses are found over the tokens, so a comment between them is stepped across and
+    // preserved.
+    assertThat(rewriteAge("SELECT * FROM age /* c */ TABLESAMPLE (2 ROWS)"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " /* c */ TABLESAMPLE (2 ROWS) AS age");
+  }
+
+  // ---------------------------------------------------------------------------
+  // The TABLE query primary.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void rewritesTableQueryPrimaryWithoutInjectingAnAlias() {
+    // The grammar's TABLE query primary is "TABLE identifierReference", which admits no table
+    // alias, so an injected alias would leave the query unparseable.
+    assertThat(rewriteAge("TABLE age")).isEqualTo("TABLE " + AGE_VIEW);
+  }
+
+  @Test
+  void rewritesTableQueryPrimaryUnderALimitWithoutInjectingAnAlias() {
+    // "TABLE age LIMIT 1" and "FROM age LIMIT 1", where an alias is legal, parse to the same plan
+    // shape, so the decision cannot come from the plan.
+    assertThat(rewriteAge("TABLE age LIMIT 1")).isEqualTo("TABLE " + AGE_VIEW + " LIMIT 1");
+  }
+
+  @Test
+  void rewritesTableQueryPrimaryUnderAnOrderByWithoutInjectingAnAlias() {
+    // The "age" in the ORDER BY clause is a column reference and survives untouched.
+    assertThat(rewriteAge("TABLE age ORDER BY age"))
+        .isEqualTo("TABLE " + AGE_VIEW + " ORDER BY age");
+  }
+
+  @Test
+  void rewritesTableQueryPrimarySeparatedFromTheKeywordByABlockComment() {
+    // Comments sit on the lexer's hidden channel, so the look-back for the TABLE keyword steps
+    // over them.
+    assertThat(rewriteAge("TABLE /* a comment */ age"))
+        .isEqualTo("TABLE /* a comment */ " + AGE_VIEW);
+  }
+
+  @Test
+  void rewritesTableQueryPrimarySeparatedFromTheKeywordByALineComment() {
+    assertThat(rewriteAge("TABLE -- a comment\nage")).isEqualTo("TABLE -- a comment\n" + AGE_VIEW);
+  }
+
+  @Test
+  void injectsAliasOnlyForTheFromClauseReferenceAlongsideATableQueryPrimary() {
+    // The two forms are decided independently within one query: the TABLE target takes no alias,
+    // the FROM-clause reference takes one.
+    assertThat(rewriteAge("TABLE age UNION ALL SELECT age FROM age"))
+        .isEqualTo("TABLE " + AGE_VIEW + " UNION ALL SELECT age FROM " + AGE_VIEW + " AS age");
+  }
+
+  @Test
+  void injectsAliasWhenALineCommentAheadOfTheReferenceEndsWithTheTableKeyword() {
+    // The look-back runs over real tokens rather than text, so the word TABLE inside a comment is
+    // never mistaken for the keyword.
+    assertThat(rewriteAge("-- FROM A TABLE\nSELECT age.age FROM age"))
+        .isEqualTo("-- FROM A TABLE\nSELECT age.age FROM " + AGE_VIEW + " AS age");
+  }
+
+  @Test
+  void rewritesTableQueryPrimaryWithinAParenthesisedQueryWithoutInjectingAnAlias() {
+    // A parenthesised query is wrapped in an auto-generated subquery alias by the parser, which
+    // already suppresses the injection.
+    assertThat(rewriteAge("SELECT * FROM (TABLE age)"))
+        .isEqualTo("SELECT * FROM (TABLE " + AGE_VIEW + ")");
   }
 
   // ---------------------------------------------------------------------------
@@ -409,10 +534,19 @@ class SqlLabelRewriterTest {
     return rewrite(sql, Map.of("age", AGE_VIEW));
   }
 
-  /** Rewrites the given SQL against the given label mapping, using the session's SQL parser. */
+  /**
+   * Rewrites the given SQL against the given label mapping, using the session's SQL parser, and
+   * checks that the result still parses. Every expectation in this class is taken from here,
+   * because the rewriter exists to hand executable SQL to Spark: an output that no longer parses is
+   * a defect however well it reads.
+   */
   @Nonnull
   private String rewrite(
       @Nonnull final String sql, @Nonnull final Map<String, String> labelToViewName) {
-    return SqlLabelRewriter.rewrite(parser, sql, labelToViewName);
+    final String rewritten = SqlLabelRewriter.rewrite(parser, sql, labelToViewName);
+    assertThatNoException()
+        .describedAs("rewritten SQL must parse: %s", rewritten)
+        .isThrownBy(() -> parser.parsePlan(rewritten));
+    return rewritten;
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriterTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlLabelRewriterTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import au.csiro.pathling.test.SpringBootUnitTest;
+import jakarta.annotation.Nonnull;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Tests for {@link SqlLabelRewriter}, the parse-guided substitution of dependency table labels with
+ * the request-scoped temporary view names their dependencies are materialised under.
+ *
+ * <p>The central contract is that only <em>table references</em> are substituted. A column that
+ * happens to share its name with a label occupies a different namespace and must survive verbatim,
+ * which is the defect reported in <a href="https://github.com/aehrc/pathling/issues/2730">issue
+ * 2730</a>. Where a relation reference carries no alias, the rewriter injects {@code AS <label>} so
+ * that a column qualified by the label (for example {@code age.age FROM age}) keeps resolving.
+ *
+ * @author John Grimes
+ */
+@SpringBootUnitTest
+class SqlLabelRewriterTest {
+
+  /** The temporary view name the {@code age} label is taken to be materialised under. */
+  private static final String AGE_VIEW = "sqlquery_req1_age";
+
+  /** The temporary view name the {@code patients} label is taken to be materialised under. */
+  private static final String PATIENTS_VIEW = "sqlquery_req1_patients";
+
+  @Autowired private SparkSession spark;
+
+  private ParserInterface parser;
+
+  @BeforeEach
+  void setUp() {
+    parser = spark.sessionState().sqlParser();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Column names colliding with a label (issue 2730).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void rewritesRelationButNotAliasQualifiedColumnOfTheSameName() {
+    // Issue variant A. The relation reference is substituted; the column reference t.age, which
+    // merely shares the label's name, is not.
+    assertThat(rewriteAge("SELECT t.age FROM age AS t"))
+        .isEqualTo("SELECT t.age FROM " + AGE_VIEW + " AS t");
+  }
+
+  @Test
+  void rewritesRelationButNotUnqualifiedColumnOfTheSameName() {
+    // Issue variant B. The bare "age" in the projection is a column reference and must survive; the
+    // relation gains an injected alias so the label still names a table.
+    assertThat(rewriteAge("SELECT age FROM age"))
+        .isEqualTo("SELECT age FROM " + AGE_VIEW + " AS age");
+  }
+
+  @Test
+  void injectsAliasSoLabelQualifiedColumnReferencesKeepResolving() {
+    // The qualifier "age" names the labelled table rather than an alias, so the substituted
+    // relation must be re-exposed under the label's own name.
+    assertThat(rewriteAge("SELECT age.age FROM age"))
+        .isEqualTo("SELECT age.age FROM " + AGE_VIEW + " AS age");
+  }
+
+  @Test
+  void leavesUnrelatedColumnNamesAlone() {
+    // Issue variant C, the control: a column whose name merely starts with the label is untouched.
+    assertThat(rewriteAge("SELECT t.age_years FROM age AS t"))
+        .isEqualTo("SELECT t.age_years FROM " + AGE_VIEW + " AS t");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Alias handling.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void doesNotInjectAliasWhenRelationIsAliasedWithAsKeyword() {
+    assertThat(rewriteAge("SELECT * FROM age AS t"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " AS t");
+  }
+
+  @Test
+  void doesNotInjectAliasWhenRelationIsAliasedWithoutAsKeyword() {
+    assertThat(rewriteAge("SELECT * FROM age t")).isEqualTo("SELECT * FROM " + AGE_VIEW + " t");
+  }
+
+  @Test
+  void doesNotInjectAliasWhenRelationCarriesColumnAliases() {
+    // AS t(a, b) parses to an UnresolvedSubqueryColumnAliases wrapped in a SubqueryAlias; the
+    // relation is aliased either way.
+    assertThat(rewriteAge("SELECT * FROM age AS t(a, b)"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " AS t(a, b)");
+  }
+
+  @Test
+  void leavesTableAliasNamedAfterALabelAlone() {
+    // "age" here is an alias for another relation, not a table reference.
+    assertThat(rewriteAge("SELECT * FROM pt AS age")).isEqualTo("SELECT * FROM pt AS age");
+  }
+
+  @Test
+  void leavesColumnAliasNamedAfterALabelAlone() {
+    assertThat(rewriteAge("SELECT 1 AS age FROM pt")).isEqualTo("SELECT 1 AS age FROM pt");
+  }
+
+  @Test
+  void leavesFunctionNamedAfterALabelAlone() {
+    assertThat(rewriteAge("SELECT age(x) FROM pt")).isEqualTo("SELECT age(x) FROM pt");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Identifier shapes and word boundaries.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void rewritesBacktickQuotedRelation() {
+    // The parse origin covers the backticks, so the whole delimited identifier is replaced.
+    assertThat(rewriteAge("SELECT * FROM `age`"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " AS age");
+  }
+
+  @Test
+  void leavesRelationWhoseNameMerelyStartsWithALabelAlone() {
+    assertThat(
+            rewrite(
+                "SELECT * FROM patients JOIN patients_archive ON patients.id ="
+                    + " patients_archive.id",
+                Map.of("patients", PATIENTS_VIEW)))
+        .isEqualTo(
+            "SELECT * FROM "
+                + PATIENTS_VIEW
+                + " AS patients JOIN patients_archive ON patients.id = patients_archive.id");
+  }
+
+  @Test
+  void rewritesEveryReferenceToTheSameLabel() {
+    assertThat(rewriteAge("SELECT * FROM age AS a JOIN age AS b ON a.id = b.id"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " AS a JOIN " + AGE_VIEW + " AS b ON a.id = b.id");
+  }
+
+  @Test
+  void rewritesDistinctLabelsIndependently() {
+    final Map<String, String> labels = new LinkedHashMap<>();
+    labels.put("age", AGE_VIEW);
+    labels.put("patients", PATIENTS_VIEW);
+    assertThat(rewrite("SELECT * FROM age JOIN patients ON age.id = patients.id", labels))
+        .isEqualTo(
+            "SELECT * FROM "
+                + AGE_VIEW
+                + " AS age JOIN "
+                + PATIENTS_VIEW
+                + " AS patients ON age.id = patients.id");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Relation-primary wrappers.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void injectsAliasAfterSampleClauseWhenRelationIsNotAliased() {
+    // The grammar orders the clauses as identifier, sample, alias, so the injected alias must
+    // follow the TABLESAMPLE clause rather than the identifier.
+    assertThat(rewriteAge("SELECT * FROM age TABLESAMPLE (10 PERCENT)"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " TABLESAMPLE (10 PERCENT) AS age");
+  }
+
+  @Test
+  void doesNotInjectAliasAfterSampleClauseWhenRelationIsAliased() {
+    assertThat(rewriteAge("SELECT * FROM age TABLESAMPLE (10 PERCENT) AS t"))
+        .isEqualTo("SELECT * FROM " + AGE_VIEW + " TABLESAMPLE (10 PERCENT) AS t");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Nested plans.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void rewritesRelationInsideASubqueryExpression() {
+    assertThat(rewriteAge("SELECT * FROM pt WHERE EXISTS (SELECT 1 FROM age)"))
+        .isEqualTo("SELECT * FROM pt WHERE EXISTS (SELECT 1 FROM " + AGE_VIEW + " AS age)");
+  }
+
+  @Test
+  void rewritesRelationInsideADerivedTable() {
+    assertThat(rewriteAge("SELECT * FROM (SELECT age FROM age) AS t"))
+        .isEqualTo("SELECT * FROM (SELECT age FROM " + AGE_VIEW + " AS age) AS t");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Degenerate inputs.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void returnsInputUnchangedWhenThereAreNoLabels() {
+    final String sql = "SELECT age FROM age";
+    assertThat(rewrite(sql, Map.of())).isEqualTo(sql);
+  }
+
+  /** Rewrites the given SQL against the single {@code age} label. */
+  @Nonnull
+  private String rewriteAge(@Nonnull final String sql) {
+    return rewrite(sql, Map.of("age", AGE_VIEW));
+  }
+
+  /** Rewrites the given SQL against the given label mapping, using the session's SQL parser. */
+  @Nonnull
+  private String rewrite(
+      @Nonnull final String sql, @Nonnull final Map<String, String> labelToViewName) {
+    return SqlLabelRewriter.rewrite(parser, sql, labelToViewName);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlSourceTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlSourceTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sqlquery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SqlSource}, the token view {@link SqlLabelRewriter} uses to place the table
+ * alias it injects after a substituted relation reference.
+ *
+ * <p>The rewriter's own tests cover the cases that arise from queries Spark will parse. These tests
+ * exercise the token rules directly, which is the only way to reach the fail-safe refusal for a
+ * temporal clause (a time-travel relation parses to an unresolved leaf, so the walk never reaches
+ * the relation) and the requirement that an options clause be parenthesised.
+ *
+ * @author John Grimes
+ */
+class SqlSourceTest {
+
+  @Test
+  void insertsAliasDirectlyAfterAPlainRelationReference() {
+    assertThat(insertionPoint("SELECT * FROM age", "age")).isEqualTo(17);
+  }
+
+  @Test
+  void refusesAliasForTheTargetOfATableQueryPrimary() {
+    assertThat(insertionPoint("TABLE age", "age")).isEqualTo(SqlSource.NO_ALIAS);
+  }
+
+  @Test
+  void refusesAliasForATableQueryPrimaryTargetSeparatedByComments() {
+    // Comments sit on the hidden channel, so the look-back reaches the keyword across them.
+    assertThat(insertionPoint("TABLE /* c */ age", "age")).isEqualTo(SqlSource.NO_ALIAS);
+    assertThat(insertionPoint("TABLE -- c\nage", "age")).isEqualTo(SqlSource.NO_ALIAS);
+  }
+
+  @Test
+  void allowsAliasWhenTheWordTableAppearsOnlyWithinAComment() {
+    // The look-back is over tokens rather than text, so the comment cannot supply the keyword.
+    assertThat(insertionPoint("-- FROM A TABLE\nSELECT * FROM age", "age")).isEqualTo(33);
+  }
+
+  @Test
+  void placesAliasAfterASampleClause() {
+    final String sql = "SELECT * FROM age TABLESAMPLE (10 PERCENT)";
+    assertThat(insertionPoint(sql, "age")).isEqualTo(sql.length());
+  }
+
+  @Test
+  void placesAliasAfterAnOptionsClause() {
+    final String sql = "SELECT * FROM age WITH (`k` = 'v')";
+    assertThat(insertionPoint(sql, "age")).isEqualTo(sql.length());
+  }
+
+  @Test
+  void placesAliasAfterBothAnOptionsAndASampleClause() {
+    final String sql = "SELECT * FROM age WITH (`k` = 'v') TABLESAMPLE (2 ROWS)";
+    assertThat(insertionPoint(sql, "age")).isEqualTo(sql.length());
+  }
+
+  @Test
+  void placesAliasAfterASampleClauseContainingNestedParentheses() {
+    // The group is closed by matching parentheses rather than by the first one seen.
+    final String sql = "SELECT * FROM age TABLESAMPLE ((1 + 1) PERCENT)";
+    assertThat(insertionPoint(sql, "age")).isEqualTo(sql.length());
+  }
+
+  @Test
+  void treatsAnUnparenthesisedWithAsSomethingOtherThanAnOptionsClause() {
+    // Only "WITH (" opens an options clause. A WITH that introduces a common table expression is
+    // followed by a name, and must not be swallowed into the relation primary.
+    assertThat(insertionPoint("SELECT * FROM age WITH c AS (SELECT 1)", "age")).isEqualTo(17);
+  }
+
+  @Test
+  void refusesAliasWhenATemporalClauseFollowsTheReference() {
+    // Time travel is rejected before the rewriter runs, and refusing an alias only costs the
+    // resolution of a label-qualified column, whereas guessing where the clause ends could produce
+    // text that does not parse.
+    assertThat(insertionPoint("SELECT * FROM age VERSION AS OF 1", "age"))
+        .isEqualTo(SqlSource.NO_ALIAS);
+    assertThat(insertionPoint("SELECT * FROM age TIMESTAMP AS OF '2020-01-01'", "age"))
+        .isEqualTo(SqlSource.NO_ALIAS);
+    assertThat(insertionPoint("SELECT * FROM age FOR VERSION AS OF 1", "age"))
+        .isEqualTo(SqlSource.NO_ALIAS);
+    assertThat(insertionPoint("SELECT * FROM age SYSTEM_VERSION AS OF 1", "age"))
+        .isEqualTo(SqlSource.NO_ALIAS);
+    assertThat(insertionPoint("SELECT * FROM age SYSTEM_TIME AS OF '2020-01-01'", "age"))
+        .isEqualTo(SqlSource.NO_ALIAS);
+  }
+
+  @Test
+  void returnsTheTextBetweenTwoOffsets() {
+    assertThat(new SqlSource("SELECT * FROM age").substring(14, 17)).isEqualTo("age");
+  }
+
+  /** Returns the alias insertion point for the first occurrence of the given identifier. */
+  private int insertionPoint(@Nonnull final String sql, @Nonnull final String identifier) {
+    final int start = sql.indexOf(identifier);
+    return new SqlSource(sql).aliasInsertionPoint(start, start + identifier.length() - 1);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlViewRunProviderIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlViewRunProviderIT.java
@@ -322,6 +322,17 @@ class SqlViewRunProviderIT {
     assertThat(body).contains("\"age\":1");
   }
 
+  @Test
+  void runsQueryWhoseCteShadowsTheDependencyLabel() {
+    // A CTE named after the label shadows it per standard SQL scoping, so the single row comes
+    // from the CTE rather than from the dependency.
+    final String body =
+        postOk(parametersJson(ageQueryLibrary("WITH age AS (SELECT 99 AS v) SELECT v FROM age")));
+
+    assertThat(body.trim().split("\n")).hasSize(1);
+    assertThat(body).contains("\"v\":99");
+  }
+
   /**
    * Builds a SQLQuery Library over the age-source SQLView under the colliding label {@code age}.
    */

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlViewRunProviderIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlViewRunProviderIT.java
@@ -333,6 +333,26 @@ class SqlViewRunProviderIT {
     assertThat(body).contains("\"v\":99");
   }
 
+  @Test
+  void runsTableQueryOverADependencyWhoseLabelCollidesWithAColumn() {
+    // The TABLE query primary admits no table alias, so the substitution must not inject one here.
+    final String body = postOk(parametersJson(ageQueryLibrary("TABLE age")));
+
+    assertThat(body.trim().split("\n")).hasSize(3);
+    assertThat(body).contains("\"age\":1");
+  }
+
+  @Test
+  void runsRowCountSampleQueryOverADependencyWhoseLabelCollidesWithAColumn() {
+    // The alias the substitution injects has to follow the TABLESAMPLE clause, which for a row
+    // count is not visible as a sample node in the parsed plan.
+    final String body =
+        postOk(parametersJson(ageQueryLibrary("SELECT age FROM age TABLESAMPLE (2 ROWS)")));
+
+    assertThat(body.trim().split("\n")).hasSize(2);
+    assertThat(body).contains("\"age\":1");
+  }
+
   /**
    * Builds a SQLQuery Library over the age-source SQLView under the colliding label {@code age}.
    */

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlViewRunProviderIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlViewRunProviderIT.java
@@ -233,6 +233,104 @@ class SqlViewRunProviderIT {
     assertThat(body).containsIgnoringCase("cycl");
   }
 
+  // ---------------------------------------------------------------------------
+  // Issue 2730: a column sharing a dependency label's name must not be rewritten.
+  // The age-source SQLView exposes patient_key, age and age_years, so the label
+  // "age" collides with the column "age".
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void runsQueryWhoseAliasQualifiedColumnSharesTheDependencyLabelsName() {
+    // Issue variant A.
+    final String body = postOk(parametersJson(ageQueryLibrary("SELECT t.age FROM age AS t")));
+
+    assertThat(body.trim().split("\n")).hasSize(3);
+    assertThat(body).contains("\"age\":1");
+  }
+
+  @Test
+  void runsQueryWhoseUnqualifiedColumnSharesTheDependencyLabelsName() {
+    // Issue variant B.
+    final String body = postOk(parametersJson(ageQueryLibrary("SELECT age FROM age")));
+
+    assertThat(body.trim().split("\n")).hasSize(3);
+    assertThat(body).contains("\"age\":1");
+  }
+
+  @Test
+  void runsQuerySelectingAColumnThatMerelyStartsWithTheDependencyLabelsName() {
+    // Issue variant C, the control: this worked before the fix and must keep working.
+    final String body = postOk(parametersJson(ageQueryLibrary("SELECT t.age_years FROM age AS t")));
+
+    assertThat(body.trim().split("\n")).hasSize(3);
+    assertThat(body).contains("\"age_years\":2");
+  }
+
+  @Test
+  void runsQueryWhoseColumnDoesNotCollideWithTheDependencyLabel() {
+    // Issue variant D, the control: with a non-colliding label the column resolves as before.
+    final Library library =
+        sqlQueryLibrary(
+            "SELECT t.age FROM dep_age AS t",
+            "dep_age",
+            SqlViewTestConfiguration.libraryUrl(SqlViewTestConfiguration.AGE_SOURCE_ID));
+
+    final String body = postOk(parametersJson(library));
+
+    assertThat(body.trim().split("\n")).hasSize(3);
+    assertThat(body).contains("\"age\":1");
+  }
+
+  @Test
+  void runsQueryQualifyingAColumnByTheDependencyLabelItself() {
+    // The qualifier names the labelled table rather than an alias, so the substituted relation must
+    // still be reachable under the label's own name.
+    final String body = postOk(parametersJson(ageQueryLibrary("SELECT age.age FROM age")));
+
+    assertThat(body.trim().split("\n")).hasSize(3);
+    assertThat(body).contains("\"age\":1");
+  }
+
+  @Test
+  void runsMimicStyleQueryScoringACollidingColumn() {
+    // The MIMIC-IV charlson pattern: a dependency labelled "age" exposing a column "age",
+    // referenced as "FROM age AS src_age" with "src_age.age" predicates.
+    final String body =
+        postOk(
+            parametersJson(
+                ageQueryLibrary(
+                    "SELECT CASE WHEN src_age.age <= 50 THEN 0 ELSE 1 END AS age_score "
+                        + "FROM age AS src_age")));
+
+    assertThat(body.trim().split("\n")).hasSize(3);
+    assertThat(body).contains("\"age_score\":0").doesNotContain("\"age_score\":1");
+  }
+
+  @Test
+  void runsQueryWhoseNestedNodeSuffersTheLabelCollision() {
+    // A three-level chain where the collision sits in the middle node (age-middle runs
+    // "SELECT age FROM age"), not in the top-level query.
+    final Library library =
+        sqlQueryLibrary(
+            "SELECT age FROM m",
+            "m",
+            SqlViewTestConfiguration.libraryUrl(SqlViewTestConfiguration.AGE_MIDDLE_ID));
+
+    final String body = postOk(parametersJson(library));
+
+    assertThat(body.trim().split("\n")).hasSize(3);
+    assertThat(body).contains("\"age\":1");
+  }
+
+  /**
+   * Builds a SQLQuery Library over the age-source SQLView under the colliding label {@code age}.
+   */
+  @Nonnull
+  private Library ageQueryLibrary(@Nonnull final String sql) {
+    return sqlQueryLibrary(
+        sql, "age", SqlViewTestConfiguration.libraryUrl(SqlViewTestConfiguration.AGE_SOURCE_ID));
+  }
+
   @Nonnull
   private String postExpect4xx(@Nonnull final String body) {
     final EntityExchangeResult<byte[]> result =

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlViewTestConfiguration.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlViewTestConfiguration.java
@@ -62,6 +62,10 @@ import org.springframework.context.annotation.Primary;
  *   <li>{@code Library/active-patients} - SQLView over {@code patient-view}.
  *   <li>{@code Library/refined-patients} - SQLView over {@code active-patients} (a nested chain).
  *   <li>{@code Library/cycle-a} / {@code Library/cycle-b} - a mutually-referencing cycle.
+ *   <li>{@code Library/age-source} - SQLView exposing {@code patient_key}, {@code age} and {@code
+ *       age_years}, so a dependency label can collide with one of its own column names.
+ *   <li>{@code Library/age-middle} - SQLView over {@code age-source} that itself suffers the
+ *       label/column collision, placing the collision in a nested node.
  * </ul>
  *
  * @author John Grimes
@@ -118,6 +122,18 @@ public class SqlViewTestConfiguration {
   /** The id of the right arm of a diamond, over {@link #SHARED_PATIENTS_ID}. */
   public static final String RIGHT_PATIENTS_ID = "right-patients";
 
+  /**
+   * The id of a SQLView exposing a column named {@code age}, used by the issue 2730 regression
+   * tests where a dependency label collides with one of the dependency's own column names.
+   */
+  public static final String AGE_SOURCE_ID = "age-source";
+
+  /**
+   * The id of a SQLView that itself suffers the label/column collision, used to prove the
+   * substitution is applied correctly in a nested (non-top-level) node.
+   */
+  public static final String AGE_MIDDLE_ID = "age-middle";
+
   @Primary
   @Bean
   @Nonnull
@@ -152,6 +168,13 @@ public class SqlViewTestConfiguration {
     resources.add(
         sqlView(
             RIGHT_PATIENTS_ID, "SELECT id FROM sp", Map.of("sp", libraryUrl(SHARED_PATIENTS_ID))));
+    resources.add(
+        sqlView(
+            AGE_SOURCE_ID,
+            "SELECT id AS patient_key, 1 AS age, 2 AS age_years FROM patient_view",
+            Map.of("patient_view", PATIENT_VIEW_URL)));
+    resources.add(
+        sqlView(AGE_MIDDLE_ID, "SELECT age FROM age", Map.of("age", libraryUrl(AGE_SOURCE_ID))));
     resources.add(patient("p1", "Smith"));
     resources.add(patient("p2", "Johnson"));
     resources.add(patient("p3", "Williams"));

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
@@ -171,7 +171,8 @@ class ViewRegistrationServiceTest {
   void rewriteSqlSubstitutesLabelsWithViewNames() {
     final String rewritten =
         service.rewriteSql("SELECT * FROM patients", Map.of("patients", "sqlquery_req1_patients"));
-    assertThat(rewritten).isEqualTo("SELECT * FROM sqlquery_req1_patients");
+    // The unaliased reference gains "AS patients" so the label still names a table.
+    assertThat(rewritten).isEqualTo("SELECT * FROM sqlquery_req1_patients AS patients");
   }
 
   @Test
@@ -183,8 +184,9 @@ class ViewRegistrationServiceTest {
             "SELECT * FROM patients JOIN patients_archive ON patients.id = patients_archive.id",
             Map.of("patients", "sqlquery_req1_patients"));
     assertThat(rewritten)
-        .contains("FROM sqlquery_req1_patients JOIN patients_archive")
-        .contains("ON sqlquery_req1_patients.id = patients_archive.id");
+        .contains("FROM sqlquery_req1_patients AS patients JOIN patients_archive")
+        // The qualifiers are column references, so they keep the names the query author wrote.
+        .contains("ON patients.id = patients_archive.id");
   }
 
   @Test
@@ -205,7 +207,8 @@ class ViewRegistrationServiceTest {
         service.rewriteSql(
             "SELECT * FROM patients WHERE name = 'patients'",
             Map.of("patients", "sqlquery_req1_patients"));
-    assertThat(rewritten).isEqualTo("SELECT * FROM sqlquery_req1_patients WHERE name = 'patients'");
+    assertThat(rewritten)
+        .isEqualTo("SELECT * FROM sqlquery_req1_patients AS patients WHERE name = 'patients'");
   }
 
   @Test
@@ -216,7 +219,8 @@ class ViewRegistrationServiceTest {
             Map.of("patients", "sqlquery_req1_patients"));
     assertThat(rewritten)
         .isEqualTo(
-            "SELECT * FROM sqlquery_req1_patients WHERE note = \"patients are interesting\"");
+            "SELECT * FROM sqlquery_req1_patients AS patients WHERE note = \"patients are"
+                + " interesting\"");
   }
 
   @Test
@@ -226,7 +230,8 @@ class ViewRegistrationServiceTest {
             "SELECT * FROM patients -- patients comment\nWHERE x = 1",
             Map.of("patients", "sqlquery_req1_patients"));
     assertThat(rewritten)
-        .isEqualTo("SELECT * FROM sqlquery_req1_patients -- patients comment\nWHERE x = 1");
+        .isEqualTo(
+            "SELECT * FROM sqlquery_req1_patients AS patients -- patients comment\nWHERE x = 1");
   }
 
   @Test
@@ -235,7 +240,8 @@ class ViewRegistrationServiceTest {
         service.rewriteSql(
             "SELECT /* patients in here */ * FROM patients",
             Map.of("patients", "sqlquery_req1_patients"));
-    assertThat(rewritten).isEqualTo("SELECT /* patients in here */ * FROM sqlquery_req1_patients");
+    assertThat(rewritten)
+        .isEqualTo("SELECT /* patients in here */ * FROM sqlquery_req1_patients AS patients");
   }
 
   @Test
@@ -247,7 +253,8 @@ class ViewRegistrationServiceTest {
             "SELECT * FROM patients WHERE label = 'pat''s patients'",
             Map.of("patients", "sqlquery_req1_patients"));
     assertThat(rewritten)
-        .isEqualTo("SELECT * FROM sqlquery_req1_patients WHERE label = 'pat''s patients'");
+        .isEqualTo(
+            "SELECT * FROM sqlquery_req1_patients AS patients WHERE label = 'pat''s patients'");
   }
 
   @Test
@@ -255,7 +262,7 @@ class ViewRegistrationServiceTest {
     final String rewritten =
         service.rewriteSql(
             "SELECT * FROM `patients`", Map.of("patients", "sqlquery_req1_patients"));
-    assertThat(rewritten).isEqualTo("SELECT * FROM sqlquery_req1_patients");
+    assertThat(rewritten).isEqualTo("SELECT * FROM sqlquery_req1_patients AS patients");
   }
 
   @Test
@@ -265,7 +272,17 @@ class ViewRegistrationServiceTest {
             "SELECT * FROM patients WHERE `random col` = 'x'",
             Map.of("patients", "sqlquery_req1_patients"));
     assertThat(rewritten)
-        .isEqualTo("SELECT * FROM sqlquery_req1_patients WHERE `random col` = 'x'");
+        .isEqualTo("SELECT * FROM sqlquery_req1_patients AS patients WHERE `random col` = 'x'");
+  }
+
+  @Test
+  void rewriteSqlLeavesColumnSharingALabelsNameAlone() {
+    // Regression test for issue 2730. The label "age" names a table; the column "t.age" merely
+    // shares its name and occupies a different namespace, so only the relation reference is
+    // substituted.
+    final String rewritten =
+        service.rewriteSql("SELECT t.age FROM age AS t", Map.of("age", "sqlquery_req1_age"));
+    assertThat(rewritten).isEqualTo("SELECT t.age FROM sqlquery_req1_age AS t");
   }
 
   // ---------------------------------------------------------------------------

--- a/site/docs/server/operations/sql-run.md
+++ b/site/docs/server/operations/sql-run.md
@@ -190,10 +190,12 @@ A fault in the subject's own SQL that only Spark's analyser can catch - an
 unresolved column, an unknown function, a missing `GROUP BY`, an ambiguous
 reference - is a `422`, and its diagnostics carry the analyser's own message,
 including any suggested identifier. The analyser sees the query as rewritten
-for execution rather than as submitted: each dependency label is replaced with
-an internal request-scoped view name before analysis, so a reported line and
-column position can differ from the position in the submitted text, and a
-qualified suggestion can name one of those internal views.
+for execution rather than as submitted: each table reference naming a
+dependency label is replaced with an internal request-scoped view name before
+analysis, so a reported line and column position can differ from the position
+in the submitted text, and a qualified suggestion can name one of those
+internal views. Only table references are replaced, so a column, alias or
+function that happens to share a label's name is left as submitted.
 
 ## Conformance
 


### PR DESCRIPTION
Fixes #2730.

Dependency label substitution was applied to identifier tokens by name, so a column whose name happened to equal a `relatedArtifact.label` was rewritten into the generated view identifier and the query failed to analyse. The substitution is now parse-guided: the SQL is parsed and only the character spans of relation references are rewritten, leaving column references, aliases, function names, literals and comments structurally out of reach.

Two things follow from moving the rewrite onto the parsed plan. Where a substituted reference carries no alias of its own, `AS <label>` is injected after it, so a column qualified by the label (`SELECT age.age FROM age`) keeps resolving; the insertion point is taken from the query's tokens, because a row-count `TABLESAMPLE` and an options clause leave nothing distinguishable in the plan, and `TABLE`/`DESCRIBE` targets admit no alias at all. A reference is also now left alone when a common table expression of the same name is in scope, following Spark's own `CTESubstitution` scoping.

Covered by unit tests over the rewriter and the token scan, and by end-to-end tests carrying the four variants from the issue plus the MIMIC-IV charlson pattern that prompted it.
