### PR TITLE
Support external tables in SQL on FHIR queries

### DIFF
--- a/server/src/main/java/au/csiro/pathling/config/ExternalTableConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/ExternalTableConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.config;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+/**
+ * One operator-configured external table that a SQLQuery or SQLView may declare as a dependency and
+ * read by its label. Bound from {@code pathling.sqlQuery.externalTables.N.*}.
+ *
+ * <p>Validation here is purely structural and happens at bind time; no path is probed at startup,
+ * so an unreachable store or late-bound credentials never prevent the server from starting.
+ *
+ * @author John Grimes
+ */
+@Data
+public class ExternalTableConfiguration {
+
+  /**
+   * The canonical URL that a Library's {@code relatedArtifact.resource} uses to reference this
+   * table. Must be unique across the configured tables and must not contain {@code |}, which is the
+   * separator between a canonical URL and its version pin and so could never be referenced.
+   */
+  @NotBlank
+  @Pattern(regexp = "[^|]+")
+  private String url;
+
+  /**
+   * The storage location of the table, accepting the same filesystem schemes as the warehouse URL
+   * ({@code file://}, {@code s3a://}, {@code hdfs://}).
+   */
+  @NotBlank private String path;
+
+  /**
+   * The Spark data source name passed to {@code DataFrameReader.format}: {@code delta} or {@code
+   * parquet}.
+   */
+  @NotBlank
+  @Pattern(regexp = "delta|parquet")
+  private String format = "delta";
+}

--- a/server/src/main/java/au/csiro/pathling/config/ServerConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/ServerConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.validation.annotation.Validated;
  * Configuration properties for the Pathling server.
  *
  * @author Felix Naumann
+ * @author John Grimes
  */
 @ConfigurationProperties(prefix = "pathling")
 @Validated
@@ -117,9 +118,20 @@ public class ServerConfiguration {
   /** Configuration for the admin UI. */
   @Valid @NotNull private AdminUiConfiguration adminUi = new AdminUiConfiguration();
 
-  /** Logs the server configuration on startup. */
+  /**
+   * Logs the server configuration on startup. Each configured external table is recorded at {@code
+   * INFO} so that operators can see which tables are reachable from SQL on FHIR queries; no table
+   * path is probed here.
+   */
   @PostConstruct
   public void logConfiguration() {
     log.debug("Server configuration: {}", this);
+    for (final ExternalTableConfiguration table : sqlQuery.getExternalTables()) {
+      log.info(
+          "External table: url={}, path={}, format={}",
+          table.getUrl(),
+          table.getPath(),
+          table.getFormat());
+    }
   }
 }

--- a/server/src/main/java/au/csiro/pathling/config/SqlQueryConfiguration.java
+++ b/server/src/main/java/au/csiro/pathling/config/SqlQueryConfiguration.java
@@ -17,13 +17,21 @@
 
 package au.csiro.pathling.config;
 
+import jakarta.annotation.Nonnull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import lombok.Data;
 import lombok.ToString;
 
 /**
  * Configuration for the SQL query operations. Bounds the resolution of a query's dependency graph,
- * which happens before any query execution.
+ * which happens before any query execution, and declares the external tables that a query may
+ * reference alongside stored ViewDefinitions and SQLViews.
  *
  * @author John Grimes
  */
