### PR TITLE
Verify FHIR packages against the registry checksum on import

### DIFF
--- a/lib/R/R/terminology_import.R
+++ b/lib/R/R/terminology_import.R
@@ -74,19 +74,41 @@ pathling_import_snomed <- function(pc, source, storage_path, edition_uri = NULL,
 #' Imports FHIR R4 CodeSystem, ValueSet, and ConceptMap resources into a local terminology store.
 #' The source may be a JSON file, a directory of JSON files, or a FHIR NPM package (.tgz).
 #'
+#' When the source is a package, its checksum is compared with the one its registry publishes
+#' before anything is written, and the import fails if the two differ. Turning verification off
+#' imports without consulting a registry, which is also how an import runs offline; the store then
+#' records the verification as skipped.
+#'
 #' @param pc The PathlingContext object.
 #' @param source The path to a JSON file, a directory of JSON files, or a FHIR NPM package, on any
 #'   filesystem accessible through the Hadoop FileSystem API.
 #' @param storage_path The terminology store location, created if absent.
+#' @param verify_package Whether a FHIR NPM package is checked against the checksum its registry
+#'   publishes. Defaults to TRUE.
+#' @param package_registry The base URL of the registry consulted for the checksum. When NULL, the
+#'   default registry (https://packages.fhir.org) is used. Defaults to NULL.
 #'
 #' @return The PathlingContext object, invisibly.
 #'
 #' @family terminology import functions
 #'
-#' @importFrom sparklyr j_invoke
+#' @importFrom sparklyr j_invoke j_invoke_static spark_connection
 #'
 #' @export
-pathling_import_fhir_terminology <- function(pc, source, storage_path) {
-  j_invoke(pc, "importFhirTerminology", source, storage_path)
+pathling_import_fhir_terminology <- function(pc, source, storage_path, verify_package = TRUE,
+                                             package_registry = NULL) {
+  options <- NULL
+  if (!verify_package || !is.null(package_registry)) {
+    builder <- j_invoke_static(
+      spark_connection(pc),
+      "au.csiro.pathling.library.terminology.FhirImportOptions", "builder"
+    )
+    builder <- j_invoke(builder, "verifyPackage", as.logical(verify_package))
+    if (!is.null(package_registry)) {
+      builder <- j_invoke(builder, "packageRegistry", package_registry)
+    }
+    options <- j_invoke(builder, "build")
+  }
+  j_invoke(pc, "importFhirTerminology", source, storage_path, options)
   invisible(pc)
 }

--- a/lib/R/tests/testthat/test-terminology-import.R
+++ b/lib/R/tests/testthat/test-terminology-import.R
@@ -9,6 +9,53 @@ fhir_fixtures_dir <- function() {
     mustWork = FALSE
   )
 }
+build_fhir_package <- function(tarfile) {
+  # Builds a FHIR NPM package from the JSON fixtures, with a package.json that names and versions
+  # it, so that the import has a package identity to record.
+  build_dir <- file.path(tempdir(), "r-fhir-package-build")
+  unlink(build_dir, recursive = TRUE)
+  package_dir <- file.path(build_dir, "package")
+  dir.create(package_dir, recursive = TRUE)
+  file.copy(
+    list.files(fhir_fixtures_dir(), pattern = "\\.json$", full.names = TRUE),
+    package_dir
+  )
+  writeLines(
+    '{"name": "fixtures", "version": "1.0.0"}',
+    file.path(package_dir, "package.json")
+  )
+
+  # The archive holds the package directory at its root, as a published FHIR package does, so the
+  # tar runs from the build directory.
+  previous_dir <- setwd(build_dir)
+  on.exit(setwd(previous_dir), add = TRUE)
+  utils::tar(tarfile, files = "package", compression = "gzip")
+  tarfile
+}
+
+test_that("pathling_import_fhir_terminology records skipped verification", {
+  spark <- def_spark()
+  store <- file.path(tempdir(), "r-fhir-store-skipped")
+  unlink(store, recursive = TRUE)
+  package <- build_fhir_package(file.path(tempdir(), "r-fixtures-1.0.0.tgz"))
+
+  pc_import <- pathling_connect(spark)
+  pathling_import_fhir_terminology(pc_import, package, store, verify_package = FALSE)
+
+  manifest <- sparklyr::spark_read_delta(
+    spark,
+    path = file.path(store, "manifest"),
+    name = "r_fhir_manifest_skipped",
+    memory = FALSE
+  ) %>% sdf_collect()
+
+  # Turning the check off records the package identity and the source hash, but no registry.
+  expect_true(nrow(manifest) > 0)
+  expect_equal(unique(manifest$package_verification), "skipped")
+  expect_equal(unique(manifest$package_name), "fixtures")
+  expect_equal(unique(manifest$package_version), "1.0.0")
+  expect_false(any(is.na(manifest$source_sha256)))
+})
 
 test_that("pathling_import_fhir_terminology enables local member_of", {
   spark <- def_spark()

--- a/lib/python/pathling/cli/config.py
+++ b/lib/python/pathling/cli/config.py
@@ -55,7 +55,15 @@ PROJECT_CONFIG_FILENAME = "pathling.toml"
 
 # Valid top-level keys in the config file.
 VALID_CONFIG_KEYS = frozenset(
-    {"tx-server", "fhir-version", "terminology-auth", "bulk-auth", "spark", "tx-store"}
+    {
+        "tx-server",
+        "fhir-version",
+        "terminology-auth",
+        "bulk-auth",
+        "spark",
+        "tx-store",
+        "package-registry",
+    }
 )
 
 # Valid keys within the [terminology-auth] and [bulk-auth] tables.
@@ -181,6 +189,10 @@ class CliConfig:
     :param tx_server_explicit: whether the terminology server URL was set
            explicitly (via flag or config key) rather than falling back to the
            built-in default. Drives the store-wins conflict warning.
+    :param package_registry: the FHIR package registry that a package import
+           checks a package against, or None to leave the choice to the library
+           default. Concerns package distribution rather than the store, so it
+           is a top-level key rather than part of ``[tx-store]``.
     """
 
     tx_server: str = DEFAULT_TX_SERVER
@@ -192,6 +204,7 @@ class CliConfig:
     bulk_auth_table: Optional[dict] = None
     tx_store: Optional[TxStore] = None
     tx_server_explicit: bool = False
+    package_registry: Optional[str] = None
 
 
 def _load_toml(path: Path) -> dict:
@@ -751,4 +764,5 @@ def resolve_config(
         bulk_auth_table=file_data.get("bulk-auth"),
         tx_store=resolved_tx_store,
         tx_server_explicit=tx_server_explicit,
+        package_registry=file_data.get("package-registry"),
     )

--- a/lib/python/pathling/cli/import_terminology.py
+++ b/lib/python/pathling/cli/import_terminology.py
@@ -35,12 +35,25 @@ from rich.console import Console
 
 from pathling.cli import session
 from pathling.cli.config import CliConfig
-from pathling.cli.errors import EXIT_USAGE, CliError
+from pathling.cli.errors import EXIT_USAGE, CliError, unwrap_java_exception
 from pathling.cli.render import progress_status
 
 if TYPE_CHECKING:
+    from pyspark.sql import Row, SparkSession
+
     from pathling import PathlingContext
     from pathling.cli.main import CliContext
+
+# The name of the manifest table within a terminology store.
+MANIFEST_TABLE = "manifest"
+
+# The fixed phrase the library uses when a package does not match the checksum
+# its registry publishes. The library must not name a CLI flag, so the hint
+# naming --no-verify is added here, keyed off this phrase.
+MISMATCH_PHRASE = "does not match the registry checksum"
+
+# The hint appended to a checksum mismatch failure.
+MISMATCH_HINT = "Re-run with --no-verify to import it anyway."
 
 
 def _import_context(config: CliConfig, console: Console) -> PathlingContext:
@@ -82,6 +95,91 @@ def _resolve_storage_path(config: CliConfig, storage_path: Optional[str]) -> str
         "'tx-store.path' (or the --tx-store flag).",
         exit_code=EXIT_USAGE,
     )
+
+
+def read_latest_import_row(
+    spark: SparkSession, store: str, source: str
+) -> Optional[Row]:
+    """Reads the most recent manifest row recorded for a source.
+
+    The store manifest carries the provenance of each import: the source hash,
+    the package identity, and the outcome of the registry check. The latest row
+    for this source describes the import that has just completed.
+
+    A failure to read the manifest yields None rather than an error: the import
+    has already committed, and reporting less detail is better than failing a
+    command whose work succeeded.
+
+    :param spark: the Spark session to read with.
+    :param store: the terminology store path.
+    :param source: the import source, matched against the manifest ``source``
+           column.
+    :return: the latest manifest row for the source, or None when there is none
+             or the manifest cannot be read.
+    """
+    from pyspark.sql import functions as F
+
+    manifest_path = f"{store.rstrip('/')}/{MANIFEST_TABLE}"
+    try:
+        rows = (
+            spark.read.format("delta")
+            .load(manifest_path)
+            .filter(F.col("source") == source)
+            .orderBy(F.col("imported_at").desc())
+            .take(1)
+        )
+    except Exception:  # noqa: BLE001 - detail only; the import already committed.
+        return None
+    return rows[0] if rows else None
+
+
+def format_import_summary(
+    command_noun: str, source: str, store: str, row: Optional[Row]
+) -> str:
+    """Renders the completion line for a finished import.
+
+    The line always names what was imported, from where, and into where. Where
+    the manifest records provenance it is reported in parentheses: the source
+    hash, and for a package the identity and the outcome of the registry check.
+
+    :param command_noun: what was imported, such as ``"SNOMED CT"``.
+    :param source: the import source as given on the command line.
+    :param store: the resolved store path.
+    :param row: the manifest row describing the import, or None when it could
+           not be read.
+    :return: the completion line.
+    """
+    summary = f"Imported {command_noun} from {source} into {store}"
+    if row is None:
+        return summary
+    values = row.asDict() if hasattr(row, "asDict") else dict(row)
+    sha256 = values.get("source_sha256")
+    if sha256 is None:
+        # A directory source has no single set of bytes to fingerprint.
+        return summary
+    status = values.get("package_verification")
+    name = values.get("package_name")
+    version = values.get("package_version")
+    identity = f"{name} {version}" if name and version else None
+    if status == "verified":
+        registry = values.get("package_registry")
+        detail = f"verified {identity} against {registry}"
+    elif status == "unverified":
+        subject = identity if identity else "package"
+        detail = (
+            f"{subject} not verified against a registry; re-run with --verbose "
+            "for the reason"
+        )
+    elif status == "skipped":
+        detail = (
+            f"{identity}, verification skipped"
+            if identity
+            else "package verification skipped"
+        )
+    else:
+        # Not a package: the hash alone is the provenance.
+        return f"{summary} (sha256 {sha256})"
+    return f"{summary} ({detail}; sha256 {sha256})"
 
 
 @click.command(name="import-snomed")
@@ -142,20 +240,46 @@ def import_snomed(
         pc.import_snomed(
             source, resolved_path, edition_uri, dense_id_order, resolved_dialect
         )
-    click.echo(f"Imported SNOMED CT from {source} into {resolved_path}")
+    row = read_latest_import_row(pc.spark, resolved_path, source)
+    click.echo(format_import_summary("SNOMED CT", source, resolved_path, row))
 
 
 @click.command(name="import-fhir-terminology")
 @click.argument("source")
 @click.argument("storage_path", required=False)
+@click.option(
+    "--no-verify",
+    "no_verify",
+    is_flag=True,
+    help=(
+        "Do not check a FHIR NPM package against its registry's published "
+        "checksum. Use for offline imports or packages not published to a "
+        "registry."
+    ),
+)
+@click.option(
+    "--package-registry",
+    "package_registry",
+    metavar="URL",
+    help=(
+        "The FHIR package registry to check a package against. Falls back to "
+        "the 'package-registry' config key, then https://packages.fhir.org."
+    ),
+)
 @click.pass_obj
 def import_fhir_terminology(
-    obj: CliContext, source: str, storage_path: Optional[str]
+    obj: CliContext,
+    source: str,
+    storage_path: Optional[str],
+    no_verify: bool,
+    package_registry: Optional[str],
 ) -> None:
     """Import FHIR CodeSystem, ValueSet, and ConceptMap resources into a store.
 
     The source may be a JSON file, a directory of JSON files, or a FHIR NPM
-    package (.tgz). STORAGE_PATH may be omitted when 'tx-store.path' (or
+    package (.tgz). A package is checked against the checksum its registry
+    publishes; a package that does not match fails the import and leaves the
+    store unchanged. STORAGE_PATH may be omitted when 'tx-store.path' (or
     --tx-store) is set.
 
     Example:
@@ -165,10 +289,27 @@ def import_fhir_terminology(
     config = obj.config
     console = obj.console
     resolved_path = _resolve_storage_path(config, storage_path)
+    # The flag wins over the config key; with neither set no registry is named
+    # and the library default applies, so the CLI never holds that URL.
+    resolved_registry = (
+        package_registry if package_registry is not None else config.package_registry
+    )
     pc = _import_context(config, console)
     with progress_status(console, "Importing FHIR terminology...", config.verbose):
-        pc.import_fhir_terminology(source, resolved_path)
-    click.echo(f"Imported FHIR terminology from {source} into {resolved_path}")
+        try:
+            pc.import_fhir_terminology(
+                source,
+                resolved_path,
+                verify_package=not no_verify,
+                package_registry=resolved_registry,
+            )
+        except Exception as exc:  # noqa: BLE001 - enrich a mismatch failure.
+            root_message = unwrap_java_exception(exc)
+            if MISMATCH_PHRASE not in root_message:
+                raise
+            raise CliError(f"{root_message} {MISMATCH_HINT}") from exc
+    row = read_latest_import_row(pc.spark, resolved_path, source)
+    click.echo(format_import_summary("FHIR terminology", source, resolved_path, row))
 
 
 #: The terminology import commands registered by the root command group.

--- a/lib/python/pathling/context.py
+++ b/lib/python/pathling/context.py
@@ -473,18 +473,46 @@ class PathlingContext:
             options = builder.build()
         self._jpc.importSnomed(source, storage_path, options)
 
-    def import_fhir_terminology(self, source: str, storage_path: str) -> None:
+    def import_fhir_terminology(
+        self,
+        source: str,
+        storage_path: str,
+        verify_package: bool = True,
+        package_registry: Optional[str] = None,
+    ) -> None:
         """
         Imports FHIR R4 CodeSystem, ValueSet, and ConceptMap resources into a local terminology
         store.
 
+        A FHIR NPM package (``.tgz``) is checked against the checksum its registry publishes before
+        anything is written: a package that does not match fails the import and leaves the store
+        untouched. A package the registry does not describe, or a registry that cannot be reached,
+        is imported and recorded as unverified. For an offline import, or a package that was never
+        published to a registry, pass ``verify_package=False``; the import is then recorded as
+        having skipped verification.
+
         :param source: the path to a JSON file, a directory of JSON files, or a FHIR NPM package
                (``.tgz``), on any filesystem accessible through the Hadoop FileSystem API
         :param storage_path: the terminology store location, created if absent
+        :param verify_package: whether a package source is checked against its registry's published
+               checksum; ``True`` by default
+        :param package_registry: the FHIR package registry to check a package against; when omitted
+               the library default (``https://packages.fhir.org``) is used
         :raises: the mapped JVM ``TerminologyImportException`` if the source contains no importable
-                 resources or an invalid resource; the store is left unmodified
+                 resources or an invalid resource, or the package does not match the registry
+                 checksum; the store is left unmodified
         """
-        self._jpc.importFhirTerminology(source, storage_path)
+        options = None
+        if not verify_package or package_registry is not None:
+            jvm = self._spark._jvm
+            builder = (
+                jvm.au.csiro.pathling.library.terminology.FhirImportOptions.builder()
+            )
+            builder = builder.verifyPackage(verify_package)
+            if package_registry is not None:
+                builder = builder.packageRegistry(package_registry)
+            options = builder.build()
+        self._jpc.importFhirTerminology(source, storage_path, options)
 
     def encode(
         self,

--- a/lib/python/tests/cli/test_config.py
+++ b/lib/python/tests/cli/test_config.py
@@ -281,6 +281,8 @@ def test_unknown_top_level_key_warns(tmp_path):
 
     assert any("unknown-key" in message for message in warnings)
     assert any("Valid keys" in message for message in warnings)
+    # Every valid top-level key is named, including the package registry.
+    assert any("package-registry" in message for message in warnings)
 
 
 def test_unknown_auth_key_warns(tmp_path):
@@ -1144,3 +1146,24 @@ def test_config_driven_store_matches_flag_driven(tmp_path, monkeypatch):
     )
 
     assert from_config.tx_store == from_flag.tx_store
+
+
+# ========== The package registry key (059) ==========
+
+
+def test_package_registry_key_resolves(tmp_path):
+    """The top-level package-registry key resolves into the configuration."""
+    path = _write_config(
+        tmp_path, 'package-registry = "https://packages.simplifier.net"\n'
+    )
+
+    config = resolve_config(config_path=path)
+
+    assert config.package_registry == "https://packages.simplifier.net"
+
+
+def test_package_registry_absent_is_none(tmp_path, monkeypatch):
+    """Without the key, no registry is held and the library default applies."""
+    config = resolve_config(**_isolated_defaults(monkeypatch, tmp_path))
+
+    assert config.package_registry is None

--- a/lib/python/tests/cli/test_import_terminology.py
+++ b/lib/python/tests/cli/test_import_terminology.py
@@ -24,6 +24,10 @@ cases return a non-zero exit code.
 
 import os
 
+import pytest
+from pyspark.sql import Row
+
+from pathling.cli.import_terminology import format_import_summary
 from pathling.cli.main import cli
 
 PROJECT_ROOT = os.path.abspath(
@@ -237,3 +241,207 @@ def test_import_fhir_no_path_anywhere_is_usage_error(runner, patched_context, tm
     result = runner.invoke(cli, ["import-fhir-terminology", FHIR_FIXTURES])
     assert result.exit_code == 2
     assert "tx-store.path" in result.stderr
+
+
+# ========== Package verification (059) ==========
+
+
+def _fake_import(monkeypatch, patched_context, captured):
+    """Replaces the library FHIR import with a call recorder."""
+
+    def fake(source, storage_path, **kwargs):
+        captured["args"] = (source, storage_path)
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(patched_context, "import_fhir_terminology", fake)
+
+
+def _manifest_row(**overrides):
+    """Builds a manifest row with the given provenance values."""
+    values = {
+        "source": "/data/source",
+        "source_sha256": None,
+        "package_name": None,
+        "package_version": None,
+        "package_verification": None,
+        "package_registry": None,
+    }
+    values.update(overrides)
+    return Row(**values)
+
+
+def test_import_fhir_terminology_help_documents_verification_flags(runner):
+    """Both verification options are discoverable from the command's help."""
+    result = runner.invoke(cli, ["import-fhir-terminology", "--help"])
+    assert result.exit_code == 0
+    assert "--no-verify" in result.stdout
+    assert "--package-registry" in result.stdout
+    assert "checksum" in result.stdout
+    assert "package-registry" in result.stdout
+
+
+def test_no_verify_and_registry_reach_the_library_call(
+    runner, patched_context, tmp_path, monkeypatch
+):
+    """The flags are passed to the library as keyword arguments."""
+    captured = {}
+    _fake_import(monkeypatch, patched_context, captured)
+    store = str(tmp_path / "store")
+
+    result = runner.invoke(
+        cli,
+        [
+            "import-fhir-terminology",
+            "--no-verify",
+            "--package-registry",
+            "http://reg",
+            FHIR_FIXTURES,
+            store,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["args"] == (FHIR_FIXTURES, store)
+    assert captured["kwargs"] == {
+        "verify_package": False,
+        "package_registry": "http://reg",
+    }
+
+
+def test_registry_falls_back_to_config_then_none(
+    runner, patched_context, tmp_path, monkeypatch
+):
+    """Without the flag the config key is used; with neither, no registry."""
+    captured = {}
+    _fake_import(monkeypatch, patched_context, captured)
+    store = str(tmp_path / "store")
+    config = tmp_path / "config.toml"
+    config.write_text(
+        'package-registry = "https://packages.example.com"\n', encoding="utf-8"
+    )
+
+    result = runner.invoke(
+        cli,
+        ["--config", str(config), "import-fhir-terminology", FHIR_FIXTURES, store],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["kwargs"] == {
+        "verify_package": True,
+        "package_registry": "https://packages.example.com",
+    }
+
+    result = runner.invoke(cli, ["import-fhir-terminology", FHIR_FIXTURES, store])
+    assert result.exit_code == 0, result.output
+    assert captured["kwargs"] == {"verify_package": True, "package_registry": None}
+
+
+@pytest.mark.parametrize(
+    "row, expected_suffix",
+    [
+        (
+            _manifest_row(
+                source_sha256="abcdef",
+                package_name="pkg",
+                package_version="1.0.0",
+                package_verification="verified",
+                package_registry="https://reg",
+            ),
+            " (verified pkg 1.0.0 against https://reg; sha256 abcdef)",
+        ),
+        (
+            _manifest_row(
+                source_sha256="abcdef",
+                package_name="pkg",
+                package_version="1.0.0",
+                package_verification="unverified",
+            ),
+            " (pkg 1.0.0 not verified against a registry; re-run with --verbose "
+            "for the reason; sha256 abcdef)",
+        ),
+        (
+            _manifest_row(source_sha256="abcdef", package_verification="unverified"),
+            " (package not verified against a registry; re-run with --verbose "
+            "for the reason; sha256 abcdef)",
+        ),
+        (
+            _manifest_row(
+                source_sha256="abcdef",
+                package_name="pkg",
+                package_version="1.0.0",
+                package_verification="skipped",
+            ),
+            " (pkg 1.0.0, verification skipped; sha256 abcdef)",
+        ),
+        (
+            _manifest_row(source_sha256="abcdef", package_verification="skipped"),
+            " (package verification skipped; sha256 abcdef)",
+        ),
+        (_manifest_row(source_sha256="abcdef"), " (sha256 abcdef)"),
+        (_manifest_row(), ""),
+        (None, ""),
+    ],
+)
+def test_completion_line_for_each_status(row, expected_suffix):
+    """Each provenance shape renders the completion line from the contract."""
+    summary = format_import_summary(
+        "FHIR terminology", "/data/source", "/data/store", row
+    )
+
+    assert summary == (
+        "Imported FHIR terminology from /data/source into /data/store" + expected_suffix
+    )
+
+
+def test_snomed_completion_line_includes_hash_for_archive():
+    """An RF2 archive import reports its hash; a directory import does not."""
+    archive = format_import_summary(
+        "SNOMED CT", "/data/rf2.zip", "/data/store", _manifest_row(source_sha256="ff")
+    )
+    directory = format_import_summary(
+        "SNOMED CT", "/data/rf2", "/data/store", _manifest_row()
+    )
+
+    assert (
+        archive == "Imported SNOMED CT from /data/rf2.zip into /data/store (sha256 ff)"
+    )
+    assert directory == "Imported SNOMED CT from /data/rf2 into /data/store"
+
+
+def test_mismatch_failure_adds_no_verify_hint(
+    runner, patched_context, tmp_path, monkeypatch, wide_stderr
+):
+    """A checksum mismatch is reported with the flag that overrides it."""
+    message = (
+        "The package pkg 1.0.0 does not match the registry checksum published "
+        "by https://reg: expected SHA-1 aa but the source has SHA-1 bb."
+    )
+
+    def fake(source, storage_path, **kwargs):
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(patched_context, "import_fhir_terminology", fake)
+    store = str(tmp_path / "store")
+
+    result = runner.invoke(cli, ["import-fhir-terminology", FHIR_FIXTURES, store])
+
+    assert result.exit_code == 1
+    assert message in result.stderr
+    assert "Re-run with --no-verify to import it anyway." in result.stderr
+
+
+def test_other_import_failure_carries_no_hint(
+    runner, patched_context, tmp_path, monkeypatch, wide_stderr
+):
+    """An unrelated failure is reported without the verification hint."""
+
+    def fake(source, storage_path, **kwargs):
+        raise RuntimeError("The source contains no importable resources.")
+
+    monkeypatch.setattr(patched_context, "import_fhir_terminology", fake)
+    store = str(tmp_path / "store")
+
+    result = runner.invoke(cli, ["import-fhir-terminology", FHIR_FIXTURES, store])
+
+    assert result.exit_code != 0
+    assert "no importable resources" in result.stderr
+    assert "--no-verify" not in result.stderr

--- a/lib/python/tests/cli/test_local_mode_e2e.py
+++ b/lib/python/tests/cli/test_local_mode_e2e.py
@@ -27,8 +27,12 @@ Author: John Grimes.
 """
 
 import csv
+import hashlib
+import json
 import logging
 import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from tempfile import mkdtemp
 
 from pyspark.sql import SparkSession
@@ -39,6 +43,11 @@ from pathling._version import __delta_version__, __java_version__, __scala_versi
 from pathling.cli import session as session_module
 from pathling.cli.main import cli
 from tests.cli.conftest import make_cli_runner
+from tests.test_terminology_import import (
+    PACKAGE_NAME,
+    PACKAGE_VERSION,
+    build_package,
+)
 
 PROJECT_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir, os.pardir)
@@ -249,3 +258,120 @@ def test_import_into_fresh_configured_store(monkeypatch, spark_session, tmp_path
     # The store was actually created and populated on disk.
     assert os.path.isdir(fresh_store)
     assert os.listdir(fresh_store)
+
+
+# ========== Package verification against a local registry (059) ==========
+
+
+class _RegistryHandler(BaseHTTPRequestHandler):
+    """Serves a package listing and records the paths that were requested.
+
+    The listing is the minimum the verifier reads: a ``versions`` map with a
+    ``dist.shasum`` for the version under test.
+    """
+
+    #: The listing served for any path, set by each test.
+    listing = b"{}"
+    #: The request paths seen so far, so a test can prove no lookup was made.
+    requests = []
+
+    def do_GET(self):  # noqa: N802
+        """Records the request and returns the listing."""
+        type(self).requests.append(self.path)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(type(self).listing)))
+        self.end_headers()
+        self.wfile.write(type(self).listing)
+
+    def log_message(self, format, *args):
+        """Silences the default stderr request log."""
+
+
+def _digest_hex(path, digest):
+    """Feeds a file through a digest and returns its hexadecimal value."""
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@fixture
+def registry(request):
+    """Runs a local package registry on a background thread.
+
+    :return: a ``(base_url, requests)`` pair, where ``requests`` is the mutable
+             list of request paths the server has seen.
+    """
+    _RegistryHandler.requests = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _RegistryHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    def stop():
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=10)
+
+    request.addfinalizer(stop)
+    return f"http://127.0.0.1:{server.server_address[1]}", _RegistryHandler.requests
+
+
+def test_import_package_verified_against_local_registry(
+    monkeypatch, spark_session, registry, tmp_path
+):
+    """A package matching the registry checksum is reported as verified."""
+    base_url, requests = registry
+    package = build_package(str(tmp_path))
+    _RegistryHandler.listing = json.dumps(
+        {
+            "name": PACKAGE_NAME,
+            "versions": {
+                PACKAGE_VERSION: {
+                    "dist": {"shasum": _digest_hex(package, hashlib.sha1())}
+                }
+            },
+        }
+    ).encode("utf-8")
+    _real_context_over_shared_spark(monkeypatch, spark_session)
+    store = os.path.join(str(tmp_path), "verified-store")
+    runner = make_cli_runner()
+
+    result = runner.invoke(
+        cli,
+        ["import-fhir-terminology", "--package-registry", base_url, package, store],
+    )
+
+    assert result.exit_code == 0, result.output + "\n" + result.stderr
+    assert (
+        f"verified {PACKAGE_NAME} {PACKAGE_VERSION} against {base_url}" in result.stdout
+    )
+    assert f"sha256 {_digest_hex(package, hashlib.sha256())}" in result.stdout
+    assert requests == [f"/{PACKAGE_NAME}"]
+
+
+def test_import_package_skipped_makes_no_request(
+    monkeypatch, spark_session, registry, tmp_path
+):
+    """With --no-verify no lookup is made and the outcome says so."""
+    base_url, requests = registry
+    package = build_package(str(tmp_path))
+    _real_context_over_shared_spark(monkeypatch, spark_session)
+    store = os.path.join(str(tmp_path), "skipped-store")
+    runner = make_cli_runner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "import-fhir-terminology",
+            "--no-verify",
+            "--package-registry",
+            base_url,
+            package,
+            store,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output + "\n" + result.stderr
+    assert "verification skipped" in result.stdout
+    assert requests == []

--- a/lib/python/tests/test_terminology_import.py
+++ b/lib/python/tests/test_terminology_import.py
@@ -22,8 +22,11 @@ context is created over the resulting store, and ``member_of`` is evaluated over
 network access (quickstart scenario 2).
 """
 
+import hashlib
+import json
 import logging
 import os
+import tarfile
 from tempfile import mkdtemp
 
 from pyspark.sql import SparkSession
@@ -43,6 +46,44 @@ FHIR_FIXTURES = os.path.join(
 )
 ANIMAL_SPECIES = "http://example.org/fhir/CodeSystem/animal-species"
 MAMMALS = "http://example.org/fhir/ValueSet/mammals-enumerated"
+PACKAGE_NAME = "fixtures"
+PACKAGE_VERSION = "1.0.0"
+
+
+def build_package(directory, name=PACKAGE_NAME, version=PACKAGE_VERSION):
+    """Builds a FHIR NPM package from the checked-in JSON fixtures.
+
+    The package holds a ``package.json`` naming the package and version, plus
+    every fixture resource, so an import records the package identity.
+
+    :param directory: the directory the tarball and its manifest are written to.
+    :param name: the package name recorded in ``package.json``.
+    :param version: the package version recorded in ``package.json``.
+    :return: the path to the built ``.tgz``.
+    """
+    manifest_path = os.path.join(directory, "package.json")
+    with open(manifest_path, "w", encoding="utf-8") as handle:
+        json.dump({"name": name, "version": version, "type": "fhir.ig"}, handle)
+    package_path = os.path.join(directory, f"{name}-{version}.tgz")
+    with tarfile.open(package_path, "w:gz") as tar:
+        tar.add(manifest_path, arcname="package/package.json")
+        for entry in sorted(os.listdir(FHIR_FIXTURES)):
+            if entry.endswith(".json"):
+                tar.add(os.path.join(FHIR_FIXTURES, entry), arcname=f"package/{entry}")
+    return package_path
+
+
+def sha256_hex(path):
+    """Computes the SHA-256 of a file as a lower-case hexadecimal string.
+
+    :param path: the file to digest.
+    :return: the hexadecimal digest.
+    """
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 @fixture(scope="module")
@@ -87,3 +128,63 @@ def test_import_fhir_and_member_of(spark_session):
     membership = {row["code"]: row["member"] for row in result.collect()}
     assert membership["dog"] is True
     assert membership["sparrow"] is False
+
+
+class _JpcSpy:
+    """Captures the arguments of ``importFhirTerminology`` calls on the JVM context.
+
+    Standing in for the JVM ``PathlingContext``, this records what the Python
+    binding built so the options object can be inspected, without an import
+    actually running.
+    """
+
+    def __init__(self):
+        self.calls = []
+
+    # Named to match the JVM method the binding invokes.
+    def importFhirTerminology(self, source, storage_path, options):  # noqa: N802
+        """Records one call and returns nothing, as the JVM method does."""
+        self.calls.append((source, storage_path, options))
+
+
+def test_import_fhir_terminology_skipped_records_status(spark_session):
+    """A package imported with verification off records skipped provenance."""
+    work = mkdtemp()
+    package = build_package(work)
+    store = os.path.join(work, "store")
+    PathlingContext.create(spark_session).import_fhir_terminology(
+        package, store, verify_package=False
+    )
+
+    manifest = spark_session.read.format("delta").load(os.path.join(store, "manifest"))
+    rows = manifest.select(
+        "package_verification", "package_name", "package_version", "source_sha256"
+    ).collect()
+    assert rows
+    for row in rows:
+        assert row["package_verification"] == "skipped"
+        assert row["package_name"] == PACKAGE_NAME
+        assert row["package_version"] == PACKAGE_VERSION
+        assert row["source_sha256"] == sha256_hex(package)
+
+
+def test_import_fhir_terminology_passes_registry(spark_session):
+    """The verification arguments are carried on a built FhirImportOptions."""
+    pc = PathlingContext.create(spark_session)
+    spy = _JpcSpy()
+    pc._jpc = spy
+
+    pc.import_fhir_terminology(
+        "source.tgz",
+        "store",
+        verify_package=False,
+        package_registry="https://packages.example.com",
+    )
+    source, storage_path, options = spy.calls[0]
+    assert (source, storage_path) == ("source.tgz", "store")
+    assert options.getPackageRegistry() == "https://packages.example.com"
+    assert options.isVerifyPackage() is False
+
+    # The defaults are left to the library rather than restated as options.
+    pc.import_fhir_terminology("source.tgz", "store")
+    assert spy.calls[1][2] is None

--- a/library-api/src/main/java/au/csiro/pathling/library/PathlingContext.java
+++ b/library-api/src/main/java/au/csiro/pathling/library/PathlingContext.java
@@ -31,6 +31,7 @@ import au.csiro.pathling.encoders.ResourceTypes;
 import au.csiro.pathling.fhirpath.evaluation.SingleInstanceEvaluationResult;
 import au.csiro.pathling.fhirpath.evaluation.SingleInstanceEvaluator;
 import au.csiro.pathling.library.io.source.DataSourceBuilder;
+import au.csiro.pathling.library.terminology.FhirImportOptions;
 import au.csiro.pathling.library.terminology.TerminologyImportOptions;
 import au.csiro.pathling.search.SearchColumnBuilder;
 import au.csiro.pathling.sql.PathlingUdfConfigurer;
@@ -679,7 +680,37 @@ public class PathlingContext {
   @Nonnull
   public PathlingContext importFhirTerminology(
       @Nonnull final String source, @Nonnull final String storagePath) {
-    new FhirTerminologyImporter(spark, storagePath).importFrom(source);
+    return importFhirTerminology(source, storagePath, null);
+  }
+
+  /**
+   * Imports FHIR R4 CodeSystem, ValueSet, and ConceptMap resources into a local terminology store,
+   * with control over the package checksum check. The source may be a single JSON file, a directory
+   * of JSON files, or a FHIR NPM package ({@code .tgz}), on any filesystem accessible through the
+   * Hadoop FileSystem API. Bundles are unwrapped.
+   *
+   * <p>When the source is a package, its checksum is compared with the one its registry publishes
+   * before anything is written, and the import fails if the two differ. Turn {@code verifyPackage}
+   * off to import without consulting a registry, which is also how an import runs offline; the
+   * store then records the verification as skipped.
+   *
+   * @param source the path to a JSON file, a directory of JSON files, or a FHIR NPM package
+   * @param storagePath the terminology store location, created if absent
+   * @param options the verification overrides, or null for the defaults
+   * @return this context, for chaining
+   * @throws au.csiro.pathling.terminology.store.TerminologyImportException if the source contains
+   *     no importable resources or an invalid resource, or if a package does not match the checksum
+   *     its registry publishes; the store is left unmodified
+   */
+  @Nonnull
+  public PathlingContext importFhirTerminology(
+      @Nonnull final String source,
+      @Nonnull final String storagePath,
+      @Nullable final FhirImportOptions options) {
+    final boolean verifyPackage = options == null || options.isVerifyPackage();
+    final String packageRegistry = options == null ? null : options.getPackageRegistry();
+    new FhirTerminologyImporter(spark, storagePath)
+        .importFrom(source, verifyPackage, packageRegistry);
     return this;
   }
 

--- a/library-api/src/main/java/au/csiro/pathling/library/terminology/FhirImportOptions.java
+++ b/library-api/src/main/java/au/csiro/pathling/library/terminology/FhirImportOptions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.library.terminology;
+
+import jakarta.annotation.Nullable;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Options controlling the import of FHIR terminology into a local store.
+ *
+ * @author John Grimes
+ */
+@Value
+@Builder
+public class FhirImportOptions {
+
+  /** Whether a FHIR NPM package is checked against its registry's published checksum. */
+  @Builder.Default boolean verifyPackage = true;
+
+  /** The registry base URL; null selects the default. Trailing slashes are ignored. */
+  @Nullable String packageRegistry;
+}

--- a/library-api/src/test/java/au/csiro/pathling/library/LocalTerminologyFhirImportTest.java
+++ b/library-api/src/test/java/au/csiro/pathling/library/LocalTerminologyFhirImportTest.java
@@ -23,14 +23,27 @@ import static au.csiro.pathling.sql.Terminology.translate;
 import static org.apache.spark.sql.functions.lit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import au.csiro.pathling.config.LocalTerminologyConfiguration;
 import au.csiro.pathling.config.TerminologyConfiguration;
 import au.csiro.pathling.config.TerminologyMode;
+import au.csiro.pathling.library.terminology.FhirImportOptions;
 import au.csiro.pathling.terminology.local.LocalTerminologyServiceFactory;
+import au.csiro.pathling.terminology.store.ManifestEntry;
+import au.csiro.pathling.terminology.store.PackageVerification;
+import au.csiro.pathling.terminology.store.TerminologyStoreReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -119,5 +132,74 @@ class LocalTerminologyFhirImportTest {
         evaluate(translate(species("dog"), CONCEPT_MAP, false, null)).getList(0);
     assertEquals(1, matches.size());
     assertEquals(CATEGORY, matches.get(0).getString(matches.get(0).fieldIndex("system")));
+  }
+
+  @Test
+  void optionsOverloadPassesVerifyPackageFalse(@TempDir final Path dir) throws Exception {
+    final Path archive = buildPackage(dir);
+    final String packageStore = dir.resolve("package-store").toString();
+
+    PathlingContext.builder(spark)
+        .build()
+        .importFhirTerminology(
+            archive.toString(),
+            packageStore,
+            FhirImportOptions.builder().verifyPackage(false).build());
+
+    final List<ManifestEntry> manifest =
+        TerminologyStoreReader.open(packageStore, Map.of()).readManifest();
+    assertFalse(manifest.isEmpty());
+    for (final ManifestEntry entry : manifest) {
+      // The caller declined the check, so no registry was consulted and the store says so.
+      assertEquals(PackageVerification.SKIPPED, entry.getPackageVerification());
+      assertNull(entry.getPackageRegistry());
+    }
+  }
+
+  @Test
+  void nullOptionsAreAccepted(@TempDir final Path dir) {
+    final String directoryStore = dir.resolve("directory-store").toString();
+
+    PathlingContext.builder(spark)
+        .build()
+        .importFhirTerminology(fixturePath(), directoryStore, null);
+
+    final List<ManifestEntry> manifest =
+        TerminologyStoreReader.open(directoryStore, Map.of()).readManifest();
+    assertFalse(manifest.isEmpty());
+    // A directory source has no package identity and no verification outcome at all.
+    assertNull(manifest.get(0).getPackageVerification());
+    assertNull(manifest.get(0).getSourceSha256());
+  }
+
+  /** Builds a FHIR NPM package from the fixture resources, so no network or registry is needed. */
+  private static Path buildPackage(final Path directory) throws Exception {
+    final Path archive = directory.resolve("fixtures.tgz");
+    try (TarArchiveOutputStream tar =
+        new TarArchiveOutputStream(
+            new GzipCompressorOutputStream(Files.newOutputStream(archive)))) {
+      tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+      writeEntry(
+          tar,
+          "package/package.json",
+          "{\"name\":\"example.fhir.animals\",\"version\":\"1.0.0\"}"
+              .getBytes(StandardCharsets.UTF_8));
+      try (Stream<Path> files = Files.list(Path.of(fixturePath()))) {
+        for (final Path file : files.filter(p -> p.toString().endsWith(".json")).toList()) {
+          writeEntry(tar, "package/" + file.getFileName(), Files.readAllBytes(file));
+        }
+      }
+    }
+    return archive;
+  }
+
+  private static void writeEntry(
+      final TarArchiveOutputStream tar, final String name, final byte[] content) throws Exception {
+    final TarArchiveEntry entry = new TarArchiveEntry(name);
+    entry.setSize(content.length);
+    tar.putArchiveEntry(entry);
+    final OutputStream out = tar;
+    out.write(content);
+    tar.closeArchiveEntry();
   }
 }

--- a/library-api/src/test/java/au/csiro/pathling/library/PathlingContextLocalModeTest.java
+++ b/library-api/src/test/java/au/csiro/pathling/library/PathlingContextLocalModeTest.java
@@ -77,7 +77,12 @@ class PathlingContextLocalModeTest {
                     "http://snomed.info/sct",
                     "http://snomed.info/sct/900000000000207008/version/20250101",
                     "rf2.zip",
-                    Instant.now())),
+                    Instant.now(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null)),
             SaveMode.Append);
     return store;
   }

--- a/site/docs/libraries/cli.md
+++ b/site/docs/libraries/cli.md
@@ -392,6 +392,51 @@ pathling import-snomed --default-dialect en-GB /data/rf2.zip /data/tx-store
 FHIR NPM package (`.tgz`), and imports CodeSystems of any size with bounded
 memory (for example, the multi-gigabyte OMOP vocabulary CodeSystem).
 
+A package source is checked against the checksum its registry publishes before
+anything is written: the import reads the package name and version from the
+package's `package.json`, fetches the registry's version listing, and compares
+the SHA-1 the registry publishes for that version with the SHA-1 of the tarball
+in hand. A package whose checksum differs fails the import with exit code 1,
+leaves the store unchanged, and reports the expected and computed SHA-1
+followed by `Re-run with --no-verify to import it anyway.` Where no comparison
+can be made, because the registry publishes no checksum for the version, does
+not list it, or cannot be reached, the import warns and proceeds. See
+[provenance and verification](terminology/local#provenance-and-verification)
+for what the store records.
+
+Two options control the check. Both apply only when `SOURCE` is a `.tgz` or
+`.tar.gz`; for any other source they are accepted and have no effect.
+
+- `--no-verify` imports without consulting a registry. Use it for an offline
+  import, or a package that was never published to a registry.
+- `--package-registry URL` names the registry to check against. The flag
+  overrides the `package-registry` config key (see
+  [configuration file](#configuration-file)), which overrides the default of
+  `https://packages.fhir.org`.
+
+`import-snomed` takes neither option, since an RF2 release is not distributed
+through a package registry.
+
+Each command prints one completion line naming what was imported, from where
+and into where, such as `Imported FHIR terminology from SRC into STORE`,
+followed by what the store recorded of the source:
+
+| Case                          | Suffix on the completion line                                                                      |
+| ----------------------------- | -------------------------------------------------------------------------------------------------- |
+| Directory source              | none                                                                                               |
+| RF2 `.zip` or JSON file       | `(sha256 HEX)`                                                                                     |
+| Package, verified             | `(verified NAME VERSION against REGISTRY; sha256 HEX)`                                             |
+| Package, not verified         | `(NAME VERSION not verified against a registry; re-run with --verbose for the reason; sha256 HEX)` |
+| Package, verification skipped | `(NAME VERSION, verification skipped; sha256 HEX)`                                                 |
+
+A directory has no single set of bytes to fingerprint, so it carries no hash
+and no verification statement. Where the package declares no name or version,
+`NAME VERSION` is replaced by the word `package`, giving
+`(package not verified against a registry; …)` and
+`(package verification skipped; …)`. The reason a package was not verified is
+in the library's warning log, which `--verbose` shows, as for every other
+import message.
+
 An RF2 source given to `import-snomed` must be
 [self-contained](terminology/local#rf2-sources-must-be-self-contained): rows
 referencing concepts the source does not itself ship are dropped, which is the
@@ -473,6 +518,7 @@ Defaults for the global options can be set in a TOML file at
 ```toml
 tx-server = "https://tx.example.org/fhir"
 fhir-version = "R4"
+package-registry = "https://packages.simplifier.net"
 
 [terminology-auth]
 client-id = "my-client"
@@ -503,6 +549,12 @@ table selects [local terminology mode](#local-terminology-mode); its tuning keys
 are config-file only, while the store path can also be set with `--tx-store`,
 and `default-dialect` with the `import-snomed` command's `--default-dialect`
 flag.
+
+The optional `package-registry` key names the FHIR package registry that
+`import-fhir-terminology` checks a package against, and is overridden by
+`--package-registry`. It is a top-level key rather than part of `[tx-store]`,
+because it concerns where a package was distributed from rather than the store
+the package is imported into.
 
 ### Spark configuration
 

--- a/site/docs/libraries/terminology/local.md
+++ b/site/docs/libraries/terminology/local.md
@@ -272,6 +272,196 @@ version of that CodeSystem and advises re-running the import. Because content is
 keyed by system version, re-running with a corrected source fully replaces the
 partial version and repairs the store.
 
+### Provenance and verification
+
+Every import records the provenance of what it loaded in the store's
+`manifest` table, a Delta table under the store root. There is one row per
+imported CodeSystem, ValueSet or ConceptMap, keyed by canonical URL and
+version; re-importing replaces the row, so a row always describes the most
+recent import of that content. Every row written by a single import carries the
+same provenance values.
+
+| Column                 | Type      | Null | Meaning                                                                                                                                                                                             |
+| ---------------------- | --------- | ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `store_format_version` | int       | no   | The store layout version, always `1`.                                                                                                                                                               |
+| `entry_type`           | string    | no   | `code_system`, `value_set` or `concept_map`.                                                                                                                                                        |
+| `canonical_url`        | string    | no   | The canonical URL of the imported resource.                                                                                                                                                         |
+| `version`              | string    | yes  | Its version, where the resource declares one.                                                                                                                                                       |
+| `source`               | string    | yes  | The source path, as passed to the import.                                                                                                                                                           |
+| `imported_at`          | timestamp | yes  | When the import wrote the row.                                                                                                                                                                      |
+| `source_sha256`        | string    | yes  | The SHA-256 of the source file's bytes, as 64 lowercase hexadecimal characters. Null for a directory source, which has no single set of bytes, and for rows written before provenance was recorded. |
+| `package_name`         | string    | yes  | The `name` from the package's `package.json`. Null unless the source is a FHIR NPM package that declares one.                                                                                       |
+| `package_version`      | string    | yes  | The `version` from the package's `package.json`, with the same nullability as `package_name`.                                                                                                       |
+| `package_verification` | string    | yes  | `verified`, `unverified` or `skipped`. Null when the source was not a package.                                                                                                                      |
+| `package_registry`     | string    | yes  | The registry that vouched for the bytes, with any trailing slash removed. Set only when `package_verification` is `verified`.                                                                       |
+
+The store format version is unchanged by the last five columns, so a store
+built before they were recorded opens, answers queries and accepts new imports
+without migration, its existing rows reading back as null; and a store carrying
+them opens with the preceding version of Pathling, which ignores them.
+
+The SHA-256 is taken from the bytes the import already reads, so it adds no
+further pass over an archive, and it covers the whole file: it agrees with
+`shasum -a 256` run on the same file. Where a publisher gives a SHA-256 out of
+band, for example in an NCTS syndication feed entry, `source_sha256` can be
+compared with it directly. This is the only fingerprint available for an RF2
+release or an unpublished package, neither of which has a registry checksum.
+
+#### What is checked against the registry
+
+FHIR package registries implement the npm registry protocol:
+`GET {registry}/{name}` returns a listing of every published version, and a
+version may carry `dist.shasum`, the SHA-1 of the tarball the registry
+distributes. When the source of a FHIR terminology import is a package (`.tgz`
+or `.tar.gz`), the import reads the name and version from the package's
+`package.json`, fetches that listing, and compares the `dist.shasum` published
+for that version, case-insensitively, with the SHA-1 of the tarball in hand.
+
+The check applies to packages only. An RF2 release, a directory of JSON files
+and a single JSON file are not distributed through a package registry, so no
+registry is consulted for them, no verification warning is raised, and
+`package_verification` and `package_registry` are left null. That holds for a
+directory even when it contains a `package.json`. The check is made at import
+time, against the bytes being read; nothing is re-checked when the store is
+later opened for querying.
+
+The outcome recorded in `package_verification` is one of:
+
+- `verified`: the registry published a `shasum` for the version and it equals
+  the tarball's SHA-1. `package_registry` names the registry consulted.
+- `unverified`: the source was a package, but no comparison could be made. The
+  import warns with the reason and proceeds, and `package_registry` is null.
+  The reasons are: the package has no `package.json`, or it declares no name or
+  version, in which case no registry is contacted at all; the registry could
+  not be reached, or did not answer within the timeout; it answered with an
+  error status, or with something that is not a version listing; it does not
+  list the package, or does not list the version; or it lists the version
+  without a `shasum`. A registry that cannot answer is not evidence that the
+  bytes are wrong, so none of these fails the import.
+- `skipped`: the source was a package and verification was turned off. No
+  registry is contacted, and the package name and version are still recorded.
+- null: the source was not a package.
+
+A published checksum that differs is the only outcome that fails the import.
+The failure comes before any table or manifest row is written, so a store that
+did not exist beforehand is not created, and an existing store is left as it
+was. The message names the package, the version, the registry, the expected
+SHA-1 and the SHA-1 of the source in hand, and how to import the package
+anyway:
+
+```text
+The package hl7.terminology.r4 6.5.0 does not match the registry checksum published by https://packages.fhir.org: expected SHA-1 8a7a096866b9b6e96e288ce8d72bf99aa31714a3 but the source has SHA-1 3b1f0f16d6f0e14a29b0a4ba3a0b0e9d7c5a1f42. The source may be corrupt or tampered with; import it anyway by turning off the verifyPackage option.
+```
+
+The library logs the outcome: a verified package at `INFO`, naming the package,
+its version, the registry and the SHA-1; an unverified one at `WARN`, naming
+the reason. Both appear wherever logging for `au.csiro.pathling` is enabled at
+that level, and the CLI shows them in `--verbose` mode.
+
+#### Importing offline, and choosing a registry
+
+Verification is on by default and can be turned off for a single import, which
+is how a package is imported with no network access, or a package that was
+never published to a registry. The registry can also be pointed elsewhere, for
+instance at Simplifier for a package that `packages.fhir.org` does not mirror.
+The default registry is `https://packages.fhir.org`, and a trailing slash on a
+supplied URL makes no difference. Both settings are accepted for a source that
+is not a package, where they have no effect.
+
+<Tabs>
+<TabItem value="python" label="Python">
+
+```python
+pc.import_fhir_terminology(
+    "/data/my-own-package.tgz", "/data/tx-store", verify_package=False
+)
+pc.import_fhir_terminology(
+    "/data/hl7.terminology.r4-6.5.0.tgz",
+    "/data/tx-store",
+    package_registry="https://packages.simplifier.net",
+)
+```
+
+</TabItem>
+<TabItem value="r" label="R">
+
+```r
+pathling_import_fhir_terminology(
+  pc, "/data/my-own-package.tgz", "/data/tx-store",
+  verify_package = FALSE
+)
+pathling_import_fhir_terminology(
+  pc, "/data/hl7.terminology.tgz", "/data/tx-store",
+  package_registry = "https://packages.simplifier.net"
+)
+```
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+```bash
+pathling import-fhir-terminology --no-verify \
+  /data/my-own-package.tgz /data/tx-store
+pathling import-fhir-terminology \
+  --package-registry https://packages.simplifier.net \
+  /data/hl7.terminology.tgz /data/tx-store
+```
+
+A registry used routinely can be recorded once as the top-level
+`package-registry` config key, and the outcome of the check is reported on the
+completion line of each import. See the
+[command line interface documentation](../cli#terminology-import-commands).
+
+</TabItem>
+</Tabs>
+
+In Java, both are set on `FhirImportOptions`, passed to
+`PathlingContext.importFhirTerminology`.
+
+#### Comparing two stores
+
+Two environments that imported the same content can be compared by reading both
+manifests and taking the rows that appear in one and not in the other. An empty
+result means the two imported byte-identical sources.
+
+<Tabs>
+<TabItem value="python" label="Python">
+
+```python
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder.getOrCreate()
+columns = [
+    "canonical_url",
+    "version",
+    "source_sha256",
+    "package_verification",
+    "package_registry",
+]
+a = spark.read.format("delta").load("/env-a/tx-store/manifest").select(columns)
+b = spark.read.format("delta").load("/env-b/tx-store/manifest").select(columns)
+a.exceptAll(b).union(b.exceptAll(a)).show(truncate=False)
+```
+
+</TabItem>
+<TabItem value="r" label="R">
+
+```r
+library(dplyr)
+
+sc <- pathling_spark(pc)
+a <- spark_read_delta(sc, name = "manifest_a", path = "/env-a/tx-store/manifest") %>%
+        select(canonical_url, version, source_sha256, package_verification,
+               package_registry)
+b <- spark_read_delta(sc, name = "manifest_b", path = "/env-b/tx-store/manifest") %>%
+        select(canonical_url, version, source_sha256, package_verification,
+               package_registry)
+union_all(setdiff(a, b), setdiff(b, a)) %>% collect()
+```
+
+</TabItem>
+</Tabs>
+
 ## Querying in local mode
 
 Create a context configured for local mode by setting the terminology mode to

--- a/site/docs/libraries/terminology/local.md
+++ b/site/docs/libraries/terminology/local.md
@@ -356,7 +356,9 @@ The package hl7.terminology.r4 6.5.0 does not match the registry checksum publis
 The library logs the outcome: a verified package at `INFO`, naming the package,
 its version, the registry and the SHA-1; an unverified one at `WARN`, naming
 the reason. Both appear wherever logging for `au.csiro.pathling` is enabled at
-that level, and the CLI shows them in `--verbose` mode.
+that level. The CLI runs the library at `WARN`, so `--verbose` shows the reason
+for an unverified package; the verified outcome is reported on the completion
+line instead.
 
 #### Importing offline, and choosing a registry
 

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/CodeSystemStageLoader.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/CodeSystemStageLoader.java
@@ -105,14 +105,14 @@ public class CodeSystemStageLoader {
    * @param url the CodeSystem canonical URL
    * @param version the CodeSystem version, or null
    * @param hierarchyMeaning the CodeSystem hierarchy meaning, or null (defaults to {@code is-a})
-   * @param source the source path recorded in the manifest for provenance
+   * @param provenance where the content came from, recorded in the manifest
    */
   public void load(
       @Nonnull final CodeSystemStaging staging,
       @Nonnull final String url,
       @Nullable final String version,
       @Nullable final String hierarchyMeaning,
-      @Nonnull final String source) {
+      @Nonnull final ImportProvenance provenance) {
     final String systemVersionId =
         TerminologyStoreSchema.systemVersionId(url, version == null ? "" : version);
 
@@ -173,13 +173,7 @@ public class CodeSystemStageLoader {
     writer.writePartitionedBySystemVersion(closure, CLOSURE, systemVersionId);
     closure.unpersist();
     writer.upsertManifestEntry(
-        new ManifestEntry(
-            TerminologyStoreSchema.STORE_FORMAT_VERSION,
-            "code_system",
-            url,
-            version,
-            source,
-            Instant.now()));
+        ManifestEntry.forImport("code_system", url, version, provenance, Instant.now()));
     survivors.unpersist();
     relationships.unpersist();
   }

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/DigestingInputStream.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/DigestingInputStream.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import jakarta.annotation.Nonnull;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Computes the SHA-1 and SHA-256 of everything read through a stream, so a source can be hashed
+ * during the pass that already reads it rather than in a pass of its own. A reader that stops early
+ * calls {@link #drain()} to pull the remaining bytes through the digests, so the hashes always
+ * cover the whole file.
+ *
+ * @author John Grimes
+ */
+public class DigestingInputStream extends FilterInputStream {
+
+  private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+  private static final int DRAIN_BUFFER_BYTES = 8192;
+
+  @Nonnull private final MessageDigest sha1 = digest("SHA-1");
+
+  @Nonnull private final MessageDigest sha256 = digest("SHA-256");
+
+  /**
+   * Wraps a stream so that every byte read through it is digested.
+   *
+   * @param in the stream to digest
+   */
+  public DigestingInputStream(@Nonnull final InputStream in) {
+    super(in);
+  }
+
+  @Override
+  public int read() throws IOException {
+    final int value = in.read();
+    if (value != -1) {
+      sha1.update((byte) value);
+      sha256.update((byte) value);
+    }
+    return value;
+  }
+
+  @Override
+  public int read(@Nonnull final byte[] buffer, final int offset, final int length)
+      throws IOException {
+    final int read = in.read(buffer, offset, length);
+    if (read > 0) {
+      sha1.update(buffer, offset, read);
+      sha256.update(buffer, offset, read);
+    }
+    return read;
+  }
+
+  /**
+   * Skipped bytes are read rather than seeked past, so that they are digested like any other. A
+   * digest of part of a file is worse than no digest at all.
+   */
+  @Override
+  public long skip(final long n) throws IOException {
+    if (n <= 0) {
+      return 0;
+    }
+    final byte[] buffer = new byte[(int) Math.min(DRAIN_BUFFER_BYTES, n)];
+    long skipped = 0;
+    while (skipped < n) {
+      final int read = read(buffer, 0, (int) Math.min(buffer.length, n - skipped));
+      if (read == -1) {
+        break;
+      }
+      skipped += read;
+    }
+    return skipped;
+  }
+
+  /**
+   * Reads whatever remains of the stream so the digests cover the whole file, even when the reader
+   * stopped at a structure that ends before the last byte.
+   *
+   * @throws IOException if the remainder cannot be read
+   */
+  public void drain() throws IOException {
+    final byte[] buffer = new byte[DRAIN_BUFFER_BYTES];
+    while (read(buffer, 0, buffer.length) != -1) {
+      // The read itself updates the digests.
+    }
+  }
+
+  /**
+   * Returns the SHA-1 of everything read so far.
+   *
+   * @return the digest as lowercase hexadecimal
+   */
+  @Nonnull
+  public String sha1Hex() {
+    return hex(snapshot(sha1));
+  }
+
+  /**
+   * Returns the SHA-256 of everything read so far.
+   *
+   * @return the digest as lowercase hexadecimal
+   */
+  @Nonnull
+  public String sha256Hex() {
+    return hex(snapshot(sha256));
+  }
+
+  /** Digests a copy, so the stream can go on being read after its hash has been taken. */
+  @Nonnull
+  private static byte[] snapshot(@Nonnull final MessageDigest digest) {
+    try {
+      return ((MessageDigest) digest.clone()).digest();
+    } catch (final CloneNotSupportedException e) {
+      throw new IllegalStateException(digest.getAlgorithm() + " digests cannot be copied", e);
+    }
+  }
+
+  @Nonnull
+  private static MessageDigest digest(@Nonnull final String algorithm) {
+    try {
+      return MessageDigest.getInstance(algorithm);
+    } catch (final NoSuchAlgorithmException e) {
+      throw new IllegalStateException(algorithm + " is not available", e);
+    }
+  }
+
+  @Nonnull
+  private static String hex(@Nonnull final byte[] bytes) {
+    final char[] chars = new char[bytes.length * 2];
+    for (int i = 0; i < bytes.length; i++) {
+      final int value = bytes[i] & 0xFF;
+      chars[i * 2] = HEX[value >>> 4];
+      chars[i * 2 + 1] = HEX[value & 0x0F];
+    }
+    return new String(chars);
+  }
+}

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/ExtractedArchive.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/ExtractedArchive.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import jakarta.annotation.Nonnull;
+import java.nio.file.Path;
+import lombok.Value;
+
+/**
+ * The outcome of extracting an archive: the temporary directory holding its content, and the digest
+ * of the archive bytes, taken during the extraction rather than in a pass of its own.
+ *
+ * @author John Grimes
+ */
+@Value
+public class ExtractedArchive {
+
+  /** The temporary directory holding the extracted release. */
+  @Nonnull Path directory;
+
+  /** The SHA-256 of the whole archive as lowercase hexadecimal. */
+  @Nonnull String sha256;
+}

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/FhirResourceScanner.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/FhirResourceScanner.java
@@ -19,6 +19,7 @@ package au.csiro.pathling.terminology.store;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
@@ -29,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -42,9 +44,13 @@ import org.apache.hadoop.fs.RemoteIterator;
  * size before writing anything, with peak memory independent of the source size.
  *
  * <p>The scan handles the same three source shapes as the importer: a bare JSON file, a directory
- * of JSON files, and a FHIR NPM package ({@code .tgz}). Package metadata entries are skipped. For
- * an archive the scan is a single streamed pass; the importer reads the archive a second time for
- * the content pass, since a gzip stream is not seekable.
+ * of JSON files, and a FHIR NPM package ({@code .tgz}). A package's {@code package.json} is read
+ * for the package identity rather than scanned as a resource, and other metadata entries are
+ * skipped. For an archive the scan is a single streamed pass; the importer reads the archive a
+ * second time for the content pass, since a gzip stream is not seekable.
+ *
+ * <p>The same pass digests a single-file source, so its SHA-1 and SHA-256 are known before the
+ * import writes anything.
  *
  * @author John Grimes
  */
@@ -61,6 +67,12 @@ public class FhirResourceScanner {
   private static final String FIELD_CONCEPT = "concept";
 
   private static final String FIELD_ENTRY = "entry";
+
+  /** The package manifest field naming the package, alongside the shared {@code version} field. */
+  private static final String FIELD_NAME = "name";
+
+  /** The name of the package manifest entry, which carries the package identity. */
+  private static final String PACKAGE_MANIFEST = "package.json";
 
   private static final JsonFactory FACTORY = newFactory();
 
@@ -87,11 +99,11 @@ public class FhirResourceScanner {
    * Scans every resource in a source, returning their metadata without reading their content.
    *
    * @param source a JSON file, a directory of JSON files, or a FHIR NPM package ({@code .tgz})
-   * @return the scanned resources, in the order they were encountered
+   * @return the scanned resources with the digests and package identity of the source
    * @throws TerminologyImportException if the source does not exist or cannot be read
    */
   @Nonnull
-  public List<ScannedResource> scan(@Nonnull final String source) {
+  public FhirSourceScan scan(@Nonnull final String source) {
     final Path root = new Path(source);
     final List<ScannedResource> scanned = new ArrayList<>();
     log.info("Scanning FHIR terminology source {}", source);
@@ -101,18 +113,23 @@ public class FhirResourceScanner {
         throw new TerminologyImportException("FHIR source path does not exist: " + source);
       }
       if (fs.getFileStatus(root).isDirectory()) {
+        // A directory is a set of files with no single set of bytes to hash.
         scanDirectory(fs, root, scanned);
-      } else if (isPackage(source)) {
-        scanPackage(fs, root, scanned);
-      } else {
-        try (InputStream in = fs.open(root)) {
-          scanned.add(scanStream(in, source, fs.getFileStatus(root).getLen()));
-        }
+        return new FhirSourceScan(scanned, null, null, null, null, false);
+      }
+      if (isPackage(source)) {
+        return scanPackage(fs, root, scanned);
+      }
+      try (DigestingInputStream in = new DigestingInputStream(fs.open(root))) {
+        scanned.add(scanStream(in, source, fs.getFileStatus(root).getLen()));
+        // The pre-scan stops at the first large content array, so the rest of the file is pulled
+        // through the digests here.
+        in.drain();
+        return new FhirSourceScan(scanned, in.sha1Hex(), in.sha256Hex(), null, null, false);
       }
     } catch (final IOException e) {
       throw new TerminologyImportException("Unable to read the FHIR source at " + source, e);
     }
-    return scanned;
   }
 
   private void scanDirectory(
@@ -132,27 +149,76 @@ public class FhirResourceScanner {
     }
   }
 
-  private void scanPackage(
+  @Nonnull
+  private FhirSourceScan scanPackage(
       @Nonnull final FileSystem fs,
       @Nonnull final Path root,
       @Nonnull final List<ScannedResource> scanned)
       throws IOException {
-    try (TarArchiveInputStream tar =
-        new TarArchiveInputStream(new GzipCompressorInputStream(fs.open(root)))) {
-      TarArchiveEntry entry;
-      while ((entry = tar.getNextEntry()) != null) {
-        if (entry.isDirectory()) {
-          continue;
-        }
-        final String name = new Path(entry.getName()).getName();
-        if (name.endsWith(".json") && !isPackageMetadata(name)) {
-          // The tar input stream reports end-of-entry, so Jackson never reads past the entry
-          // boundary; any unread bytes of an early-exited entry are skipped by the next call to
-          // getNextEntry.
-          scanned.add(scanStream(tar, entry.getName(), entry.getSize()));
+    String packageName = null;
+    String packageVersion = null;
+    try (DigestingInputStream digesting = new DigestingInputStream(fs.open(root))) {
+      // Closing the tar and gzip readers must not close the digesting stream, which still has the
+      // bytes trailing the last entry to give up.
+      try (TarArchiveInputStream tar =
+          new TarArchiveInputStream(
+              new GzipCompressorInputStream(CloseShieldInputStream.wrap(digesting)))) {
+        TarArchiveEntry entry;
+        while ((entry = tar.getNextEntry()) != null) {
+          if (entry.isDirectory()) {
+            continue;
+          }
+          final String name = new Path(entry.getName()).getName();
+          if (name.equals(PACKAGE_MANIFEST)) {
+            final String[] identity = readPackageIdentity(tar);
+            packageName = identity[0];
+            packageVersion = identity[1];
+          } else if (name.endsWith(".json") && !isPackageMetadata(name)) {
+            // The tar input stream reports end-of-entry, so Jackson never reads past the entry
+            // boundary; any unread bytes of an early-exited entry are skipped by the next call to
+            // getNextEntry.
+            scanned.add(scanStream(tar, entry.getName(), entry.getSize()));
+          }
         }
       }
+      // The gzip and tar readers stop at the end of the archive's last entry, so the trailing
+      // padding and any bytes beyond it are pulled through the digests here.
+      digesting.drain();
+      return new FhirSourceScan(
+          scanned, digesting.sha1Hex(), digesting.sha256Hex(), packageName, packageVersion, true);
     }
+  }
+
+  /**
+   * Reads the {@code name} and {@code version} of a package from its {@code package.json} entry,
+   * leaving either null when the field is absent.
+   *
+   * @param in the {@code package.json} entry stream, which is not closed
+   * @return the name at index zero and the version at index one
+   * @throws IOException if the entry cannot be read
+   */
+  @Nonnull
+  private static String[] readPackageIdentity(@Nonnull final InputStream in) throws IOException {
+    final String[] identity = new String[2];
+    try (JsonParser parser = FACTORY.createParser(in)) {
+      if (parser.nextToken() != JsonToken.START_OBJECT) {
+        return identity;
+      }
+      while (parser.nextToken() == JsonToken.FIELD_NAME) {
+        final String field = parser.currentName();
+        parser.nextToken();
+        switch (field) {
+          case FIELD_NAME -> identity[0] = parser.getValueAsString();
+          case FIELD_VERSION -> identity[1] = parser.getValueAsString();
+          default -> parser.skipChildren();
+        }
+      }
+    } catch (final JsonProcessingException e) {
+      // A package.json that is not readable JSON leaves the package unidentified, exactly as an
+      // absent one does; the import then records it as unverified.
+      log.warn("Unable to read the package.json of the package being imported", e);
+    }
+    return identity;
   }
 
   /**
@@ -206,6 +272,6 @@ public class FhirResourceScanner {
 
   /** Excludes the package manifest and index, which are not FHIR resources. */
   static boolean isPackageMetadata(@Nonnull final String name) {
-    return name.equals("package.json") || name.startsWith(".");
+    return name.equals(PACKAGE_MANIFEST) || name.startsWith(".");
   }
 }

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/FhirSourceScan.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/FhirSourceScan.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import lombok.Value;
+
+/**
+ * The result of the pre-scan of a FHIR terminology source: the resources it holds, the digests of
+ * its bytes when it is a single file, and the identity of the FHIR NPM package it is, if it is one.
+ *
+ * @author John Grimes
+ */
+@Value
+public class FhirSourceScan {
+
+  /** The scanned resources, in the order they were encountered. */
+  @Nonnull List<ScannedResource> resources;
+
+  /** The SHA-1 of the source file bytes as lowercase hexadecimal, or null for a directory. */
+  @Nullable String sha1;
+
+  /** The SHA-256 of the source file bytes as lowercase hexadecimal, or null for a directory. */
+  @Nullable String sha256;
+
+  /** The {@code name} from the package's {@code package.json}, or null if there is none. */
+  @Nullable String packageName;
+
+  /** The {@code version} from the package's {@code package.json}, or null if there is none. */
+  @Nullable String packageVersion;
+
+  /** Whether the source is a FHIR NPM package. */
+  boolean isPackage;
+}

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/FhirTerminologyImporter.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/FhirTerminologyImporter.java
@@ -152,13 +152,23 @@ public class FhirTerminologyImporter {
    * Imports FHIR terminology resources from a source.
    *
    * @param source a JSON file, a directory of JSON files, or a FHIR NPM package ({@code .tgz})
+   * @param verifyPackage whether a package is checked against the checksum its registry publishes
+   * @param registryUrl the registry to consult, or null for the default
    * @throws TerminologyImportException if the source contains no importable resources or an invalid
-   *     resource; the store is left unmodified
+   *     resource, or if a package does not match the registry's checksum; the store is left
+   *     unmodified
    */
-  public void importFrom(@Nonnull final String source) {
+  public void importFrom(
+      @Nonnull final String source,
+      final boolean verifyPackage,
+      @Nullable final String registryUrl) {
     // Pre-scan and validate before any write so an invalid source leaves the store untouched.
-    final List<ScannedResource> scanned = new FhirResourceScanner(hadoopConf).scan(source);
+    final FhirSourceScan scan = new FhirResourceScanner(hadoopConf).scan(source);
+    final List<ScannedResource> scanned = scan.getResources();
     validate(scanned, source);
+    // The verification runs before anything is written, so a package that does not match its
+    // registry leaves the store exactly as it was.
+    final ImportProvenance provenance = resolveProvenance(scan, source, verifyPackage, registryUrl);
     // The pre-scan already established each entry's type, URL, and version, so the import pass
     // routes by looking these up rather than re-reading each entry's content into memory.
     final Map<String, ScannedResource> byEntry = new HashMap<>();
@@ -175,7 +185,7 @@ public class FhirTerminologyImporter {
     final String previousBlockSize =
         applyBoundedParquetRowGroup(baseHadoopConf, IMPORT_PARQUET_BLOCK_SIZE_BYTES);
     try {
-      importPass(source, byEntry, writer, loader, counts);
+      importPass(provenance, byEntry, writer, loader, counts);
     } catch (final IOException e) {
       throw new TerminologyImportException("Unable to read the FHIR source at " + source, e);
     } finally {
@@ -186,6 +196,56 @@ public class FhirTerminologyImporter {
         counts.codeSystems,
         counts.valueSets,
         counts.conceptMaps);
+  }
+
+  /**
+   * Establishes what this import records about where its content came from, consulting the registry
+   * when the source is an identified package and the caller asked for the check.
+   *
+   * @param scan the pre-scan of the source, carrying its digests and package identity
+   * @param source the source path, as passed to the import
+   * @param verifyPackage whether a package is checked against the registry
+   * @param registryUrl the registry to consult, or null for the default
+   * @return the provenance every manifest row of this import carries
+   * @throws TerminologyImportException if the package does not match the registry's checksum
+   */
+  @Nonnull
+  private static ImportProvenance resolveProvenance(
+      @Nonnull final FhirSourceScan scan,
+      @Nonnull final String source,
+      final boolean verifyPackage,
+      @Nullable final String registryUrl) {
+    if (scan.getSha256() != null) {
+      log.info("Source {} has SHA-256 {}", source, scan.getSha256());
+    }
+    if (!scan.isPackage()) {
+      return ImportProvenance.of(source, scan.getSha256());
+    }
+    final String name = scan.getPackageName();
+    final String version = scan.getPackageVersion();
+    final PackageVerificationResult result;
+    if (name == null || version == null || scan.getSha1() == null) {
+      // Without an identity there is nothing to ask the registry about.
+      result = PackageVerificationResult.unverified("the package could not be identified");
+      log.warn("The package at {} was not verified: {}", source, result.getReason());
+    } else if (!verifyPackage) {
+      result = new PackageVerificationResult(PackageVerification.SKIPPED, null, null);
+      log.info("Package verification skipped for {} {}", name, version);
+    } else {
+      result = new PackageRegistryVerifier(registryUrl).verify(name, version, scan.getSha1());
+      if (result.getStatus() == PackageVerification.VERIFIED) {
+        log.info(
+            "Verified package {} {} against {} (SHA-1 {})",
+            name,
+            version,
+            result.getRegistry(),
+            scan.getSha1());
+      } else {
+        log.warn("Package {} {} was not verified: {}", name, version, result.getReason());
+      }
+    }
+    return new ImportProvenance(
+        source, scan.getSha256(), name, version, result.getStatus(), result.getRegistry());
   }
 
   /**
@@ -275,12 +335,13 @@ public class FhirTerminologyImporter {
   // --- Import pass. ---
 
   private void importPass(
-      @Nonnull final String source,
+      @Nonnull final ImportProvenance provenance,
       @Nonnull final Map<String, ScannedResource> byEntry,
       @Nonnull final TerminologyStoreWriter writer,
       @Nonnull final CodeSystemStageLoader loader,
       @Nonnull final ImportCounts counts)
       throws IOException {
+    final String source = provenance.getSource();
     final Path root = new Path(source);
     final FileSystem fs = root.getFileSystem(hadoopConf);
     if (fs.getFileStatus(root).isDirectory()) {
@@ -290,7 +351,8 @@ public class FhirTerminologyImporter {
         final String name = status.getPath().getName();
         if (name.endsWith(".json") && !FhirResourceScanner.isPackageMetadata(name)) {
           try (InputStream in = fs.open(status.getPath())) {
-            importEntry(in, status.getPath().toString(), source, byEntry, writer, loader, counts);
+            importEntry(
+                in, status.getPath().toString(), provenance, byEntry, writer, loader, counts);
           }
         }
       }
@@ -303,13 +365,13 @@ public class FhirTerminologyImporter {
           if (!entry.isDirectory()
               && name.endsWith(".json")
               && !FhirResourceScanner.isPackageMetadata(name)) {
-            importEntry(tar, entry.getName(), source, byEntry, writer, loader, counts);
+            importEntry(tar, entry.getName(), provenance, byEntry, writer, loader, counts);
           }
         }
       }
     } else {
       try (InputStream in = fs.open(root)) {
-        importEntry(in, source, source, byEntry, writer, loader, counts);
+        importEntry(in, source, provenance, byEntry, writer, loader, counts);
       }
     }
   }
@@ -324,7 +386,7 @@ public class FhirTerminologyImporter {
   private void importEntry(
       @Nonnull final InputStream in,
       @Nonnull final String entryName,
-      @Nonnull final String source,
+      @Nonnull final ImportProvenance provenance,
       @Nonnull final Map<String, ScannedResource> byEntry,
       @Nonnull final TerminologyStoreWriter writer,
       @Nonnull final CodeSystemStageLoader loader,
@@ -336,9 +398,9 @@ public class FhirTerminologyImporter {
     }
     if (scanned.isCodeSystem()) {
       requireUrl(scanned.getUrl(), "CodeSystem", entryName);
-      flattenAndLoad(in, scanned.getUrl(), scanned.getVersion(), source, loader, counts);
+      flattenAndLoad(in, scanned.getUrl(), scanned.getVersion(), provenance, loader, counts);
     } else {
-      importWholeResource(IOUtils.toByteArray(in), entryName, source, writer, loader, counts);
+      importWholeResource(IOUtils.toByteArray(in), entryName, provenance, writer, loader, counts);
     }
   }
 
@@ -351,7 +413,7 @@ public class FhirTerminologyImporter {
       @Nonnull final InputStream in,
       @Nonnull final String url,
       @Nullable final String version,
-      @Nonnull final String source,
+      @Nonnull final ImportProvenance provenance,
       @Nonnull final CodeSystemStageLoader loader,
       @Nonnull final ImportCounts counts) {
     log.info("Streaming CodeSystem {}", url);
@@ -367,14 +429,14 @@ public class FhirTerminologyImporter {
             "Unable to parse CodeSystem "
                 + url
                 + " from "
-                + source
+                + provenance.getSource()
                 + "; the source may be corrupt.",
             e);
       }
       staging.sealForReading();
       counts.writeBegun = true;
       try {
-        loader.load(staging, url, version, flattener.getHierarchyMeaning(), source);
+        loader.load(staging, url, version, flattener.getHierarchyMeaning(), provenance);
       } catch (final RuntimeException e) {
         throw partialFailure(url, version, e);
       }
@@ -398,7 +460,7 @@ public class FhirTerminologyImporter {
   private void importWholeResource(
       @Nonnull final byte[] bytes,
       @Nonnull final String entryName,
-      @Nonnull final String source,
+      @Nonnull final ImportProvenance provenance,
       @Nonnull final TerminologyStoreWriter writer,
       @Nonnull final CodeSystemStageLoader loader,
       @Nonnull final ImportCounts counts) {
@@ -413,18 +475,18 @@ public class FhirTerminologyImporter {
       for (final Bundle.BundleEntryComponent bundleEntry : bundle.getEntry()) {
         final Resource resource = bundleEntry.getResource();
         if (resource != null) {
-          importBundleResource(resource, entryName, source, writer, loader, counts);
+          importBundleResource(resource, entryName, provenance, writer, loader, counts);
         }
       }
     } else if (parsed instanceof final Resource resource) {
-      importBundleResource(resource, entryName, source, writer, loader, counts);
+      importBundleResource(resource, entryName, provenance, writer, loader, counts);
     }
   }
 
   private void importBundleResource(
       @Nonnull final Resource resource,
       @Nonnull final String entryName,
-      @Nonnull final String source,
+      @Nonnull final ImportProvenance provenance,
       @Nonnull final TerminologyStoreWriter writer,
       @Nonnull final CodeSystemStageLoader loader,
       @Nonnull final ImportCounts counts) {
@@ -437,7 +499,7 @@ public class FhirTerminologyImporter {
           new java.io.ByteArrayInputStream(json),
           codeSystem.getUrl(),
           codeSystem.getVersion(),
-          source,
+          provenance,
           loader,
           counts);
     } else if (resource instanceof final ValueSet valueSet) {
@@ -450,7 +512,7 @@ public class FhirTerminologyImporter {
           valueSet.getUrl(),
           valueSet.getVersion(),
           valueSet,
-          source);
+          provenance);
       counts.valueSets++;
     } else if (resource instanceof final ConceptMap conceptMap) {
       requireUrl(conceptMap.getUrl(), "ConceptMap", entryName);
@@ -462,7 +524,7 @@ public class FhirTerminologyImporter {
           conceptMap.getUrl(),
           conceptMap.getVersion(),
           conceptMap,
-          source);
+          provenance);
       counts.conceptMaps++;
     }
   }
@@ -476,7 +538,7 @@ public class FhirTerminologyImporter {
       @Nonnull final String url,
       @Nullable final String version,
       @Nonnull final Resource resource,
-      @Nonnull final String source) {
+      @Nonnull final ImportProvenance provenance) {
     final String json = parser().encodeResourceToString(resource);
     final Dataset<Row> data =
         spark.createDataFrame(
@@ -495,13 +557,7 @@ public class FhirTerminologyImporter {
       writer.writeTable(data, tableName, SaveMode.Overwrite, List.of());
     }
     writer.upsertManifestEntry(
-        new ManifestEntry(
-            TerminologyStoreSchema.STORE_FORMAT_VERSION,
-            entryType,
-            url,
-            version,
-            source,
-            Instant.now()));
+        ManifestEntry.forImport(entryType, url, version, provenance, Instant.now()));
   }
 
   /** Mutable running counts and the write-begun flag across an import. */

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/ImportProvenance.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/ImportProvenance.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.Value;
+
+/**
+ * Everything an import records about where its content came from: the source as the caller supplied
+ * it, the digest of the source bytes, and the identity and verification outcome of the package it
+ * came from. Every manifest row written by one import carries the same values.
+ *
+ * @author John Grimes
+ */
+@Value
+public class ImportProvenance implements Serializable {
+
+  @Serial private static final long serialVersionUID = 1L;
+
+  /** The source path or archive, as passed to the import. */
+  @Nonnull String source;
+
+  /** The SHA-256 of the source file bytes as lowercase hexadecimal, or null for a directory. */
+  @Nullable String sourceSha256;
+
+  /** The package name from the tarball's {@code package.json}, or null if not a named package. */
+  @Nullable String packageName;
+
+  /** The package version from the tarball's {@code package.json}, or null if not versioned. */
+  @Nullable String packageVersion;
+
+  /** The registry verification outcome, or null if the source was not a package. */
+  @Nullable PackageVerification packageVerification;
+
+  /** The registry that vouched for the bytes, set only when the package was verified. */
+  @Nullable String packageRegistry;
+
+  /**
+   * Creates the provenance of a source that is not a FHIR NPM package, which carries no package
+   * identity and no verification outcome.
+   *
+   * @param source the source path, as passed to the import
+   * @param sourceSha256 the SHA-256 of the source file bytes, or null for a directory
+   * @return the provenance of the source
+   */
+  @Nonnull
+  public static ImportProvenance of(
+      @Nonnull final String source, @Nullable final String sourceSha256) {
+    return new ImportProvenance(source, sourceSha256, null, null, null, null);
+  }
+}

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/ManifestEntry.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/ManifestEntry.java
@@ -33,7 +33,7 @@ import lombok.Value;
 @Value
 public class ManifestEntry implements Serializable {
 
-  @Serial private static final long serialVersionUID = 1L;
+  @Serial private static final long serialVersionUID = 2L;
 
   /** The store format version at the time this entry was written. */
   int storeFormatVersion;
@@ -52,4 +52,52 @@ public class ManifestEntry implements Serializable {
 
   /** When the entry was imported, or null if not recorded. */
   @Nullable Instant importedAt;
+
+  /** The SHA-256 of the source file bytes as lowercase hexadecimal, or null if not recorded. */
+  @Nullable String sourceSha256;
+
+  /** The name of the package the entry came from, or null if it did not come from one. */
+  @Nullable String packageName;
+
+  /** The version of the package the entry came from, or null if it did not come from one. */
+  @Nullable String packageVersion;
+
+  /** The registry verification outcome of the package, or null if the source was not a package. */
+  @Nullable PackageVerification packageVerification;
+
+  /** The registry that vouched for the package bytes, set only when the package was verified. */
+  @Nullable String packageRegistry;
+
+  /**
+   * Creates an entry describing a resource written by an import, taking the provenance values from
+   * the import that wrote it.
+   *
+   * @param entryType the kind of entry: {@code code_system}, {@code value_set} or {@code
+   *     concept_map}
+   * @param canonicalUrl the canonical URL of the entry
+   * @param version the version of the entry, or null if unversioned
+   * @param provenance the provenance of the import that wrote the entry
+   * @param importedAt when the entry was imported
+   * @return the manifest entry
+   */
+  @Nonnull
+  public static ManifestEntry forImport(
+      @Nonnull final String entryType,
+      @Nonnull final String canonicalUrl,
+      @Nullable final String version,
+      @Nonnull final ImportProvenance provenance,
+      @Nonnull final Instant importedAt) {
+    return new ManifestEntry(
+        TerminologyStoreSchema.STORE_FORMAT_VERSION,
+        entryType,
+        canonicalUrl,
+        version,
+        provenance.getSource(),
+        importedAt,
+        provenance.getSourceSha256(),
+        provenance.getPackageName(),
+        provenance.getPackageVersion(),
+        provenance.getPackageVerification(),
+        provenance.getPackageRegistry());
+  }
 }

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/PackageRegistryVerifier.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/PackageRegistryVerifier.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serial;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+/**
+ * Checks a FHIR NPM package against the checksum its registry publishes, by fetching the package's
+ * version listing and comparing the tarball's SHA-1 with {@code versions.<version>.dist.shasum}.
+ *
+ * <p>Only a checksum that is present and differs fails the import: every other outcome, from an
+ * unreachable registry to a version published without a checksum, leaves the package unverified
+ * with a reason, since a registry that cannot answer is not evidence that the bytes are wrong.
+ *
+ * @author John Grimes
+ */
+@Slf4j
+public class PackageRegistryVerifier {
+
+  /** The registry consulted when the caller names none. */
+  public static final String DEFAULT_REGISTRY_URL = "https://packages.fhir.org";
+
+  /** The time allowed to establish a connection to the registry. */
+  private static final int CONNECT_TIMEOUT_MS = 10_000;
+
+  /** The time allowed between bytes of the registry's answer. */
+  private static final int READ_TIMEOUT_MS = 30_000;
+
+  private static final String FIELD_VERSIONS = "versions";
+
+  private static final String FIELD_DIST = "dist";
+
+  private static final String FIELD_SHASUM = "shasum";
+
+  private static final JsonFactory FACTORY = new JsonFactory();
+
+  @Nonnull private final String registryUrl;
+
+  /**
+   * Creates a verifier pointed at a registry.
+   *
+   * @param registryUrl the registry base URL, or null to use {@link #DEFAULT_REGISTRY_URL}; any
+   *     trailing slashes are ignored
+   */
+  public PackageRegistryVerifier(@Nullable final String registryUrl) {
+    this.registryUrl = normalise(registryUrl == null ? DEFAULT_REGISTRY_URL : registryUrl);
+  }
+
+  /**
+   * Returns the registry this verifier consults, as it will be recorded in the store manifest.
+   *
+   * @return the normalised registry base URL
+   */
+  @Nonnull
+  public String getRegistryUrl() {
+    return registryUrl;
+  }
+
+  /**
+   * Checks a package's bytes against the checksum the registry publishes for its version.
+   *
+   * @param packageName the package name from its {@code package.json}
+   * @param packageVersion the package version from its {@code package.json}
+   * @param sha1Hex the SHA-1 of the tarball, as lowercase hexadecimal
+   * @return a verified result naming the registry, or an unverified result carrying the reason no
+   *     comparison could be made
+   * @throws TerminologyImportException if the registry publishes a checksum that differs
+   */
+  @Nonnull
+  public PackageVerificationResult verify(
+      @Nonnull final String packageName,
+      @Nonnull final String packageVersion,
+      @Nonnull final String sha1Hex) {
+    final String url = registryUrl + "/" + encodeSegment(packageName);
+    final String published;
+    try {
+      published = fetchShasum(url, packageVersion);
+    } catch (final UnusableAnswer e) {
+      return PackageVerificationResult.unverified(e.getMessage());
+    } catch (final IOException e) {
+      final String message = e.getMessage();
+      return PackageVerificationResult.unverified(
+          message == null ? e.getClass().getSimpleName() : message);
+    }
+    if (published == null) {
+      return PackageVerificationResult.unverified("the registry publishes no checksum");
+    }
+    if (!published.equalsIgnoreCase(sha1Hex)) {
+      throw new TerminologyImportException(
+          "The package "
+              + packageName
+              + " "
+              + packageVersion
+              + " does not match the registry checksum published by "
+              + registryUrl
+              + ": expected SHA-1 "
+              + published
+              + " but the source has SHA-1 "
+              + sha1Hex
+              + ". The source may be corrupt or tampered with; import it anyway by turning off the"
+              + " verifyPackage option.");
+    }
+    return PackageVerificationResult.verified(registryUrl);
+  }
+
+  /**
+   * Fetches the checksum a registry publishes for a version of a package.
+   *
+   * @param url the listing URL
+   * @param packageVersion the version whose checksum is wanted
+   * @return the published checksum, or null if the version carries none
+   * @throws UnusableAnswer if the registry did not answer with a listing holding the version
+   * @throws IOException if the registry could not be reached
+   */
+  @Nullable
+  private static String fetchShasum(@Nonnull final String url, @Nonnull final String packageVersion)
+      throws IOException {
+    final RequestConfig config =
+        RequestConfig.custom()
+            .setConnectTimeout(CONNECT_TIMEOUT_MS)
+            .setConnectionRequestTimeout(CONNECT_TIMEOUT_MS)
+            .setSocketTimeout(READ_TIMEOUT_MS)
+            .setRedirectsEnabled(true)
+            .build();
+    try (CloseableHttpClient client =
+        HttpClients.custom().setDefaultRequestConfig(config).build()) {
+      final HttpGet request = new HttpGet(url);
+      request.setHeader("Accept", "application/json");
+      try (CloseableHttpResponse response = client.execute(request)) {
+        final int status = response.getStatusLine().getStatusCode();
+        if (status == 404) {
+          throw new UnusableAnswer("package not found");
+        }
+        if (status < 200 || status >= 300) {
+          throw new UnusableAnswer("HTTP " + status);
+        }
+        final HttpEntity entity = response.getEntity();
+        if (entity == null) {
+          throw new UnusableAnswer("unexpected response");
+        }
+        try (InputStream body = entity.getContent()) {
+          return readShasum(body, packageVersion);
+        }
+      }
+    }
+  }
+
+  /**
+   * Walks a version listing to the checksum of one version, skipping everything else, so a listing
+   * of hundreds of versions costs no more than the bytes it takes to reach the one that matters.
+   *
+   * @param body the listing document
+   * @param packageVersion the version whose checksum is wanted
+   * @return the published checksum, or null if the version carries none
+   * @throws UnusableAnswer if the document is not a listing holding the version
+   * @throws IOException if the body cannot be read
+   */
+  @Nullable
+  private static String readShasum(
+      @Nonnull final InputStream body, @Nonnull final String packageVersion) throws IOException {
+    try (JsonParser parser = FACTORY.createParser(body)) {
+      if (parser.nextToken() != JsonToken.START_OBJECT) {
+        throw new UnusableAnswer("unexpected response");
+      }
+      while (parser.nextToken() == JsonToken.FIELD_NAME) {
+        final boolean versions = FIELD_VERSIONS.equals(parser.currentName());
+        parser.nextToken();
+        if (!versions) {
+          parser.skipChildren();
+          continue;
+        }
+        if (parser.currentToken() != JsonToken.START_OBJECT) {
+          throw new UnusableAnswer("unexpected response");
+        }
+        return readVersion(parser, packageVersion);
+      }
+    } catch (final JsonProcessingException e) {
+      throw new UnusableAnswer("unexpected response");
+    }
+    throw new UnusableAnswer("unexpected response");
+  }
+
+  /** Reads the checksum of one version out of the {@code versions} object. */
+  @Nullable
+  private static String readVersion(
+      @Nonnull final JsonParser parser, @Nonnull final String packageVersion) throws IOException {
+    while (parser.nextToken() == JsonToken.FIELD_NAME) {
+      final boolean wanted = packageVersion.equals(parser.currentName());
+      parser.nextToken();
+      if (!wanted) {
+        parser.skipChildren();
+        continue;
+      }
+      return readDist(parser);
+    }
+    throw new UnusableAnswer("version not listed");
+  }
+
+  /** Reads {@code dist.shasum} out of the metadata of one version. */
+  @Nullable
+  private static String readDist(@Nonnull final JsonParser parser) throws IOException {
+    if (parser.currentToken() != JsonToken.START_OBJECT) {
+      throw new UnusableAnswer("unexpected response");
+    }
+    String shasum = null;
+    while (parser.nextToken() == JsonToken.FIELD_NAME) {
+      final boolean dist = FIELD_DIST.equals(parser.currentName());
+      parser.nextToken();
+      if (!dist) {
+        parser.skipChildren();
+        continue;
+      }
+      if (parser.currentToken() != JsonToken.START_OBJECT) {
+        parser.skipChildren();
+        continue;
+      }
+      while (parser.nextToken() == JsonToken.FIELD_NAME) {
+        final boolean isShasum = FIELD_SHASUM.equals(parser.currentName());
+        parser.nextToken();
+        if (isShasum) {
+          shasum = parser.getValueAsString();
+        } else {
+          parser.skipChildren();
+        }
+      }
+    }
+    return shasum;
+  }
+
+  @Nonnull
+  private static String encodeSegment(@Nonnull final String packageName) {
+    // A path segment encodes a space as %20, where the form encoding of URLEncoder uses a plus.
+    return URLEncoder.encode(packageName, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  @Nonnull
+  private static String normalise(@Nonnull final String url) {
+    int end = url.length();
+    while (end > 0 && url.charAt(end - 1) == '/') {
+      end--;
+    }
+    return url.substring(0, end);
+  }
+
+  /** A registry answer that carries no checksum to compare, along with the reason it does not. */
+  private static final class UnusableAnswer extends IOException {
+
+    @Serial private static final long serialVersionUID = 1L;
+
+    UnusableAnswer(@Nonnull final String reason) {
+      super(reason);
+    }
+  }
+}

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/PackageVerification.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/PackageVerification.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import jakarta.annotation.Nonnull;
+
+/**
+ * The outcome of checking an imported FHIR NPM package against the checksum its registry publishes.
+ * A source that is not a package records no status at all.
+ *
+ * @author John Grimes
+ */
+public enum PackageVerification {
+
+  /** The tarball's SHA-1 equals the {@code dist.shasum} the registry publishes for the version. */
+  VERIFIED("verified"),
+
+  /**
+   * The source is a package, but no registry checksum could be compared: the package could not be
+   * identified, the registry could not be consulted or did not list the package or version, or the
+   * version carries no checksum.
+   */
+  UNVERIFIED("unverified"),
+
+  /** The source is a package, but the caller disabled verification. */
+  SKIPPED("skipped");
+
+  @Nonnull private final String code;
+
+  PackageVerification(@Nonnull final String code) {
+    this.code = code;
+  }
+
+  /**
+   * Returns the code this status is recorded as in the store manifest.
+   *
+   * @return the manifest code
+   */
+  @Nonnull
+  public String getCode() {
+    return code;
+  }
+
+  /**
+   * Resolves a status from the code recorded in the store manifest.
+   *
+   * @param code the manifest code
+   * @return the corresponding status
+   * @throws IllegalArgumentException if the code is not a known status
+   */
+  @Nonnull
+  public static PackageVerification fromCode(@Nonnull final String code) {
+    for (final PackageVerification value : values()) {
+      if (value.code.equals(code)) {
+        return value;
+      }
+    }
+    throw new IllegalArgumentException("Unknown package verification status: " + code);
+  }
+}

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/PackageVerificationResult.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/PackageVerificationResult.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import lombok.Value;
+
+/**
+ * The outcome of consulting a registry about a package, short of a mismatch: a mismatch is not a
+ * result but a thrown {@link TerminologyImportException}.
+ *
+ * @author John Grimes
+ */
+@Value
+public class PackageVerificationResult {
+
+  /** The verification outcome. */
+  @Nonnull PackageVerification status;
+
+  /** The registry that vouched for the bytes, set only when the status is verified. */
+  @Nullable String registry;
+
+  /** Why the package could not be verified, for the warning; null when it was verified. */
+  @Nullable String reason;
+
+  /**
+   * Creates the result of a successful comparison against a registry's checksum.
+   *
+   * @param registry the normalised registry URL that published the checksum
+   * @return the verified result
+   */
+  @Nonnull
+  public static PackageVerificationResult verified(@Nonnull final String registry) {
+    return new PackageVerificationResult(PackageVerification.VERIFIED, registry, null);
+  }
+
+  /**
+   * Creates the result of a lookup that could not establish a checksum to compare.
+   *
+   * @param reason why no comparison was possible
+   * @return the unverified result
+   */
+  @Nonnull
+  public static PackageVerificationResult unverified(@Nonnull final String reason) {
+    return new PackageVerificationResult(PackageVerification.UNVERIFIED, null, reason);
+  }
+}

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
@@ -88,6 +88,7 @@ import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -218,14 +219,20 @@ public class SnomedRf2Importer {
       @Nonnull final DenseIdOrder denseIdOrder,
       @Nullable final String defaultDialect) {
     // A zip archive is extracted to a temporary directory first, since the file discovery and Spark
-    // readers operate on the extracted release layout. A plain directory is read in place.
-    final java.nio.file.Path extracted = isZipArchive(source) ? extractArchive(source) : null;
+    // readers operate on the extracted release layout. A plain directory is read in place, and has
+    // no bytes of its own to fingerprint.
+    final ExtractedArchive extracted = isZipArchive(source) ? extractArchive(source) : null;
+    final ImportProvenance provenance =
+        ImportProvenance.of(source, extracted != null ? extracted.getSha256() : null);
+    if (extracted != null) {
+      log.info("Source {} has SHA-256 {}", source, extracted.getSha256());
+    }
     try {
-      final String releaseRoot = extracted != null ? extracted.toString() : source;
-      importFromRelease(releaseRoot, source, editionUriOverride, denseIdOrder, defaultDialect);
+      final String releaseRoot = extracted != null ? extracted.getDirectory().toString() : source;
+      importFromRelease(releaseRoot, provenance, editionUriOverride, denseIdOrder, defaultDialect);
     } finally {
       if (extracted != null) {
-        deleteRecursively(extracted);
+        deleteRecursively(extracted.getDirectory());
       }
     }
   }
@@ -234,7 +241,7 @@ public class SnomedRf2Importer {
    * Imports an RF2 snapshot release from an extracted directory layout.
    *
    * @param releaseRoot the directory holding the extracted release, scanned for the Snapshot files
-   * @param source the original source path, recorded in the manifest for provenance
+   * @param provenance where the release came from, recorded in every manifest row it writes
    * @param editionUriOverride an explicit edition/version URI, or null to detect it
    * @param denseIdOrder the rule for assigning dense identifiers
    * @param defaultDialect the dialect whose preferred synonyms become each concept's display, or
@@ -242,7 +249,7 @@ public class SnomedRf2Importer {
    */
   private void importFromRelease(
       @Nonnull final String releaseRoot,
-      @Nonnull final String source,
+      @Nonnull final ImportProvenance provenance,
       @Nullable final String editionUriOverride,
       @Nonnull final DenseIdOrder denseIdOrder,
       @Nullable final String defaultDialect) {
@@ -315,7 +322,7 @@ public class SnomedRf2Importer {
     closure.unpersist();
     writer.writePartitionedBySystemVersion(refsets.members, REFSET_MEMBER, systemVersionId);
     logResolutions(refsets.resolutions);
-    writeManifest(writer, version, source);
+    writeManifest(writer, version, provenance);
     descriptions.cached.forEach(Dataset::unpersist);
     concepts.unpersist();
     codeOrdered.unpersist();
@@ -499,13 +506,14 @@ public class SnomedRf2Importer {
    * Extracts a zip archive to a fresh local temporary directory, reading the archive through the
    * Hadoop file system so it may reside on any accessible storage. Entries are streamed to disk to
    * bound memory use, and paths are validated to prevent extraction outside the target directory.
+   * The archive is digested as it is read, so its fingerprint costs no additional pass over it.
    *
    * @param source the path of the zip archive
-   * @return the temporary directory containing the extracted release
+   * @return the temporary directory containing the extracted release, and the archive's SHA-256
    * @throws TerminologyImportException if the archive cannot be read or extracted
    */
   @Nonnull
-  private java.nio.file.Path extractArchive(@Nonnull final String source) {
+  private ExtractedArchive extractArchive(@Nonnull final String source) {
     final Path archive = new Path(source);
     try {
       final FileSystem fs = archive.getFileSystem(hadoopConf);
@@ -514,24 +522,31 @@ public class SnomedRf2Importer {
       }
       final java.nio.file.Path target = SecureTempDirectory.create("pathling-rf2-");
       log.info("Extracting RF2 archive {} to {}", source, target);
-      try (final ZipInputStream zip =
-          new ZipInputStream(new BufferedInputStream(fs.open(archive)))) {
-        ZipEntry entry;
-        while ((entry = zip.getNextEntry()) != null) {
-          if (entry.isDirectory()) {
-            continue;
+      try (final DigestingInputStream digesting = new DigestingInputStream(fs.open(archive))) {
+        // Closing the zip reader must not close the digesting stream, which still has the central
+        // directory trailing the last entry to give up.
+        try (final ZipInputStream zip =
+            new ZipInputStream(new BufferedInputStream(CloseShieldInputStream.wrap(digesting)))) {
+          ZipEntry entry;
+          while ((entry = zip.getNextEntry()) != null) {
+            if (entry.isDirectory()) {
+              continue;
+            }
+            final java.nio.file.Path destination = target.resolve(entry.getName()).normalize();
+            if (!destination.startsWith(target)) {
+              throw new TerminologyImportException(
+                  "Refusing to extract archive entry outside the target directory: "
+                      + entry.getName());
+            }
+            Files.createDirectories(destination.getParent());
+            Files.copy(zip, destination, StandardCopyOption.REPLACE_EXISTING);
           }
-          final java.nio.file.Path destination = target.resolve(entry.getName()).normalize();
-          if (!destination.startsWith(target)) {
-            throw new TerminologyImportException(
-                "Refusing to extract archive entry outside the target directory: "
-                    + entry.getName());
-          }
-          Files.createDirectories(destination.getParent());
-          Files.copy(zip, destination, StandardCopyOption.REPLACE_EXISTING);
         }
+        // The zip reader stops at the central directory, so the bytes describing it are pulled
+        // through the digest here and the hash covers the whole file.
+        digesting.drain();
+        return new ExtractedArchive(target, digesting.sha256Hex());
       }
-      return target;
     } catch (final IOException e) {
       throw new TerminologyImportException("Unable to extract the RF2 archive at " + source, e);
     }
@@ -1198,10 +1213,9 @@ public class SnomedRf2Importer {
   private void writeManifest(
       @Nonnull final TerminologyStoreWriter writer,
       @Nonnull final String version,
-      @Nonnull final String source) {
+      @Nonnull final ImportProvenance provenance) {
     writer.upsertManifestEntry(
-        ManifestEntry.forImport(
-            "code_system", SNOMED_URI, version, ImportProvenance.of(source, null), Instant.now()));
+        ManifestEntry.forImport("code_system", SNOMED_URI, version, provenance, Instant.now()));
   }
 
   // --- Version detection. ---

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/SnomedRf2Importer.java
@@ -1200,13 +1200,8 @@ public class SnomedRf2Importer {
       @Nonnull final String version,
       @Nonnull final String source) {
     writer.upsertManifestEntry(
-        new ManifestEntry(
-            TerminologyStoreSchema.STORE_FORMAT_VERSION,
-            "code_system",
-            SNOMED_URI,
-            version,
-            source,
-            Instant.now()));
+        ManifestEntry.forImport(
+            "code_system", SNOMED_URI, version, ImportProvenance.of(source, null), Instant.now()));
   }
 
   // --- Version detection. ---

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/TerminologyStoreReader.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/TerminologyStoreReader.java
@@ -20,7 +20,12 @@ package au.csiro.pathling.terminology.store;
 import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_CANONICAL_URL;
 import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_ENTRY_TYPE;
 import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_IMPORTED_AT;
+import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_PACKAGE_NAME;
+import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_PACKAGE_REGISTRY;
+import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_PACKAGE_VERIFICATION;
+import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_PACKAGE_VERSION;
 import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_SOURCE;
+import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_SOURCE_SHA256;
 import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_STORE_FORMAT_VERSION;
 import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.COLUMN_VERSION;
 import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.STORE_FORMAT_VERSION;
@@ -41,6 +46,7 @@ import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -125,18 +131,35 @@ public class TerminologyStoreReader {
   @Nonnull
   public List<ManifestEntry> readManifest() {
     final List<ManifestEntry> entries = new ArrayList<>();
-    readTable(
-        TerminologyStoreSchema.MANIFEST,
-        row ->
-            entries.add(
-                new ManifestEntry(
-                    row.getInt(COLUMN_STORE_FORMAT_VERSION),
-                    row.getString(COLUMN_ENTRY_TYPE),
-                    row.getString(COLUMN_CANONICAL_URL),
-                    row.getString(COLUMN_VERSION),
-                    row.getString(COLUMN_SOURCE),
-                    row.getInstant(COLUMN_IMPORTED_AT))));
+    readTable(TerminologyStoreSchema.MANIFEST, row -> entries.add(manifestEntry(row)));
     return entries;
+  }
+
+  /**
+   * Builds a manifest entry from a manifest row, tolerating a manifest written before the
+   * provenance columns existed by reading them only where they are present.
+   */
+  @Nonnull
+  private static ManifestEntry manifestEntry(@Nonnull final TerminologyStoreRow row) {
+    final String verification = stringIfPresent(row, COLUMN_PACKAGE_VERIFICATION);
+    return new ManifestEntry(
+        row.getInt(COLUMN_STORE_FORMAT_VERSION),
+        row.getString(COLUMN_ENTRY_TYPE),
+        row.getString(COLUMN_CANONICAL_URL),
+        row.getString(COLUMN_VERSION),
+        row.getString(COLUMN_SOURCE),
+        row.getInstant(COLUMN_IMPORTED_AT),
+        stringIfPresent(row, COLUMN_SOURCE_SHA256),
+        stringIfPresent(row, COLUMN_PACKAGE_NAME),
+        stringIfPresent(row, COLUMN_PACKAGE_VERSION),
+        verification == null ? null : PackageVerification.fromCode(verification),
+        stringIfPresent(row, COLUMN_PACKAGE_REGISTRY));
+  }
+
+  @Nullable
+  private static String stringIfPresent(
+      @Nonnull final TerminologyStoreRow row, @Nonnull final String column) {
+    return row.hasColumn(column) ? row.getString(column) : null;
   }
 
   /**

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/TerminologyStoreRow.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/TerminologyStoreRow.java
@@ -45,6 +45,16 @@ public class TerminologyStoreRow {
   }
 
   /**
+   * Returns whether the named column is present in this row.
+   *
+   * @param column the column name
+   * @return true if the column is present
+   */
+  public boolean hasColumn(@Nonnull final String column) {
+    return row.getSchema().indexOf(column) >= 0;
+  }
+
+  /**
    * Returns whether the named column is null in this row.
    *
    * @param column the column name

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/TerminologyStoreSchema.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/TerminologyStoreSchema.java
@@ -91,6 +91,21 @@ public final class TerminologyStoreSchema {
   /** The manifest column recording when the entry was imported. */
   public static final String COLUMN_IMPORTED_AT = "imported_at";
 
+  /** The manifest column recording the SHA-256 of the source file bytes. */
+  public static final String COLUMN_SOURCE_SHA256 = "source_sha256";
+
+  /** The manifest column recording the name of the package the entry was imported from. */
+  public static final String COLUMN_PACKAGE_NAME = "package_name";
+
+  /** The manifest column recording the version of the package the entry was imported from. */
+  public static final String COLUMN_PACKAGE_VERSION = "package_version";
+
+  /** The manifest column recording the registry verification outcome of the package. */
+  public static final String COLUMN_PACKAGE_VERIFICATION = "package_verification";
+
+  /** The manifest column recording the registry that vouched for the package bytes. */
+  public static final String COLUMN_PACKAGE_REGISTRY = "package_registry";
+
   /**
    * The stable identifier of a code system version, a hash of its URL and version. This is the
    * partition column of every content table so that versions coexist and replace atomically.
@@ -254,6 +269,11 @@ public final class TerminologyStoreSchema {
         .add(COLUMN_CANONICAL_URL, DataTypes.StringType, false)
         .add(COLUMN_VERSION, DataTypes.StringType, true)
         .add(COLUMN_SOURCE, DataTypes.StringType, true)
-        .add(COLUMN_IMPORTED_AT, DataTypes.TimestampType, true);
+        .add(COLUMN_IMPORTED_AT, DataTypes.TimestampType, true)
+        .add(COLUMN_SOURCE_SHA256, DataTypes.StringType, true)
+        .add(COLUMN_PACKAGE_NAME, DataTypes.StringType, true)
+        .add(COLUMN_PACKAGE_VERSION, DataTypes.StringType, true)
+        .add(COLUMN_PACKAGE_VERIFICATION, DataTypes.StringType, true)
+        .add(COLUMN_PACKAGE_REGISTRY, DataTypes.StringType, true);
   }
 }

--- a/terminology/src/main/java/au/csiro/pathling/terminology/store/TerminologyStoreWriter.java
+++ b/terminology/src/main/java/au/csiro/pathling/terminology/store/TerminologyStoreWriter.java
@@ -155,7 +155,7 @@ public class TerminologyStoreWriter {
       rows.add(manifestRow(entry));
     }
     final Dataset<Row> data = spark.createDataFrame(rows, TerminologyStoreSchema.manifestSchema());
-    writeTable(data, MANIFEST, mode, List.of());
+    writeManifestRows(data, mode, null);
   }
 
   /**
@@ -170,9 +170,9 @@ public class TerminologyStoreWriter {
       final Dataset<Row> data =
           spark.createDataFrame(
               List.of(manifestRow(entry)), TerminologyStoreSchema.manifestSchema());
-      replaceWhere(
+      writeManifestRows(
           data,
-          MANIFEST,
+          SaveMode.Overwrite,
           COLUMN_CANONICAL_URL
               + " = '"
               + entry.getCanonicalUrl()
@@ -183,15 +183,37 @@ public class TerminologyStoreWriter {
     }
   }
 
+  /**
+   * Writes rows into the manifest, allowing the manifest schema to gain columns that a store
+   * written by an earlier version of Pathling does not have. Schema drift on content tables remains
+   * a failure.
+   */
+  private void writeManifestRows(
+      @Nonnull final Dataset<Row> data,
+      @Nonnull final SaveMode mode,
+      @Nullable final String condition) {
+    var writer = data.write().format(DELTA_FORMAT).mode(mode).option("mergeSchema", "true");
+    if (condition != null) {
+      writer = writer.option("replaceWhere", condition);
+    }
+    writer.save(TerminologyStoreSchema.tablePath(storagePath, MANIFEST));
+  }
+
   @Nonnull
   private static Row manifestRow(@Nonnull final ManifestEntry entry) {
+    final PackageVerification verification = entry.getPackageVerification();
     return RowFactory.create(
         entry.getStoreFormatVersion(),
         entry.getEntryType(),
         entry.getCanonicalUrl(),
         entry.getVersion(),
         entry.getSource(),
-        entry.getImportedAt() == null ? null : Timestamp.from(entry.getImportedAt()));
+        entry.getImportedAt() == null ? null : Timestamp.from(entry.getImportedAt()),
+        entry.getSourceSha256(),
+        entry.getPackageName(),
+        entry.getPackageVersion(),
+        verification == null ? null : verification.getCode(),
+        entry.getPackageRegistry());
   }
 
   /** Builds a SQL predicate matching a nullable version. */

--- a/terminology/src/test/java/au/csiro/pathling/terminology/local/FhirTerminologyFixture.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/local/FhirTerminologyFixture.java
@@ -67,7 +67,8 @@ final class FhirTerminologyFixture {
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
-    new FhirTerminologyImporter(spark, path).importFrom(FhirFixtures.jsonDirectory().toString());
+    new FhirTerminologyImporter(spark, path)
+        .importFrom(FhirFixtures.jsonDirectory().toString(), false, null);
     storagePath = path;
   }
 

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/CodeSystemStageLoaderTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/CodeSystemStageLoaderTest.java
@@ -208,6 +208,7 @@ class CodeSystemStageLoaderTest {
 
   private void load(final CodeSystemStaging staging, final String store) {
     final TerminologyStoreWriter writer = new TerminologyStoreWriter(spark, store);
-    new CodeSystemStageLoader(spark, writer).load(staging, URL, VERSION, "is-a", store);
+    new CodeSystemStageLoader(spark, writer)
+        .load(staging, URL, VERSION, "is-a", ImportProvenance.of(store, null));
   }
 }

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/DigestingInputStreamTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/DigestingInputStreamTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the digesting stream reproduces the known digests of a short input, and that the
+ * digests cover the whole stream whether its bytes were read, skipped or drained.
+ *
+ * @author John Grimes
+ */
+class DigestingInputStreamTest {
+
+  /** The published SHA-1 of the three bytes {@code abc}. */
+  private static final String ABC_SHA1 = "a9993e364706816aba3e25717850c26c9cd0d89d";
+
+  /** The published SHA-256 of the three bytes {@code abc}. */
+  private static final String ABC_SHA256 =
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+  /** The published SHA-1 of the empty input. */
+  private static final String EMPTY_SHA1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+
+  /** The published SHA-256 of the empty input. */
+  private static final String EMPTY_SHA256 =
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+  @Test
+  void digestsMatchTheKnownAnswersForABC() throws IOException {
+    try (DigestingInputStream in = digesting("abc")) {
+      assertEquals(3, in.read(new byte[8], 0, 8));
+      assertEquals(ABC_SHA1, in.sha1Hex());
+      assertEquals(ABC_SHA256, in.sha256Hex());
+    }
+  }
+
+  @Test
+  void digestsMatchTheKnownAnswersWhenReadOneByteAtATime() throws IOException {
+    try (DigestingInputStream in = digesting("abc")) {
+      while (in.read() != -1) {
+        // Each single-byte read updates the digests.
+      }
+      assertEquals(ABC_SHA1, in.sha1Hex());
+      assertEquals(ABC_SHA256, in.sha256Hex());
+    }
+  }
+
+  @Test
+  void drainCoversBytesTheReaderLeftUnread() throws IOException {
+    try (DigestingInputStream in = digesting("abc")) {
+      assertEquals('a', in.read());
+      in.drain();
+      // The reader stopped after one byte, yet the digests describe the whole input.
+      assertEquals(ABC_SHA1, in.sha1Hex());
+      assertEquals(ABC_SHA256, in.sha256Hex());
+    }
+  }
+
+  @Test
+  void skipIsIncludedInTheDigest() throws IOException {
+    try (DigestingInputStream in = digesting("abc")) {
+      assertEquals(2, in.skip(2));
+      assertEquals('c', in.read());
+      // Skipped bytes were read through the digests rather than seeked past.
+      assertEquals(ABC_SHA1, in.sha1Hex());
+      assertEquals(ABC_SHA256, in.sha256Hex());
+    }
+  }
+
+  @Test
+  void skipPastTheEndDigestsOnlyWhatExists() throws IOException {
+    try (DigestingInputStream in = digesting("abc")) {
+      assertEquals(3, in.skip(100));
+      assertEquals(ABC_SHA256, in.sha256Hex());
+    }
+  }
+
+  @Test
+  void emptyStreamDigests() throws IOException {
+    try (DigestingInputStream in = digesting("")) {
+      in.drain();
+      assertEquals(EMPTY_SHA1, in.sha1Hex());
+      assertEquals(EMPTY_SHA256, in.sha256Hex());
+    }
+  }
+
+  @Test
+  void digestsCanBeReadRepeatedlyWhileReadingContinues() throws IOException {
+    try (DigestingInputStream in = digesting("abc")) {
+      assertEquals('a', in.read());
+      final String afterFirstByte = in.sha256Hex();
+      assertEquals(afterFirstByte, in.sha256Hex(), "taking a digest does not consume it");
+      in.drain();
+      assertEquals(ABC_SHA256, in.sha256Hex());
+    }
+  }
+
+  private static DigestingInputStream digesting(final String content) {
+    return new DigestingInputStream(
+        new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+  }
+}

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/FhirPackageFixtures.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/FhirPackageFixtures.java
@@ -18,7 +18,9 @@
 package au.csiro.pathling.terminology.store;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.net.URL;
@@ -26,21 +28,36 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipParameters;
 
 /**
  * Builds FHIR NPM packages ({@code .tgz}) from the JSON fixtures under {@code
  * terminology/src/test/resources/fhir-import/} at test runtime, so the streaming import can be
- * exercised in its package form without checking binary archives into the repository. Every package
- * carries a {@code package.json} metadata entry, which the importer must skip.
+ * exercised in its package form without checking binary archives into the repository. A package
+ * carries a {@code package.json} metadata entry unless one is explicitly withheld, and the importer
+ * must skip it.
  *
  * @author John Grimes
  */
 public final class FhirPackageFixtures {
 
   private static final String FIXTURE_ROOT = "/fhir-import/";
+
+  /** The package name recorded in the {@code package.json} of every package built by default. */
+  public static final String PACKAGE_NAME = "fixtures";
+
+  /** The package version recorded in the {@code package.json} of every default package. */
+  public static final String PACKAGE_VERSION = "1.0.0";
+
+  /** The {@code package.json} content written into a package unless another is supplied. */
+  public static final String DEFAULT_PACKAGE_JSON =
+      "{\"name\":\"" + PACKAGE_NAME + "\",\"version\":\"" + PACKAGE_VERSION + "\"}";
 
   private FhirPackageFixtures() {
     // Test helper.
@@ -64,7 +81,8 @@ public final class FhirPackageFixtures {
 
   /**
    * Builds a {@code .tgz} package from the named fixtures, each stored under the package's {@code
-   * package/} directory, alongside a {@code package.json} metadata entry.
+   * package/} directory, alongside a {@code package.json} metadata entry naming {@link
+   * #PACKAGE_NAME} and {@link #PACKAGE_VERSION}.
    *
    * @param directory the directory to write the archive into
    * @param archiveName the archive file name (for example {@code fixtures.tgz})
@@ -78,12 +96,36 @@ public final class FhirPackageFixtures {
       @Nonnull final String archiveName,
       @Nonnull final String... fixtureNames)
       throws IOException {
+    return buildPackageWithJson(directory, archiveName, DEFAULT_PACKAGE_JSON, fixtureNames);
+  }
+
+  /**
+   * Builds a {@code .tgz} package from the named fixtures with an explicit {@code package.json}
+   * content, or none at all. This method carries a distinct name rather than overloading {@link
+   * #buildPackage}, whose trailing variable arity parameter would make the two calls ambiguous.
+   *
+   * @param directory the directory to write the archive into
+   * @param archiveName the archive file name (for example {@code fixtures.tgz})
+   * @param packageJson the content of the {@code package.json} entry, or null to omit the entry
+   * @param fixtureNames the fixture file names to include, in the order they should appear
+   * @return the path to the created archive
+   * @throws IOException if the archive cannot be written
+   */
+  @Nonnull
+  public static Path buildPackageWithJson(
+      @Nonnull final Path directory,
+      @Nonnull final String archiveName,
+      @Nullable final String packageJson,
+      @Nonnull final String... fixtureNames)
+      throws IOException {
     final Path archive = directory.resolve(archiveName);
     try (TarArchiveOutputStream tar =
         new TarArchiveOutputStream(
             new GzipCompressorOutputStream(Files.newOutputStream(archive)))) {
       tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
-      writeEntry(tar, "package/package.json", "{\"name\":\"fixtures\",\"version\":\"1.0.0\"}");
+      if (packageJson != null) {
+        writeEntry(tar, "package/package.json", packageJson);
+      }
       for (final String fixtureName : fixtureNames) {
         final byte[] content = Files.readAllBytes(resource(fixtureName));
         writeEntry(tar, "package/" + fixtureName, content);
@@ -118,6 +160,55 @@ public final class FhirPackageFixtures {
   }
 
   /**
+   * Rewrites a gzipped tarball with a different compression level, yielding a readable package with
+   * exactly the same content but different bytes. A byte flipped inside the gzip payload would
+   * instead fail as a corrupt archive, before any checksum is compared.
+   *
+   * @param archive the archive to rewrite
+   * @return the path to the rewritten archive, a sibling of the original
+   * @throws IOException if the archive cannot be read or written
+   */
+  @Nonnull
+  public static Path recompress(@Nonnull final Path archive) throws IOException {
+    final byte[] uncompressed;
+    try (InputStream in = new GzipCompressorInputStream(Files.newInputStream(archive))) {
+      uncompressed = in.readAllBytes();
+    }
+    final Path rewritten = archive.resolveSibling("recompressed-" + archive.getFileName());
+    final GzipParameters parameters = new GzipParameters();
+    parameters.setCompressionLevel(1);
+    try (OutputStream out =
+        new GzipCompressorOutputStream(Files.newOutputStream(rewritten), parameters)) {
+      out.write(uncompressed);
+    }
+    return rewritten;
+  }
+
+  /**
+   * Computes the SHA-1 of a file, as the registry publishes it.
+   *
+   * @param file the file to digest
+   * @return the digest as lowercase hexadecimal
+   * @throws IOException if the file cannot be read
+   */
+  @Nonnull
+  public static String sha1Hex(@Nonnull final Path file) throws IOException {
+    return digestHex(file, "SHA-1");
+  }
+
+  /**
+   * Computes the SHA-256 of a file, as the manifest records it.
+   *
+   * @param file the file to digest
+   * @return the digest as lowercase hexadecimal
+   * @throws IOException if the file cannot be read
+   */
+  @Nonnull
+  public static String sha256Hex(@Nonnull final Path file) throws IOException {
+    return digestHex(file, "SHA-256");
+  }
+
+  /**
    * Reads a fixture file as a UTF-8 string.
    *
    * @param fixtureName the fixture file name
@@ -130,6 +221,29 @@ public final class FhirPackageFixtures {
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
+  }
+
+  @Nonnull
+  private static String digestHex(@Nonnull final Path file, @Nonnull final String algorithm)
+      throws IOException {
+    final MessageDigest digest;
+    try {
+      digest = MessageDigest.getInstance(algorithm);
+    } catch (final NoSuchAlgorithmException e) {
+      throw new IllegalStateException(algorithm + " is not available", e);
+    }
+    try (InputStream in = Files.newInputStream(file)) {
+      final byte[] buffer = new byte[8192];
+      int read;
+      while ((read = in.read(buffer)) != -1) {
+        digest.update(buffer, 0, read);
+      }
+    }
+    final StringBuilder builder = new StringBuilder();
+    for (final byte b : digest.digest()) {
+      builder.append(String.format("%02x", b));
+    }
+    return builder.toString();
   }
 
   /** Produces a ValueSet with a large filler {@code text} narrative to inflate its byte size. */

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/FhirResourceScannerTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/FhirResourceScannerTest.java
@@ -18,6 +18,7 @@
 package au.csiro.pathling.terminology.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -66,7 +67,7 @@ class FhirResourceScannerTest {
     Files.copy(FhirPackageFixtures.resource("nested-hierarchy.json"), dir.resolve("nested.json"));
 
     final List<ScannedResource> scanned =
-        new FhirResourceScanner(new Configuration()).scan(dir.toString());
+        new FhirResourceScanner(new Configuration()).scan(dir.toString()).getResources();
 
     assertEquals(1, scanned.size());
     assertEquals("CodeSystem", scanned.get(0).getResourceType());
@@ -82,7 +83,7 @@ class FhirResourceScannerTest {
             dir, "cs.tgz", "nested-hierarchy.json", "valueset-simple.json");
 
     final List<ScannedResource> scanned =
-        new FhirResourceScanner(new Configuration()).scan(archive.toString());
+        new FhirResourceScanner(new Configuration()).scan(archive.toString()).getResources();
 
     final Map<String, ScannedResource> byType =
         scanned.stream().collect(Collectors.toMap(ScannedResource::getResourceType, s -> s));
@@ -150,10 +151,69 @@ class FhirResourceScannerTest {
     final Path archive = FhirPackageFixtures.buildPackage(dir, "cs.tgz", "nested-hierarchy.json");
 
     final List<ScannedResource> scanned =
-        new FhirResourceScanner(new Configuration()).scan(archive.toString());
+        new FhirResourceScanner(new Configuration()).scan(archive.toString()).getResources();
 
     assertEquals(1, scanned.size());
     assertEquals("CodeSystem", scanned.get(0).getResourceType());
+  }
+
+  @Test
+  void scanOfPackageReturnsIdentityAndDigests(@TempDir final Path dir) throws Exception {
+    final Path archive = FhirPackageFixtures.buildPackage(dir, "cs.tgz", "nested-hierarchy.json");
+
+    final FhirSourceScan scan =
+        new FhirResourceScanner(new Configuration()).scan(archive.toString());
+
+    assertTrue(scan.isPackage());
+    assertEquals(FhirPackageFixtures.PACKAGE_NAME, scan.getPackageName());
+    assertEquals(FhirPackageFixtures.PACKAGE_VERSION, scan.getPackageVersion());
+    // The digests cover the whole archive file, including the bytes that trail the last entry.
+    assertEquals(FhirPackageFixtures.sha1Hex(archive), scan.getSha1());
+    assertEquals(FhirPackageFixtures.sha256Hex(archive), scan.getSha256());
+    assertEquals(1, scan.getResources().size());
+  }
+
+  @Test
+  void scanOfPackageWithoutPackageJsonHasNullIdentity(@TempDir final Path dir) throws Exception {
+    final Path archive =
+        FhirPackageFixtures.buildPackageWithJson(dir, "anon.tgz", null, "nested-hierarchy.json");
+
+    final FhirSourceScan scan =
+        new FhirResourceScanner(new Configuration()).scan(archive.toString());
+
+    assertTrue(scan.isPackage());
+    assertNull(scan.getPackageName());
+    assertNull(scan.getPackageVersion());
+    // An unidentified package is still hashed.
+    assertEquals(FhirPackageFixtures.sha1Hex(archive), scan.getSha1());
+  }
+
+  @Test
+  void scanOfPackageJsonLackingVersionHasNullVersion(@TempDir final Path dir) throws Exception {
+    final Path archive =
+        FhirPackageFixtures.buildPackageWithJson(
+            dir, "unversioned.tgz", "{\"name\":\"fixtures\"}", "nested-hierarchy.json");
+
+    final FhirSourceScan scan =
+        new FhirResourceScanner(new Configuration()).scan(archive.toString());
+
+    assertEquals("fixtures", scan.getPackageName());
+    assertNull(scan.getPackageVersion());
+  }
+
+  @Test
+  void scanOfDirectoryHasNullDigestsAndIdentity(@TempDir final Path dir) throws Exception {
+    Files.copy(FhirPackageFixtures.resource("nested-hierarchy.json"), dir.resolve("nested.json"));
+
+    final FhirSourceScan scan = new FhirResourceScanner(new Configuration()).scan(dir.toString());
+
+    // A directory has no single set of bytes to hash and no package identity.
+    assertFalse(scan.isPackage());
+    assertNull(scan.getSha1());
+    assertNull(scan.getSha256());
+    assertNull(scan.getPackageName());
+    assertNull(scan.getPackageVersion());
+    assertEquals(1, scan.getResources().size());
   }
 
   /** A stream that counts the bytes read through it, for asserting the pre-scan's early exit. */

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/FhirTerminologyImporterTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/FhirTerminologyImporterTest.java
@@ -32,11 +32,16 @@ import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.CONCEPT
 import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.DESCRIPTION;
 import static au.csiro.pathling.terminology.store.TerminologyStoreSchema.PROPERTY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import au.csiro.pathling.test.FhirFixtures;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -47,7 +52,9 @@ import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -62,6 +69,8 @@ import org.junit.jupiter.api.io.TempDir;
 class FhirTerminologyImporterTest {
 
   private static SparkSession spark;
+
+  private WireMockServer registry;
 
   @BeforeAll
   static void setUp(@TempDir final Path warehouse) {
@@ -87,6 +96,17 @@ class FhirTerminologyImporterTest {
       spark.stop();
       spark = null;
     }
+  }
+
+  @BeforeEach
+  void startRegistry() {
+    registry = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+    registry.start();
+  }
+
+  @AfterEach
+  void stopRegistry() {
+    registry.stop();
   }
 
   // The import path bounds the Parquet row-group size while writing, so the many concurrent Delta
@@ -136,7 +156,8 @@ class FhirTerminologyImporterTest {
   @Test
   void importsASingleCodeSystemFile(@TempDir final Path storeDir) {
     final String store = storeDir.resolve("store").toString();
-    new FhirTerminologyImporter(spark, store).importFrom(FhirFixtures.codeSystemFile().toString());
+    new FhirTerminologyImporter(spark, store)
+        .importFrom(FhirFixtures.codeSystemFile().toString(), false, null);
 
     final TerminologyStoreReader reader = TerminologyStoreReader.open(store, Map.of());
     final List<ManifestEntry> manifest = reader.readManifest();
@@ -199,7 +220,8 @@ class FhirTerminologyImporterTest {
   @Test
   void importsADirectoryOfResources(@TempDir final Path storeDir) {
     final String store = storeDir.resolve("store").toString();
-    new FhirTerminologyImporter(spark, store).importFrom(FhirFixtures.jsonDirectory().toString());
+    new FhirTerminologyImporter(spark, store)
+        .importFrom(FhirFixtures.jsonDirectory().toString(), false, null);
 
     final Map<String, Set<String>> byType = manifestByType(store);
     assertTrue(byType.get("code_system").contains(FhirFixtures.ANIMAL_SPECIES));
@@ -211,7 +233,8 @@ class FhirTerminologyImporterTest {
   @Test
   void importsAFhirPackage(@TempDir final Path storeDir) {
     final String store = storeDir.resolve("store").toString();
-    new FhirTerminologyImporter(spark, store).importFrom(FhirFixtures.packageArchive().toString());
+    new FhirTerminologyImporter(spark, store)
+        .importFrom(FhirFixtures.packageArchive().toString(), false, null);
 
     final Map<String, Set<String>> byType = manifestByType(store);
     assertTrue(byType.get("code_system").contains(FhirFixtures.ANIMAL_SPECIES));
@@ -230,7 +253,8 @@ class FhirTerminologyImporterTest {
     final FhirTerminologyImporter importer = new FhirTerminologyImporter(spark, store);
     final TerminologyImportException e =
         assertThrows(
-            TerminologyImportException.class, () -> importer.importFrom(invalid.toString()));
+            TerminologyImportException.class,
+            () -> importer.importFrom(invalid.toString(), false, null));
     assertTrue(e.getMessage().toLowerCase().contains("canonical url"));
     // Nothing was written to the store.
     assertThrows(
@@ -244,7 +268,9 @@ class FhirTerminologyImporterTest {
     final String store = dir.resolve("store").toString();
 
     final FhirTerminologyImporter importer = new FhirTerminologyImporter(spark, store);
-    assertThrows(TerminologyImportException.class, () -> importer.importFrom(patient.toString()));
+    assertThrows(
+        TerminologyImportException.class,
+        () -> importer.importFrom(patient.toString(), false, null));
   }
 
   // --- Streaming import (feature 024). ---
@@ -263,13 +289,13 @@ class FhirTerminologyImporterTest {
     Files.copy(
         FhirPackageFixtures.resource("nested-hierarchy.json"), dirSource.resolve("nested.json"));
     final String dirStore = dir.resolve("dir-store").toString();
-    new FhirTerminologyImporter(spark, dirStore).importFrom(dirSource.toString());
+    new FhirTerminologyImporter(spark, dirStore).importFrom(dirSource.toString(), false, null);
     assertEquals(fileClosure, closurePairs(dirStore));
 
     final Path archive =
         FhirPackageFixtures.buildPackage(dir, "nested.tgz", "nested-hierarchy.json");
     final String pkgStore = dir.resolve("pkg-store").toString();
-    new FhirTerminologyImporter(spark, pkgStore).importFrom(archive.toString());
+    new FhirTerminologyImporter(spark, pkgStore).importFrom(archive.toString(), false, null);
     assertEquals(fileClosure, closurePairs(pkgStore));
   }
 
@@ -277,7 +303,7 @@ class FhirTerminologyImporterTest {
   void streamingImportPreservesConceptDetail(@TempDir final Path dir) {
     final String store = dir.resolve("store").toString();
     new FhirTerminologyImporter(spark, store)
-        .importFrom(FhirPackageFixtures.resource("nested-hierarchy.json").toString());
+        .importFrom(FhirPackageFixtures.resource("nested-hierarchy.json").toString(), false, null);
 
     final TerminologyStoreReader reader = TerminologyStoreReader.open(store, Map.of());
     final Map<String, String> display = new HashMap<>();
@@ -305,7 +331,9 @@ class FhirTerminologyImporterTest {
             TerminologyImportException.class,
             () ->
                 importer.importFrom(
-                    FhirPackageFixtures.resource("codesystem-no-url.json").toString()));
+                    FhirPackageFixtures.resource("codesystem-no-url.json").toString(),
+                    false,
+                    null));
     assertTrue(e.getMessage().toLowerCase().contains("canonical url"));
     // The pre-scan failed before any write, so the store was never created.
     assertThrows(
@@ -325,7 +353,8 @@ class FhirTerminologyImporterTest {
 
     final TerminologyImportException e =
         assertThrows(
-            TerminologyImportException.class, () -> importer.importFrom(corruptPackage.toString()));
+            TerminologyImportException.class,
+            () -> importer.importFrom(corruptPackage.toString(), false, null));
     final String message = e.getMessage();
     assertTrue(message.contains("http://example.org/fhir/CodeSystem/corrupt"), message);
     assertTrue(message.toLowerCase().contains("partial"), message);
@@ -335,7 +364,7 @@ class FhirTerminologyImporterTest {
     final Path fixedPackage =
         FhirPackageFixtures.buildPackage(
             dir, "fixed.tgz", "simple-valid.json", "corrupt-concepts-fixed.json");
-    new FhirTerminologyImporter(spark, store).importFrom(fixedPackage.toString());
+    new FhirTerminologyImporter(spark, store).importFrom(fixedPackage.toString(), false, null);
 
     final Map<String, Set<String>> byType = manifestByType(store);
     assertTrue(byType.get("code_system").contains("http://example.org/fhir/CodeSystem/corrupt"));
@@ -357,7 +386,8 @@ class FhirTerminologyImporterTest {
 
     final TerminologyImportException e =
         assertThrows(
-            TerminologyImportException.class, () -> importer.importFrom(guardPackage.toString()));
+            TerminologyImportException.class,
+            () -> importer.importFrom(guardPackage.toString(), false, null));
     assertTrue(e.getMessage().contains("ValueSet"), e.getMessage());
     assertTrue(e.getMessage().toLowerCase().contains("limit"), e.getMessage());
     // The guard fired during validation, before any write.
@@ -369,7 +399,7 @@ class FhirTerminologyImporterTest {
   void importsACodeSystemWrappedInABundleThroughTheStreamingPath(@TempDir final Path dir) {
     final String store = dir.resolve("store").toString();
     new FhirTerminologyImporter(spark, store)
-        .importFrom(FhirPackageFixtures.resource("bundle-codesystem.json").toString());
+        .importFrom(FhirPackageFixtures.resource("bundle-codesystem.json").toString(), false, null);
 
     final Map<String, Set<String>> byType = manifestByType(store);
     assertTrue(byType.get("code_system").contains("http://example.org/fhir/CodeSystem/bundled"));
@@ -404,18 +434,218 @@ class FhirTerminologyImporterTest {
     assertEquals(Set.of("A->B", "A->C"), mixed);
   }
 
+  // --- Provenance and registry verification (feature 059). ---
+
+  @Test
+  void packageImportRecordsVerifiedProvenanceOnEveryRow(@TempDir final Path dir) throws Exception {
+    final Path archive =
+        FhirPackageFixtures.buildPackage(
+            dir, "fixtures.tgz", "nested-hierarchy.json", "valueset-simple.json");
+    RegistryStub.stubListing(
+        registry,
+        FhirPackageFixtures.PACKAGE_NAME,
+        FhirPackageFixtures.PACKAGE_VERSION,
+        FhirPackageFixtures.sha1Hex(archive));
+    final String store = dir.resolve("store").toString();
+
+    new FhirTerminologyImporter(spark, store)
+        .importFrom(archive.toString(), true, registry.baseUrl());
+
+    final List<ManifestEntry> manifest = manifest(store);
+    assertEquals(2, manifest.size());
+    for (final ManifestEntry entry : manifest) {
+      assertEquals(FhirPackageFixtures.sha256Hex(archive), entry.getSourceSha256());
+      assertEquals(FhirPackageFixtures.PACKAGE_NAME, entry.getPackageName());
+      assertEquals(FhirPackageFixtures.PACKAGE_VERSION, entry.getPackageVersion());
+      assertEquals(PackageVerification.VERIFIED, entry.getPackageVerification());
+      assertEquals(registry.baseUrl(), entry.getPackageRegistry());
+    }
+  }
+
+  @Test
+  void mismatchFailsBeforeAnyWriteIntoAFreshStore(@TempDir final Path dir) throws Exception {
+    final Path archive =
+        FhirPackageFixtures.buildPackage(dir, "fixtures.tgz", "nested-hierarchy.json");
+    stubMismatch(archive);
+    final String store = dir.resolve("store").toString();
+    final FhirTerminologyImporter importer = new FhirTerminologyImporter(spark, store);
+
+    final TerminologyImportException e =
+        assertThrows(
+            TerminologyImportException.class,
+            () -> importer.importFrom(archive.toString(), true, registry.baseUrl()));
+
+    assertTrue(e.getMessage().contains("does not match the registry checksum"), e.getMessage());
+    // The store was never created: the check ran before anything was written.
+    assertTrue(Files.notExists(Path.of(store)));
+  }
+
+  @Test
+  void mismatchLeavesAnExistingStoreUnchanged(@TempDir final Path dir) throws Exception {
+    final Path first = FhirPackageFixtures.buildPackage(dir, "first.tgz", "nested-hierarchy.json");
+    final String store = dir.resolve("store").toString();
+    new FhirTerminologyImporter(spark, store).importFrom(first.toString(), false, null);
+    final List<ManifestEntry> before = manifest(store);
+
+    final Path tampered =
+        FhirPackageFixtures.buildPackage(dir, "tampered.tgz", "simple-valid.json");
+    stubMismatch(tampered);
+    final FhirTerminologyImporter importer = new FhirTerminologyImporter(spark, store);
+    assertThrows(
+        TerminologyImportException.class,
+        () -> importer.importFrom(tampered.toString(), true, registry.baseUrl()));
+
+    assertEquals(before, manifest(store));
+  }
+
+  @Test
+  void noShasumImportsAsUnverifiedWithNullRegistry(@TempDir final Path dir) throws Exception {
+    final Path archive =
+        FhirPackageFixtures.buildPackage(dir, "fixtures.tgz", "nested-hierarchy.json");
+    RegistryStub.stubListing(
+        registry, FhirPackageFixtures.PACKAGE_NAME, FhirPackageFixtures.PACKAGE_VERSION, null);
+    final String store = dir.resolve("store").toString();
+
+    new FhirTerminologyImporter(spark, store)
+        .importFrom(archive.toString(), true, registry.baseUrl());
+
+    final ManifestEntry entry = manifest(store).get(0);
+    assertEquals(PackageVerification.UNVERIFIED, entry.getPackageVerification());
+    assertNull(entry.getPackageRegistry());
+    // The package is still identified and hashed even though it could not be verified.
+    assertEquals(FhirPackageFixtures.PACKAGE_NAME, entry.getPackageName());
+    assertEquals(FhirPackageFixtures.sha256Hex(archive), entry.getSourceSha256());
+  }
+
+  @Test
+  void unreachableRegistryImportsAsUnverified(@TempDir final Path dir) throws Exception {
+    final Path archive =
+        FhirPackageFixtures.buildPackage(dir, "fixtures.tgz", "nested-hierarchy.json");
+    final String store = dir.resolve("store").toString();
+
+    new FhirTerminologyImporter(spark, store)
+        .importFrom(archive.toString(), true, "http://127.0.0.1:" + closedPort());
+
+    final ManifestEntry entry = manifest(store).get(0);
+    assertEquals(PackageVerification.UNVERIFIED, entry.getPackageVerification());
+    assertNull(entry.getPackageRegistry());
+  }
+
+  @Test
+  void packageWithoutPackageJsonImportsAsUnverifiedWithNullIdentity(@TempDir final Path dir)
+      throws Exception {
+    final Path archive =
+        FhirPackageFixtures.buildPackageWithJson(dir, "anon.tgz", null, "nested-hierarchy.json");
+    final String store = dir.resolve("store").toString();
+
+    new FhirTerminologyImporter(spark, store)
+        .importFrom(archive.toString(), true, registry.baseUrl());
+
+    final ManifestEntry entry = manifest(store).get(0);
+    assertEquals(PackageVerification.UNVERIFIED, entry.getPackageVerification());
+    assertNull(entry.getPackageName());
+    assertNull(entry.getPackageVersion());
+    assertNotNull(entry.getSourceSha256());
+    // An unidentifiable package is never looked up.
+    assertEquals(0, registry.getAllServeEvents().size());
+  }
+
+  @Test
+  void skippedVerificationMakesNoRequestAndRecordsSkipped(@TempDir final Path dir)
+      throws Exception {
+    final Path archive =
+        FhirPackageFixtures.buildPackage(dir, "fixtures.tgz", "nested-hierarchy.json");
+    final String store = dir.resolve("store").toString();
+
+    new FhirTerminologyImporter(spark, store)
+        .importFrom(archive.toString(), false, registry.baseUrl());
+
+    final ManifestEntry entry = manifest(store).get(0);
+    assertEquals(PackageVerification.SKIPPED, entry.getPackageVerification());
+    assertNull(entry.getPackageRegistry());
+    // The identity and hash are recorded even when the check is declined.
+    assertEquals(FhirPackageFixtures.PACKAGE_NAME, entry.getPackageName());
+    assertEquals(FhirPackageFixtures.PACKAGE_VERSION, entry.getPackageVersion());
+    assertEquals(FhirPackageFixtures.sha256Hex(archive), entry.getSourceSha256());
+    assertEquals(0, registry.getAllServeEvents().size());
+  }
+
+  @Test
+  void jsonFileAndDirectorySourcesRecordNullStatusAndMakeNoRequest(@TempDir final Path dir)
+      throws Exception {
+    final Path file = FhirPackageFixtures.resource("nested-hierarchy.json");
+    final String fileStore = dir.resolve("file-store").toString();
+    new FhirTerminologyImporter(spark, fileStore)
+        .importFrom(file.toString(), true, registry.baseUrl());
+
+    final ManifestEntry fromFile = manifest(fileStore).get(0);
+    // A single file is hashed but carries no package identity or verification status.
+    assertEquals(FhirPackageFixtures.sha256Hex(file), fromFile.getSourceSha256());
+    assertNull(fromFile.getPackageVerification());
+    assertNull(fromFile.getPackageName());
+
+    final Path dirSource = dir.resolve("source");
+    Files.createDirectories(dirSource);
+    Files.copy(file, dirSource.resolve("nested.json"));
+    final String dirStore = dir.resolve("dir-store").toString();
+    new FhirTerminologyImporter(spark, dirStore)
+        .importFrom(dirSource.toString(), true, registry.baseUrl());
+
+    final ManifestEntry fromDirectory = manifest(dirStore).get(0);
+    assertNull(fromDirectory.getSourceSha256());
+    assertNull(fromDirectory.getPackageVerification());
+    assertEquals(0, registry.getAllServeEvents().size());
+  }
+
+  @Test
+  void verificationOptionHasNoEffectOnNonPackageSources(@TempDir final Path dir) {
+    final Path file = FhirPackageFixtures.resource("nested-hierarchy.json");
+    final String verifying = dir.resolve("verifying").toString();
+    final String skipping = dir.resolve("skipping").toString();
+
+    new FhirTerminologyImporter(spark, verifying)
+        .importFrom(file.toString(), true, registry.baseUrl());
+    new FhirTerminologyImporter(spark, skipping).importFrom(file.toString(), false, null);
+
+    final ManifestEntry verified = manifest(verifying).get(0);
+    final ManifestEntry skipped = manifest(skipping).get(0);
+    assertEquals(verified.getSourceSha256(), skipped.getSourceSha256());
+    assertNull(verified.getPackageVerification());
+    assertNull(skipped.getPackageVerification());
+    assertEquals(0, registry.getAllServeEvents().size());
+  }
+
+  /** Stubs a listing whose checksum belongs to a differently compressed copy of the archive. */
+  private void stubMismatch(final Path archive) throws IOException {
+    RegistryStub.stubListing(
+        registry,
+        FhirPackageFixtures.PACKAGE_NAME,
+        FhirPackageFixtures.PACKAGE_VERSION,
+        FhirPackageFixtures.sha1Hex(FhirPackageFixtures.recompress(archive)));
+  }
+
+  private static int closedPort() throws IOException {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    }
+  }
+
+  private List<ManifestEntry> manifest(final String store) {
+    return TerminologyStoreReader.open(store, Map.of()).readManifest();
+  }
+
   private Set<String> importFixtureClosure(
       final Path dir, final String fixtureName, final String suffix) {
     final String store = dir.resolve("store-" + suffix).toString();
     new FhirTerminologyImporter(spark, store)
-        .importFrom(FhirPackageFixtures.resource(fixtureName).toString());
+        .importFrom(FhirPackageFixtures.resource(fixtureName).toString(), false, null);
     return closurePairs(store);
   }
 
   private Set<String> importNestedAndReadClosure(final Path dir, final String suffix) {
     final String store = dir.resolve("store-" + suffix).toString();
     new FhirTerminologyImporter(spark, store)
-        .importFrom(FhirPackageFixtures.resource("nested-hierarchy.json").toString());
+        .importFrom(FhirPackageFixtures.resource("nested-hierarchy.json").toString(), false, null);
     return closurePairs(store);
   }
 

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/FhirTerminologyImporterTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/FhirTerminologyImporterTest.java
@@ -615,6 +615,65 @@ class FhirTerminologyImporterTest {
     assertEquals(0, registry.getAllServeEvents().size());
   }
 
+  // --- Source fingerprint (feature 059, user story 2). ---
+
+  @Test
+  void jsonFileSourceRecordsTheFileSha256(@TempDir final Path dir) throws Exception {
+    final Path file = FhirPackageFixtures.resource("nested-hierarchy.json");
+    final String store = dir.resolve("store").toString();
+
+    new FhirTerminologyImporter(spark, store).importFrom(file.toString(), true, registry.baseUrl());
+
+    final ManifestEntry entry = manifest(store).get(0);
+    assertEquals(FhirPackageFixtures.sha256Hex(file), entry.getSourceSha256());
+  }
+
+  @Test
+  void directorySourceRecordsNullsEvenWithAPackageJson(@TempDir final Path dir) throws Exception {
+    final Path source = dir.resolve("source");
+    Files.createDirectories(source);
+    Files.writeString(source.resolve("package.json"), FhirPackageFixtures.DEFAULT_PACKAGE_JSON);
+    Files.copy(
+        FhirPackageFixtures.resource("nested-hierarchy.json"), source.resolve("nested.json"));
+    final String store = dir.resolve("store").toString();
+
+    new FhirTerminologyImporter(spark, store)
+        .importFrom(source.toString(), true, registry.baseUrl());
+
+    final ManifestEntry entry = manifest(store).get(0);
+    // A directory is not an archive, so its resources are not the content of any one file: a
+    // package.json sitting beside them names nothing that was imported as a package.
+    assertNull(entry.getSourceSha256());
+    assertNull(entry.getPackageName());
+    assertNull(entry.getPackageVersion());
+    assertNull(entry.getPackageVerification());
+    assertNull(entry.getPackageRegistry());
+    assertEquals(0, registry.getAllServeEvents().size());
+  }
+
+  @Test
+  void reimportReplacesTheRowsProvenance(@TempDir final Path dir) throws Exception {
+    final Path archive =
+        FhirPackageFixtures.buildPackage(dir, "fixtures.tgz", "nested-hierarchy.json");
+    final String store = dir.resolve("store").toString();
+    new FhirTerminologyImporter(spark, store).importFrom(archive.toString(), false, null);
+    assertEquals(PackageVerification.SKIPPED, manifest(store).get(0).getPackageVerification());
+
+    RegistryStub.stubListing(
+        registry,
+        FhirPackageFixtures.PACKAGE_NAME,
+        FhirPackageFixtures.PACKAGE_VERSION,
+        FhirPackageFixtures.sha1Hex(archive));
+    new FhirTerminologyImporter(spark, store)
+        .importFrom(archive.toString(), true, registry.baseUrl());
+
+    // The manifest row was replaced, so it describes the most recent import rather than the first.
+    final List<ManifestEntry> manifest = manifest(store);
+    assertEquals(1, manifest.size());
+    assertEquals(PackageVerification.VERIFIED, manifest.get(0).getPackageVerification());
+    assertEquals(registry.baseUrl(), manifest.get(0).getPackageRegistry());
+  }
+
   /** Stubs a listing whose checksum belongs to a differently compressed copy of the archive. */
   private void stubMismatch(final Path archive) throws IOException {
     RegistryStub.stubListing(

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/PackageRegistryVerifierTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/PackageRegistryVerifierTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.net.ServerSocket;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the registry checksum lookup against a stubbed registry: a matching checksum verifies, a
+ * differing one fails the import, and every way the registry can fail to answer with a usable
+ * checksum leaves the package unverified with a reason rather than failing.
+ *
+ * @author John Grimes
+ */
+class PackageRegistryVerifierTest {
+
+  private static final String NAME = "fixtures";
+  private static final String VERSION = "1.0.0";
+  private static final String SHA1 = "8a7a096866b9b6e96e288ce8d72bf99aa31714a3";
+  private static final String OTHER_SHA1 = "0000000000000000000000000000000000000001";
+
+  private WireMockServer server;
+
+  @BeforeEach
+  void startServer() {
+    server = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+    server.start();
+  }
+
+  @AfterEach
+  void stopServer() {
+    server.stop();
+  }
+
+  @Test
+  void verifiedWhenShasumMatches() {
+    RegistryStub.stubListing(server, NAME, VERSION, SHA1);
+
+    final PackageVerificationResult result = verifier(server.baseUrl()).verify(NAME, VERSION, SHA1);
+
+    assertEquals(PackageVerification.VERIFIED, result.getStatus());
+    // The registry that vouched for the bytes is recorded alongside the outcome.
+    assertEquals(server.baseUrl(), result.getRegistry());
+    assertNull(result.getReason());
+    server.verify(getRequestedFor(urlEqualTo(RegistryStub.path(NAME))));
+  }
+
+  @Test
+  void verifiedIgnoresShasumCase() {
+    RegistryStub.stubListing(server, NAME, VERSION, SHA1.toUpperCase());
+
+    final PackageVerificationResult result = verifier(server.baseUrl()).verify(NAME, VERSION, SHA1);
+
+    assertEquals(PackageVerification.VERIFIED, result.getStatus());
+  }
+
+  @Test
+  void mismatchThrowsNamingBothHashes() {
+    RegistryStub.stubListing(server, NAME, VERSION, OTHER_SHA1);
+    final PackageRegistryVerifier verifier = verifier(server.baseUrl());
+
+    final TerminologyImportException e =
+        assertThrows(TerminologyImportException.class, () -> verifier.verify(NAME, VERSION, SHA1));
+
+    final String message = e.getMessage();
+    assertTrue(message.contains("does not match the registry checksum"), message);
+    assertTrue(message.contains(NAME), message);
+    assertTrue(message.contains(VERSION), message);
+    assertTrue(message.contains(server.baseUrl()), message);
+    assertTrue(message.contains(OTHER_SHA1), message);
+    assertTrue(message.contains(SHA1), message);
+    assertTrue(message.contains("verifyPackage"), message);
+  }
+
+  @Test
+  void unverifiedWhenNoShasum() {
+    RegistryStub.stubListing(server, NAME, VERSION, null);
+
+    assertUnverified(verifier(server.baseUrl()).verify(NAME, VERSION, SHA1));
+  }
+
+  @Test
+  void unverifiedWhenNoDist() {
+    RegistryStub.stubListingWithoutDist(server, NAME, VERSION);
+
+    assertUnverified(verifier(server.baseUrl()).verify(NAME, VERSION, SHA1));
+  }
+
+  @Test
+  void unverifiedWhenVersionNotListed() {
+    RegistryStub.stubListing(server, NAME, "2.0.0", SHA1);
+
+    assertUnverified(verifier(server.baseUrl()).verify(NAME, VERSION, SHA1));
+  }
+
+  @Test
+  void unverifiedOn404() {
+    RegistryStub.stubNotFound(server, NAME);
+
+    assertUnverified(verifier(server.baseUrl()).verify(NAME, VERSION, SHA1));
+  }
+
+  @Test
+  void unverifiedOn500() {
+    RegistryStub.stubServerError(server, NAME);
+
+    assertUnverified(verifier(server.baseUrl()).verify(NAME, VERSION, SHA1));
+  }
+
+  @Test
+  void unverifiedOnMalformedBody() {
+    RegistryStub.stubMalformed(server, NAME);
+
+    assertUnverified(verifier(server.baseUrl()).verify(NAME, VERSION, SHA1));
+  }
+
+  @Test
+  void unverifiedWhenConnectionRefused() throws IOException {
+    final int closedPort;
+    try (ServerSocket socket = new ServerSocket(0)) {
+      closedPort = socket.getLocalPort();
+    }
+
+    assertUnverified(verifier("http://127.0.0.1:" + closedPort).verify(NAME, VERSION, SHA1));
+  }
+
+  @Test
+  void followsRedirect() {
+    RegistryStub.stubRedirect(server, NAME, VERSION, SHA1);
+
+    final PackageVerificationResult result =
+        verifier(server.baseUrl() + RegistryStub.REDIRECT_PREFIX).verify(NAME, VERSION, SHA1);
+
+    assertEquals(PackageVerification.VERIFIED, result.getStatus());
+    server.verify(getRequestedFor(urlEqualTo(RegistryStub.path(NAME))));
+  }
+
+  @Test
+  void trailingSlashOnRegistryIsIgnored() {
+    RegistryStub.stubListing(server, NAME, VERSION, SHA1);
+    final PackageRegistryVerifier verifier = verifier(server.baseUrl() + "//");
+
+    assertEquals(server.baseUrl(), verifier.getRegistryUrl());
+    assertEquals(PackageVerification.VERIFIED, verifier.verify(NAME, VERSION, SHA1).getStatus());
+    server.verify(getRequestedFor(urlEqualTo(RegistryStub.path(NAME))));
+  }
+
+  @Test
+  void packageNameIsPathEncoded() {
+    final String spaced = "spaced name";
+    RegistryStub.stubListing(server, spaced, VERSION, SHA1);
+
+    final PackageVerificationResult result =
+        verifier(server.baseUrl()).verify(spaced, VERSION, SHA1);
+
+    assertEquals(PackageVerification.VERIFIED, result.getStatus());
+    server.verify(getRequestedFor(urlEqualTo("/spaced%20name")));
+  }
+
+  @Test
+  void nullRegistrySelectsTheDefault() {
+    // No lookup is made, so the default is exercised without contacting the real registry.
+    assertEquals(
+        PackageRegistryVerifier.DEFAULT_REGISTRY_URL,
+        new PackageRegistryVerifier(null).getRegistryUrl());
+    assertEquals("https://packages.fhir.org", PackageRegistryVerifier.DEFAULT_REGISTRY_URL);
+    assertEquals(0, server.getAllServeEvents().size());
+  }
+
+  private static void assertUnverified(@Nonnull final PackageVerificationResult result) {
+    assertEquals(PackageVerification.UNVERIFIED, result.getStatus());
+    // No registry vouched for the bytes, but the reason is available for the warning.
+    assertNull(result.getRegistry());
+    assertNotNull(result.getReason());
+  }
+
+  @Nonnull
+  private static PackageRegistryVerifier verifier(@Nonnull final String registryUrl) {
+    return new PackageRegistryVerifier(registryUrl);
+  }
+}

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/RegistryStub.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/RegistryStub.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Stubs a FHIR package registry on a {@link WireMockServer}, so the registry checksum lookup can be
+ * exercised without contacting a real registry. A registry answers {@code GET /{name}} with a
+ * listing of every published version, each of which may carry {@code dist.shasum}.
+ *
+ * @author John Grimes
+ */
+public final class RegistryStub {
+
+  /**
+   * The path prefix that {@link #stubRedirect} serves, redirecting to the real listing. A test
+   * points the verifier at {@code <baseUrl>/redirect} to exercise redirect following.
+   */
+  public static final String REDIRECT_PREFIX = "/redirect";
+
+  private RegistryStub() {
+    // Test helper.
+  }
+
+  /**
+   * Returns the path a lookup of the named package requests, with the name percent-encoded.
+   *
+   * @param packageName the package name
+   * @return the request path, including its leading slash
+   */
+  @Nonnull
+  public static String path(@Nonnull final String packageName) {
+    return "/" + URLEncoder.encode(packageName, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  /**
+   * Stubs the listing of a package with a single published version.
+   *
+   * @param server the server to stub on
+   * @param packageName the package name
+   * @param version the published version
+   * @param shasum the SHA-1 published for the version, or null to omit {@code dist.shasum}
+   */
+  public static void stubListing(
+      @Nonnull final WireMockServer server,
+      @Nonnull final String packageName,
+      @Nonnull final String version,
+      @Nullable final String shasum) {
+    final Map<String, String> versions = new LinkedHashMap<>();
+    versions.put(version, shasum);
+    stubListing(server, packageName, versions);
+  }
+
+  /**
+   * Stubs the listing of a package with several published versions.
+   *
+   * @param server the server to stub on
+   * @param packageName the package name
+   * @param shasumsByVersion the SHA-1 published for each version, a null value omitting {@code
+   *     dist.shasum} for that version
+   */
+  public static void stubListing(
+      @Nonnull final WireMockServer server,
+      @Nonnull final String packageName,
+      @Nonnull final Map<String, String> shasumsByVersion) {
+    stubBody(server, packageName, listingJson(packageName, shasumsByVersion));
+  }
+
+  /**
+   * Stubs the listing of a package whose version carries no {@code dist} object at all.
+   *
+   * @param server the server to stub on
+   * @param packageName the package name
+   * @param version the published version
+   */
+  public static void stubListingWithoutDist(
+      @Nonnull final WireMockServer server,
+      @Nonnull final String packageName,
+      @Nonnull final String version) {
+    final String body =
+        "{\"name\":\""
+            + escape(packageName)
+            + "\",\"versions\":{\""
+            + escape(version)
+            + "\":{\"name\":\""
+            + escape(packageName)
+            + "\",\"version\":\""
+            + escape(version)
+            + "\"}}}";
+    stubBody(server, packageName, body);
+  }
+
+  /**
+   * Stubs a registry that does not know the package.
+   *
+   * @param server the server to stub on
+   * @param packageName the package name
+   */
+  public static void stubNotFound(
+      @Nonnull final WireMockServer server, @Nonnull final String packageName) {
+    server.stubFor(
+        get(urlEqualTo(path(packageName)))
+            .willReturn(aResponse().withStatus(404).withBody("Not found")));
+  }
+
+  /**
+   * Stubs a registry that fails with a server error.
+   *
+   * @param server the server to stub on
+   * @param packageName the package name
+   */
+  public static void stubServerError(
+      @Nonnull final WireMockServer server, @Nonnull final String packageName) {
+    server.stubFor(
+        get(urlEqualTo(path(packageName)))
+            .willReturn(aResponse().withStatus(500).withBody("Internal server error")));
+  }
+
+  /**
+   * Stubs a registry that answers with something that is not a version listing.
+   *
+   * @param server the server to stub on
+   * @param packageName the package name
+   */
+  public static void stubMalformed(
+      @Nonnull final WireMockServer server, @Nonnull final String packageName) {
+    stubBody(server, packageName, "this is not JSON {");
+  }
+
+  /**
+   * Stubs a redirect from {@link #REDIRECT_PREFIX} to the real listing of a package, which is
+   * stubbed as well.
+   *
+   * @param server the server to stub on
+   * @param packageName the package name
+   * @param version the published version
+   * @param shasum the SHA-1 published for the version, or null to omit {@code dist.shasum}
+   */
+  public static void stubRedirect(
+      @Nonnull final WireMockServer server,
+      @Nonnull final String packageName,
+      @Nonnull final String version,
+      @Nullable final String shasum) {
+    stubListing(server, packageName, version, shasum);
+    server.stubFor(
+        get(urlEqualTo(REDIRECT_PREFIX + path(packageName)))
+            .willReturn(
+                aResponse()
+                    .withStatus(302)
+                    .withHeader("Location", server.baseUrl() + path(packageName))));
+  }
+
+  /**
+   * Renders the version listing document a registry publishes for a package.
+   *
+   * @param packageName the package name
+   * @param shasumsByVersion the SHA-1 published for each version, a null value omitting {@code
+   *     dist.shasum} for that version
+   * @return the listing document as JSON
+   */
+  @Nonnull
+  public static String listingJson(
+      @Nonnull final String packageName, @Nonnull final Map<String, String> shasumsByVersion) {
+    final StringBuilder builder = new StringBuilder();
+    builder
+        .append("{\"_id\":\"")
+        .append(escape(packageName))
+        .append("\",\"name\":\"")
+        .append(escape(packageName))
+        .append("\",\"versions\":{");
+    boolean first = true;
+    for (final Map.Entry<String, String> entry : shasumsByVersion.entrySet()) {
+      if (!first) {
+        builder.append(",");
+      }
+      first = false;
+      final String version = entry.getKey();
+      builder
+          .append("\"")
+          .append(escape(version))
+          .append("\":{\"name\":\"")
+          .append(escape(packageName))
+          .append("\",\"version\":\"")
+          .append(escape(version))
+          .append("\",\"dist\":{\"tarball\":\"https://example.com/")
+          .append(escape(packageName))
+          .append("/")
+          .append(escape(version))
+          .append("\"");
+      if (entry.getValue() != null) {
+        builder.append(",\"shasum\":\"").append(escape(entry.getValue())).append("\"");
+      }
+      builder.append("}}");
+    }
+    builder.append("}}");
+    return builder.toString();
+  }
+
+  private static void stubBody(
+      @Nonnull final WireMockServer server,
+      @Nonnull final String packageName,
+      @Nonnull final String body) {
+    server.stubFor(
+        get(urlEqualTo(path(packageName)))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(body)));
+  }
+
+  @Nonnull
+  private static String escape(@Nonnull final String value) {
+    return value.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+}

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterProvenanceTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/SnomedRf2ImporterProvenanceTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.terminology.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import au.csiro.pathling.test.Rf2Mini;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies what an RF2 import records about the bytes it read: an archive source is fingerprinted
+ * with the SHA-256 of the whole zip file, and a directory source records no hash at all. Each test
+ * imports into a store of its own, since the source shape is what is under test.
+ *
+ * @author John Grimes
+ */
+class SnomedRf2ImporterProvenanceTest {
+
+  private static SparkSession spark;
+
+  @BeforeAll
+  static void setUp(@TempDir final Path warehouse) {
+    spark =
+        SparkSession.builder()
+            .appName("SnomedRf2ImporterProvenanceTest")
+            .master("local[2]")
+            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+            .config(
+                "spark.sql.catalog.spark_catalog",
+                "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+            .config("spark.sql.warehouse.dir", warehouse.toString())
+            .config("spark.sql.shuffle.partitions", "2")
+            .config("spark.driver.bindAddress", "localhost")
+            .config("spark.driver.host", "localhost")
+            .config("spark.ui.enabled", "false")
+            .getOrCreate();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (spark != null) {
+      spark.stop();
+      spark = null;
+    }
+  }
+
+  @Test
+  void zipSourceRecordsItsSha256(@TempDir final Path work) throws Exception {
+    final Path archive = work.resolve("rf2.zip");
+    zipDirectory(Rf2Mini.baseRelease(), archive);
+    final String store = work.resolve("zip-store").toString();
+
+    new SnomedRf2Importer(spark, store).importFrom(archive.toString(), null);
+
+    final List<ManifestEntry> manifest = manifest(store);
+    assertEquals(1, manifest.size());
+    final ManifestEntry entry = manifest.get(0);
+    // The recorded hash covers the whole archive, including the central directory that follows the
+    // last entry the extraction read.
+    assertEquals(sha256Hex(archive), entry.getSourceSha256());
+    assertEquals(archive.toString(), entry.getSource());
+    // An RF2 release is not a FHIR NPM package, so it carries no package identity or status.
+    assertNull(entry.getPackageName());
+    assertNull(entry.getPackageVersion());
+    assertNull(entry.getPackageVerification());
+    assertNull(entry.getPackageRegistry());
+  }
+
+  @Test
+  void directorySourceRecordsNullHash(@TempDir final Path work) {
+    final String store = work.resolve("dir-store").toString();
+
+    new SnomedRf2Importer(spark, store).importFrom(Rf2Mini.baseRelease().toString(), null);
+
+    final ManifestEntry entry = manifest(store).get(0);
+    assertNull(entry.getSourceSha256());
+    assertNull(entry.getPackageName());
+    assertNull(entry.getPackageVersion());
+    assertNull(entry.getPackageVerification());
+    assertNull(entry.getPackageRegistry());
+  }
+
+  private static List<ManifestEntry> manifest(final String store) {
+    return TerminologyStoreReader.open(store, Map.of()).readManifest();
+  }
+
+  /** Computes the SHA-256 of a file independently of the importer's own digesting stream. */
+  private static String sha256Hex(final Path file) throws Exception {
+    final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    try (InputStream in = Files.newInputStream(file)) {
+      final byte[] buffer = new byte[8192];
+      int read;
+      while ((read = in.read(buffer)) != -1) {
+        digest.update(buffer, 0, read);
+      }
+    }
+    final StringBuilder builder = new StringBuilder();
+    for (final byte b : digest.digest()) {
+      builder.append(String.format("%02x", b));
+    }
+    return builder.toString();
+  }
+
+  /** Writes every regular file beneath {@code directory} into a zip archive at {@code archive}. */
+  private static void zipDirectory(final Path directory, final Path archive) throws Exception {
+    try (final OutputStream fileOut = Files.newOutputStream(archive);
+        final ZipOutputStream zipOut = new ZipOutputStream(fileOut);
+        final Stream<Path> files = Files.walk(directory)) {
+      for (final Path file : (Iterable<Path>) files.filter(Files::isRegularFile)::iterator) {
+        zipOut.putNextEntry(new ZipEntry(directory.relativize(file).toString().replace('\\', '/')));
+        Files.copy(file, zipOut);
+        zipOut.closeEntry();
+      }
+    }
+  }
+}

--- a/terminology/src/test/java/au/csiro/pathling/terminology/store/TerminologyStoreTest.java
+++ b/terminology/src/test/java/au/csiro/pathling/terminology/store/TerminologyStoreTest.java
@@ -17,11 +17,15 @@
 
 package au.csiro.pathling.terminology.store;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import jakarta.annotation.Nonnull;
 import java.nio.file.Path;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -54,6 +58,14 @@ class TerminologyStoreTest {
   private static final String COL_CODE = "code";
   private static final String COL_DENSE_ID = "dense_id";
   private static final String COL_ACTIVE = "active";
+  private static final String SHA_256 = "0".repeat(64);
+  private static final List<String> NEW_COLUMNS =
+      List.of(
+          TerminologyStoreSchema.COLUMN_SOURCE_SHA256,
+          TerminologyStoreSchema.COLUMN_PACKAGE_NAME,
+          TerminologyStoreSchema.COLUMN_PACKAGE_VERSION,
+          TerminologyStoreSchema.COLUMN_PACKAGE_VERIFICATION,
+          TerminologyStoreSchema.COLUMN_PACKAGE_REGISTRY);
 
   private static SparkSession spark;
 
@@ -99,12 +111,11 @@ class TerminologyStoreTest {
     final String store = storeDir.resolve("store").toString();
     final Instant importedAt = Instant.now().truncatedTo(ChronoUnit.MICROS);
     final ManifestEntry entry =
-        new ManifestEntry(
-            TerminologyStoreSchema.STORE_FORMAT_VERSION,
+        ManifestEntry.forImport(
             "code_system",
             "http://snomed.info/sct",
             "http://snomed.info/sct/900000000000207008/version/20250101",
-            "rf2.zip",
+            ImportProvenance.of("rf2.zip", null),
             importedAt);
 
     new TerminologyStoreWriter(spark, store).writeManifest(List.of(entry), SaveMode.Append);
@@ -161,7 +172,12 @@ class TerminologyStoreTest {
             "http://example.org/cs",
             "1.0.0",
             "future.json",
-            Instant.now());
+            Instant.now(),
+            null,
+            null,
+            null,
+            null,
+            null);
     new TerminologyStoreWriter(spark, store).writeManifest(List.of(future), SaveMode.Append);
 
     final TerminologyStoreException e =
@@ -208,14 +224,172 @@ class TerminologyStoreTest {
     assertEquals(new TreeSet<>(List.of("v1|NEW", "v2|KEEP")), new TreeSet<>(rows));
   }
 
+  @Test
+  void manifestRoundTripsProvenanceColumns(@TempDir final Path storeDir) {
+    final String store = storeDir.resolve("store").toString();
+    final Instant importedAt = Instant.now().truncatedTo(ChronoUnit.MICROS);
+    final ManifestEntry entry =
+        ManifestEntry.forImport(
+            "code_system", "http://example.org/cs", "1.0.0", fullProvenance(), importedAt);
+
+    new TerminologyStoreWriter(spark, store).writeManifest(List.of(entry), SaveMode.Append);
+
+    final List<ManifestEntry> manifest =
+        TerminologyStoreReader.open(store, Map.of()).readManifest();
+    assertEquals(1, manifest.size());
+    final ManifestEntry read = manifest.get(0);
+    assertEquals("fixtures.tgz", read.getSource());
+    assertEquals(SHA_256, read.getSourceSha256());
+    assertEquals("fixtures", read.getPackageName());
+    assertEquals("1.0.0", read.getPackageVersion());
+    assertEquals(PackageVerification.VERIFIED, read.getPackageVerification());
+    assertEquals("https://packages.fhir.org", read.getPackageRegistry());
+    assertEquals(importedAt, read.getImportedAt());
+
+    final StructType schema = TerminologyStoreSchema.manifestSchema();
+    assertEquals(11, schema.fields().length, "manifest should have eleven columns");
+    for (final String column : NEW_COLUMNS) {
+      assertTrue(schema.apply(column).nullable(), column + " should be nullable");
+    }
+  }
+
+  @Test
+  void readsAManifestWrittenWithoutProvenanceColumns(@TempDir final Path storeDir) {
+    final String store = storeDir.resolve("store").toString();
+    final Instant importedAt = Instant.now().truncatedTo(ChronoUnit.MICROS);
+    writeLegacyManifest(store, "http://example.org/legacy", importedAt);
+
+    final TerminologyStoreReader reader =
+        assertDoesNotThrow(() -> TerminologyStoreReader.open(store, Map.of()));
+    final List<ManifestEntry> manifest = reader.readManifest();
+
+    assertEquals(1, manifest.size());
+    final ManifestEntry read = manifest.get(0);
+    assertEquals("http://example.org/legacy", read.getCanonicalUrl());
+    assertEquals("legacy.json", read.getSource());
+    assertEquals(importedAt, read.getImportedAt());
+    assertNull(read.getSourceSha256());
+    assertNull(read.getPackageName());
+    assertNull(read.getPackageVersion());
+    assertNull(read.getPackageVerification());
+    assertNull(read.getPackageRegistry());
+  }
+
+  @Test
+  void upsertIntoAnOldManifestAddsTheColumns(@TempDir final Path storeDir) {
+    final String store = storeDir.resolve("store").toString();
+    writeLegacyManifest(store, "http://example.org/legacy", Instant.now());
+
+    new TerminologyStoreWriter(spark, store)
+        .upsertManifestEntry(
+            ManifestEntry.forImport(
+                "code_system",
+                "http://example.org/cs",
+                "1.0.0",
+                fullProvenance(),
+                Instant.now().truncatedTo(ChronoUnit.MICROS)));
+
+    final List<ManifestEntry> manifest =
+        TerminologyStoreReader.open(store, Map.of()).readManifest();
+    assertEquals(2, manifest.size());
+
+    final ManifestEntry legacy = entryFor(manifest, "http://example.org/legacy");
+    assertNull(legacy.getSourceSha256());
+    assertNull(legacy.getPackageName());
+    assertNull(legacy.getPackageVersion());
+    assertNull(legacy.getPackageVerification());
+    assertNull(legacy.getPackageRegistry());
+
+    final ManifestEntry imported = entryFor(manifest, "http://example.org/cs");
+    assertEquals(SHA_256, imported.getSourceSha256());
+    assertEquals("fixtures", imported.getPackageName());
+    assertEquals("1.0.0", imported.getPackageVersion());
+    assertEquals(PackageVerification.VERIFIED, imported.getPackageVerification());
+    assertEquals("https://packages.fhir.org", imported.getPackageRegistry());
+
+    final StructType schema =
+        spark
+            .read()
+            .format("delta")
+            .load(TerminologyStoreSchema.tablePath(store, TerminologyStoreSchema.MANIFEST))
+            .schema();
+    assertEquals(11, schema.fields().length, "manifest should have gained the five columns");
+  }
+
+  @Test
+  void hasColumnReportsPresenceWithoutThrowing(@TempDir final Path storeDir) {
+    final String store = storeDir.resolve("store").toString();
+    writeLegacyManifest(store, "http://example.org/legacy", Instant.now());
+
+    final List<Boolean> present = new ArrayList<>();
+    final List<Boolean> absent = new ArrayList<>();
+    TerminologyStoreReader.open(store, Map.of())
+        .readTable(
+            TerminologyStoreSchema.MANIFEST,
+            row -> {
+              present.add(row.hasColumn(TerminologyStoreSchema.COLUMN_SOURCE));
+              absent.add(row.hasColumn(TerminologyStoreSchema.COLUMN_SOURCE_SHA256));
+            });
+
+    assertEquals(List.of(true), present);
+    assertEquals(List.of(false), absent);
+  }
+
+  @Nonnull
+  private static ManifestEntry entryFor(
+      @Nonnull final List<ManifestEntry> manifest, @Nonnull final String canonicalUrl) {
+    return manifest.stream()
+        .filter(entry -> canonicalUrl.equals(entry.getCanonicalUrl()))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  @Nonnull
+  private static ImportProvenance fullProvenance() {
+    return new ImportProvenance(
+        "fixtures.tgz",
+        SHA_256,
+        "fixtures",
+        "1.0.0",
+        PackageVerification.VERIFIED,
+        "https://packages.fhir.org");
+  }
+
+  /** Writes the manifest table with the six-column schema that preceded this feature. */
+  private void writeLegacyManifest(
+      @Nonnull final String store,
+      @Nonnull final String canonicalUrl,
+      @Nonnull final Instant importedAt) {
+    final StructType legacySchema =
+        new StructType()
+            .add(TerminologyStoreSchema.COLUMN_STORE_FORMAT_VERSION, DataTypes.IntegerType, false)
+            .add(TerminologyStoreSchema.COLUMN_ENTRY_TYPE, DataTypes.StringType, false)
+            .add(TerminologyStoreSchema.COLUMN_CANONICAL_URL, DataTypes.StringType, false)
+            .add(TerminologyStoreSchema.COLUMN_VERSION, DataTypes.StringType, true)
+            .add(TerminologyStoreSchema.COLUMN_SOURCE, DataTypes.StringType, true)
+            .add(TerminologyStoreSchema.COLUMN_IMPORTED_AT, DataTypes.TimestampType, true);
+    final Dataset<Row> data =
+        spark.createDataFrame(
+            List.of(
+                RowFactory.create(
+                    TerminologyStoreSchema.STORE_FORMAT_VERSION,
+                    "code_system",
+                    canonicalUrl,
+                    "1.0.0",
+                    "legacy.json",
+                    Timestamp.from(importedAt))),
+            legacySchema);
+    new TerminologyStoreWriter(spark, store)
+        .writeTable(data, TerminologyStoreSchema.MANIFEST, SaveMode.Append, List.of());
+  }
+
   private static List<ManifestEntry> minimalManifest() {
     return List.of(
-        new ManifestEntry(
-            TerminologyStoreSchema.STORE_FORMAT_VERSION,
+        ManifestEntry.forImport(
             "code_system",
             "http://snomed.info/sct",
             "http://snomed.info/sct/900000000000207008/version/20250101",
-            "rf2.zip",
+            ImportProvenance.of("rf2.zip", null),
             Instant.now()));
   }
 }


### PR DESCRIPTION
Resolves #2744.

`import_fhir_terminology` now reads the package name and version from a `.tgz` source's `package.json`, fetches `GET {registry}/{name}` and compares the tarball's SHA-1 with the registry's `dist.shasum`. A mismatch fails the import before anything is written; a registry that publishes no checksum, cannot be reached or does not list the package warns and records `unverified`. Verification is on by default and can be turned off per import (`verifyPackage`/`verify_package`/`--no-verify`), and the registry can be chosen (`packageRegistry`/`package_registry`/`--package-registry`, or the `package-registry` config key), defaulting to `https://packages.fhir.org`.

Every manifest row gains five nullable columns: `source_sha256` (recorded for every single-file source, including RF2 `.zip`), `package_name`, `package_version`, `package_verification` (`verified`, `unverified`, `skipped` or null) and `package_registry`. The store format version is unchanged; existing stores open, query and accept imports, evolving the manifest schema in place. The CLI completion line reports the outcome and hash, and the documentation describes the manifest and how to compare two stores.

Observed CLI output (SHA-256 values checked against `shasum -a 256`; `hl7.terminology.r4` 6.5.0 from packages.simplifier.net, the rest `hl7.fhir.uv.sdc` 3.0.0):

```
$ pathling import-fhir-terminology hl7.terminology.r4-6.5.0.tgz store
Imported FHIR terminology from hl7.terminology.r4-6.5.0.tgz into store (verified hl7.terminology.r4 6.5.0 against https://packages.fhir.org; sha256 a28b638483a11df696ed92198276236d759e41c7a3a8960c9e7e7d0a1185bd06)

$ pathling import-fhir-terminology tampered.tgz store      # recompressed with gzip -9
... does not match the registry checksum published by https://packages.fhir.org: expected SHA-1 73fe242b9aec1b71dd78a4a874080c89c559e3e3 but the source has SHA-1 5d05e14b1c08903515c1414ab6d834102eb20302. ... Re-run with --no-verify to import it anyway.
(exit 1; store directory not created)

$ pathling --verbose import-fhir-terminology --package-registry http://127.0.0.1:9 small.tgz store-4
WARN FhirTerminologyImporter: Package hl7.fhir.uv.sdc 3.0.0 was not verified: Connect to 127.0.0.1:9 [/127.0.0.1] failed: Connection refused
Imported FHIR terminology from small.tgz into store-4 (hl7.fhir.uv.sdc 3.0.0 not verified against a registry; re-run with --verbose for the reason; sha256 be5c3f0a...23dca2)

$ pathling import-fhir-terminology --no-verify small.tgz store-5
Imported FHIR terminology from small.tgz into store-5 (hl7.fhir.uv.sdc 3.0.0, verification skipped; sha256 be5c3f0a...23dca2)

$ pathling import-snomed rf2.zip store-7
Imported SNOMED CT from rf2.zip into store-7 (sha256 65777056...19ad0)

$ pathling import-fhir-terminology codesystem.json store-8
Imported FHIR terminology from codesystem.json into store-8 (sha256 ffc3eb68...999c6c)
```

Directory sources produce a completion line with no suffix and null provenance columns. A `.tgz` without a usable `package.json` records `unverified` even under `--no-verify`, since there is no identity to skip verification for; this follows the data model in the spec.

Not in scope: the importer commits one Delta manifest write per resource, which makes a full `hl7.terminology.r4` import slow (around one second per resource once the log is large). That behaviour predates this change.