@@ -40,4 +48,23 @@ public class SqlQueryConfiguration {
    */
   @Min(1)
   private int maxDependencyDepth = 10;
+
+  /**
+   * The external tables reachable from SQL on FHIR queries, each bound to a canonical URL. An
+   * absent property is indistinguishable from no tables. Entry violations are reported as {@code
+   * externalTables[N].<field>}.
+   */
+  @Valid @Nonnull private List<ExternalTableConfiguration> externalTables = new ArrayList<>();
+
+  /**
+   * Checks that no two external tables share a URL, since a reference could otherwise resolve to
+   * either of them.
+   *
+   * @return true if every configured URL is distinct
+   */
+  @AssertTrue(message = "externalTables must not contain duplicate urls")
+  public boolean isExternalTableUrlsUnique() {
+    final Set<String> seen = new HashSet<>();
+    return externalTables.stream().map(ExternalTableConfiguration::getUrl).allMatch(seen::add);
+  }
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sql/SqlOperationError.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sql/SqlOperationError.java
@@ -199,6 +199,23 @@ public final class SqlOperationError {
   }
 
   /**
+   * Builds a {@code 500 Internal Server Error} carrying {@code issue.code = processing} and no
+   * expression, for a server-side fault such as an external table that cannot be read.
+   *
+   * <p>No cause is attached, deliberately. {@code ErrorHandlingInterceptor} unwraps an {@code
+   * InternalErrorException} to its cause and reprocesses that instead, which would discard this
+   * message and its {@code OperationOutcome}; with no cause the exception passes through unchanged.
+   * Callers that hold an underlying exception should log it before throwing.
+   *
+   * @param message the diagnostics message
+   * @return the exception to throw
+   */
+  @Nonnull
+  public static BaseServerResponseException internalError(@Nonnull final String message) {
+    return of(500, List.of(issue(IssueType.PROCESSING, null, message)));
+  }
+
+  /**
    * Builds a single error-severity {@code OperationOutcome} issue.
    *
    * @param code the {@code issue.code} to report

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ResolvedExternalTable.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ResolvedExternalTable.java
@@ -18,24 +18,24 @@
 package au.csiro.pathling.operations.sqlquery;
 
 import jakarta.annotation.Nonnull;
+import lombok.Value;
 
 /**
- * A resolved node in a SQL on FHIR dependency graph: a {@link ResolvedViewDefinition} leaf, a
- * {@link ResolvedExternalTable} leaf or a {@link ResolvedSqlView}. Each node is identified by a
- * stable canonical key that is the basis of its request-scoped temp-view name and of diamond
- * deduplication.
+ * A resolved leaf node for an operator-configured external table. The table is read directly from
+ * its storage path by Spark rather than projected from FHIR resources, declares no further
+ * dependencies and carries no version, so it is always a leaf of the dependency graph.
  *
  * @author John Grimes
  */
-public interface ResolvedDependency {
+@Value
+public class ResolvedExternalTable implements ResolvedDependency {
 
-  /**
-   * Returns the stable canonical identity of the resolved resource. Two references to the same
-   * resource share a key, so a node is materialised only once per request, and the key cannot
-   * collide with a different resource even when both are reached under the same table label.
-   *
-   * @return the canonical key
-   */
-  @Nonnull
-  String getCanonicalKey();
+  /** The configured canonical URL, verbatim. External tables have no version. */
+  @Nonnull String canonicalKey;
+
+  /** The storage location of the table, used only by the Spark read. */
+  @Nonnull String path;
+
+  /** The Spark data source name ({@code delta} or {@code parquet}), used only by the Spark read. */
+  @Nonnull String format;
 }

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlDependencyResolver.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlDependencyResolver.java
@@ -17,6 +17,7 @@
 
 package au.csiro.pathling.operations.sqlquery;
 
+import au.csiro.pathling.config.ExternalTableConfiguration;
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.operations.sql.SuppliedArtefact;
 import au.csiro.pathling.operations.sql.SuppliedArtefacts;
@@ -30,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.hl7.fhir.r4.model.Library;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -47,10 +50,11 @@ import org.springframework.stereotype.Component;
  *
  * <ol>
  *   <li>prefers a request-supplied view whose URL matches;
- *   <li>otherwise searches stored {@code ViewDefinition}s by url, then {@code SQLView Library}s by
- *       url;
+ *   <li>otherwise matches the bare URL (a reference carrying no version) against the external
+ *       tables the operator has configured, and searches stored {@code ViewDefinition}s by url,
+ *       then {@code SQLView Library}s by url;
  *   <li>rejects a URL that matches both a ViewDefinition and a SQLView as ambiguous, and a URL that
- *       matches neither as not found - each naming the label and the reference.
+ *       matches nothing as not found - each naming the label and the reference.
  * </ol>
  *
  * <p>The resolution memoises by the resolved canonical key (the matched resource's url plus its
@@ -73,13 +77,17 @@ public class SqlDependencyResolver {
 
   @Nonnull private final ServerConfiguration serverConfiguration;
 
+  /** The operator-configured external tables, indexed by their canonical URL. */
+  @Nonnull private final Map<String, ExternalTableConfiguration> externalTablesByUrl;
+
   /**
    * Constructs a new SqlDependencyResolver.
    *
    * @param viewResolver resolves ViewDefinition leaves by url, preferring request-supplied views
    * @param libraryReferenceResolver resolves a SQLView Library by canonical url from storage
    * @param libraryParser the shared parser for SQLView Libraries
-   * @param serverConfiguration the server configuration (auth toggle and the dependency depth cap)
+   * @param serverConfiguration the server configuration (auth toggle, the dependency depth cap and
+   *     the configured external tables)
    */
   @Autowired
   public SqlDependencyResolver(
@@ -91,6 +99,12 @@ public class SqlDependencyResolver {
     this.libraryReferenceResolver = libraryReferenceResolver;
     this.libraryParser = libraryParser;
     this.serverConfiguration = serverConfiguration;
+    // URL uniqueness is enforced by Bean Validation at bind time, so the keys cannot collide.
+    this.externalTablesByUrl =
+        serverConfiguration.getSqlQuery().getExternalTables().stream()
+            .collect(
+                Collectors.toUnmodifiableMap(
+                    ExternalTableConfiguration::getUrl, Function.identity()));
   }
 
   /**
@@ -162,9 +176,10 @@ public class SqlDependencyResolver {
 
   /**
    * Resolves a single reference into the canonical key of its node, registering it if new. A
-   * request-supplied artefact wins; otherwise the canonical url is matched against stored
-   * ViewDefinitions then SQLView Libraries, rejecting an ambiguous match (both types) and a
-   * not-found match (neither type).
+   * request-supplied artefact wins; otherwise the canonical url is matched against the configured
+   * external tables (only when the reference carries no version) and against stored ViewDefinitions
+   * then SQLView Libraries, rejecting an ambiguous match (both stored types) and a not-found match
+   * (nothing).
    */
   @Nonnull
   private String resolveReference(
@@ -208,6 +223,17 @@ public class SqlDependencyResolver {
           nodesByKey);
     }
 
+    // A configured external table matches the bare url only: tables have no version, so a pinned
+    // reference can never mean one.
+    final ExternalTableConfiguration externalTable =
+        canonical.getVersion() == null ? externalTablesByUrl.get(canonical.getUrl()) : null;
+    if (externalTable != null) {
+      return registerLeaf(
+          new ResolvedExternalTable(
+              externalTable.getUrl(), externalTable.getPath(), externalTable.getFormat()),
+          nodesByKey);
+    }
+
     // Search stored ViewDefinitions, then stored SQLView Libraries, both by url.
     final Optional<ResolvedViewDefinition> storedViewDefinition =
         viewResolver.resolveStoredViewDefinition(reference);
@@ -245,10 +271,13 @@ public class SqlDependencyResolver {
             + "': no ViewDefinition or SQLView matches that canonical URL");
   }
 
-  /** Registers a resolved ViewDefinition leaf (deduplicating diamonds) and returns its key. */
+  /**
+   * Registers a resolved leaf (a ViewDefinition or an external table), deduplicating diamonds, and
+   * returns its key.
+   */
   @Nonnull
   private String registerLeaf(
-      @Nonnull final ResolvedViewDefinition leaf,
+      @Nonnull final ResolvedDependency leaf,
       @Nonnull final Map<String, ResolvedDependency> nodesByKey) {
     nodesByKey.putIfAbsent(leaf.getCanonicalKey(), leaf);
     return leaf.getCanonicalKey();

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlDependencyResolver.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlDependencyResolver.java
@@ -51,10 +51,10 @@ import org.springframework.stereotype.Component;
  * <ol>
  *   <li>prefers a request-supplied view whose URL matches;
  *   <li>otherwise matches the bare URL (a reference carrying no version) against the external
- *       tables the operator has configured, and searches stored {@code ViewDefinition}s by url,
- *       then {@code SQLView Library}s by url;
- *   <li>rejects a URL that matches both a ViewDefinition and a SQLView as ambiguous, and a URL that
- *       matches nothing as not found - each naming the label and the reference.
+ *       tables the operator has configured, and searches stored {@code ViewDefinition}s by url and
+ *       {@code SQLView Library}s by url;
+ *   <li>rejects a URL that matches more than one of those three sources as ambiguous, and a URL
+ *       that matches nothing as not found - each naming the label and the reference.
  * </ol>
  *
  * <p>The resolution memoises by the resolved canonical key (the matched resource's url plus its
@@ -115,7 +115,8 @@ public class SqlDependencyResolver {
    * @return the resolved dependency graph, topologically ordered
    * @throws InvalidRequestException if a reference is ambiguous, a cycle or depth-limit breach is
    *     detected, or a dependency is a malformed or wrong-typed resource
-   * @throws ResourceNotFoundException if a reference matches no stored ViewDefinition or SQLView
+   * @throws ResourceNotFoundException if a reference matches no ViewDefinition, SQLView or external
+   *     table
    */
   @Nonnull
   public ResolvedDependencyGraph resolve(
@@ -137,7 +138,8 @@ public class SqlDependencyResolver {
    * @return the resolved dependency graph, topologically ordered
    * @throws InvalidRequestException if a reference is ambiguous, a cycle or depth-limit breach is
    *     detected, or a dependency is a malformed or wrong-typed resource
-   * @throws ResourceNotFoundException if a reference matches no stored ViewDefinition or SQLView
+   * @throws ResourceNotFoundException if a reference matches no ViewDefinition, SQLView or external
+   *     table
    */
   @Nonnull
   public ResolvedDependencyGraph resolve(
@@ -177,8 +179,8 @@ public class SqlDependencyResolver {
   /**
    * Resolves a single reference into the canonical key of its node, registering it if new. A
    * request-supplied artefact wins; otherwise the canonical url is matched against the configured
-   * external tables (only when the reference carries no version) and against stored ViewDefinitions
-   * then SQLView Libraries, rejecting an ambiguous match (both stored types) and a not-found match
+   * external tables (only when the reference carries no version), stored ViewDefinitions and
+   * SQLView Libraries, rejecting an ambiguous match (more than one source) and a not-found match
    * (nothing).
    */
   @Nonnull
@@ -224,29 +226,41 @@ public class SqlDependencyResolver {
     }
 
     // A configured external table matches the bare url only: tables have no version, so a pinned
-    // reference can never mean one.
+    // reference can never mean one. Storage is still searched so that a URL bound to a table and
+    // also stored as an artefact is reported as ambiguous rather than one side silently winning;
+    // the
+    // stored lookups enforce their metadata read checks only once they find a match.
     final ExternalTableConfiguration externalTable =
         canonical.getVersion() == null ? externalTablesByUrl.get(canonical.getUrl()) : null;
-    if (externalTable != null) {
-      return registerLeaf(
-          new ResolvedExternalTable(
-              externalTable.getUrl(), externalTable.getPath(), externalTable.getFormat()),
-          nodesByKey);
-    }
-
-    // Search stored ViewDefinitions, then stored SQLView Libraries, both by url.
     final Optional<ResolvedViewDefinition> storedViewDefinition =
         viewResolver.resolveStoredViewDefinition(reference);
     final Optional<Library> sqlViewLibrary =
         libraryReferenceResolver.tryResolveSqlViewLibrary(reference.getCanonicalUrl());
 
-    if (storedViewDefinition.isPresent() && sqlViewLibrary.isPresent()) {
+    final List<String> matchedKinds = new ArrayList<>(3);
+    if (externalTable != null) {
+      matchedKinds.add("an external table");
+    }
+    if (storedViewDefinition.isPresent()) {
+      matchedKinds.add("a ViewDefinition");
+    }
+    if (sqlViewLibrary.isPresent()) {
+      matchedKinds.add("a SQLView");
+    }
+    if (matchedKinds.size() > 1) {
       throw new InvalidRequestException(
           "The dependency for label '"
               + reference.getLabel()
               + "' (reference '"
               + reference.getCanonicalUrl()
-              + "') is ambiguous: the canonical URL matches both a ViewDefinition and a SQLView");
+              + "') is ambiguous: the canonical URL matches "
+              + describeKinds(matchedKinds));
+    }
+    if (externalTable != null) {
+      return registerLeaf(
+          new ResolvedExternalTable(
+              externalTable.getUrl(), externalTable.getPath(), externalTable.getFormat()),
+          nodesByKey);
     }
     if (storedViewDefinition.isPresent()) {
       return registerLeaf(storedViewDefinition.get(), nodesByKey);
@@ -268,7 +282,15 @@ public class SqlDependencyResolver {
             + reference.getLabel()
             + "' with reference '"
             + reference.getCanonicalUrl()
-            + "': no ViewDefinition or SQLView matches that canonical URL");
+            + "': no ViewDefinition, SQLView or external table matches that canonical URL");
+  }
+
+  /** Joins two or more matched kinds into prose: "both X and Y" for two, "X, Y and Z" for three. */
+  @Nonnull
+  private static String describeKinds(@Nonnull final List<String> kinds) {
+    final String last = kinds.get(kinds.size() - 1);
+    final String head = String.join(", ", kinds.subList(0, kinds.size() - 1));
+    return (kinds.size() == 2 ? "both " : "") + head + " and " + last;
   }
 
   /**

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlDependencyResolver.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlDependencyResolver.java
@@ -227,9 +227,8 @@ public class SqlDependencyResolver {
 
     // A configured external table matches the bare url only: tables have no version, so a pinned
     // reference can never mean one. Storage is still searched so that a URL bound to a table and
-    // also stored as an artefact is reported as ambiguous rather than one side silently winning;
-    // the
-    // stored lookups enforce their metadata read checks only once they find a match.
+    // also stored as an artefact is reported as ambiguous rather than one side silently winning.
+    // The stored lookups enforce their metadata read checks only once they find a match.
     final ExternalTableConfiguration externalTable =
         canonical.getVersion() == null ? externalTablesByUrl.get(canonical.getUrl()) : null;
     final Optional<ResolvedViewDefinition> storedViewDefinition =

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutor.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutor.java
@@ -37,10 +37,11 @@ import org.springframework.stereotype.Component;
  * lifecycle. The only piece of the pipeline that touches Spark.
  *
  * <p>Each node of the graph is materialised in topological order: a {@code ViewDefinition} leaf is
- * executed as a view, and a {@code SQLView} node's SQL is rewritten against the temp views of its
- * already-materialised children, validated, and run. The top-level SQL is then rewritten against
- * its own direct dependencies' temp views and run. Every node's SQL is validated statically before
- * execution and against its analysed plan during execution.
+ * executed as a view, an external table leaf is read from its configured path, and a {@code
+ * SQLView} node's SQL is rewritten against the temp views of its already-materialised children,
+ * validated, and run. The top-level SQL is then rewritten against its own direct dependencies' temp
+ * views and run. Every node's SQL is validated statically before execution and against its analysed
+ * plan during execution.
  *
  * @author John Grimes
  */
@@ -144,8 +145,11 @@ public class SqlQueryExecutor {
 
   /**
    * Materialises a single graph node as a request-scoped temp view, recording its name by canonical
-   * key. A {@code SQLView} node's analysed plan is validated against its own children's temp views
-   * before registration, so it cannot reach an unauthorised data source.
+   * key. A {@code ViewDefinition} leaf is executed against the data source, an external table leaf
+   * is read from its configured path, and a {@code SQLView} node's analysed plan is validated
+   * against its own children's temp views before registration, so it cannot reach an unauthorised
+   * data source. Neither leaf kind needs that check: a leaf's relation is exposed only through the
+   * trusted alias registered here, which is what the parent's own analysed-plan check accepts.
    */
   private void materialiseNode(
       @Nonnull final ResolvedDependency node,
@@ -155,6 +159,8 @@ public class SqlQueryExecutor {
     final Dataset<Row> dataset;
     if (node instanceof final ResolvedViewDefinition viewDefinition) {
       dataset = viewRegistrationService.buildViewDefinition(viewDefinition.getView(), dataSource);
+    } else if (node instanceof final ResolvedExternalTable externalTable) {
+      dataset = viewRegistrationService.buildExternalTable(externalTable);
     } else if (node instanceof final ResolvedSqlView sqlView) {
       dataset = viewRegistrationService.buildSqlView(sqlView, registeredByKey);
       final Set<String> childViewNames =

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/SqlValidator.java
@@ -175,9 +175,17 @@ public class SqlValidator {
           "org.apache.spark.sql.execution.command.DescribeTableCommand",
           "org.apache.spark.sql.execution.command.DescribeQueryCommand");
 
-  // Function names rejected outright because they enable arbitrary code execution.
+  // Function names rejected outright: the reflection functions enable arbitrary code execution, and
+  // the input file functions disclose the storage path of a scanned file, which for an external
+  // table is the operator's configured path.
   private static final Set<String> REJECTED_FUNCTION_NAMES =
-      Set.of("reflect", "java_method", "try_reflect");
+      Set.of(
+          "reflect",
+          "java_method",
+          "try_reflect",
+          "input_file_name",
+          "input_file_block_start",
+          "input_file_block_length");
 
   // Source marker used by Spark's ExpressionInfo for built-in functions. Anything else (scala_udf,
   // hive, python_udf, sql_udf, java_udf, ...) is implementation-specific and rejected from user

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
@@ -20,9 +20,11 @@ package au.csiro.pathling.operations.sqlquery;
 import au.csiro.pathling.config.QueryConfiguration;
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.io.source.DataSource;
+import au.csiro.pathling.operations.sql.SqlOperationError;
 import au.csiro.pathling.views.FhirView;
 import au.csiro.pathling.views.FhirViewExecutor;
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import jakarta.annotation.Nonnull;
 import java.util.Collection;
@@ -163,12 +165,29 @@ public class ViewRegistrationService {
    * relation and schema eagerly, so a missing or unreadable path fails here rather than at collect
    * time.
    *
+   * <p>Any failure of the read is an operator-side fault, not a defect in the caller's SQL, so it
+   * is translated into a 500 that names the table's URL only; the path and the Spark cause are
+   * logged but not returned. The cause is deliberately not attached to the thrown exception because
+   * the error interceptor unwraps an internal error to its cause, which would discard this message.
+   *
    * @param node the resolved external table
    * @return the table's dataset
+   * @throws BaseServerResponseException with status 500 if the table cannot be read
    */
   @Nonnull
   public Dataset<Row> buildExternalTable(@Nonnull final ResolvedExternalTable node) {
-    return sparkSession.read().format(node.getFormat()).load(node.getPath());
+    try {
+      return sparkSession.read().format(node.getFormat()).load(node.getPath());
+    } catch (final Exception e) {
+      log.error(
+          "Failed to read external table {} ({} at {})",
+          node.getCanonicalKey(),
+          node.getFormat(),
+          node.getPath(),
+          e);
+      throw SqlOperationError.internalError(
+          "Failed to read external table '" + node.getCanonicalKey() + "'");
+    }
   }
 
   /**

--- a/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
+++ b/server/src/main/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationService.java
@@ -158,6 +158,20 @@ public class ViewRegistrationService {
   }
 
   /**
+   * Builds the dataset for a resolved external table leaf by reading its configured path in its
+   * configured format. The result is not registered; the caller registers it. The read resolves the
+   * relation and schema eagerly, so a missing or unreadable path fails here rather than at collect
+   * time.
+   *
+   * @param node the resolved external table
+   * @return the table's dataset
+   */
+  @Nonnull
+  public Dataset<Row> buildExternalTable(@Nonnull final ResolvedExternalTable node) {
+    return sparkSession.read().format(node.getFormat()).load(node.getPath());
+  }
+
+  /**
    * Drops the specified temporary views from the Spark session.
    *
    * @param tempViewNames the names of the temporary views to drop

--- a/server/src/test/java/au/csiro/pathling/config/ServerConfigurationTest.java
+++ b/server/src/test/java/au/csiro/pathling/config/ServerConfigurationTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import au.csiro.pathling.util.LogCapture;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import jakarta.annotation.Nonnull;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ServerConfiguration#logConfiguration()}, covering the startup log line
+ * emitted for each configured external table.
+ *
+ * @author John Grimes
+ */
+class ServerConfigurationTest {
+
+  @Test
+  void logsOneInfoLinePerExternalTable() {
+    // Operators learn which tables are reachable from SQL from the startup log, so each entry must
+    // be recorded with everything needed to recognise it: url, path and format.
+    final ServerConfiguration config = new ServerConfiguration();
+    config
+        .getSqlQuery()
+        .setExternalTables(
+            List.of(
+                externalTable(
+                    "https://example.org/data/refsets", "s3a://bucket/reference/refsets", "delta"),
+                externalTable(
+                    "https://example.org/data/postcodes", "file:///data/postcodes", "parquet")));
+
+    try (final LogCapture capture = LogCapture.forClass(ServerConfiguration.class)) {
+      config.logConfiguration();
+
+      final List<ILoggingEvent> infoEvents =
+          capture.events().stream().filter(event -> event.getLevel() == Level.INFO).toList();
+      assertThat(infoEvents).hasSize(2);
+      assertThat(infoEvents.get(0).getFormattedMessage())
+          .contains("https://example.org/data/refsets")
+          .contains("s3a://bucket/reference/refsets")
+          .contains("delta");
+      assertThat(infoEvents.get(1).getFormattedMessage())
+          .contains("https://example.org/data/postcodes")
+          .contains("file:///data/postcodes")
+          .contains("parquet");
+    }
+  }
+
+  @Test
+  void logsNothingAtInfoWhenNoExternalTablesAreConfigured() {
+    final ServerConfiguration config = new ServerConfiguration();
+
+    try (final LogCapture capture = LogCapture.forClass(ServerConfiguration.class)) {
+      config.logConfiguration();
+
+      assertThat(capture.events()).noneMatch(event -> event.getLevel() == Level.INFO);
+    }
+  }
+
+  @Nonnull
+  private static ExternalTableConfiguration externalTable(
+      @Nonnull final String url, @Nonnull final String path, @Nonnull final String format) {
+    final ExternalTableConfiguration entry = new ExternalTableConfiguration();
+    entry.setUrl(url);
+    entry.setPath(path);
+    entry.setFormat(format);
+    return entry;
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/config/SqlQueryConfigurationTest.java
+++ b/server/src/test/java/au/csiro/pathling/config/SqlQueryConfigurationTest.java
@@ -18,22 +18,34 @@
 package au.csiro.pathling.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import jakarta.annotation.Nonnull;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.BindException;
+import org.springframework.boot.context.properties.bind.BindHandler;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.bind.validation.BindValidationException;
+import org.springframework.boot.context.properties.bind.validation.ValidationBindHandler;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
 
 /**
  * Unit tests for {@link SqlQueryConfiguration}, covering the {@code maxDependencyDepth} default and
- * its {@code @Min(1)} validation, and guarding against the reintroduction of a server-side row cap
- * or query timeout.
+ * its {@code @Min(1)} validation, guarding against the reintroduction of a server-side row cap or
+ * query timeout, and the Bean Validation rules for {@code externalTables}.
  *
  * @author John Grimes
  */
@@ -47,7 +59,7 @@ class SqlQueryConfigurationTest {
   }
 
   @Test
-  void exposesOnlyTheDependencyDepthSetting() {
+  void exposesOnlyTheDependencyDepthAndExternalTableSettings() {
     // The dependency-depth limit is the only resource limit this configuration carries. A row cap
     // silently truncates results and a wall-clock timeout aborts legitimate long-running work, so
     // neither may return: this test fails if a new setting is added here.
@@ -58,7 +70,7 @@ class SqlQueryConfigurationTest {
             .map(Field::getName)
             .collect(Collectors.toSet());
 
-    assertThat(declaredSettings).containsExactly("maxDependencyDepth");
+    assertThat(declaredSettings).containsExactlyInAnyOrder("maxDependencyDepth", "externalTables");
   }
 
   @Test
@@ -98,5 +110,128 @@ class SqlQueryConfigurationTest {
     final Set<ConstraintViolation<SqlQueryConfiguration>> violations = validator.validate(config);
 
     assertThat(violations).isNotEmpty();
+  }
+
+  // -------------------------------------------------------------------------
+  // External tables
+  // -------------------------------------------------------------------------
+
+  @Test
+  void externalTablesDefaultToEmptyAndAreValid() {
+    // An absent property must be indistinguishable from "no tables", so the default is an empty
+    // list rather than null.
+    final SqlQueryConfiguration config = new SqlQueryConfiguration();
+
+    assertThat(config.getExternalTables()).isEmpty();
+    assertThat(validator.validate(config)).isEmpty();
+  }
+
+  @Test
+  void formatDefaultsToDelta() {
+    assertThat(new ExternalTableConfiguration().getFormat()).isEqualTo("delta");
+  }
+
+  @Test
+  void acceptsValidDeltaAndParquetEntries() {
+    final SqlQueryConfiguration config = new SqlQueryConfiguration();
+    config.setExternalTables(
+        List.of(
+            externalTable("https://example.org/data/refsets", "s3a://bucket/refsets", "delta"),
+            externalTable(
+                "https://example.org/data/postcodes", "file:///data/postcodes", "parquet")));
+
+    assertThat(validator.validate(config)).isEmpty();
+  }
+
+  @Test
+  void rejectsBlankUrl() {
+    assertSingleEntryViolation(externalTable("  ", "s3a://bucket/refsets", "delta"), "url");
+  }
+
+  @Test
+  void rejectsUrlContainingPipe() {
+    // CanonicalReference.parse splits "url|version" on the pipe, so such a URL could never be
+    // referenced from a Library.
+    assertSingleEntryViolation(
+        externalTable("https://example.org/data/refsets|1", "s3a://bucket/refsets", "delta"),
+        "url");
+  }
+
+  @Test
+  void rejectsBlankPath() {
+    assertSingleEntryViolation(
+        externalTable("https://example.org/data/refsets", "", "delta"), "path");
+  }
+
+  @Test
+  void rejectsUnsupportedFormat() {
+    assertSingleEntryViolation(
+        externalTable("https://example.org/data/refsets", "s3a://bucket/refsets", "csv"), "format");
+  }
+
+  @Test
+  void rejectsDuplicateUrls() {
+    final SqlQueryConfiguration config = new SqlQueryConfiguration();
+    config.setExternalTables(
+        List.of(
+            externalTable("https://example.org/data/refsets", "s3a://bucket/a", "delta"),
+            externalTable("https://example.org/data/refsets", "s3a://bucket/b", "parquet")));
+
+    final Set<ConstraintViolation<SqlQueryConfiguration>> violations = validator.validate(config);
+
+    assertThat(violations).hasSize(1);
+    assertThat(violations.iterator().next().getMessage())
+        .isEqualTo("externalTables must not contain duplicate urls");
+  }
+
+  @Test
+  void bindingFailsForUnsupportedFormat() {
+    // Binding is the mechanism Spring Boot uses to populate configuration properties at startup, so
+    // a rejected value here is what prevents the server from starting.
+    final MapConfigurationPropertySource source =
+        new MapConfigurationPropertySource(
+            Map.of(
+                "pathling.sqlQuery.externalTables.0.url", "https://example.org/data/refsets",
+                "pathling.sqlQuery.externalTables.0.path", "s3a://bucket/refsets",
+                "pathling.sqlQuery.externalTables.0.format", "csv"));
+    final BindHandler handler =
+        new ValidationBindHandler(
+            new SpringValidatorAdapter(Validation.buildDefaultValidatorFactory().getValidator()));
+
+    // The property source keeps the camel-case form used in the property files; the bind name
+    // itself must be canonical (kebab-case), as Spring Boot normalises it at startup.
+    assertThatThrownBy(
+            () ->
+                new Binder(source)
+                    .bind("pathling.sql-query", Bindable.of(SqlQueryConfiguration.class), handler))
+        .isInstanceOf(BindException.class)
+        .rootCause()
+        .isInstanceOf(BindValidationException.class)
+        .hasMessageContaining("external-tables[0]")
+        .hasMessageContaining("on field 'format'")
+        .hasMessageContaining("pathling.sqlQuery.externalTables.0.format")
+        .hasMessageContaining("csv");
+  }
+
+  private void assertSingleEntryViolation(
+      @Nonnull final ExternalTableConfiguration entry, @Nonnull final String field) {
+    final SqlQueryConfiguration config = new SqlQueryConfiguration();
+    config.setExternalTables(List.of(entry));
+
+    final Set<ConstraintViolation<SqlQueryConfiguration>> violations = validator.validate(config);
+
+    assertThat(violations).hasSize(1);
+    assertThat(violations.iterator().next().getPropertyPath())
+        .hasToString("externalTables[0]." + field);
+  }
+
+  @Nonnull
+  private static ExternalTableConfiguration externalTable(
+      @Nonnull final String url, @Nonnull final String path, @Nonnull final String format) {
+    final ExternalTableConfiguration entry = new ExternalTableConfiguration();
+    entry.setUrl(url);
+    entry.setPath(path);
+    entry.setFormat(format);
+    return entry;
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/sql/SqlExternalTableIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sql/SqlExternalTableIT.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sql;
+
+import static au.csiro.pathling.operations.sqlquery.SqlLibraryParser.LIBRARY_TYPE_SYSTEM;
+import static au.csiro.pathling.operations.sqlquery.SqlLibraryParser.SQL_QUERY_TYPE_CODE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import au.csiro.pathling.operations.sqlquery.SqlQueryOutputFormat;
+import au.csiro.pathling.operations.sqlquery.SqlViewTestConfiguration;
+import au.csiro.pathling.util.DirectoryCleanup;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.hl7.fhir.r4.model.Attachment;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.RelatedArtifact;
+import org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+
+/**
+ * End-to-end integration test for operator-configured external tables in SQL on FHIR queries (spec
+ * 060). Follows the scenarios of the feature's quickstart: a SQLQuery joins a stored ViewDefinition
+ * to a Delta table and to a Parquet table, reads a table on its own, describes it, and is still
+ * refused when it names the table by anything other than its declared label.
+ *
+ * <p>Backed by {@link SqlViewTestConfiguration} for the stored FHIR artefacts and data, and by two
+ * small tables written into a temporary directory before the server reads them. Four tables are
+ * configured: the Delta and Parquet cohorts tables, a table whose URL collides with a stored
+ * SQLView, and a table whose path is never written.
+ *
+ * @author John Grimes
+ */
+@Tag("IntegrationTest")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ResourceLock("wiremock")
+@ActiveProfiles({"integration-test"})
+@Import(SqlViewTestConfiguration.class)
+class SqlExternalTableIT extends AbstractAsyncExportIT {
+
+  /** The configured URL of the Delta cohorts table. */
+  static final String COHORTS_DELTA_URL = "https://example.org/data/cohorts";
+
+  /** The configured URL of the Parquet cohorts table. */
+  static final String COHORTS_PARQUET_URL = "https://example.org/data/cohorts-parquet";
+
+  /** A configured table URL that is also the URL of a stored SQLView. */
+  static final String AMBIGUOUS_URL =
+      SqlViewTestConfiguration.libraryUrl(SqlViewTestConfiguration.ACTIVE_PATIENTS_ID);
+
+  /** A configured table URL whose path is never written. */
+  static final String MISSING_URL = "https://example.org/data/missing";
+
+  /** The directory name under the temp directory of the path that is never written. */
+  static final String MISSING_DIRECTORY = "does-not-exist";
+
+  @TempDir static Path tablesDir;
+
+  @Autowired private FhirContext fhirContext;
+
+  private IParser jsonParser;
+
+  @DynamicPropertySource
+  static void configureProperties(final DynamicPropertyRegistry registry) {
+    final Path warehouseDir =
+        Path.of("src/test/resources/test-data/bulk/fhir/delta").toAbsolutePath();
+    registry.add("pathling.storage.warehouseUrl", () -> "file://" + warehouseDir);
+
+    registry.add("pathling.sqlQuery.externalTables.0.url", () -> COHORTS_DELTA_URL);
+    registry.add("pathling.sqlQuery.externalTables.0.path", () -> cohortsDeltaPath());
+    registry.add("pathling.sqlQuery.externalTables.1.url", () -> COHORTS_PARQUET_URL);
+    registry.add("pathling.sqlQuery.externalTables.1.path", () -> cohortsParquetPath());
+    registry.add("pathling.sqlQuery.externalTables.1.format", () -> "parquet");
+    registry.add("pathling.sqlQuery.externalTables.2.url", () -> AMBIGUOUS_URL);
+    registry.add("pathling.sqlQuery.externalTables.2.path", () -> cohortsDeltaPath());
+    registry.add("pathling.sqlQuery.externalTables.3.url", () -> MISSING_URL);
+    registry.add(
+        "pathling.sqlQuery.externalTables.3.path",
+        () -> "file://" + tablesDir.resolve(MISSING_DIRECTORY).toAbsolutePath());
+  }
+
+  @Nonnull
+  static String cohortsDeltaPath() {
+    return "file://" + tablesDir.resolve("cohorts_delta").toAbsolutePath();
+  }
+
+  @Nonnull
+  static String cohortsParquetPath() {
+    return "file://" + tablesDir.resolve("cohorts_parquet").toAbsolutePath();
+  }
+
+  /**
+   * Writes the Delta and Parquet fixtures once the temp directory exists. The Spark session is
+   * resolved as a parameter because a static lifecycle method cannot see the autowired fields.
+   */
+  @BeforeAll
+  static void writeTables(@Autowired final SparkSession sparkSession) {
+    final StructType schema =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("family_name", DataTypes.StringType, false),
+              DataTypes.createStructField("cohort", DataTypes.StringType, false)
+            });
+    final List<Row> rows =
+        List.of(RowFactory.create("Smith", "A"), RowFactory.create("Williams", "B"));
+    sparkSession.createDataFrame(rows, schema).write().format("delta").save(cohortsDeltaPath());
+    sparkSession.createDataFrame(rows, schema).write().format("parquet").save(cohortsParquetPath());
+  }
+
+  @AfterAll
+  static void cleanupAll() throws IOException {
+    // Clean the temp directory before JUnit's @TempDir cleanup runs, so Spark/Delta file handles do
+    // not prevent directory deletion.
+    DirectoryCleanup.cleanDirectoryTolerantly(tablesDir);
+  }
+
+  @BeforeEach
+  void setUpParser() {
+    jsonParser = fhirContext.newJsonParser();
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenarios 1 and 2: a FHIR view joined to the Delta and the Parquet table.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void joinsAFhirViewToTheDeltaTable() {
+    final String body = postOk(parametersJson(joinQuery(COHORTS_DELTA_URL)));
+
+    assertThat(rowsOf(body, "id", "cohort")).containsExactly("p1/A", "p3/B");
+  }
+
+  @Test
+  void joinsAFhirViewToTheParquetTable() {
+    final String body = postOk(parametersJson(joinQuery(COHORTS_PARQUET_URL)));
+
+    assertThat(rowsOf(body, "id", "cohort")).containsExactly("p1/A", "p3/B");
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 3: the table on its own, selected and described.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void selectsFromTheTableAlone() {
+    final Library library =
+        sqlQueryLibrary(
+            "SELECT family_name, cohort FROM cohort ORDER BY family_name",
+            Map.of("cohort", COHORTS_DELTA_URL));
+
+    final String body = postOk(parametersJson(library));
+
+    assertThat(rowsOf(body, "family_name", "cohort")).containsExactly("Smith/A", "Williams/B");
+  }
+
+  @Test
+  void describesTheTable() {
+    final Library library = sqlQueryLibrary("DESCRIBE cohort", Map.of("cohort", COHORTS_DELTA_URL));
+
+    final String body = postOk(parametersJson(library));
+
+    assertThat(rowsOf(body, "col_name", "data_type"))
+        .containsExactlyInAnyOrder("family_name/string", "cohort/string");
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 4: naming the table by anything other than its label is refused.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void rejectsNamingTheTableByPath() {
+    final Library library =
+        sqlQueryLibrary(
+            "SELECT * FROM parquet.`" + cohortsParquetPath() + "`",
+            Map.of("cohort", COHORTS_PARQUET_URL));
+
+    final String body = postExpectStatus(parametersJson(library), 400);
+
+    assertThat(body).contains("SQL references an undeclared table");
+  }
+
+  // -------------------------------------------------------------------------
+  // Request helpers
+  // -------------------------------------------------------------------------
+
+  /** Builds the Scenario 1 SQLQuery joining the stored Patient view to the given cohorts table. */
+  @Nonnull
+  Library joinQuery(@Nonnull final String cohortsUrl) {
+    final Map<String, String> dependencies = new LinkedHashMap<>();
+    dependencies.put("patient", SqlViewTestConfiguration.PATIENT_VIEW_URL);
+    dependencies.put("cohort", cohortsUrl);
+    return sqlQueryLibrary(
+        "SELECT p.id, c.cohort FROM patient p JOIN cohort c ON c.family_name = p.family_name"
+            + " ORDER BY p.id",
+        dependencies);
+  }
+
+  /**
+   * Projects each NDJSON row of a response body to {@code <first>/<second>} using the two named
+   * columns, in response order.
+   */
+  @Nonnull
+  @SuppressWarnings("unchecked")
+  List<String> rowsOf(
+      @Nonnull final String body, @Nonnull final String first, @Nonnull final String second) {
+    return Arrays.stream(body.trim().split("\n"))
+        .map(line -> (Map<String, Object>) gson.fromJson(line, Map.class))
+        .map(row -> row.get(first) + "/" + row.get(second))
+        .toList();
+  }
+
+  @Nonnull
+  String postOk(@Nonnull final String body) {
+    final EntityExchangeResult<byte[]> result =
+        webTestClient
+            .post()
+            .uri("http://localhost:" + port + "/fhir/$sql-run")
+            .header("Content-Type", "application/fhir+json")
+            .header("Accept", SqlQueryOutputFormat.NDJSON.getContentType())
+            .bodyValue(body)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectHeader()
+            .contentTypeCompatibleWith(
+                MediaType.parseMediaType(SqlQueryOutputFormat.NDJSON.getContentType()))
+            .expectBody()
+            .returnResult();
+    return new String(
+        Objects.requireNonNull(result.getResponseBodyContent()), StandardCharsets.UTF_8);
+  }
+
+  @Nonnull
+  String postExpectStatus(@Nonnull final String body, final int status) {
+    final EntityExchangeResult<byte[]> result =
+        webTestClient
+            .post()
+            .uri("http://localhost:" + port + "/fhir/$sql-run")
+            .header("Content-Type", "application/fhir+json")
+            .header("Accept", SqlQueryOutputFormat.NDJSON.getContentType())
+            .bodyValue(body)
+            .exchange()
+            .expectStatus()
+            .isEqualTo(status)
+            .expectBody()
+            .returnResult();
+    final byte[] payload = result.getResponseBodyContent();
+    return payload == null ? "" : new String(payload, StandardCharsets.UTF_8);
+  }
+
+  /** Builds an inline SQLQuery Library with the given depends-on dependencies (label to URL). */
+  @Nonnull
+  Library sqlQueryLibrary(
+      @Nonnull final String sql, @Nonnull final Map<String, String> dependenciesByLabel) {
+    final Library library = new Library();
+    library.setStatus(PublicationStatus.ACTIVE);
+    library.setType(
+        new CodeableConcept()
+            .addCoding(new Coding().setSystem(LIBRARY_TYPE_SYSTEM).setCode(SQL_QUERY_TYPE_CODE)));
+    final Attachment content = new Attachment();
+    content.setContentType("application/sql");
+    content.setData(sql.getBytes(StandardCharsets.UTF_8));
+    library.addContent(content);
+    new LinkedHashMap<>(dependenciesByLabel)
+        .forEach(
+            (label, resource) ->
+                library.addRelatedArtifact(
+                    new RelatedArtifact()
+                        .setType(RelatedArtifactType.DEPENDSON)
+                        .setLabel(label)
+                        .setResource(resource)));
+    return library;
+  }
+
+  /** Wraps the Library as the {@code subjectResource} of a {@code $sql-run} Parameters body. */
+  @Nonnull
+  String parametersJson(@Nonnull final Library library) {
+    final String libraryJson = jsonParser.encodeResourceToString(library);
+    final Map<String, Object> parameters = new LinkedHashMap<>();
+    parameters.put("resourceType", "Parameters");
+    final List<Map<String, Object>> parameterList = new ArrayList<>();
+
+    final Map<String, Object> queryResourceParam = new LinkedHashMap<>();
+    queryResourceParam.put("name", "subjectResource");
+    queryResourceParam.put("resource", gson.fromJson(libraryJson, Map.class));
+    parameterList.add(queryResourceParam);
+
+    final Map<String, Object> formatParam = new LinkedHashMap<>();
+    formatParam.put("name", "_format");
+    formatParam.put("valueString", SqlQueryOutputFormat.NDJSON.getCode());
+    parameterList.add(formatParam);
+
+    parameters.put("parameter", parameterList);
+    return gson.toJson(parameters);
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sql/SqlExternalTableIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sql/SqlExternalTableIT.java
@@ -19,6 +19,7 @@ package au.csiro.pathling.operations.sql;
 
 import static au.csiro.pathling.operations.sqlquery.SqlLibraryParser.LIBRARY_TYPE_SYSTEM;
 import static au.csiro.pathling.operations.sqlquery.SqlLibraryParser.SQL_QUERY_TYPE_CODE;
+import static au.csiro.pathling.operations.sqlquery.SqlLibraryParser.SQL_VIEW_TYPE_CODE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import au.csiro.pathling.operations.sqlquery.SqlQueryOutputFormat;
@@ -30,7 +31,6 @@ import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -69,7 +69,9 @@ import org.springframework.test.web.reactive.server.EntityExchangeResult;
  * End-to-end integration test for operator-configured external tables in SQL on FHIR queries (spec
  * 060). Follows the scenarios of the feature's quickstart: a SQLQuery joins a stored ViewDefinition
  * to a Delta table and to a Parquet table, reads a table on its own, describes it, and is still
- * refused when it names the table by anything other than its declared label.
+ * refused when it names the table by anything other than its declared label. A SQLView over the
+ * table is run through {@code $sql-run} and exported through {@code $sql-export}, and the {@code
+ * patient} filter is shown to narrow the FHIR side of a join without touching the table.
  *
  * <p>Backed by {@link SqlViewTestConfiguration} for the stored FHIR artefacts and data, and by two
  * small tables written into a temporary directory before the server reads them. Four tables are
@@ -100,6 +102,9 @@ class SqlExternalTableIT extends AbstractAsyncExportIT {
 
   /** The directory name under the temp directory of the path that is never written. */
   static final String MISSING_DIRECTORY = "does-not-exist";
+
+  /** The URL of the SQLView over the Delta cohorts table, supplied inline through context. */
+  static final String COHORT_VIEW_URL = "https://example.org/Library/cohort-view";
 
   @TempDir static Path tablesDir;
 
@@ -227,6 +232,64 @@ class SqlExternalTableIT extends AbstractAsyncExportIT {
   }
 
   // -------------------------------------------------------------------------
+  // Scenario 5: a SQLView over the table, run through $sql-run and exported.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void runsASqlViewOverTheTableSuppliedThroughContext() {
+    final Library query =
+        sqlQueryLibrary("SELECT * FROM cv ORDER BY family_name", Map.of("cv", COHORT_VIEW_URL));
+
+    final String body = postOk(parametersJson(query, resourceParam("context", cohortView())));
+
+    assertThat(rowsOf(body, "family_name", "cohort")).containsExactly("Smith/A", "Williams/B");
+  }
+
+  @Test
+  void exportsASqlViewOverTheTableAsAnInlineSubject() throws InterruptedException {
+    final Map<String, Object> body =
+        parameters(
+            subject(
+                simpleParam("name", "valueString", "cohort_view"),
+                resourcePart("subjectResource", libraryMap(cohortView()))),
+            simpleParam("_format", "valueString", SqlQueryOutputFormat.NDJSON.getCode()));
+
+    final Map<String, Object> manifest = exportToCompletion(systemLevelUri(), body);
+
+    assertThat(findParamValue(manifest, "status", "valueCode")).isEqualTo("completed");
+    final List<Map<String, Object>> outputs = paramsByName(manifest, "output");
+    assertThat(outputs).hasSize(1);
+    assertThat(partValue(outputs.get(0), "name", "valueString")).isEqualTo("cohort_view");
+    final String content = downloadAll(outputs.get(0));
+    assertThat(rowsOf(content, "family_name", "cohort"))
+        .containsExactlyInAnyOrder("Smith/A", "Williams/B");
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 6: the patient filter narrows the FHIR side of a join but never the table.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void patientFilterNarrowsTheJoinThroughTheFhirView() {
+    final String body =
+        postOk(parametersJson(joinQuery(COHORTS_DELTA_URL), patientParam("Patient/p1")));
+
+    assertThat(rowsOf(body, "id", "cohort")).containsExactly("p1/A");
+  }
+
+  @Test
+  void patientFilterLeavesTheTableItselfUntouched() {
+    final Library library =
+        sqlQueryLibrary(
+            "SELECT family_name, cohort FROM cohort ORDER BY family_name",
+            Map.of("cohort", COHORTS_DELTA_URL));
+
+    final String body = postOk(parametersJson(library, patientParam("Patient/p1")));
+
+    assertThat(rowsOf(body, "family_name", "cohort")).containsExactly("Smith/A", "Williams/B");
+  }
+
+  // -------------------------------------------------------------------------
   // Request helpers
   // -------------------------------------------------------------------------
 
@@ -299,11 +362,31 @@ class SqlExternalTableIT extends AbstractAsyncExportIT {
   @Nonnull
   Library sqlQueryLibrary(
       @Nonnull final String sql, @Nonnull final Map<String, String> dependenciesByLabel) {
+    return sqlLibrary(SQL_QUERY_TYPE_CODE, sql, dependenciesByLabel);
+  }
+
+  /** Builds the Scenario 5 SQLView selecting every row of the Delta cohorts table. */
+  @Nonnull
+  Library cohortView() {
+    final Library view =
+        sqlLibrary(
+            SQL_VIEW_TYPE_CODE,
+            "SELECT family_name, cohort FROM cohort",
+            Map.of("cohort", COHORTS_DELTA_URL));
+    view.setUrl(COHORT_VIEW_URL);
+    return view;
+  }
+
+  @Nonnull
+  private Library sqlLibrary(
+      @Nonnull final String typeCode,
+      @Nonnull final String sql,
+      @Nonnull final Map<String, String> dependenciesByLabel) {
     final Library library = new Library();
     library.setStatus(PublicationStatus.ACTIVE);
     library.setType(
         new CodeableConcept()
-            .addCoding(new Coding().setSystem(LIBRARY_TYPE_SYSTEM).setCode(SQL_QUERY_TYPE_CODE)));
+            .addCoding(new Coding().setSystem(LIBRARY_TYPE_SYSTEM).setCode(typeCode)));
     final Attachment content = new Attachment();
     content.setContentType("application/sql");
     content.setData(sql.getBytes(StandardCharsets.UTF_8));
@@ -319,25 +402,40 @@ class SqlExternalTableIT extends AbstractAsyncExportIT {
     return library;
   }
 
-  /** Wraps the Library as the {@code subjectResource} of a {@code $sql-run} Parameters body. */
+  /** Encodes a Library as the generic JSON map the Gson-built request bodies carry. */
   @Nonnull
-  String parametersJson(@Nonnull final Library library) {
-    final String libraryJson = jsonParser.encodeResourceToString(library);
-    final Map<String, Object> parameters = new LinkedHashMap<>();
-    parameters.put("resourceType", "Parameters");
-    final List<Map<String, Object>> parameterList = new ArrayList<>();
+  @SuppressWarnings("unchecked")
+  Map<String, Object> libraryMap(@Nonnull final Library library) {
+    return gson.fromJson(jsonParser.encodeResourceToString(library), Map.class);
+  }
 
-    final Map<String, Object> queryResourceParam = new LinkedHashMap<>();
-    queryResourceParam.put("name", "subjectResource");
-    queryResourceParam.put("resource", gson.fromJson(libraryJson, Map.class));
-    parameterList.add(queryResourceParam);
+  /** A resource-valued {@code $sql-run} parameter such as {@code context}. */
+  @Nonnull
+  Map<String, Object> resourceParam(@Nonnull final String name, @Nonnull final Library library) {
+    return resourcePart(name, libraryMap(library));
+  }
 
-    final Map<String, Object> formatParam = new LinkedHashMap<>();
-    formatParam.put("name", "_format");
-    formatParam.put("valueString", SqlQueryOutputFormat.NDJSON.getCode());
-    parameterList.add(formatParam);
+  /** The {@code patient} filter parameter carrying one reference. */
+  @Nonnull
+  Map<String, Object> patientParam(@Nonnull final String reference) {
+    return referencePart("patient", reference);
+  }
 
-    parameters.put("parameter", parameterList);
+  /**
+   * Wraps the Library as the {@code subjectResource} of a {@code $sql-run} Parameters body, along
+   * with the NDJSON format and any further parameters.
+   */
+  @SafeVarargs
+  @Nonnull
+  final String parametersJson(
+      @Nonnull final Library library, @Nonnull final Map<String, Object>... extraParameters) {
+    final Map<String, Object> parameters =
+        parameters(
+            resourceParam("subjectResource", library),
+            simpleParam("_format", "valueString", SqlQueryOutputFormat.NDJSON.getCode()));
+    for (final Map<String, Object> extra : extraParameters) {
+      addParam(parameters, extra);
+    }
     return gson.toJson(parameters);
   }
 }

--- a/server/src/test/java/au/csiro/pathling/operations/sql/SqlExternalTableIT.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sql/SqlExternalTableIT.java
@@ -290,6 +290,42 @@ class SqlExternalTableIT extends AbstractAsyncExportIT {
   }
 
   // -------------------------------------------------------------------------
+  // Scenario 7: version pins, URL collisions and unreadable paths are reported precisely.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void rejectsAVersionPinnedReferenceToTheTableAsNotFound() {
+    final Library library =
+        sqlQueryLibrary("SELECT * FROM cohort", Map.of("cohort", COHORTS_DELTA_URL + "|2"));
+
+    final String body = postExpectStatus(parametersJson(library), 404);
+
+    assertThat(body)
+        .contains("no ViewDefinition, SQLView or external table matches that canonical URL");
+  }
+
+  @Test
+  void rejectsAUrlSharedByTheTableAndAStoredSqlViewAsAmbiguous() {
+    final Library library =
+        sqlQueryLibrary("SELECT * FROM cohort", Map.of("cohort", AMBIGUOUS_URL));
+
+    final String body = postExpectStatus(parametersJson(library), 400);
+
+    assertThat(body).contains("is ambiguous");
+  }
+
+  @Test
+  void reportsAnUnreadablePathWithoutRevealingIt() {
+    final Library library = sqlQueryLibrary("SELECT * FROM cohort", Map.of("cohort", MISSING_URL));
+
+    final String body = postExpectStatus(parametersJson(library), 500);
+
+    assertThat(body)
+        .contains("Failed to read external table '" + MISSING_URL + "'")
+        .doesNotContain(MISSING_DIRECTORY);
+  }
+
+  // -------------------------------------------------------------------------
   // Request helpers
   // -------------------------------------------------------------------------
 

--- a/server/src/test/java/au/csiro/pathling/operations/sql/SqlOperationErrorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sql/SqlOperationErrorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2018-2026 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.pathling.operations.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
+import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SqlOperationError#internalError(String)}.
+ *
+ * @author John Grimes
+ */
+class SqlOperationErrorTest {
+
+  @Test
+  void internalErrorCarriesA500WithAProcessingIssueAndNoCause() {
+    // ErrorHandlingInterceptor unwraps an InternalErrorException to its cause and reprocesses it,
+    // so a crafted message survives only when no cause is attached.
+    final BaseServerResponseException exception = SqlOperationError.internalError("msg");
+
+    assertThat(exception.getStatusCode()).isEqualTo(500);
+    assertThat(exception.getMessage()).isEqualTo("msg");
+    assertThat(exception.getCause()).isNull();
+
+    final OperationOutcome outcome = (OperationOutcome) exception.getOperationOutcome();
+    assertThat(outcome.getIssue()).hasSize(1);
+    final OperationOutcomeIssueComponent issue = outcome.getIssueFirstRep();
+    assertThat(issue.getSeverity()).isEqualTo(IssueSeverity.ERROR);
+    assertThat(issue.getCode()).isEqualTo(IssueType.PROCESSING);
+    assertThat(issue.getDiagnostics()).isEqualTo("msg");
+    assertThat(issue.getExpression()).isEmpty();
+  }
+}

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlDependencyResolverTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlDependencyResolverTest.java
@@ -378,7 +378,6 @@ class SqlDependencyResolverTest {
     assertThat(graph.getOrderedNodes().get(1).getCanonicalKey()).isEqualTo(viewUrl);
     final ResolvedSqlView sqlView = (ResolvedSqlView) graph.getNodesByKey().get(viewUrl);
     assertThat(sqlView.getChildKeysByLabel()).containsExactly(Map.entry("cohort", TABLE_URL));
-    verifyNoInteractions(viewResolver);
   }
 
   @Test
@@ -406,6 +405,73 @@ class SqlDependencyResolverTest {
     assertThat(graph.getNodesByKey().get(TABLE_URL))
         .isSameAs(graph.getOrderedNodes().get(0))
         .isInstanceOf(ResolvedExternalTable.class);
+  }
+
+  // ---------------------------------------------------------------------------
+  // External table faults (spec 060 US3): version pins, collisions and context precedence.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void rejectsAVersionPinnedReferenceToAnExternalTableAsNotFound() {
+    // Tables carry no version, so a pinned reference can never mean one; with nothing stored under
+    // that URL either, the reference is not found.
+    configureExternalTable(TABLE_URL, TABLE_PATH, "delta");
+
+    assertThatThrownBy(
+            () ->
+                resolver.resolve(
+                    sqlQuery("SELECT * FROM c", "c", TABLE_URL + "|2"), SuppliedArtefacts.empty()))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContainingAll("'c'", TABLE_URL + "|2")
+        .hasMessageEndingWith(
+            "no ViewDefinition, SQLView or external table matches that canonical URL");
+  }
+
+  @Test
+  void rejectsAUrlMatchingAnExternalTableAndAStoredViewDefinitionAsAmbiguous() {
+    configureExternalTable(TABLE_URL, TABLE_PATH, "delta");
+    stubStoredViewDefinition(TABLE_URL, TABLE_URL, "Patient");
+
+    assertThatThrownBy(
+            () ->
+                resolver.resolve(
+                    sqlQuery("SELECT * FROM c", "c", TABLE_URL), SuppliedArtefacts.empty()))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContainingAll(
+            "'c'", TABLE_URL, "is ambiguous", "external table", "ViewDefinition")
+        .hasMessageNotContaining("SQLView");
+  }
+
+  @Test
+  void rejectsAUrlMatchingAnExternalTableAndAStoredSqlViewAsAmbiguous() {
+    configureExternalTable(TABLE_URL, TABLE_PATH, "delta");
+    stubSqlView(TABLE_URL, "SELECT * FROM pv", "pv", PATIENT_VIEW_URL);
+
+    assertThatThrownBy(
+            () ->
+                resolver.resolve(
+                    sqlQuery("SELECT * FROM c", "c", TABLE_URL), SuppliedArtefacts.empty()))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContainingAll("'c'", TABLE_URL, "is ambiguous", "external table", "SQLView")
+        .hasMessageNotContaining("ViewDefinition");
+  }
+
+  @Test
+  void prefersASuppliedViewDefinitionOverAnExternalTableWithTheSameUrl() {
+    // A context artefact outranks both configuration and storage, and neither is consulted.
+    configureExternalTable(TABLE_URL, TABLE_PATH, "delta");
+    final FhirView supplied = fhirView("Patient");
+
+    final ResolvedDependencyGraph graph =
+        resolver.resolve(
+            sqlQuery("SELECT * FROM c", "c", TABLE_URL),
+            SuppliedArtefacts.ofViews(Map.of(TABLE_URL, supplied)));
+
+    assertThat(graph.getOrderedNodes()).hasSize(1);
+    final ResolvedDependency node = graph.getNodesByKey().get(TABLE_URL);
+    assertThat(node).isInstanceOf(ResolvedViewDefinition.class);
+    assertThat(((ResolvedViewDefinition) node).getView()).isSameAs(supplied);
+    verifyNoInteractions(viewResolver, libraryReferenceResolver);
   }
 
   // ---------------------------------------------------------------------------
@@ -463,15 +529,16 @@ class SqlDependencyResolverTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  void reportsNotFoundWhenNeitherAViewDefinitionNorASqlViewMatches() {
+  void reportsNotFoundWhenNothingMatches() {
     final String missingUrl = SqlLibraryFixtures.viewDefinitionUrl("missing");
 
     assertThatThrownBy(
             () ->
                 resolver.resolve(sqlQuery("SELECT 1", "x", missingUrl), SuppliedArtefacts.empty()))
         .isInstanceOf(ResourceNotFoundException.class)
-        .hasMessageContaining("x")
-        .hasMessageContaining(missingUrl);
+        .hasMessageContainingAll("'x'", missingUrl)
+        .hasMessageEndingWith(
+            "no ViewDefinition, SQLView or external table matches that canonical URL");
   }
 
   @Test
@@ -483,9 +550,8 @@ class SqlDependencyResolverTest {
     assertThatThrownBy(
             () -> resolver.resolve(sqlQuery("SELECT 1", "c", clashUrl), SuppliedArtefacts.empty()))
         .isInstanceOf(InvalidRequestException.class)
-        .hasMessageContaining("ambiguous")
-        .hasMessageContaining("c")
-        .hasMessageContaining(clashUrl);
+        .hasMessageContainingAll("is ambiguous", "'c'", clashUrl, "ViewDefinition", "SQLView")
+        .hasMessageNotContaining("external table");
   }
 
   @Test

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlDependencyResolverTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlDependencyResolverTest.java
@@ -353,6 +353,62 @@ class SqlDependencyResolverTest {
   }
 
   // ---------------------------------------------------------------------------
+  // External tables beneath SQLViews (spec 060 US2).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void resolvesAConfiguredExternalTableBeneathASuppliedSqlView() {
+    // The table is a leaf of the SQLView, so it is ordered before the view and the view's child
+    // map binds the label to the table's bare URL.
+    configureExternalTable(TABLE_URL, TABLE_PATH, "delta");
+    final String viewUrl = SqlLibraryFixtures.sqlViewUrl("cohort-view");
+    final Library suppliedSqlView =
+        SqlLibraryFixtures.sqlViewWithUrl(
+            viewUrl, "SELECT family_name, cohort FROM cohort", "cohort", TABLE_URL);
+
+    final ResolvedDependencyGraph graph =
+        resolver.resolve(
+            sqlQuery("SELECT * FROM cv", "cv", viewUrl),
+            SuppliedArtefacts.of(
+                List.of(SuppliedArtefact.ofSqlView(viewUrl, null, suppliedSqlView))));
+
+    assertThat(graph.getOrderedNodes()).hasSize(2);
+    assertThat(graph.getOrderedNodes().get(0)).isInstanceOf(ResolvedExternalTable.class);
+    assertThat(graph.getOrderedNodes().get(0).getCanonicalKey()).isEqualTo(TABLE_URL);
+    assertThat(graph.getOrderedNodes().get(1).getCanonicalKey()).isEqualTo(viewUrl);
+    final ResolvedSqlView sqlView = (ResolvedSqlView) graph.getNodesByKey().get(viewUrl);
+    assertThat(sqlView.getChildKeysByLabel()).containsExactly(Map.entry("cohort", TABLE_URL));
+    verifyNoInteractions(viewResolver);
+  }
+
+  @Test
+  void resolvesADiamondOverAnExternalTableToASingleTableNode() {
+    // Two SQLViews reach the same table under different labels; the table is keyed by its URL and
+    // so is resolved once and shared by both arms.
+    configureExternalTable(TABLE_URL, TABLE_PATH, "parquet");
+    final String leftUrl = SqlLibraryFixtures.sqlViewUrl("left");
+    final String rightUrl = SqlLibraryFixtures.sqlViewUrl("right");
+    stubSqlView(leftUrl, "SELECT * FROM c", "c", TABLE_URL);
+    stubSqlView(rightUrl, "SELECT * FROM t", "t", TABLE_URL);
+
+    final ResolvedDependencyGraph graph =
+        resolver.resolve(
+            sqlQueryWithDeps("SELECT * FROM l JOIN r", Map.of("l", leftUrl, "r", rightUrl)),
+            SuppliedArtefacts.empty());
+
+    assertThat(graph.getOrderedNodes()).hasSize(3);
+    assertThat(graph.getOrderedNodes().get(0)).isInstanceOf(ResolvedExternalTable.class);
+    assertThat(graph.getOrderedNodes().get(0).getCanonicalKey()).isEqualTo(TABLE_URL);
+    final ResolvedSqlView left = (ResolvedSqlView) graph.getNodesByKey().get(leftUrl);
+    final ResolvedSqlView right = (ResolvedSqlView) graph.getNodesByKey().get(rightUrl);
+    assertThat(left.getChildKeysByLabel()).containsEntry("c", TABLE_URL);
+    assertThat(right.getChildKeysByLabel()).containsEntry("t", TABLE_URL);
+    assertThat(graph.getNodesByKey().get(TABLE_URL))
+        .isSameAs(graph.getOrderedNodes().get(0))
+        .isInstanceOf(ResolvedExternalTable.class);
+  }
+
+  // ---------------------------------------------------------------------------
   // Cycles and depth (keyed by canonical identity).
   // ---------------------------------------------------------------------------
 

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlDependencyResolverTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlDependencyResolverTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import au.csiro.pathling.config.AuthorizationConfiguration;
+import au.csiro.pathling.config.ExternalTableConfiguration;
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.config.SqlQueryConfiguration;
 import au.csiro.pathling.operations.sql.SuppliedArtefact;
@@ -45,8 +46,9 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link SqlDependencyResolver} covering canonical-URL resolution, the resolved
  * graph shape for a {@code SQLQuery -> SQLView -> ViewDefinition} chain, supplied-artefact
- * precedence and traversal, diamond de-duplication (including bare-url vs {@code url|version}), and
- * the structural rejections (cycles, depth, ambiguity, not-found, and wrong-typed dependencies).
+ * precedence and traversal, diamond de-duplication (including bare-url vs {@code url|version}),
+ * configured external tables, and the structural rejections (cycles, depth, ambiguity, not-found,
+ * and wrong-typed dependencies).
  *
  * @author John Grimes
  */
@@ -54,6 +56,10 @@ class SqlDependencyResolverTest {
 
   private static final String PATIENT_VIEW_URL =
       SqlLibraryFixtures.viewDefinitionUrl("patient-view");
+
+  private static final String TABLE_URL = "https://example.org/data/cohorts";
+
+  private static final String TABLE_PATH = "file:///data/reference/cohorts";
 
   private ViewResolver viewResolver;
   private LibraryReferenceResolver libraryReferenceResolver;
@@ -292,6 +298,61 @@ class SqlDependencyResolverTest {
   }
 
   // ---------------------------------------------------------------------------
+  // Configured external tables (spec 060 US1).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void resolvesAConfiguredExternalTableByUrl() {
+    configureExternalTable(TABLE_URL, TABLE_PATH, "parquet");
+
+    final ResolvedDependencyGraph graph =
+        resolver.resolve(sqlQuery("SELECT * FROM c", "c", TABLE_URL), SuppliedArtefacts.empty());
+
+    assertThat(graph.getTopLevelKeysByLabel()).containsEntry("c", TABLE_URL);
+    final ResolvedDependency node = graph.getNodesByKey().get(TABLE_URL);
+    assertThat(node).isInstanceOf(ResolvedExternalTable.class);
+    final ResolvedExternalTable table = (ResolvedExternalTable) node;
+    assertThat(table.getCanonicalKey()).isEqualTo(TABLE_URL);
+    assertThat(table.getPath()).isEqualTo(TABLE_PATH);
+    assertThat(table.getFormat()).isEqualTo("parquet");
+  }
+
+  @Test
+  void resolvesTheSameExternalTableUnderTwoLabelsOnce() {
+    // The table is keyed by its bare URL, so two labels over it share one leaf and the SQL can join
+    // the table to itself.
+    configureExternalTable(TABLE_URL, TABLE_PATH, "delta");
+
+    final ResolvedDependencyGraph graph =
+        resolver.resolve(
+            sqlQueryWithDeps(
+                "SELECT * FROM a JOIN b ON a.k = b.k", Map.of("a", TABLE_URL, "b", TABLE_URL)),
+            SuppliedArtefacts.empty());
+
+    assertThat(graph.getOrderedNodes()).hasSize(1);
+    assertThat(graph.getTopLevelKeysByLabel())
+        .containsEntry("a", TABLE_URL)
+        .containsEntry("b", TABLE_URL);
+  }
+
+  @Test
+  void rejectsAnExternalTableBeyondTheDepthLimit() {
+    // A table leaf counts towards the depth like any other leaf: a SQLView at depth 1 referencing
+    // the table places it at depth 2, over a limit of 1.
+    serverConfiguration.getSqlQuery().setMaxDependencyDepth(1);
+    configureExternalTable(TABLE_URL, TABLE_PATH, "delta");
+    final String viewUrl = SqlLibraryFixtures.sqlViewUrl("over-table");
+    stubSqlView(viewUrl, "SELECT * FROM c", "c", TABLE_URL);
+
+    assertThatThrownBy(
+            () ->
+                resolver.resolve(
+                    sqlQuery("SELECT * FROM v", "v", viewUrl), SuppliedArtefacts.empty()))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContainingAll("deeper", "1", TABLE_URL);
+  }
+
+  // ---------------------------------------------------------------------------
   // Cycles and depth (keyed by canonical identity).
   // ---------------------------------------------------------------------------
 
@@ -406,6 +467,22 @@ class SqlDependencyResolverTest {
     dependenciesByLabel.forEach(
         (label, resource) -> references.add(new ViewArtifactReference(label, resource)));
     return new ParsedSqlQuery(sql, references, List.of(), SqlLibraryParser.SQL_QUERY_TYPE_CODE);
+  }
+
+  /**
+   * Adds one external table to the configuration and rebuilds the resolver, since the resolver
+   * indexes the configured tables when it is constructed.
+   */
+  private void configureExternalTable(
+      @Nonnull final String url, @Nonnull final String path, @Nonnull final String format) {
+    final ExternalTableConfiguration table = new ExternalTableConfiguration();
+    table.setUrl(url);
+    table.setPath(path);
+    table.setFormat(format);
+    serverConfiguration.getSqlQuery().getExternalTables().add(table);
+    resolver =
+        new SqlDependencyResolver(
+            viewResolver, libraryReferenceResolver, new SqlLibraryParser(), serverConfiguration);
   }
 
   /**

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryAuthTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryAuthTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import au.csiro.pathling.config.AuthorizationConfiguration;
+import au.csiro.pathling.config.ExternalTableConfiguration;
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.config.SqlQueryConfiguration;
 import au.csiro.pathling.encoders.FhirEncoders;
@@ -61,8 +62,9 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
  * {@link LibraryReferenceResolver}, and {@link SqlDependencyResolver} with authorisation enabled.
  * Verifies the metadata-resource authorisation matrix: a stored ViewDefinition dependency (resolved
  * by canonical URL) requires {@code ViewDefinition} READ, a stored SQLView dependency requires
- * {@code Library} READ, the per-projected-resource READ still applies at each leaf, and a
- * request-supplied (inline) view requires no metadata READ.
+ * {@code Library} READ, the per-projected-resource READ still applies at each leaf, a
+ * request-supplied (inline) view requires no metadata READ, and a configured external table
+ * requires no READ authority at all while waiving none for the FHIR dependencies alongside it.
  *
  * @author John Grimes
  */
@@ -71,6 +73,7 @@ class SqlQueryAuthTest {
 
   private static final String PV_URL = "https://example.org/ViewDefinition/pv";
   private static final String BASE_URL = "https://example.org/Library/base";
+  private static final String TABLE_URL = "https://example.org/data/refsets";
 
   @Autowired private SparkSession spark;
   @Autowired private FhirEncoders fhirEncoders;
@@ -93,7 +96,13 @@ class SqlQueryAuthTest {
     final AuthorizationConfiguration auth = new AuthorizationConfiguration();
     auth.setEnabled(true);
     serverConfiguration.setAuth(auth);
-    serverConfiguration.setSqlQuery(new SqlQueryConfiguration());
+    final SqlQueryConfiguration sqlQuery = new SqlQueryConfiguration();
+    final ExternalTableConfiguration table = new ExternalTableConfiguration();
+    table.setUrl(TABLE_URL);
+    table.setPath("/data/refsets");
+    table.setFormat("parquet");
+    sqlQuery.setExternalTables(List.of(table));
+    serverConfiguration.setSqlQuery(sqlQuery);
 
     final ViewResolver viewResolver =
         new ViewResolver(dataSource, fhirEncoders, serverConfiguration, fhirContext);
@@ -192,6 +201,37 @@ class SqlQueryAuthTest {
     assertThat(libraryReferenceResolver.resolve(new Reference("Library/base"))).isNotNull();
   }
 
+  @Test
+  void externalTableDependencyRequiresNoReadAuthority() {
+    // A configured external table is resolved from configuration, never from storage, so the
+    // operation authority alone is enough: no pathling:read:* authority is held here.
+    setSecurityContext("pathling:sql-run");
+    final ResolvedDependencyGraph graph =
+        resolver.resolve(sqlQuery(TABLE_URL), SuppliedArtefacts.empty());
+
+    assertThat(graph.getOrderedNodes()).singleElement().isInstanceOf(ResolvedExternalTable.class);
+  }
+
+  @Test
+  void externalTableWaivesNoAuthorityForFhirDependenciesAlongsideIt() {
+    when(dataSource.read("ViewDefinition"))
+        .thenReturn(viewDefinitionDataset(simpleViewDefinition("pv", PV_URL, "Patient")));
+    final ParsedSqlQuery join =
+        sqlQuery(
+            "SELECT * FROM pv JOIN t ON pv.id = t.id",
+            new ViewArtifactReference("pv", PV_URL),
+            new ViewArtifactReference("t", TABLE_URL));
+
+    // The stored ViewDefinition keeps its metadata READ requirement when joined to a table.
+    setSecurityContext("pathling:sql-run", "pathling:read:Patient");
+    assertThatThrownBy(() -> resolver.resolve(join, SuppliedArtefacts.empty()))
+        .isInstanceOf(AccessDeniedError.class)
+        .hasMessageContaining("ViewDefinition");
+
+    setSecurityContext("pathling:sql-run", "pathling:read:ViewDefinition", "pathling:read:Patient");
+    assertThatNoException().isThrownBy(() -> resolver.resolve(join, SuppliedArtefacts.empty()));
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers.
   // ---------------------------------------------------------------------------
@@ -210,11 +250,14 @@ class SqlQueryAuthTest {
 
   @Nonnull
   private static ParsedSqlQuery sqlQuery(@Nonnull final String resource) {
+    return sqlQuery("SELECT * FROM t", new ViewArtifactReference("t", resource));
+  }
+
+  @Nonnull
+  private static ParsedSqlQuery sqlQuery(
+      @Nonnull final String sql, @Nonnull final ViewArtifactReference... references) {
     return new ParsedSqlQuery(
-        "SELECT * FROM t",
-        List.of(new ViewArtifactReference("t", resource)),
-        List.of(),
-        SqlLibraryParser.SQL_QUERY_TYPE_CODE);
+        sql, List.of(references), List.of(), SqlLibraryParser.SQL_QUERY_TYPE_CODE);
   }
 
   private void setSecurityContext(final String... authorities) {

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlQueryExecutorTest.java
@@ -18,14 +18,17 @@
 package au.csiro.pathling.operations.sqlquery;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.io.source.DataSource;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -39,6 +42,7 @@ import org.apache.spark.sql.catalyst.expressions.Literal;
 import org.apache.spark.sql.catalyst.plans.logical.GlobalLimit;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import scala.jdk.javaapi.CollectionConverters;
@@ -57,7 +61,12 @@ import scala.jdk.javaapi.CollectionConverters;
  *       {@code validateAnalyzed} sequence the executor uses and yields the engine's describe rows.
  *       This exercises the analysed-mode carve-out end to end in the JVM, since the executor calls
  *       {@link SqlValidator#validateAnalyzed} on the eagerly-executed command plan (spec 029 US1).
+ *   <li>That a configured external table leaf is materialised under its request-scoped temp view
+ *       and so passes the analysed-plan check, while naming the same data by path is still rejected
+ *       (spec 060 US1).
  * </ul>
+ *
+ * @author John Grimes
  */
 @Import(SqlValidator.class)
 @SpringBootUnitTest
@@ -218,6 +227,66 @@ class SqlQueryExecutorTest {
   }
 
   // -------------------------------------------------------------------------
+  // External table leaves: reachable under the declared label only.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void executesAQueryOverAnExternalTableLeaf(@TempDir final Path tempDir) {
+    // The table's relation sits beneath the trusted temp-view alias the executor registers for the
+    // leaf, so validateAnalyzed accepts the plan and the rows flow through.
+    final ResolvedExternalTable table = writeExternalTable(tempDir);
+    final AtomicReference<List<Row>> rows = new AtomicReference<>();
+
+    newExecutor()
+        .execute(
+            request("SELECT * FROM t ORDER BY id", null, table.getCanonicalKey()),
+            graphOf(table),
+            mock(DataSource.class),
+            REQUEST_ID,
+            dataset -> rows.set(dataset.collectAsList()));
+
+    assertThat(rows.get()).extracting(row -> row.getInt(0)).containsExactly(1, 2);
+    assertThat(rows.get()).extracting(row -> row.getString(1)).containsExactly("alice", "bob");
+  }
+
+  @Test
+  void rejectsNamingTheExternalTableByPathInsteadOfLabel(@TempDir final Path tempDir) {
+    // A data-source short name bypasses the label and must fall foul of the existing allow-list.
+    final ResolvedExternalTable table = writeExternalTable(tempDir);
+    final SqlQueryRequest byPath =
+        request("SELECT * FROM parquet.`" + table.getPath() + "`", null, table.getCanonicalKey());
+
+    assertThatThrownBy(
+            () ->
+                newExecutor()
+                    .execute(
+                        byPath, graphOf(table), mock(DataSource.class), REQUEST_ID, dataset -> {}))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("SQL references an undeclared table");
+  }
+
+  /** Writes a two-row Delta table into the temp directory and returns the leaf that reads it. */
+  @Nonnull
+  private ResolvedExternalTable writeExternalTable(@Nonnull final Path tempDir) {
+    final String path = "file://" + tempDir.resolve("external_delta").toAbsolutePath();
+    sparkSession
+        .sql("SELECT * FROM (VALUES (1, 'alice'), (2, 'bob')) AS t(id, name)")
+        .write()
+        .format("delta")
+        .save(path);
+    return new ResolvedExternalTable("https://example.org/data/external", path, "delta");
+  }
+
+  /** Builds a graph whose only node is the given leaf, exposed under the top-level label t. */
+  @Nonnull
+  private static ResolvedDependencyGraph graphOf(@Nonnull final ResolvedExternalTable table) {
+    return new ResolvedDependencyGraph(
+        List.of(table),
+        Map.of("t", table.getCanonicalKey()),
+        Map.of(table.getCanonicalKey(), table));
+  }
+
+  // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
 
@@ -267,6 +336,22 @@ class SqlQueryExecutorTest {
   private static SqlQueryRequest request(@Nonnull final String sql, @Nullable final Integer limit) {
     return new SqlQueryRequest(
         new ParsedSqlQuery(sql, List.of(), List.of(), SqlLibraryParser.SQL_QUERY_TYPE_CODE),
+        SqlQueryOutputFormat.NDJSON,
+        /* includeHeader= */ true,
+        limit,
+        Map.of());
+  }
+
+  /** Builds a request over SQL that declares one dependency under the label t. */
+  @Nonnull
+  private static SqlQueryRequest request(
+      @Nonnull final String sql, @Nullable final Integer limit, @Nonnull final String resource) {
+    return new SqlQueryRequest(
+        new ParsedSqlQuery(
+            sql,
+            List.of(new ViewArtifactReference("t", resource)),
+            List.of(),
+            SqlLibraryParser.SQL_QUERY_TYPE_CODE),
         SqlQueryOutputFormat.NDJSON,
         /* includeHeader= */ true,
         limit,

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/SqlValidatorTest.java
@@ -30,6 +30,8 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.WithWindowDefinition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
@@ -478,6 +480,17 @@ class SqlValidatorTest {
   @Test
   void rejectsJavaMethodFunction() {
     assertThatThrownBy(() -> validate("SELECT java_method('java.lang.Math', 'random') FROM t", "t"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("disallowed function");
+  }
+
+  // The input file functions expose the storage path of a scanned file, which for an external
+  // table is the operator's configured path that responses must never disclose (spec 060 FR-012).
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"input_file_name()", "input_file_block_start()", "input_file_block_length()"})
+  void rejectsInputFileFunctions(final String call) {
+    assertThatThrownBy(() -> validate("SELECT " + call + " FROM t", "t"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("disallowed function");
   }

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
@@ -18,10 +18,12 @@
 package au.csiro.pathling.operations.sqlquery;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import jakarta.annotation.Nonnull;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -39,6 +41,8 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -54,6 +58,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 @SpringBootUnitTest
 class ViewRegistrationServiceTest {
+
+  /** The canonical URL under which the cohorts fixture is configured. */
+  private static final String TABLE_URL = "https://example.org/data/cohorts";
 
   @Autowired private SparkSession spark;
   @Autowired private FhirContext fhirContext;
@@ -179,8 +186,7 @@ class ViewRegistrationServiceTest {
     final String path = writeCohorts(tempDir.resolve("cohorts_delta"), "delta");
 
     final Dataset<Row> result =
-        service.buildExternalTable(
-            new ResolvedExternalTable("https://example.org/data/cohorts", path, "delta"));
+        service.buildExternalTable(new ResolvedExternalTable(TABLE_URL, path, "delta"));
 
     assertCohorts(result);
   }
@@ -190,10 +196,55 @@ class ViewRegistrationServiceTest {
     final String path = writeCohorts(tempDir.resolve("cohorts_parquet"), "parquet");
 
     final Dataset<Row> result =
-        service.buildExternalTable(
-            new ResolvedExternalTable("https://example.org/data/cohorts", path, "parquet"));
+        service.buildExternalTable(new ResolvedExternalTable(TABLE_URL, path, "parquet"));
 
     assertCohorts(result);
+  }
+
+  // ---------------------------------------------------------------------------
+  // External table read failures (spec 060 US3).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void buildExternalTableReportsAMissingDeltaPathAsAReadFailure(@TempDir final Path tempDir) {
+    final String path = "file://" + tempDir.resolve("does-not-exist").toAbsolutePath();
+
+    assertReadFailure(new ResolvedExternalTable(TABLE_URL, path, "delta"), path);
+  }
+
+  @Test
+  void buildExternalTableReportsAMissingParquetPathAsAReadFailure(@TempDir final Path tempDir) {
+    final String path = "file://" + tempDir.resolve("does-not-exist").toAbsolutePath();
+
+    assertReadFailure(new ResolvedExternalTable(TABLE_URL, path, "parquet"), path);
+  }
+
+  @Test
+  void buildExternalTableReportsAParquetDirectoryDeclaredAsDeltaAsAReadFailure(
+      @TempDir final Path tempDir) {
+    final String path = writeCohorts(tempDir.resolve("cohorts_parquet"), "parquet");
+
+    assertReadFailure(new ResolvedExternalTable(TABLE_URL, path, "delta"), path);
+  }
+
+  /**
+   * Asserts that reading the node fails with the operator-side 500 that names the URL, hides the
+   * path and carries a single processing issue.
+   */
+  private void assertReadFailure(
+      @Nonnull final ResolvedExternalTable node, @Nonnull final String path) {
+    assertThatThrownBy(() -> service.buildExternalTable(node))
+        .isInstanceOf(BaseServerResponseException.class)
+        .hasMessage("Failed to read external table '" + TABLE_URL + "'")
+        .hasMessageNotContaining(path)
+        .satisfies(
+            thrown -> {
+              final BaseServerResponseException exception = (BaseServerResponseException) thrown;
+              assertThat(exception.getStatusCode()).isEqualTo(500);
+              final OperationOutcome outcome = (OperationOutcome) exception.getOperationOutcome();
+              assertThat(outcome.getIssue()).hasSize(1);
+              assertThat(outcome.getIssueFirstRep().getCode()).isEqualTo(IssueType.PROCESSING);
+            });
   }
 
   /** Writes the two-row cohorts fixture in the given format and returns its {@code file://} URL. */

--- a/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
+++ b/server/src/test/java/au/csiro/pathling/operations/sqlquery/ViewRegistrationServiceTest.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import au.csiro.pathling.config.ServerConfiguration;
 import au.csiro.pathling.test.SpringBootUnitTest;
 import ca.uhn.fhir.context.FhirContext;
+import jakarta.annotation.Nonnull;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -35,15 +37,20 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Tests for {@link ViewRegistrationService}, with particular attention to the request-id
  * namespacing that prevents concurrent {@code $sql-run} requests from clobbering one another's
- * temporary views in Spark's session-global catalog.
+ * temporary views in Spark's session-global catalog, and to the reading of configured external
+ * tables.
+ *
+ * @author John Grimes
  */
 @SpringBootUnitTest
 class ViewRegistrationServiceTest {
@@ -161,6 +168,57 @@ class ViewRegistrationServiceTest {
     } finally {
       service.dropViews(List.of(childViewName));
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // External table materialisation (spec 060 US1).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void buildExternalTableReadsADeltaTable(@TempDir final Path tempDir) {
+    final String path = writeCohorts(tempDir.resolve("cohorts_delta"), "delta");
+
+    final Dataset<Row> result =
+        service.buildExternalTable(
+            new ResolvedExternalTable("https://example.org/data/cohorts", path, "delta"));
+
+    assertCohorts(result);
+  }
+
+  @Test
+  void buildExternalTableReadsAParquetTable(@TempDir final Path tempDir) {
+    final String path = writeCohorts(tempDir.resolve("cohorts_parquet"), "parquet");
+
+    final Dataset<Row> result =
+        service.buildExternalTable(
+            new ResolvedExternalTable("https://example.org/data/cohorts", path, "parquet"));
+
+    assertCohorts(result);
+  }
+
+  /** Writes the two-row cohorts fixture in the given format and returns its {@code file://} URL. */
+  @Nonnull
+  private String writeCohorts(@Nonnull final Path directory, @Nonnull final String format) {
+    final StructType schema =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("family_name", DataTypes.StringType, false),
+              DataTypes.createStructField("cohort", DataTypes.StringType, false)
+            });
+    final List<Row> rows =
+        List.of(RowFactory.create("Smith", "A"), RowFactory.create("Williams", "B"));
+    final String path = "file://" + directory.toAbsolutePath();
+    spark.createDataFrame(rows, schema).write().format(format).save(path);
+    return path;
+  }
+
+  private static void assertCohorts(@Nonnull final Dataset<Row> result) {
+    assertThat(result.schema().fieldNames()).containsExactly("family_name", "cohort");
+    assertThat(
+            result.collectAsList().stream()
+                .map(row -> row.getString(0) + "/" + row.getString(1))
+                .toList())
+        .containsExactlyInAnyOrder("Smith/A", "Williams/B");
   }
 
   // ---------------------------------------------------------------------------
@@ -339,7 +397,7 @@ class ViewRegistrationServiceTest {
   private Dataset<Row> singleColumnDataset(final String columnName, final List<String> values) {
     final StructType schema =
         DataTypes.createStructType(
-            new org.apache.spark.sql.types.StructField[] {
+            new StructField[] {
               DataTypes.createStructField(columnName, DataTypes.StringType, false)
             });
     final List<Row> rows =

--- a/site/server-docs/authorization.md
+++ b/site/server-docs/authorization.md
@@ -106,6 +106,14 @@ authority for the resource type a ViewDefinition subject projects, named in its
 requires `pathling:read:Patient` authority in addition to the operation
 authority.
 
+A configured [external table](configuration#sql-query) referenced as a
+dependency of a SQL subject requires only the operation authority. It is
+operator configuration rather than FHIR data, so no resource-type `read`
+authority applies to it and none is checked when it is read. The FHIR-backed
+dependencies alongside it are unaffected: a ViewDefinition or SQLView joined to
+an external table keeps its own resource-type read requirements, and the
+storage read checks below.
+
 ### Job ownership
 
 Asynchronous jobs are owned by the token subject that started them. When

--- a/site/server-docs/configuration.md
+++ b/site/server-docs/configuration.md
@@ -196,7 +196,10 @@ These settings govern the resolution of a query's dependency graph, for both
 - `pathling.sqlQuery.externalTables.N.path` - The location of the table.
   Accepts the same URL schemes as `pathling.storage.warehouseUrl`.
 - `pathling.sqlQuery.externalTables.N.format` - (default: `delta`) The storage
-  format of the table, either `delta` or `parquet`.
+  format of the table, either `delta` or `parquet`. The format is passed to
+  Spark as declared, so declare it accurately: a Parquet directory declared
+  `delta` fails to read, but a Delta table declared `parquet` is read as its
+  raw data files, including those superseded by later commits.
 
 `N` is a zero-based index. The list is validated at startup: every entry must
 have a non-blank `url` that contains no `|` and is unique among the configured

--- a/site/server-docs/configuration.md
+++ b/site/server-docs/configuration.md
@@ -179,7 +179,7 @@ error response and is excluded from the CapabilityStatement.
 
 ### SQL query
 
-This setting bounds the resolution of a query's dependency graph, for both
+These settings govern the resolution of a query's dependency graph, for both
 `$sql-run` and `$sql-export`.
 
 - `pathling.sqlQuery.maxDependencyDepth` - (default: `10`) The maximum nesting
@@ -188,6 +188,23 @@ This setting bounds the resolution of a query's dependency graph, for both
   nested SQLView dependency increments the depth. A graph nested deeper is
   rejected with a `400` before any Spark work, guarding against accidental
   fan-out and runaway resolution.
+- `pathling.sqlQuery.externalTables.N.url` - The canonical URL by which a
+  SQLQuery or SQLView `relatedArtifact` names this external table. Each
+  configured table is a read-only Delta or Parquet table, outside the
+  warehouse, that a SQL subject may join to its FHIR views; see
+  [$sql-run](./operations/sql-run#supporting-artefacts).
+- `pathling.sqlQuery.externalTables.N.path` - The location of the table.
+  Accepts the same URL schemes as `pathling.storage.warehouseUrl`.
+- `pathling.sqlQuery.externalTables.N.format` - (default: `delta`) The storage
+  format of the table, either `delta` or `parquet`.
+
+`N` is a zero-based index. The list is validated at startup: every entry must
+have a non-blank `url` that contains no `|` and is unique among the configured
+tables, a non-blank `path` and an allowed `format`. A violation prevents the
+server from starting, with a failure naming the offending property. No path is
+probed at startup, so an unreachable or not-yet-written table does not stop the
+server; each table is read at its current state on every request that
+references it.
 
 ### Encoding
 

--- a/site/server-docs/operations/sql-export.md
+++ b/site/server-docs/operations/sql-export.md
@@ -56,7 +56,10 @@ meaningless for a bulk file set, and is refused as `invalid`.
 ## Job guarantees
 
 - **One snapshot.** Every subject reads the Delta table versions pinned when
-  the job began, so concurrent writes are invisible to it.
+  the job began, so concurrent writes are invisible to it. The snapshot covers
+  the warehouse only: a configured
+  [external table](../configuration#sql-query) is outside it and is read at its
+  current state when the subject that references it is materialised.
 - **One resolution per canonical URL.** Dependency resolution is memoised
   across the job, so an artefact several subjects share is resolved once.
 - **One output per subject.** The manifest carries exactly one `output` per

--- a/site/server-docs/operations/sql-run.md
+++ b/site/server-docs/operations/sql-run.md
@@ -91,6 +91,22 @@ that matches no dependency of the subject is a `400`: it usually means a URL
 was mistyped, and ignoring it would run the request against different artefacts
 than the client intended.
 
+A `relatedArtifact` may also name an
+[external table](../configuration#sql-query) configured by the operator, by
+the `url` it was configured under. The reference takes the same form as a
+ViewDefinition dependency, and the SQL reaches the table only through the
+declared `label`, which obeys the usual rule (`^[A-Za-z][A-Za-z0-9_]*$`,
+unique within the Library). An external table has no version, so a reference
+carrying a `|version` pin never matches one. A URL that matches both a
+configured table and a stored ViewDefinition or SQLView is ambiguous and is a
+`400` naming the label; a `context` entry with that URL outranks the table, as
+it outranks server resolution generally. `DESCRIBE <label>` lists the table's
+columns just as it does for any other dependency.
+
+The `patient`, `group` and `_since` filters restrict the FHIR data the subject
+reads; they do not filter an external table, whose rows are constrained only by
+the SQL that joins it.
+
 ## Examples
 
 Run a stored view over `GET`, as CSV:
@@ -171,6 +187,7 @@ GET [base]/$sql-run?subjectReference=ViewDefinition/demographics&patient=Patient
 | `404 Not Found`             | The subject's canonical or reference resolves to nothing, or a dependency cannot be resolved.                                           |
 | `422 Unprocessable Entity`  | The subject is of no admitted kind, or is conformant but cannot be processed (for example a column type `_format=fhir` cannot express). |
 | `500 Internal Server Error` | An unexpected execution or infrastructure fault.                                                                                        |
+| `500 Internal Server Error` | A configured external table cannot be read; the issue names the table's `url` and never its storage path.                               |
 
 Every 4xx and 5xx response carries an
 [OperationOutcome](https://hl7.org/fhir/R4/operationoutcome.html) whose issues


### PR DESCRIPTION
Adds operator-configured external tables that a SQLQuery or SQLView can declare as an ordinary `relatedArtifact` dependency and read by its label, in both `$sql-run` and `$sql-export`.

- `pathling.sqlQuery.externalTables.N.{url,path,format}` with Bean Validation (unique URL, no `|`, non-blank path, `delta`/`parquet`), logged at startup, no storage probed.
- `SqlDependencyResolver` matches an unpinned canonical URL against configuration alongside stored ViewDefinitions and SQLViews; more than one match is an ambiguity `400`, nothing is a `404` naming all three kinds; a `context` artefact still outranks everything.
- `ViewRegistrationService.buildExternalTable` reads the table with a single Spark read; a failure is a `500` naming the URL only, with the path and cause logged.
- `SqlValidator` now rejects `input_file_name` and the input file block functions, which would otherwise disclose a configured storage path.
- No new authority: the operation authority alone grants access; FHIR-backed dependencies alongside keep their checks.
- Server documentation updated (configuration, `$sql-run`, `$sql-export`, authorisation).

Verified with the full server unit suite (2036 tests), `SqlExternalTableIT` (12 scenarios), `SqlViewRunProviderIT` and `SqlExportProviderIT`, plus manual curl validation against a locally started server.

Resolves #2750.